### PR TITLE
[patch] Support additional UDS optional parameters

### DIFF
--- a/image/installer/Dockerfile
+++ b/image/installer/Dockerfile
@@ -7,11 +7,17 @@ ADD https://github.com/krallin/tini/releases/download/v0.19.0/tini /tini
 COPY bin /installer/bin
 COPY .bashrc /opt/app-root/src/.bashrc
 
+# ibm.mas_devops 10.1.0 is already installed in the base image, but as we haven't
+# updated ansible-airgap to include the newest release of ansible-devops yet
+# we want to do an additional install of mas_devops to get the latest fixes
+# We won't always need this extra install, only when mas_devops release is newer
+# than mas_airgap release.
 RUN chmod +x /tini && \
     chmod +x /installer/bin/mas && \
     chmod +x /opt/app-root/src/.bashrc && \
     ln -s $ANSIBLE_COLLECTIONS_PATH/ibm/mas_airgap /installer/airgap && \
-    ln -s $ANSIBLE_COLLECTIONS_PATH/ibm/mas_devops /installer/devops
+    ln -s $ANSIBLE_COLLECTIONS_PATH/ibm/mas_devops /installer/devops && \
+    ansible-galaxy collection install ibm.mas_devops:10.1.1 --no-deps
 
 ENV PATH="/installer/bin:${PATH}" \
     VERSION=$VERSION_LABEL

--- a/image/installer/bin/templates/pipeline.yaml
+++ b/image/installer/bin/templates/pipeline.yaml
@@ -130,6 +130,12 @@ spec:
       type: string
     - name: uds_contact_lastname       # Required
       type: string
+    - name: uds_event_scheduler_frequency
+      type: string
+      default: ""
+    - name: mas_segment_key
+      type: string
+      default: ""
 
     # MAS Configuration
     - name: mas_instance_id            # Required
@@ -637,12 +643,16 @@ spec:
 
         - name: mas_instance_id
           value: $(params.mas_instance_id)
+        - name: mas_segment_key
+          value: $(params.mas_segment_key)
         - name: uds_contact_email
           value: "$(params.uds_contact_email)"
         - name: uds_contact_firstname
           value: "$(params.uds_contact_firstname)"
         - name: uds_contact_lastname
           value: "$(params.uds_contact_lastname)"
+        - name: uds_event_scheduler_frequency
+          value: "$(params.uds_event_scheduler_frequency)"
       taskRef:
         kind: Task
         name: mas-devops-uds


### PR DESCRIPTION
Adds support for 2 new parameters to the UDS step in the pipeline:

- `mas_segment_key`
- `uds_event_scheduler_frequency`

These are primarily used in development installations.