### PR TITLE
[patch] Fix identation in Optimizer show config

### DIFF
--- a/image/installer/bin/functions/show_config
+++ b/image/installer/bin/functions/show_config
@@ -54,10 +54,10 @@ function show_config() {
   fi
 
   if [[ "${MAS_APP_SOURCE_OPTIMIZER}/${MAS_APP_CHANNEL_OPTIMIZER}" == '/' ]]
-  then echo_reset_dim " - Optimizer ............. ${COLOR_RED}Skip Installation"
+  then echo_reset_dim "Optimizer ............. ${COLOR_RED}Skip Installation"
   else
-    echo_reset_dim " - Optimizer ............. ${COLOR_BLUE}${MAS_APP_SOURCE_OPTIMIZER}/${MAS_APP_CHANNEL_OPTIMIZER}"
-    echo_reset_dim "  > Install Plan ......... ${COLOR_BLUE}${MAS_APP_PLAN_OPTIMIZER}"
+    echo_reset_dim "Optimizer ............. ${COLOR_BLUE}${MAS_APP_SOURCE_OPTIMIZER}/${MAS_APP_CHANNEL_OPTIMIZER}"
+    echo_reset_dim " > Install Plan ......... ${COLOR_BLUE}${MAS_APP_PLAN_OPTIMIZER}"
   fi
 
   reset_colors


### PR DESCRIPTION
As confirmed by Lee that Optimizer does not need Manage, its config can be showed outside in same level of IoT and Manage. Using `-` for apps and `>` for application characteristics that worth displaying