### PR TITLE
[minor] Add support for air gap install 

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @durera @whitfiea
+* @durera

--- a/deployment.yaml
+++ b/deployment.yaml
@@ -17,6 +17,6 @@ spec:
       containers:
       - name: mas-cli
         imagePullPolicy: Always
-        image: quay.io/ibmmas/cli:1.0.0-pre.mirrorwork
+        image: quay.io/ibmmas/cli:1.0.0-pre.master
         command: [ "/bin/bash", "-c", "--" ]
         args: [ "while true; do sleep 30; done;" ]

--- a/image/cli/Dockerfile
+++ b/image/cli/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/ibmmas/ansible-airgap:1.2.0-pre.master
+FROM quay.io/ibmmas/ansible-airgap:1.2.0-pre.djp
 
 ARG VERSION_LABEL
 
@@ -7,17 +7,12 @@ ADD https://github.com/krallin/tini/releases/download/v0.19.0/tini /tini
 COPY bin /mascli/bin
 COPY .bashrc /opt/app-root/src/.bashrc
 
-# ibm.mas_devops 10.1.0 is already installed in the base image, but as we haven't
-# updated ansible-airgap to include the newest release of ansible-devops yet
-# we want to do an additional install of mas_devops to get the latest fixes
-# We won't always need this extra install, only when mas_devops release is newer
-# than mas_airgap release.
 RUN chmod +x /tini && \
     chmod +x /mascli/bin/mas && \
     chmod +x /opt/app-root/src/.bashrc && \
     ln -s $ANSIBLE_COLLECTIONS_PATH/ibm/mas_airgap /mascli/airgap && \
     ln -s $ANSIBLE_COLLECTIONS_PATH/ibm/mas_devops /mascli/devops
-#    ansible-galaxy collection install ibm.mas_devops:10.2.0 --no-deps
+#    ansible-galaxy collection install ibm.mas_devops:10.2.1 --no-deps
 
 ENV PATH="/mascli/bin:${PATH}" \
     VERSION=$VERSION_LABEL

--- a/image/cli/Dockerfile
+++ b/image/cli/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/ibmmas/ansible-airgap:1.2.0-pre.djp
+FROM quay.io/ibmmas/ansible-airgap:1.2.0-pre.master
 
 ARG VERSION_LABEL
 

--- a/image/cli/bin/functions/channel_select
+++ b/image/cli/bin/functions/channel_select
@@ -1,0 +1,178 @@
+#!/bin/bash
+
+function channel_select_mas() {
+  if [[ -z AIRGAP_MODE ]]; then
+    echo -e "${COLOR_YELLOW}MAS Version:"
+    echo "  1. 8.7"
+    echo "  2. 8.6"
+    prompt_for_input "Select Subscription Channel" MAS_CHANNEL_SELECTION "1"
+
+    case $MAS_CHANNEL_SELECTION in
+      1|8.7|8.7.x)
+        export MAS_CHANNEL=8.7.x
+        export MAS_CATALOG_SOURCE=ibm-operator-catalog
+        ;;
+
+      2|8.6|8.6.x)
+        export MAS_CHANNEL=8.6.x
+        export MAS_CATALOG_SOURCE=ibm-operator-catalog
+        ;;
+
+      *)
+        export MAS_CHANNEL=$MAS_CHANNEL_SELECTION
+        prompt_for_input 'Custom Catalog Source' MAS_CATALOG_SOURCE "ibm-mas-operators"
+        ;;
+    esac
+  else
+    echo -e "${COLOR_YELLOW}MAS Version:"
+    echo "  1. 8.7 (Airgap install)"
+    prompt_for_input "Select Subscription Channel" MAS_CHANNEL_SELECTION "1"
+
+    case $MAS_CHANNEL_SELECTION in
+      1|8.7|8.7.x)
+        export MAS_CHANNEL=8.7.x
+        export MAS_CATALOG_SOURCE=ibm-mas-operators
+        ;;
+
+      *)
+        export MAS_CHANNEL=$MAS_CHANNEL_SELECTION
+        prompt_for_input 'Custom Catalog Source' MAS_CATALOG_SOURCE "ibm-mas-operators"
+        ;;
+    esac
+  fi
+  true
+}
+
+function channel_select_iot() {
+  if [[ -z AIRGAP_MODE ]]; then
+    case $MAS_CHANNEL in
+      8.6.x|8.7.x)
+        MAS_APP_CHANNEL_IOT=8.4.x
+        MAS_APP_SOURCE_IOT=ibm-operator-catalog
+        ;;
+
+      *)
+        prompt_for_input 'Custom Subscription Channel' MAS_APP_CHANNEL_IOTT
+        prompt_for_input 'Custom Catalog Source' MAS_APP_SOURCE_IOT "ibm-mas-iot-operators"
+        ;;
+    esac
+  else
+    MAS_APP_CHANNEL_IOT=8.4.x
+    MAS_APP_SOURCE_IOT=ibm-mas-iot-operators
+    echo_warning "Sorry, air gap install of this application is not supported yet"
+    exit 1
+  fi
+  true
+}
+
+function channel_select_monitor() {
+  if [[ -z AIRGAP_MODE ]]; then
+    case $MAS_CHANNEL in
+      8.7.x)
+        MAS_APP_CHANNEL_MONITOR=8.7.x
+        MAS_APP_SOURCE_MONITOR=ibm-operator-catalog
+        ;;
+      8.6.x)
+        MAS_APP_CHANNEL_MONITOR=8.6.x
+        MAS_APP_SOURCE_MONITOR=ibm-operator-catalog
+        ;;
+      *)
+        prompt_for_input 'Custom Subscription Channel' MAS_APP_CHANNEL_MONITOR
+        prompt_for_input 'Custom Catalog Source' MAS_APP_SOURCE_MONITOR "ibm-mas-monitor-operators"
+        ;;
+    esac
+  else
+    MAS_APP_CHANNEL_MONITOR=8.7.x
+    MAS_APP_SOURCE_MONITOR=ibm-mas-monitor-operators
+    echo_warning "Sorry, air gap install of this application is not supported yet"
+    exit 1
+  fi
+}
+
+function channel_select_safety() {
+  if [[ -z AIRGAP_MODE ]]; then
+    case $MAS_CHANNEL in
+      8.6.x|8.7.x)
+        MAS_APP_CHANNEL_SAFETY=8.2.x
+        MAS_APP_SOURCE_SAFETY=ibm-operator-catalog
+        ;;
+      *)
+        prompt_for_input 'Custom Subscription Channel' MAS_APP_CHANNEL_SAFETY
+        prompt_for_input 'Custom Catalog Source' MAS_APP_SOURCE_SAFETY "ibm-mas-safety-operators"
+        ;;
+    esac
+  else
+    MAS_APP_CHANNEL_MONITOR=8.7.x
+    MAS_APP_SOURCE_MONITOR=ibm-mas-monitor-operators
+    echo_warning "Sorry, air gap install of this application is not supported yet"
+    exit 1
+  fi
+}
+
+function channel_select_manage() {
+  if [[ -z AIRGAP_MODE ]]; then
+    case $MAS_CHANNEL in
+      8.7.x)
+        MAS_APP_CHANNEL_MANAGE=8.3.x
+        MAS_APP_SOURCE_MANAGE=ibm-operator-catalog
+        ;;
+      8.6.x)
+        MAS_APP_CHANNEL_MANAGE=8.2.x
+        MAS_APP_SOURCE_MANAGE=ibm-operator-catalog
+        ;;
+      *)
+        prompt_for_input 'Custom Subscription Channel' MAS_APP_CHANNEL_MANAGE
+        prompt_for_input 'Custom Catalog Source' MAS_APP_SOURCE_MANAGE "ibm-mas-manage-operators"
+        ;;
+    esac
+  else
+    MAS_APP_CHANNEL_MANAGE=8.3.x
+    MAS_APP_SOURCE_MANAGE=ibm-mas-manage-operators
+    echo_warning "Sorry, air gap install of this application is not supported yet"
+    exit 1
+  fi
+}
+
+function channel_select_predict() {
+  if [[ -z AIRGAP_MODE ]]; then
+    case $MAS_CHANNEL in
+      8.7.x)
+        MAS_APP_CHANNEL_PREDICT=8.5.x
+        MAS_APP_SOURCE_PREDICT=ibm-operator-catalog
+        ;;
+      8.6.x)
+        MAS_APP_CHANNEL_PREDICT=8.4.x
+        MAS_APP_SOURCE_PREDICT=ibm-operator-catalog
+        ;;
+      *)
+        prompt_for_input 'Custom Subscription Channel' MAS_APP_CHANNEL_PREDICT
+        prompt_for_input 'Custom Catalog Source' MAS_APP_SOURCE_PREDICT "ibm-mas-predict-operators"
+        ;;
+    esac
+  else
+    MAS_APP_CHANNEL_PREDICT=8.7.x
+    MAS_APP_SOURCE_PREDICT=ibm-mas-predict-operators
+    echo_warning "Sorry, air gap install of this application is not supported yet"
+    exit 1
+  fi
+}
+
+channel_select_optimizer() {
+  if [[ -z AIRGAP_MODE ]]; then
+    case $MAS_CHANNEL in
+      8.8.x)
+        MAS_APP_CHANNEL_OPTIMIZER=8.2.x
+        MAS_APP_SOURCE_OPTIMIZER=ibm-operator-catalog
+        ;;
+      *)
+        prompt_for_input 'Custom Subscription Channel' MAS_APP_CHANNEL_OPTIMIZER
+        prompt_for_input 'Custom Catalog Source' MAS_APP_SOURCE_OPTIMIZER "ibm-mas-optimizer-operators"
+        ;;
+    esac
+  else
+    MAS_APP_CHANNEL_OPTIMIZER=8.2.x
+    MAS_APP_SOURCE_OPTIMIZER=ibm-mas-optimizer-operators
+    echo_warning "Sorry, air gap install of this application is not supported yet"
+    exit 1
+  fi
+}

--- a/image/cli/bin/functions/config_pipeline
+++ b/image/cli/bin/functions/config_pipeline
@@ -10,165 +10,56 @@ function config_pipeline() {
   fi
   prompt_for_input "MAS Instance ID" MAS_INSTANCE_ID
 
-  echo -e "${COLOR_YELLOW}MAS Version:"
-  echo "  1. 8.7"
-  echo "  2. 8.6"
-  prompt_for_input "Select Subscription Channel" MAS_CHANNEL_SELECTION "1"
+  channel_select_mas || exit 1
 
-  case $MAS_CHANNEL_SELECTION in
-    1|8.7|8.7.x)
-      export MAS_CHANNEL=8.7.x
-      export MAS_CATALOG_SOURCE=ibm-operator-catalog
-      ;;
-
-    2|8.6|8.6.x)
-      export MAS_CHANNEL=8.6.x
-      export MAS_CATALOG_SOURCE=ibm-operator-catalog
-      ;;
-
-    *)
-      export MAS_CHANNEL=$MAS_CHANNEL_SELECTION
-      prompt_for_input 'Custom Catalog Source' MAS_CATALOG_SOURCE "ibm-mas-operators"
-      ;;
-  esac
+  # Default all applications to "do not deploy"
+  export MAS_APP_SOURCE_IOT='';        export MAS_APP_CHANNEL_IOT=''
+  export MAS_APP_SOURCE_MONITOR='';    export MAS_APP_CHANNEL_MONITOR=''
+  export MAS_APP_SOURCE_SAFETY='';     export MAS_APP_CHANNEL_SAFETY=''
+  export MAS_APP_SOURCE_MANAGE='';     export MAS_APP_CHANNEL_MANAGE=''
+  export MAS_APP_SOURCE_PREDICT='';    export MAS_APP_CHANNEL_PREDICT=''
+  export MAS_APP_CHANNEL_OPTIMIZER=''; export MAS_APP_SOURCE_OPTIMIZER=''; export MAS_APP_PLAN_OPTIMIZER=''
 
   echo -e "${COLOR_YELLOW}Select Applications:"
   if prompt_for_confirm "Install IoT"; then
-    case $MAS_CHANNEL in
-      8.6.x|8.7.x)
-        MAS_APP_CHANNEL_IOT=8.4.x
-        MAS_APP_SOURCE_IOT=ibm-operator-catalog
-        ;;
-
-      *)
-        prompt_for_input 'Custom Subscription Channel' MAS_APP_CHANNEL_IOT
-        prompt_for_input 'Custom Catalog Source' MAS_APP_SOURCE_IOT "ibm-mas-iot-operators"
-        ;;
-    esac
-    export MAS_APP_CHANNEL_IOT; export MAS_APP_SOURCE_IOT
-  else
-    export MAS_APP_SOURCE_IOT=''; export MAS_APP_CHANNEL_IOT=''
+    channel_select_iot || exit 1
   fi
 
   # Applications that require IoT
   if [[ "$MAS_APP_CHANNEL_IOT" != '' ]]; then
     if prompt_for_confirm "Install Monitor"; then
-      case $MAS_CHANNEL in
-        8.7.x)
-          MAS_APP_CHANNEL_MONITOR=8.7.x
-          MAS_APP_SOURCE_MONITOR=ibm-operator-catalog
-          ;;
-        8.6.x)
-          MAS_APP_CHANNEL_MONITOR=8.6.x
-          MAS_APP_SOURCE_MONITOR=ibm-operator-catalog
-          ;;
-        *)
-          prompt_for_input 'Custom Subscription Channel' MAS_APP_CHANNEL_MONITOR
-          prompt_for_input 'Custom Catalog Source' MAS_APP_SOURCE_MONITOR "ibm-mas-monitor-operators"
-          ;;
-      esac
-      export MAS_APP_CHANNEL_MONITOR; export MAS_APP_SOURCE_MONITOR
-    else
-      export MAS_APP_SOURCE_MONITOR=''; export MAS_APP_CHANNEL_MONITOR=''
+      channel_select_monitor || exit 1
     fi
     if prompt_for_confirm "Install Safety"; then
-      case $MAS_CHANNEL in
-        8.6.x|8.7.x)
-          MAS_APP_CHANNEL_SAFETY=8.2.x
-          MAS_APP_SOURCE_SAFETY=ibm-operator-catalog
-          ;;
-        *)
-          prompt_for_input 'Custom Subscription Channel' MAS_APP_CHANNEL_SAFETY
-          prompt_for_input 'Custom Catalog Source' MAS_APP_SOURCE_SAFETY "ibm-mas-safety-operators"
-          ;;
-      esac
-      export MAS_APP_CHANNEL_SAFETY; export MAS_APP_SOURCE_SAFETY
-    else
-      export MAS_APP_SOURCE_SAFETY=''; export MAS_APP_CHANNEL_SAFETY=''
+      channel_select_safety || exit 1
     fi
-  else
-    # If you're not installing IoT you can't install Monitor or Safety
-    export MAS_APP_SOURCE_MONITOR=''; export MAS_APP_CHANNEL_MONITOR=''
-    export MAS_APP_SOURCE_SAFETY=''; export MAS_APP_CHANNEL_SAFETY=''
   fi
 
   if prompt_for_confirm "Install Manage"; then
-    case $MAS_CHANNEL in
-      8.7.x)
-        MAS_APP_CHANNEL_MANAGE=8.3.x
-        MAS_APP_SOURCE_MANAGE=ibm-operator-catalog
-        ;;
-      8.6.x)
-        MAS_APP_CHANNEL_MANAGE=8.2.x
-        MAS_APP_SOURCE_MANAGE=ibm-operator-catalog
-        ;;
-      *)
-        prompt_for_input 'Custom Subscription Channel' MAS_APP_CHANNEL_MANAGE
-        prompt_for_input 'Custom Catalog Source' MAS_APP_SOURCE_MANAGE "ibm-mas-manage-operators"
-        ;;
-    esac
-    export MAS_APP_CHANNEL_MANAGE; export MAS_APP_SOURCE_MANAGE
-  else
-    export MAS_APP_SOURCE_MANAGE=''; export MAS_APP_CHANNEL_MANAGE=''
+    channel_select_manage || exit 1
   fi
 
   # Applications that require Manage
   if [[ "$MAS_APP_CHANNEL_MANAGE" != '' ]]; then
     if prompt_for_confirm "Install Predict"; then
-      case $MAS_CHANNEL in
-        8.7.x)
-          MAS_APP_CHANNEL_PREDICT=8.5.x
-          MAS_APP_SOURCE_PREDICT=ibm-operator-catalog
-          ;;
-        8.6.x)
-          MAS_APP_CHANNEL_PREDICT=8.4.x
-          MAS_APP_SOURCE_PREDICT=ibm-operator-catalog
-          ;;
-        *)
-          prompt_for_input 'Custom Subscription Channel' MAS_APP_CHANNEL_PREDICT
-          prompt_for_input 'Custom Catalog Source' MAS_APP_SOURCE_PREDICT "ibm-mas-predict-operators"
-          ;;
-      esac
-      export MAS_APP_CHANNEL_PREDICT; export MAS_APP_SOURCE_PREDICT
-    else
-      export MAS_APP_SOURCE_PREDICT=''; export MAS_APP_CHANNEL_PREDICT=''
+      channel_select_predict || exit 1
     fi
-  else
-    # If you're not installing Manage you can't install Predict
-    export MAS_APP_SOURCE_PREDICT=''; export MAS_APP_CHANNEL_PREDICT=''
   fi
 
   # Optimizer can only be installed from 8.8 on
   if [[ "$MAS_CHANNEL" != '8.6.x' && "$MAS_CHANNEL" != '8.7.x' ]]; then
     if prompt_for_confirm "Install Optimizer"; then
-      case $MAS_CHANNEL in
-        8.8.x)
-          MAS_APP_CHANNEL_OPTIMIZER=8.2.x # not released yet, though not reachable since MAS_CHANNEL cannot be 8.8 (yet)
-          MAS_APP_SOURCE_OPTIMIZER=ibm-operator-catalog
-          ;;
-        *)
-          prompt_for_input 'Custom Subscription Channel' MAS_APP_CHANNEL_OPTIMIZER
-          prompt_for_input 'Custom Catalog Source' MAS_APP_SOURCE_OPTIMIZER "ibm-mas-optimizer-operators"
-          ;;
-      esac
-      export MAS_APP_CHANNEL_OPTIMIZER; export MAS_APP_SOURCE_OPTIMIZER;
+      channel_select_optimizer || exit 1
       # Optimizer install Plan + Validation
       while : ; do
-        prompt_for_input 'Optimizer Install Plan [full/limited]' MAS_APP_PLAN_OPTIMIZER "full"
+        prompt_for_input 'Optimizer Install Plan [full/limited]' MAS_APP_PLAN_OPTIMIZER "full" && export MAS_APP_PLAN_OPTIMIZER
         [[ "$MAS_APP_PLAN_OPTIMIZER" != "full" && "$MAS_APP_PLAN_OPTIMIZER" != "limited" ]] || break
       done
-      export MAS_APP_PLAN_OPTIMIZER;
-    else
-      # User chose not to install Optimizer
-      export MAS_APP_CHANNEL_OPTIMIZER=''; export MAS_APP_SOURCE_OPTIMIZER='';
     fi
-  else
-    # These versions of MAS don't support the optimizer application
-    export MAS_APP_CHANNEL_OPTIMIZER=''; export MAS_APP_SOURCE_OPTIMIZER='';
   fi
 
   echo ""
-  if [[ "$MAS_CATALOG_SOURCE" == "ibm-mas-operators" ]]; then
+  if [[ "$MAS_CATALOG_SOURCE" == "ibm-mas-operators" && -z AIRGAP_MODE ]]; then
     # Development Mode -- offer the ability to set MAS and SLS source independently
     echo_h2 "4a. Configure Artifactory"
     prompt_for_input "Artifactory Username" ARTIFACTORY_USERNAME
@@ -188,7 +79,6 @@ function config_pipeline() {
     prompt_for_input "IBM Container Registry (cpopen)" SLS_ICR_CPOPEN wiotp-docker-local.artifactory.swg-devops.com override
     prompt_for_input "Entitlement Username" SLS_ENTITLEMENT_USERNAME $ARTIFACTORY_USERNAME override
     prompt_for_input "Entitlement Key" SLS_ENTITLEMENT_KEY $ARTIFACTORY_APIKEY override
-
   else
     # Production Mode -- everything comes from the same registry (IBM container registry)
     echo_h2 "4. Configure IBM Container Registry"
@@ -204,6 +94,13 @@ function config_pipeline() {
     export SLS_ICR_CPOPEN=icr.io/cpopen
     export SLS_ENTITLEMENT_USERNAME=cp
     export SLS_ENTITLEMENT_KEY=$IBM_ENTITLEMENT_KEY
+  fi
+
+  if [[ -n AIRGAP_MODE ]]; then
+    # Override Common Services Catalog Source
+    export COMMON_SERVICES_CATALOG_SOURCE=opencloud-operators
+  else
+    export COMMON_SERVICES_CATALOG_SOURCE=ibm-operator-catalog
   fi
 
   echo

--- a/image/cli/bin/functions/config_pipeline
+++ b/image/cli/bin/functions/config_pipeline
@@ -239,9 +239,9 @@ function config_pipeline() {
     echo -e "${COLOR_GREEN}Storage class auto-detected: IBMCloud ROKS${COLOR_RESET}"
   else
     # 2. OCS
-    oc get storageclass ocs-storagecluster-ceph-rbd &>> $LOGFILE
+    oc get storageclass ocs-storagecluster-cephfs &>> $LOGFILE
     if [[ $? == "0" ]]; then
-      PIPELINE_STORAGE_CLASS=ocs-storagecluster-ceph-rbd
+      PIPELINE_STORAGE_CLASS=ocs-storagecluster-cephfs
       echo -e "${COLOR_GREEN}Storage class auto-detected: OpenShift Container Storage${COLOR_RESET}"
     else
       # 3. Azure

--- a/image/cli/bin/functions/config_pipeline
+++ b/image/cli/bin/functions/config_pipeline
@@ -183,7 +183,6 @@ function config_pipeline() {
     prompt_for_input "Entitlement Username" MAS_ENTITLEMENT_USERNAME $ARTIFACTORY_USERNAME override
     prompt_for_input "Entitlement Key" MAS_ENTITLEMENT_KEY $ARTIFACTORY_APIKEY override
 
-    echo
     echo_h2 "4d. Configure IBM Container Registry (SLS)"
     prompt_for_input "IBM Container Registry (cp)" SLS_ICR_CP wiotp-docker-local.artifactory.swg-devops.com override
     prompt_for_input "IBM Container Registry (cpopen)" SLS_ICR_CPOPEN wiotp-docker-local.artifactory.swg-devops.com override
@@ -284,7 +283,7 @@ function config_pipeline() {
   echo -en "\033[s" # Save cursor position
   echo -n "Preparing namespace 'mas-$MAS_INSTANCE_ID-pipelines' ..."
 
-  export PIPELINE_VERSION=10.2.0
+  export PIPELINE_VERSION=10.2.1-pre.master
   if [ ! -e $DIR/templates/ibm-mas-devops-tasks-$PIPELINE_VERSION.yaml ]; then
     wget https://github.com/ibm-mas/ansible-devops/releases/download/$PIPELINE_VERSION/ibm-mas-devops-tasks-$PIPELINE_VERSION.yaml -O $DIR/templates/ibm-mas-devops-tasks-$PIPELINE_VERSION.yaml  &>> $LOGFILE
   fi

--- a/image/cli/bin/functions/config_pipeline
+++ b/image/cli/bin/functions/config_pipeline
@@ -99,8 +99,10 @@ function config_pipeline() {
   if [[ -n AIRGAP_MODE ]]; then
     # Override Common Services Catalog Source
     export COMMON_SERVICES_CATALOG_SOURCE=opencloud-operators
+    export SLS_CATALOG_SOURCE=ibm-sls-operators
   else
     export COMMON_SERVICES_CATALOG_SOURCE=ibm-operator-catalog
+    export SLS_CATALOG_SOURCE=ibm-operator-catalog
   fi
 
   echo

--- a/image/cli/bin/functions/configure_ocp_for_mirror
+++ b/image/cli/bin/functions/configure_ocp_for_mirror
@@ -3,24 +3,23 @@
 function configure_ocp_for_mirror() {
   echo
   echo_h2 "2. Configure Target Mirror"
-  prompt_for_input "Mirror Registry Host" REGISTRY_PRIVATE_HOST
-  prompt_for_input "Mirror Registry Port" REGISTRY_PRIVATE_PORT
-  prompt_for_input "Mirror Registry CA File" REGISTRY_PRIVATE_CA_FILE
+  prompt_for_input "Mirror Registry Host" REGISTRY_PRIVATE_HOST && export REGISTRY_PRIVATE_HOST
+  prompt_for_input "Mirror Registry Port" REGISTRY_PRIVATE_PORT && export REGISTRY_PRIVATE_PORT
+  prompt_for_input "Mirror Registry CA File" REGISTRY_PRIVATE_CA_FILE && export REGISTRY_PRIVATE_CA_FILE
   if [[ ! -e $REGISTRY_PRIVATE_CA_FILE ]]; then
     echo_warning "Certificate file '$REGISTRY_PRIVATE_CA_FILE' does not exist"
     exit 1
   fi
 
+  echo
+  echo_h2 "2. Configure Authentication"
+  prompt_for_input "Mirror Registry Username" REGISTRY_AUTH_USERNAME && export REGISTRY_AUTH_USERNAME
+  prompt_for_input "Mirror Registry Password" REGISTRY_AUTH_PASSWORD && export REGISTRY_AUTH_PASSWORD
+
   prompt_for_confirm "Prepare a MAS instance for airgap install" INSTALL_DIGEST_CMS
   if [[ $INSTALL_DIGEST_CMS == "true" ]]; then
-    prompt_for_input "MAS Instance ID" MAS_INSTANCE_ID
+    prompt_for_input "MAS Instance ID" MAS_INSTANCE_ID && export MAS_INSTANCE_ID
   fi
-
-  # Make the environment variables available to Ansible
-  export REGISTRY_PRIVATE_HOST
-  export REGISTRY_PRIVATE_PORT
-  export REGISTRY_PRIVATE_CA_FILE
-  export MAS_INSTANCE_ID
 
   echo
   prompt_for_confirm "Proceed with these settings" || exit 0

--- a/image/cli/bin/functions/show_config
+++ b/image/cli/bin/functions/show_config
@@ -75,6 +75,11 @@ function show_config() {
   echo_reset_dim "First Name ................ ${COLOR_BLUE}${UDS_CONTACT_FIRSTNAME}"
   echo_reset_dim "Last Name ................. ${COLOR_BLUE}${UDS_CONTACT_LASTNAME}"
 
+  reset_colors
+  echo "${TEXT_DIM}"
+  echo_h2 "IBM Cloud Pak Foundation Services" "    "
+  echo_reset_dim "Catalog Source ............ ${COLOR_BLUE}${COMMON_SERVICES_CATALOG_SOURCE}"
+
   if [[ "$DEPLOY_CP4D" == "run" ]]; then
     reset_colors
     echo "${TEXT_DIM}"

--- a/image/cli/bin/functions/show_config
+++ b/image/cli/bin/functions/show_config
@@ -61,6 +61,7 @@ function show_config() {
   reset_colors
   echo "${TEXT_DIM}"
   echo_h2 "IBM Suite License Service" "    "
+  echo_reset_dim "Catalog Source ............ ${COLOR_BLUE}${SLS_CATALOG_SOURCE}"
   echo_reset_dim "License ID ................ ${COLOR_BLUE}${SLS_LICENSE_ID}"
   echo_reset_dim "License File .............. ${COLOR_BLUE}${SLS_LICENSE_FILE}"
   echo_reset_dim "IBM Entitled Registry ..... ${COLOR_BLUE}${SLS_ICR_CP}"

--- a/image/cli/bin/functions/utils
+++ b/image/cli/bin/functions/utils
@@ -101,7 +101,7 @@ function prompt_for_confirm() {
 
 
 function update_ansible_collections() {
-  if [[ "$UPDATE_ANSIBLE" == "true" ]]; then
+  if [[ "$UPDATE_ANSIBLE" == "true" || "$ANSIBLE_UPDATE" == "true" ]]; then
     if [[ "$DEV_MODE" == "true" ]]; then
       echo
       echo_h2 "Updating ansible collections from local build"
@@ -112,8 +112,8 @@ function update_ansible_collections() {
     else
       echo
       echo_h2 "Updating ansible collections from Galaxy"
-      ansible-galaxy collection install ibm.mas_devops:10.0.4 || exit 1
-      ansible-galaxy collection install ibm.mas_devops:1.0.0 || exit 1
+      ansible-galaxy collection install ibm.mas_devops:10.2.0 || exit 1
+      ansible-galaxy collection install ibm.mas_airgap:1.1.0 || exit 1
     fi
   fi
 }
@@ -131,4 +131,13 @@ function install_dependencies_ubuntu() {
   # Confirm versions
   python3 --version
   ansible-playbook --version
+}
+
+function detect_airgap() {
+  oc get ImageContentSourcePolicy ibm-mas-and-dependencies &> /dev/null
+  if [[ "$?" == "0" ]]; then
+    export AIRGAP_MODE=true
+  else
+    unset AIRGAP_MODE
+  fi
 }

--- a/image/cli/bin/mas
+++ b/image/cli/bin/mas
@@ -31,6 +31,7 @@ LOGFILE=$DIR/mas.log
 # MAS installation support
 . $DIR/functions/connect
 . $DIR/functions/install_pipeline
+. $DIR/functions/channel_select
 . $DIR/functions/config_pipeline
 . $DIR/functions/save_config
 . $DIR/functions/show_config
@@ -74,7 +75,6 @@ case $1 in
     echo
     echo "${TEXT_UNDERLINE}${TEXT_DIM}Current Limitations${TEXT_RESET}"
     echo "${TEXT_DIM}1. This is still a work in progress"
-    echo "${TEXT_DIM}2. The registry is configured without authentication enabled"
     echo
     reset_colors
     update_ansible_collections
@@ -88,20 +88,18 @@ case $1 in
     echo
     echo "${TEXT_UNDERLINE}${TEXT_DIM}Current Limitations${TEXT_RESET}"
     echo "${TEXT_DIM}1. This is still a work in progress"
-    echo "${TEXT_DIM}2. Only supports mirroring to registry without authentication enabled"
     echo
     reset_colors
     update_ansible_collections
     mirror_to_registry
     ;;
 
-  configure-ocp-for-mirror|configure-airgap|configure-mirror)
+  configure-ocp-for-mirror|configure-airgap|configure-mirror|config-airgap|config-mirror)
     echo "${TEXT_UNDERLINE}IBM Maximo Application Suite Air Gap OCP Setup${TEXT_RESET}"
     echo "Powered by ${COLOR_CYAN}${TEXT_UNDERLINE}https://github.com/ibm-mas/ansible-airgap/${TEXT_RESET}"
     echo
     echo "${TEXT_UNDERLINE}${TEXT_DIM}Current Limitations${TEXT_RESET}"
     echo "${TEXT_DIM}1. This is still a work in progress"
-    echo "${TEXT_DIM}2. Only supports mirroring from a registry without authentication enabled"
     echo
     reset_colors
     update_ansible_collections
@@ -117,6 +115,7 @@ case $1 in
     echo "${TEXT_DIM}1. Install relies on built-in automatic storage class selection (IBMCloud ROKS & OpenShift Container Storage supported)"
     echo "${TEXT_DIM}2. Installation and configuration management for Cloud Pak for Data services is not yet complete"
     echo "${TEXT_DIM}3. Predict, Assist, & Visual Inspection applications can not be deployed using the install yet"
+    echo "${TEXT_DIM}4. Support for airgap installation is limited to MAS 8.7 (core only) at present"
     echo
     reset_colors
     connect

--- a/image/cli/bin/templates/ibm-mas-devops-tasks-10.2.1-pre.master.yaml
+++ b/image/cli/bin/templates/ibm-mas-devops-tasks-10.2.1-pre.master.yaml
@@ -1,0 +1,1793 @@
+
+# --------------------------------------------------------------------------------
+# /home/runner/work/ansible-devops/ansible-devops/pipelines/tasks/appconnect.yaml
+# --------------------------------------------------------------------------------
+---
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: mas-devops-appconnect
+spec:
+  params:
+    - name: mas_instance_id
+      type: string
+
+    # Optional support built into the ansible-devops image
+    # for saving task execution results to a MongoDb instance
+    - name: devops_mongo_uri
+      type: string
+      description: Optional MongoDb connection URI, used to enable save-junit-to-mongo.py
+      default: ""
+    - name: devops_suite_name
+      type: string
+      description: Optional name for the junit suite, used to enable save-junit-to-mongo.py
+      default: ""
+    - name: devops_build_number
+      type: string
+      description: Optional identifier for the execution run, used to enable save-junit-to-mongo.py
+      default: ""
+
+  stepTemplate:
+    env:
+      - name: MAS_INSTANCE_ID
+        value: $(params.mas_instance_id)
+
+      # Optional support built into the ansible-devops image
+      # for saving task execution results to a MongoDb instance
+      - name: DEVOPS_MONGO_URI
+        value: $(params.devops_mongo_uri)
+      - name: DEVOPS_SUITE_NAME
+        value: $(params.devops_suite_name)
+      - name: DEVOPS_BUILD_NUMBER
+        value: $(params.devops_build_number)
+
+  steps:
+    - name: appconnect
+      command:
+        - /opt/app-root/src/run-role.sh
+        - appconnect
+      image: quay.io/ibmmas/ansible-devops:10.2.1-pre.master
+      imagePullPolicy: Always
+      workingDir: /workspace/configs
+# --------------------------------------------------------------------------------
+# /home/runner/work/ansible-devops/ansible-devops/pipelines/tasks/cert-manager.yaml
+# --------------------------------------------------------------------------------
+---
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: mas-devops-cert-manager
+spec:
+  params:
+    - name: mas_channel
+      type: string
+      default: ""
+
+    # Optional support built into the ansible-devops image
+    # for saving task execution results to a MongoDb instance
+    - name: mas_instance_id
+      type: string
+      description: Optional MAS instance Id, used to enable save-junit-to-mongo.py
+      default: ""
+    - name: devops_mongo_uri
+      type: string
+      description: Optional MongoDb connection URI, used to enable save-junit-to-mongo.py
+      default: ""
+    - name: devops_suite_name
+      type: string
+      description: Optional name for the junit suite, used to enable save-junit-to-mongo.py
+      default: ""
+    - name: devops_build_number
+      type: string
+      description: Optional identifier for the execution run, used to enable save-junit-to-mongo.py
+      default: ""
+
+  stepTemplate:
+    env:
+      - name: MAS_CHANNEL
+        value: $(params.mas_channel)
+
+      # Optional support built into the ansible-devops image
+      # for saving task execution results to a MongoDb instance
+      - name: MAS_INSTANCE_ID
+        value: $(params.mas_instance_id)
+      - name: DEVOPS_MONGO_URI
+        value: $(params.devops_mongo_uri)
+      - name: DEVOPS_SUITE_NAME
+        value: $(params.devops_suite_name)
+      - name: DEVOPS_BUILD_NUMBER
+        value: $(params.devops_build_number)
+
+  steps:
+    - name: cert-manager
+      command:
+        - /opt/app-root/src/run-role.sh
+        - cert_manager
+      image: quay.io/ibmmas/ansible-devops:10.2.1-pre.master
+      imagePullPolicy: Always
+      workingDir: /workspace/configs
+# --------------------------------------------------------------------------------
+# /home/runner/work/ansible-devops/ansible-devops/pipelines/tasks/cluster-monitoring.yaml
+# --------------------------------------------------------------------------------
+---
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: mas-devops-cluster-monitoring
+spec:
+  params:
+    - name: prometheus_retention_period
+      type: string
+      default: ""
+    - name: prometheus_storage_class
+      type: string
+      default: ""
+    - name: prometheus_storage_size
+      type: string
+      default: ""
+    - name: prometheus_alertmgr_storage_class
+      type: string
+      default: ""
+    - name: prometheus_alertmgr_storage_size
+      type: string
+      default: ""
+    - name: prometheus_userworkload_retention_period
+      type: string
+      default: ""
+    - name: prometheus_userworkload_storage_class
+      type: string
+      default: ""
+    - name: prometheus_userworkload_storage_size
+      type: string
+      default: ""
+
+    # Optional support built into the ansible-devops image
+    # for saving task execution results to a MongoDb instance
+    - name: mas_instance_id
+      type: string
+      description: Optional MAS instance Id, used to enable save-junit-to-mongo.py
+      default: ""
+    - name: devops_mongo_uri
+      type: string
+      description: Optional MongoDb connection URI, used to enable save-junit-to-mongo.py
+      default: ""
+    - name: devops_suite_name
+      type: string
+      description: Optional name for the junit suite, used to enable save-junit-to-mongo.py
+      default: ""
+    - name: devops_build_number
+      type: string
+      description: Optional identifier for the execution run, used to enable save-junit-to-mongo.py
+      default: ""
+
+  stepTemplate:
+    env:
+      - name: PROMETHEUS_RETENTION_PERIOD
+        value: $(params.prometheus_retention_period)
+      - name: PROMETHEUS_STORAGE_CLASS
+        value: $(params.prometheus_storage_class)
+      - name: PROMETHEUS_STORAGE_SIZE
+        value: $(params.prometheus_storage_size)
+      - name: PROMETHEUS_ALERTMGR_STORAGE_CLASS
+        value: $(params.prometheus_alertmgr_storage_class)
+      - name: PROMETHEUS_ALERTMGR_STORAGE_SIZE
+        value: $(params.prometheus_alertmgr_storage_size)
+      - name: PROMETHEUS_USERWORKLOAD_RETENTION_PERIOD
+        value: $(params.prometheus_userworkload_retention_period)
+      - name: PROMETHEUS_USERWORKLOAD_STORAGE_CLASS
+        value: $(params.prometheus_userworkload_storage_class)
+      - name: PROMETHEUS_USERWORKLOAD_STORAGE_SIZE
+        value: $(params.prometheus_userworkload_storage_size)
+
+      # Optional support built into the ansible-devops image
+      # for saving task execution results to a MongoDb instance
+      - name: MAS_INSTANCE_ID
+        value: $(params.mas_instance_id)
+      - name: DEVOPS_MONGO_URI
+        value: $(params.devops_mongo_uri)
+      - name: DEVOPS_SUITE_NAME
+        value: $(params.devops_suite_name)
+      - name: DEVOPS_BUILD_NUMBER
+        value: $(params.devops_build_number)
+
+  steps:
+    - name: cluster-monitoring
+      command:
+        - /opt/app-root/src/run-role.sh
+        - cluster_monitoring
+      image: quay.io/ibmmas/ansible-devops:10.2.1-pre.master
+      imagePullPolicy: Always
+      workingDir: /workspace/configs
+# --------------------------------------------------------------------------------
+# /home/runner/work/ansible-devops/ansible-devops/pipelines/tasks/common-services.yaml
+# --------------------------------------------------------------------------------
+---
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: mas-devops-common-services
+spec:
+  params:
+    - name: common_services_catalog_source
+      type: string
+      default: ""
+
+    # Optional support built into the ansible-devops image
+    # for saving task execution results to a MongoDb instance
+    - name: mas_instance_id
+      type: string
+      description: Optional MAS instance Id, used to enable save-junit-to-mongo.py
+      default: ""
+    - name: devops_mongo_uri
+      type: string
+      description: Optional MongoDb connection URI, used to enable save-junit-to-mongo.py
+      default: ""
+    - name: devops_suite_name
+      type: string
+      description: Optional name for the junit suite, used to enable save-junit-to-mongo.py
+      default: ""
+    - name: devops_build_number
+      type: string
+      description: Optional identifier for the execution run, used to enable save-junit-to-mongo.py
+      default: ""
+
+  stepTemplate:
+    env:
+      - name: COMMON_SERVICES_CATALOG_SOURCE
+        value: $(params.common_services_catalog_source)
+      # Optional support built into the ansible-devops image
+      # for saving task execution results to a MongoDb instance
+      - name: MAS_INSTANCE_ID
+        value: $(params.mas_instance_id)
+      - name: DEVOPS_MONGO_URI
+        value: $(params.devops_mongo_uri)
+      - name: DEVOPS_SUITE_NAME
+        value: $(params.devops_suite_name)
+      - name: DEVOPS_BUILD_NUMBER
+        value: $(params.devops_build_number)
+
+  steps:
+    - name: common-services
+      command:
+        - /opt/app-root/src/run-role.sh
+        - common_services
+      image: quay.io/ibmmas/ansible-devops:10.2.1-pre.master
+      imagePullPolicy: Always
+      workingDir: /workspace/configs
+# --------------------------------------------------------------------------------
+# /home/runner/work/ansible-devops/ansible-devops/pipelines/tasks/cos.yaml
+# --------------------------------------------------------------------------------
+---
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: mas-devops-cos
+spec:
+  params:
+    - name: mas_instance_id
+      type: string
+
+    # Optional support built into the ansible-devops image
+    # for saving task execution results to a MongoDb instance
+    - name: devops_mongo_uri
+      type: string
+      description: Optional MongoDb connection URI, used to enable save-junit-to-mongo.py
+      default: ""
+    - name: devops_suite_name
+      type: string
+      description: Optional name for the junit suite, used to enable save-junit-to-mongo.py
+      default: ""
+    - name: devops_build_number
+      type: string
+      description: Optional identifier for the execution run, used to enable save-junit-to-mongo.py
+      default: ""
+
+  stepTemplate:
+    env:
+      - name: MAS_INSTANCE_ID
+        value: $(params.mas_instance_id)
+
+      # Optional support built into the ansible-devops image
+      # for saving task execution results to a MongoDb instance
+      - name: DEVOPS_MONGO_URI
+        value: $(params.devops_mongo_uri)
+      - name: DEVOPS_SUITE_NAME
+        value: $(params.devops_suite_name)
+      - name: DEVOPS_BUILD_NUMBER
+        value: $(params.devops_build_number)
+
+  steps:
+    - name: cos
+      command:
+        - /opt/app-root/src/run-role.sh
+        - cos
+      image: quay.io/ibmmas/ansible-devops:10.2.1-pre.master
+      imagePullPolicy: Always
+      workingDir: /workspace/configs
+# --------------------------------------------------------------------------------
+# /home/runner/work/ansible-devops/ansible-devops/pipelines/tasks/cp4d.yaml
+# --------------------------------------------------------------------------------
+---
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: mas-devops-cp4d
+spec:
+  params:
+    # Namespace configuration (Optional, defaults built into Ansible role)
+    - name: cpd_operator_namespace
+      type: string
+      default: ""
+    - name: cpd_instance_namespace
+      type: string
+      default: ""
+
+    # Storage classes (Optional, defaults built into Ansible role)
+    - name: cpd_primary_storage_class
+      type: string
+      default: ""
+    - name: cpd_metadata_storage_class
+      type: string
+      default: ""
+
+    # Entitlement
+    - name: ibm_entitlement_key
+      type: string
+    - name: cpd_entitlement_key
+      type: string
+      default: ""
+      description: "Optional CP4D-specific override for the IBM entitlement key"
+
+    # Optional support built into the ansible-devops image
+    # for saving task execution results to a MongoDb instance
+    - name: mas_instance_id
+      type: string
+      description: Optional MAS instance Id, used to enable save-junit-to-mongo.py
+      default: ""
+    - name: devops_mongo_uri
+      type: string
+      description: Optional MongoDb connection URI, used to enable save-junit-to-mongo.py
+      default: ""
+    - name: devops_suite_name
+      type: string
+      description: Optional name for the junit suite, used to enable save-junit-to-mongo.py
+      default: ""
+    - name: devops_build_number
+      type: string
+      description: Optional identifier for the execution run, used to enable save-junit-to-mongo.py
+      default: ""
+
+  stepTemplate:
+    env:
+      - name: CPD_OPERATOR_NAMESPACE
+        value: $(params.cpd_operator_namespace)
+      - name: CPD_INSTANCE_NAMESPACE
+        value: $(params.cpd_instance_namespace)
+
+      - name: CPD_PRIMARY_STORAGE_CLASS
+        value: $(params.cpd_primary_storage_class)
+      - name: CPD_METADATA_STORAGE_CLASS
+        value: $(params.cpd_metadata_storage_class)
+
+      # Entitlement
+      - name: IBM_ENTITLEMENT_KEY
+        value: $(params.ibm_entitlement_key)
+      - name: CPD_ENTITLEMENT_KEY
+        value: $(params.cpd_entitlement_key)
+
+      # Optional support built into the ansible-devops image
+      # for saving task execution results to a MongoDb instance
+      - name: MAS_INSTANCE_ID
+        value: $(params.mas_instance_id)
+      - name: DEVOPS_MONGO_URI
+        value: $(params.devops_mongo_uri)
+      - name: DEVOPS_SUITE_NAME
+        value: $(params.devops_suite_name)
+      - name: DEVOPS_BUILD_NUMBER
+        value: $(params.devops_build_number)
+
+  steps:
+    - name: cp4d
+      command:
+        - /opt/app-root/src/run-role.sh
+        - cp4d
+      image: quay.io/ibmmas/ansible-devops:10.2.1-pre.master
+      imagePullPolicy: Always
+# --------------------------------------------------------------------------------
+# /home/runner/work/ansible-devops/ansible-devops/pipelines/tasks/cp4d_service.yaml
+# --------------------------------------------------------------------------------
+---
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: mas-devops-cp4d-service
+spec:
+  params:
+    # Namespace configuration (Optional, defaults built into Ansible role)
+    - name: cpd_operator_namespace
+      type: string
+      default: ""
+    - name: cpd_instance_namespace
+      type: string
+      default: ""
+
+    # CPD Service Name (Required)
+    - name: cpd_service_name
+      type: string
+
+    # CPD product Version (Required)
+    - name: cpd_product_version
+      type: string
+
+    # CPD Storage class (Optional, defaults built into Ansible role)
+    - name: cpd_service_storage_class
+      type: string
+      default: ""
+
+    - name: mas_instance_id
+      type: string
+      description: Instance ID
+      default: ""
+    - name: mas_workspace_id
+      type: string
+      description: Workspace ID
+      default: ""
+
+    # Optional support built into the ansible-devops image
+    # for saving task execution results to a MongoDb instance
+    - name: devops_mongo_uri
+      type: string
+      description: Optional MongoDb connection URI, used to enable save-junit-to-mongo.py
+      default: ""
+    - name: devops_suite_name
+      type: string
+      description: Optional name for the junit suite, used to enable save-junit-to-mongo.py
+      default: ""
+    - name: devops_build_number
+      type: string
+      description: Optional identifier for the execution run, used to enable save-junit-to-mongo.py
+      default: ""
+
+  stepTemplate:
+    env:
+      - name: MAS_CONFIG_DIR
+        value: /workspace/configs
+      - name: MAS_INSTANCE_ID
+        value: $(params.mas_instance_id)
+      - name: MAS_WORKSPACE_ID
+        value: $(params.mas_workspace_id)
+
+      - name: CPD_OPERATOR_NAMESPACE
+        value: $(params.cpd_operator_namespace)
+      - name: CPD_INSTANCE_NAMESPACE
+        value: $(params.cpd_instance_namespace)
+
+      - name: CPD_PRODUCT_VERSION
+        value: $(params.cpd_product_version)
+      - name: CPD_SERVICE_NAME
+        value: $(params.cpd_service_name)
+      - name: CPD_SERVICE_STORAGE_CLASS
+        value: $(params.cpd_service_storage_class)
+
+      # Optional support built into the ansible-devops image
+      # for saving task execution results to a MongoDb instance
+      - name: DEVOPS_MONGO_URI
+        value: $(params.devops_mongo_uri)
+      - name: DEVOPS_SUITE_NAME
+        value: $(params.devops_suite_name)
+      - name: DEVOPS_BUILD_NUMBER
+        value: $(params.devops_build_number)
+
+  steps:
+    - name: cp4d-service
+      command:
+        - /opt/app-root/src/run-role.sh
+        - cp4d_service
+      image: quay.io/ibmmas/ansible-devops:10.2.1-pre.master
+      imagePullPolicy: Always
+      workingDir: /workspace/configs
+
+  workspaces:
+    - name: configs
+# --------------------------------------------------------------------------------
+# /home/runner/work/ansible-devops/ansible-devops/pipelines/tasks/db2.yaml
+# --------------------------------------------------------------------------------
+---
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: mas-devops-db2
+spec:
+  params:
+    # Configure DB2W
+    - name: db2_instance_name
+      type: string
+      default: "" # By default, no config will be generated
+    - name: db2_version
+      type: string
+      default: "" # Use the default built into the ansible role
+    - name: db2_table_org
+      type: string
+      default: "" # Use the default built into the ansible role
+
+    # Configure JDBCCfg
+    - name: mas_config_scope
+      type: string
+      default: "" # By default, no config will be generated
+    - name: mas_instance_id
+      type: string
+      description: Instance ID
+      default: "" # By default, no config will be generated
+    - name: mas_workspace_id
+      type: string
+      default: "" # Only required if config_scope = ws or wsapp
+    - name: mas_application_id
+      type: string
+      default: "" # Only required if config_scope = app or wsapp
+
+    # Configure storage sizes
+    - name: db2_meta_storage_size
+      type: string
+      default: ""
+    - name: db2_data_storage_size
+      type: string
+      default: ""
+    - name: db2_backup_storage_size
+      type: string
+      default: ""
+    - name: db2_logs_storage_size
+      type: string
+      default: ""
+    - name: db2_temp_storage_size
+      type: string
+      default: ""
+
+    # Entitlement
+    - name: ibm_entitlement_key
+      type: string
+    - name: db2_entitlement_key
+      type: string
+      default: ""
+      description: "Optional Db2-specific override for the IBM entitlement key"
+
+    # Optional support built into the ansible-devops image
+    # for saving task execution results to a MongoDb instance
+    - name: devops_mongo_uri
+      type: string
+      description: Optional MongoDb connection URI, used to enable save-junit-to-mongo.py
+      default: ""
+    - name: devops_suite_name
+      type: string
+      description: Optional name for the junit suite, used to enable save-junit-to-mongo.py
+      default: ""
+    - name: devops_build_number
+      type: string
+      description: Optional identifier for the execution run, used to enable save-junit-to-mongo.py
+      default: ""
+
+  stepTemplate:
+    env:
+      # Configure JdbcCfg
+      - name: MAS_CONFIG_DIR
+        value: /workspace/configs
+      - name: MAS_CONFIG_SCOPE
+        value: $(params.mas_config_scope)
+      - name: MAS_INSTANCE_ID
+        value: $(params.mas_instance_id)
+      - name: MAS_APP_ID
+        value: $(params.mas_application_id)
+      - name: MAS_WORKSPACE_ID
+        value: $(params.mas_workspace_id)
+
+      # Configure Db2uCluster
+      - name: DB2_INSTANCE_NAME
+        value: $(params.db2_instance_name)
+      - name: DB2_VERSION
+        value: $(params.db2_version)
+      - name: DB2_TABLE_ORG
+        value: $(params.db2_table_org)
+
+      # Configure storage sizes (storage classes are set globally in the secret)
+      - name: DB2_META_STORAGE_SIZE
+        value: $(params.db2_meta_storage_size)
+      - name: DB2_DATA_STORAGE_SIZE
+        value: $(params.db2_data_storage_size)
+      - name: DB2_BACKUP_STORAGE_SIZE
+        value: $(params.db2_backup_storage_size)
+      - name: DB2_LOGS_STORAGE_SIZE
+        value: $(params.db2_logs_storage_size)
+      - name: DB2_TEMP_STORAGE_SIZE
+        value: $(params.db2_temp_storage_size)
+
+      # Entitlement
+      - name: IBM_ENTITLEMENT_KEY
+        value: $(params.ibm_entitlement_key)
+      - name: DB2_ENTITLEMENT_KEY
+        value: $(params.db2_entitlement_key)
+
+      # Optional support built into the ansible-devops image
+      # for saving task execution results to a MongoDb instance
+      - name: DEVOPS_MONGO_URI
+        value: $(params.devops_mongo_uri)
+      - name: DEVOPS_SUITE_NAME
+        value: $(params.devops_suite_name)
+      - name: DEVOPS_BUILD_NUMBER
+        value: $(params.devops_build_number)
+
+  steps:
+    - name: db2
+      command:
+        - /opt/app-root/src/run-role.sh
+        - db2
+      image: quay.io/ibmmas/ansible-devops:10.2.1-pre.master
+      imagePullPolicy: Always
+      workingDir: /workspace/configs
+
+  workspaces:
+    - name: configs
+# --------------------------------------------------------------------------------
+# /home/runner/work/ansible-devops/ansible-devops/pipelines/tasks/gencfg-workspace.yaml
+# --------------------------------------------------------------------------------
+---
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: mas-devops-gencfg-workspace
+spec:
+  params:
+    - name: mas_instance_id
+      type: string
+      description: Instance ID
+    - name: mas_workspace_id
+      type: string
+      description: Workspace ID
+    - name: mas_workspace_name
+      type: string
+      description: Workspace Name
+
+    # Optional support built into the ansible-devops image
+    # for saving task execution results to a MongoDb instance
+    - name: devops_mongo_uri
+      type: string
+      description: Optional MongoDb connection URI, used to enable save-junit-to-mongo.py
+      default: ""
+    - name: devops_suite_name
+      type: string
+      description: Optional name for the junit suite, used to enable save-junit-to-mongo.py
+      default: ""
+    - name: devops_build_number
+      type: string
+      description: Optional identifier for the execution run, used to enable save-junit-to-mongo.py
+      default: ""
+
+  stepTemplate:
+    env:
+      - name: MAS_CONFIG_DIR
+        value: /workspace/configs
+      - name: MAS_INSTANCE_ID
+        value: $(params.mas_instance_id)
+      - name: MAS_WORKSPACE_ID
+        value: $(params.mas_workspace_id)
+      - name: MAS_WORKSPACE_NAME
+        value: $(params.mas_workspace_name)
+
+      # Optional support built into the ansible-devops image
+      # for saving task execution results to a MongoDb instance
+      - name: DEVOPS_MONGO_URI
+        value: $(params.devops_mongo_uri)
+      - name: DEVOPS_SUITE_NAME
+        value: $(params.devops_suite_name)
+      - name: DEVOPS_BUILD_NUMBER
+        value: $(params.devops_build_number)
+
+  steps:
+    - name: gencfg-workspace
+      command:
+        - /opt/app-root/src/run-role.sh
+        - gencfg_workspace
+      image: quay.io/ibmmas/ansible-devops:10.2.1-pre.master
+      imagePullPolicy: Always
+      workingDir: /workspace/configs
+
+  workspaces:
+    - name: configs
+# --------------------------------------------------------------------------------
+# /home/runner/work/ansible-devops/ansible-devops/pipelines/tasks/ibm-catalogs.yaml
+# --------------------------------------------------------------------------------
+---
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: mas-devops-ibm-catalogs
+spec:
+  params:
+    - name: artifactory_username
+      default: ''
+      type: string
+      description: Required to install development MAS catalogs
+    - name: artifactory_apikey
+      default: ''
+      type: string
+      description: Required to install development MAS catalogs
+
+    # Optional support built into the ansible-devops image
+    # for saving task execution results to a MongoDb instance
+    - name: mas_instance_id
+      type: string
+      description: Optional MAS instance Id, used to enable save-junit-to-mongo.py
+      default: ""
+    - name: devops_mongo_uri
+      type: string
+      description: Optional MongoDb connection URI, used to enable save-junit-to-mongo.py
+      default: ""
+    - name: devops_suite_name
+      type: string
+      description: Optional name for the junit suite, used to enable save-junit-to-mongo.py
+      default: ""
+    - name: devops_build_number
+      type: string
+      description: Optional identifier for the execution run, used to enable save-junit-to-mongo.py
+      default: ""
+
+  stepTemplate:
+    env:
+      - name: ARTIFACTORY_USERNAME
+        value: $(params.artifactory_username)
+      - name: ARTIFACTORY_APIKEY
+        value: $(params.artifactory_apikey)
+
+      # Optional support built into the ansible-devops image
+      # for saving task execution results to a MongoDb instance
+      - name: MAS_INSTANCE_ID
+        value: $(params.mas_instance_id)
+      - name: DEVOPS_MONGO_URI
+        value: $(params.devops_mongo_uri)
+      - name: DEVOPS_SUITE_NAME
+        value: $(params.devops_suite_name)
+      - name: DEVOPS_BUILD_NUMBER
+        value: $(params.devops_build_number)
+
+  steps:
+    - name: ibm-catalogs
+      command:
+        - /opt/app-root/src/run-role.sh
+        - ibm_catalogs
+      image: quay.io/ibmmas/ansible-devops:10.2.1-pre.master
+      imagePullPolicy: Always
+      workingDir: /workspace/configs
+# --------------------------------------------------------------------------------
+# /home/runner/work/ansible-devops/ansible-devops/pipelines/tasks/kafka.yaml
+# --------------------------------------------------------------------------------
+---
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: mas-devops-kafka
+spec:
+  params:
+    - name: mas_instance_id
+      type: string
+      description: Instance ID
+      default: "" # By default, no config will be generated
+
+    - name: kafka_namespace
+      type: string
+      default: "amq-streams"
+    - name: kafka_cluster_name
+      type: string
+      default: "maskafka"
+    - name: kafka_cluster_size
+      type: string
+      default: "small"
+    - name: kafka_user_name
+      type: string
+      default: "masuser"
+
+    # Optional support built into the ansible-devops image
+    # for saving task execution results to a MongoDb instance
+    - name: devops_mongo_uri
+      type: string
+      description: Optional MongoDb connection URI, used to enable save-junit-to-mongo.py
+      default: ""
+    - name: devops_suite_name
+      type: string
+      description: Optional name for the junit suite, used to enable save-junit-to-mongo.py
+      default: ""
+    - name: devops_build_number
+      type: string
+      description: Optional identifier for the execution run, used to enable save-junit-to-mongo.py
+      default: ""
+
+  stepTemplate:
+    env:
+      - name: MAS_CONFIG_DIR
+        value: /workspace/configs
+      - name: MAS_INSTANCE_ID
+        value: $(params.mas_instance_id)
+
+      - name: KAFKA_NAMESPACE
+        value: $(params.kafka_namespace)
+      - name: KAFKA_CLUSTER_NAME
+        value: $(params.kafka_cluster_name)
+      - name: KAFKA_CLUSTER_SIZE
+        value: $(params.kafka_cluster_size)
+      - name: KAFKA_USER_NAME
+        value: $(params.kafka_user_name)
+
+      # Optional support built into the ansible-devops image
+      # for saving task execution results to a MongoDb instance
+      - name: DEVOPS_MONGO_URI
+        value: $(params.devops_mongo_uri)
+      - name: DEVOPS_SUITE_NAME
+        value: $(params.devops_suite_name)
+      - name: DEVOPS_BUILD_NUMBER
+        value: $(params.devops_build_number)
+
+  steps:
+    - name: kafka
+      command:
+        - /opt/app-root/src/run-role.sh
+        - kafka
+      image: quay.io/ibmmas/ansible-devops:10.2.1-pre.master
+      imagePullPolicy: Always
+      workingDir: /workspace/configs
+
+  workspaces:
+    - name: configs
+# --------------------------------------------------------------------------------
+# /home/runner/work/ansible-devops/ansible-devops/pipelines/tasks/mongodb.yaml
+# --------------------------------------------------------------------------------
+---
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: mas-devops-mongodb
+spec:
+  params:
+    - name: mas_instance_id
+      type: string
+      description: Instance ID
+      default: "" # By default, no config will be generated
+
+    # Optional support built into the ansible-devops image
+    # for saving task execution results to a MongoDb instance
+    - name: devops_mongo_uri
+      type: string
+      description: Optional MongoDb connection URI, used to enable save-junit-to-mongo.py
+      default: ""
+    - name: devops_suite_name
+      type: string
+      description: Optional name for the junit suite, used to enable save-junit-to-mongo.py
+      default: ""
+    - name: devops_build_number
+      type: string
+      description: Optional identifier for the execution run, used to enable save-junit-to-mongo.py
+      default: ""
+
+  stepTemplate:
+    env:
+      - name: MAS_CONFIG_DIR
+        value: /workspace/configs
+      - name: MAS_INSTANCE_ID
+        value: $(params.mas_instance_id)
+
+      # Optional support built into the ansible-devops image
+      # for saving task execution results to a MongoDb instance
+      - name: DEVOPS_MONGO_URI
+        value: $(params.devops_mongo_uri)
+      - name: DEVOPS_SUITE_NAME
+        value: $(params.devops_suite_name)
+      - name: DEVOPS_BUILD_NUMBER
+        value: $(params.devops_build_number)
+
+  steps:
+    - name: mongodb
+      command:
+        - /opt/app-root/src/run-role.sh
+        - mongodb
+      image: quay.io/ibmmas/ansible-devops:10.2.1-pre.master
+      imagePullPolicy: Always
+      workingDir: /workspace/configs
+
+  workspaces:
+    - name: configs
+# --------------------------------------------------------------------------------
+# /home/runner/work/ansible-devops/ansible-devops/pipelines/tasks/nvidia-gpu.yaml
+# --------------------------------------------------------------------------------
+---
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: mas-devops-nvidia-gpu
+spec:
+  params:
+    # Optional support built into the ansible-devops image
+    # for saving task execution results to a MongoDb instance
+    - name: mas_instance_id
+      type: string
+      description: Optional MAS instance Id, used to enable save-junit-to-mongo.py
+      default: ""
+    - name: devops_mongo_uri
+      type: string
+      description: Optional MongoDb connection URI, used to enable save-junit-to-mongo.py
+      default: ""
+    - name: devops_suite_name
+      type: string
+      description: Optional name for the junit suite, used to enable save-junit-to-mongo.py
+      default: ""
+    - name: devops_build_number
+      type: string
+      description: Optional identifier for the execution run, used to enable save-junit-to-mongo.py
+      default: ""
+
+  stepTemplate:
+    env:
+      # Optional support built into the ansible-devops image
+      # for saving task execution results to a MongoDb instance
+      - name: MAS_INSTANCE_ID
+        value: $(params.mas_instance_id)
+      - name: DEVOPS_MONGO_URI
+        value: $(params.devops_mongo_uri)
+      - name: DEVOPS_SUITE_NAME
+        value: $(params.devops_suite_name)
+      - name: DEVOPS_BUILD_NUMBER
+        value: $(params.devops_build_number)
+
+  steps:
+    - name: nvidi-gpu
+      command:
+        - /opt/app-root/src/run-role.sh
+        - nvidia_gpu
+      image: quay.io/ibmmas/ansible-devops:10.2.1-pre.master
+      imagePullPolicy: Always
+      workingDir: /workspace/configs
+
+  workspaces:
+    - name: configs
+# --------------------------------------------------------------------------------
+# /home/runner/work/ansible-devops/ansible-devops/pipelines/tasks/sbo.yaml
+# --------------------------------------------------------------------------------
+---
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: mas-devops-sbo
+spec:
+  params:
+    - name: mas_channel
+      type: string
+
+    # Optional support built into the ansible-devops image
+    # for saving task execution results to a MongoDb instance
+    - name: mas_instance_id
+      type: string
+      description: Optional MAS instance Id, used to enable save-junit-to-mongo.py
+      default: ""
+    - name: devops_mongo_uri
+      type: string
+      description: Optional MongoDb connection URI, used to enable save-junit-to-mongo.py
+      default: ""
+    - name: devops_suite_name
+      type: string
+      description: Optional name for the junit suite, used to enable save-junit-to-mongo.py
+      default: ""
+    - name: devops_build_number
+      type: string
+      description: Optional identifier for the execution run, used to enable save-junit-to-mongo.py
+      default: ""
+
+  stepTemplate:
+    env:
+      - name: MAS_CHANNEL
+        value: $(params.mas_channel)
+
+      # Optional support built into the ansible-devops image
+      # for saving task execution results to a MongoDb instance
+      - name: MAS_INSTANCE_ID
+        value: $(params.mas_instance_id)
+      - name: DEVOPS_MONGO_URI
+        value: $(params.devops_mongo_uri)
+      - name: DEVOPS_SUITE_NAME
+        value: $(params.devops_suite_name)
+      - name: DEVOPS_BUILD_NUMBER
+        value: $(params.devops_build_number)
+
+  steps:
+    - name: sbo
+      command:
+        - /opt/app-root/src/run-role.sh
+        - sbo
+      image: quay.io/ibmmas/ansible-devops:10.2.1-pre.master
+      imagePullPolicy: Always
+      workingDir: /workspace/configs
+# --------------------------------------------------------------------------------
+# /home/runner/work/ansible-devops/ansible-devops/pipelines/tasks/sls.yaml
+# --------------------------------------------------------------------------------
+---
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: mas-devops-sls
+spec:
+  params:
+    - name: mas_instance_id
+      type: string
+      description: Instance ID
+      default: "" # By default, no config will be generated
+
+    - name: sls_license_id
+      type: string
+    - name: sls_license_file
+      type: string
+    - name: sls_mongodb_cfg_file
+      type: string
+    - name: sls_catalog_source
+      type: string
+      default: ""
+    - name: sls_channel
+      type: string
+      default: ""
+    - name: sls_icr_cp
+      type: string
+      default: ""
+    - name: sls_icr_cpopen
+      type: string
+      default: ""
+
+    # Entitlement
+    - name: sls_entitlement_username
+      type: string
+      default: ""
+    - name: ibm_entitlement_key
+      type: string
+    - name: sls_entitlement_key
+      type: string
+      default: ""
+      description: "Optional SLS-specific override for the IBM entitlement key"
+
+    - name: artifactory_username
+      default: ''
+      type: string
+      description: Required to use development MAS builds
+    - name: artifactory_apikey
+      default: ''
+      type: string
+      description: Required to use development MAS builds
+
+    - name: artifactory_username
+      default: ''
+      type: string
+      description: Required to use development MAS builds
+    - name: artifactory_apikey
+      default: ''
+      type: string
+      description: Required to use development MAS builds
+
+    # Optional support built into the ansible-devops image
+    # for saving task execution results to a MongoDb instance
+    - name: devops_mongo_uri
+      type: string
+      description: Optional MongoDb connection URI, used to enable save-junit-to-mongo.py
+      default: ""
+    - name: devops_suite_name
+      type: string
+      description: Optional name for the junit suite, used to enable save-junit-to-mongo.py
+      default: ""
+    - name: devops_build_number
+      type: string
+      description: Optional identifier for the execution run, used to enable save-junit-to-mongo.py
+      default: ""
+
+  stepTemplate:
+    env:
+      - name: MAS_CONFIG_DIR
+        value: /workspace/configs
+      - name: MAS_INSTANCE_ID
+        value: $(params.mas_instance_id)
+
+      - name: SLS_MONGODB_CFG_FILE
+        value: $(params.sls_mongodb_cfg_file)
+      - name: SLS_LICENSE_ID
+        value: $(params.sls_license_id)
+      - name: SLS_LICENSE_FILE
+        value: $(params.sls_license_file)
+      - name: SLS_CATALOG_SOURCE
+        value: $(params.sls_catalog_source)
+      - name: SLS_CHANNEL
+        value: $(params.sls_channel)
+      - name: SLS_ICR_CP
+        value: $(params.sls_icr_cp)
+      - name: SLS_ICR_CPOPEN
+        value: $(params.sls_icr_cpopen)
+      - name: SLS_ENTITLEMENT_USERNAME
+        value: $(params.sls_entitlement_username)
+      - name: IBM_ENTITLEMENT_KEY
+        value: $(params.ibm_entitlement_key)
+      - name: SLS_ENTITLEMENT_KEY
+        value: $(params.sls_entitlement_key)
+
+      - name: ARTIFACTORY_USERNAME
+        value: $(params.artifactory_username)
+      - name: ARTIFACTORY_APIKEY
+        value: $(params.artifactory_apikey)
+
+      # Optional support built into the ansible-devops image
+      # for saving task execution results to a MongoDb instance
+      - name: DEVOPS_MONGO_URI
+        value: $(params.devops_mongo_uri)
+      - name: DEVOPS_SUITE_NAME
+        value: $(params.devops_suite_name)
+      - name: DEVOPS_BUILD_NUMBER
+        value: $(params.devops_build_number)
+
+  steps:
+    - name: sls
+      command:
+        - /opt/app-root/src/run-role.sh
+        - sls
+      image: quay.io/ibmmas/ansible-devops:10.2.1-pre.master
+      imagePullPolicy: Always
+      workingDir: /workspace/configs
+
+  workspaces:
+    - name: configs
+    - name: entitlement
+# --------------------------------------------------------------------------------
+# /home/runner/work/ansible-devops/ansible-devops/pipelines/tasks/suite-app-config.yaml
+# --------------------------------------------------------------------------------
+---
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: mas-devops-suite-app-config
+spec:
+  params:
+    - name: mas_app_id
+      type: string
+      description: Maximo Application Suite Application ID
+    - name: mas_appws_components
+      type: string
+      description: Components to configure in the workspace
+      default: ""
+    - name: mas_instance_id
+      type: string
+      description: Instance ID
+    - name: mas_workspace_id
+      type: string
+      description: Maximo Application Suite Workspace ID
+
+    # Optional support built into the ansible-devops image
+    # for saving task execution results to a MongoDb instance
+    - name: devops_mongo_uri
+      type: string
+      description: Optional MongoDb connection URI, used to enable save-junit-to-mongo.py
+      default: ""
+    - name: devops_suite_name
+      type: string
+      description: Optional name for the junit suite, used to enable save-junit-to-mongo.py
+      default: ""
+    - name: devops_build_number
+      type: string
+      description: Optional identifier for the execution run, used to enable save-junit-to-mongo.py
+      default: ""
+
+  stepTemplate:
+    env:
+      - name: MAS_INSTANCE_ID
+        value: $(params.mas_instance_id)
+      - name: MAS_WORKSPACE_ID
+        value: $(params.mas_workspace_id)
+      - name: MAS_APP_ID
+        value: $(params.mas_app_id)
+      - name: MAS_APPWS_COMPONENTS
+        value: $(params.mas_appws_components)
+
+      # Optional support built into the ansible-devops image
+      # for saving task execution results to a MongoDb instance
+      - name: DEVOPS_MONGO_URI
+        value: $(params.devops_mongo_uri)
+      - name: DEVOPS_SUITE_NAME
+        value: $(params.devops_suite_name)
+      - name: DEVOPS_BUILD_NUMBER
+        value: $(params.devops_build_number)
+
+  steps:
+    - name: suite-app-config
+      command:
+        - /opt/app-root/src/run-role.sh
+        - suite_app_config
+      image: quay.io/ibmmas/ansible-devops:10.2.1-pre.master
+      imagePullPolicy: Always
+# --------------------------------------------------------------------------------
+# /home/runner/work/ansible-devops/ansible-devops/pipelines/tasks/suite-app-install.yaml
+# --------------------------------------------------------------------------------
+---
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: mas-devops-suite-app-install
+spec:
+  params:
+    - name: artifactory_username
+      default: ''
+      type: string
+      description: Required to use development MAS builds
+    - name: artifactory_apikey
+      default: ''
+      type: string
+      description: Required to use development MAS builds
+
+    - name: mas_instance_id
+      type: string
+      description: Instance ID
+    - name: mas_app_id
+      type: string
+      description: Maximo Applicaiton Suite Application Id
+    - name: mas_app_channel
+      type: string
+      description: Catalog channel for the application operator subscription
+
+    - name: mas_app_catalog_source
+      default: 'ibm-operator-catalog'
+      type: string
+      description: Catalog source for the application operator subscription
+
+    - name: mas_icr_cp
+      type: string
+      default: ""
+
+    - name: mas_entitlement_username
+      type: string
+      default: ""
+    - name: ibm_entitlement_key
+      type: string
+    - name: mas_entitlement_key
+      type: string
+      default: ""
+      description: "Optional MAS-specific override for the IBM entitlement key"
+
+    - name: mas_app_spec
+      default: ""
+      type: string
+      description: Application specifications such as binding, settings, etc
+
+    - name: mas_app_plan
+      type: string
+      description: Application installation plan
+      default: ""
+
+    # Optional support built into the ansible-devops image
+    # for saving task execution results to a MongoDb instance
+    - name: devops_mongo_uri
+      type: string
+      description: Optional MongoDb connection URI, used to enable save-junit-to-mongo.py
+      default: ""
+    - name: devops_suite_name
+      type: string
+      description: Optional name for the junit suite, used to enable save-junit-to-mongo.py
+      default: ""
+    - name: devops_build_number
+      type: string
+      description: Optional identifier for the execution run, used to enable save-junit-to-mongo.py
+      default: ""
+
+  stepTemplate:
+    env:
+      - name: MAS_INSTANCE_ID
+        value: $(params.mas_instance_id)
+
+      - name: ARTIFACTORY_USERNAME
+        value: $(params.artifactory_username)
+      - name: ARTIFACTORY_APIKEY
+        value: $(params.artifactory_apikey)
+
+      - name: MAS_ICR_CP
+        value: $(params.mas_icr_cp)
+
+      - name: MAS_ENTITLEMENT_USERNAME
+        value: $(params.mas_entitlement_username)
+      - name: IBM_ENTITLEMENT_KEY
+        value: $(params.ibm_entitlement_key)
+      - name: MAS_ENTITLEMENT_KEY
+        value: $(params.mas_entitlement_key)
+
+      - name: MAS_APP_ID
+        value: $(params.mas_app_id)
+      - name: MAS_APP_CHANNEL
+        value: $(params.mas_app_channel)
+      - name: MAS_APP_CATALOG_SOURCE
+        value: $(params.mas_app_catalog_source)
+      - name: MAS_APP_SPEC
+        value: $(params.mas_app_spec)
+      - name: MAS_APP_PLAN
+        value: $(params.mas_app_plan)
+
+      # Optional support built into the ansible-devops image
+      # for saving task execution results to a MongoDb instance
+      - name: DEVOPS_MONGO_URI
+        value: $(params.devops_mongo_uri)
+      - name: DEVOPS_SUITE_NAME
+        value: $(params.devops_suite_name)
+      - name: DEVOPS_BUILD_NUMBER
+        value: $(params.devops_build_number)
+
+  steps:
+    - name: suite-app-install
+      command:
+        - /opt/app-root/src/run-role.sh
+        - suite_app_install
+      image: quay.io/ibmmas/ansible-devops:10.2.1-pre.master
+      imagePullPolicy: Always
+# --------------------------------------------------------------------------------
+# /home/runner/work/ansible-devops/ansible-devops/pipelines/tasks/suite-config.yaml
+# --------------------------------------------------------------------------------
+---
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: mas-devops-suite-config
+spec:
+  params:
+    - name: mas_instance_id
+      type: string
+      description: Instance ID
+
+    # Optional support built into the ansible-devops image
+    # for saving task execution results to a MongoDb instance
+    - name: devops_mongo_uri
+      type: string
+      description: Optional MongoDb connection URI, used to enable save-junit-to-mongo.py
+      default: ""
+    - name: devops_suite_name
+      type: string
+      description: Optional name for the junit suite, used to enable save-junit-to-mongo.py
+      default: ""
+    - name: devops_build_number
+      type: string
+      description: Optional identifier for the execution run, used to enable save-junit-to-mongo.py
+      default: ""
+
+  stepTemplate:
+    env:
+      - name: MAS_CONFIG_DIR
+        value: /workspace/configs
+      - name: MAS_INSTANCE_ID
+        value: $(params.mas_instance_id)
+
+      # Optional support built into the ansible-devops image
+      # for saving task execution results to a MongoDb instance
+      - name: DEVOPS_MONGO_URI
+        value: $(params.devops_mongo_uri)
+      - name: DEVOPS_SUITE_NAME
+        value: $(params.devops_suite_name)
+      - name: DEVOPS_BUILD_NUMBER
+        value: $(params.devops_build_number)
+
+  steps:
+    - name: suite-config
+      command:
+        - /opt/app-root/src/run-role.sh
+        - suite_config
+      image: quay.io/ibmmas/ansible-devops:10.2.1-pre.master
+      imagePullPolicy: Always
+      workingDir: /workspace/configs
+
+  workspaces:
+    - name: configs
+# --------------------------------------------------------------------------------
+# /home/runner/work/ansible-devops/ansible-devops/pipelines/tasks/suite-db2-setup-for-manage.yaml
+# --------------------------------------------------------------------------------
+---
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: mas-devops-suite-db2-setup-for-manage
+spec:
+  params:
+    - name: db2_instance_name
+      type: string
+      description: Name (specifically, not the ID) of the DB2 Warehouse instance to execute the hack
+    - name: db2_namespace
+      type: string
+      description: Namespace where the DB2 Warehouse instance to execute the hack resides
+      default: "db2u"
+
+    # Optional support built into the ansible-devops image
+    # for saving task execution results to a MongoDb instance
+    - name: mas_instance_id
+      type: string
+      description: Optional MAS instance Id, used to enable save-junit-to-mongo.py
+      default: ""
+    - name: devops_mongo_uri
+      type: string
+      description: Optional MongoDb connection URI, used to enable save-junit-to-mongo.py
+      default: ""
+    - name: devops_suite_name
+      type: string
+      description: Optional name for the junit suite, used to enable save-junit-to-mongo.py
+      default: ""
+    - name: devops_build_number
+      type: string
+      description: Optional identifier for the execution run, used to enable save-junit-to-mongo.py
+      default: ""
+
+  stepTemplate:
+    env:
+      - name: DB2_INSTANCE_NAME
+        value: $(params.db2_instance_name)
+      - name: DB2_NAMESPACE
+        value: $(params.db2_namespace)
+
+      # Optional support built into the ansible-devops image
+      # for saving task execution results to a MongoDb instance
+      - name: MAS_INSTANCE_ID
+        value: $(params.mas_instance_id)
+      - name: DEVOPS_MONGO_URI
+        value: $(params.devops_mongo_uri)
+      - name: DEVOPS_SUITE_NAME
+        value: $(params.devops_suite_name)
+      - name: DEVOPS_BUILD_NUMBER
+        value: $(params.devops_build_number)
+
+  steps:
+    - name: suite-db2-setup-for-manage
+      command:
+        - /opt/app-root/src/run-role.sh
+        - suite_db2_setup_for_manage
+      image: quay.io/ibmmas/ansible-devops:10.2.1-pre.master
+      imagePullPolicy: Always
+# --------------------------------------------------------------------------------
+# /home/runner/work/ansible-devops/ansible-devops/pipelines/tasks/suite-dns.yaml
+# --------------------------------------------------------------------------------
+---
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: mas-devops-suite-dns
+spec:
+  params:
+    - name: mas_instance_id
+      type: string
+      description: Instance ID
+
+    # Optional support built into the ansible-devops image
+    # for saving task execution results to a MongoDb instance
+    - name: devops_mongo_uri
+      type: string
+      description: Optional MongoDb connection URI, used to enable save-junit-to-mongo.py
+      default: ""
+    - name: devops_suite_name
+      type: string
+      description: Optional name for the junit suite, used to enable save-junit-to-mongo.py
+      default: ""
+    - name: devops_build_number
+      type: string
+      description: Optional identifier for the execution run, used to enable save-junit-to-mongo.py
+      default: ""
+
+  stepTemplate:
+    env:
+      - name: MAS_INSTANCE_ID
+        value: $(params.mas_instance_id)
+
+      # Optional support built into the ansible-devops image
+      # for saving task execution results to a MongoDb instance
+      - name: DEVOPS_MONGO_URI
+        value: $(params.devops_mongo_uri)
+      - name: DEVOPS_SUITE_NAME
+        value: $(params.devops_suite_name)
+      - name: DEVOPS_BUILD_NUMBER
+        value: $(params.devops_build_number)
+
+  steps:
+    - name: suite-dns
+      command:
+        - /opt/app-root/src/run-role.sh
+        - suite_dns
+      image: quay.io/ibmmas/ansible-devops:10.2.1-pre.master
+      imagePullPolicy: Always
+# --------------------------------------------------------------------------------
+# /home/runner/work/ansible-devops/ansible-devops/pipelines/tasks/suite-install.yaml
+# --------------------------------------------------------------------------------
+---
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: mas-devops-suite-install
+spec:
+  params:
+    - name: mas_instance_id
+      type: string
+    - name: mas_channel
+      type: string
+    - name: mas_catalog_source
+      type: string
+      default: ""
+
+    - name: mas_icr_cp
+      type: string
+      default: ""
+    - name: mas_icr_cpopen
+      type: string
+      default: ""
+
+    - name: mas_entitlement_username
+      type: string
+      default: ""
+    - name: ibm_entitlement_key
+      type: string
+    - name: mas_entitlement_key
+      type: string
+      default: ""
+      description: "Optional MAS-specific override for the IBM entitlement key"
+
+    - name: artifactory_username
+      default: ''
+      type: string
+      description: Required to install development MAS catalogs
+    - name: artifactory_apikey
+      default: ''
+      type: string
+      description: Required to install development MAS catalogs
+    - name: mas_annotations
+      default: ''
+      type: string
+      description: Required to install  MAS with annotations (e.g. for saas)
+    - name: mas_domain
+      default: ''
+      type: string
+      description: Optional. If not provided the role will use the default cluster subdomain
+    - name: mas_upgrade_strategy
+      type: string
+      description: Optional identifier for the Upgrade strategy for MAS Operator. Default is set to Automatic
+      default: ""
+
+    # Optional support built into the ansible-devops image
+    # for saving task execution results to a MongoDb instance
+    - name: devops_mongo_uri
+      type: string
+      description: Optional MongoDb connection URI, used to enable save-junit-to-mongo.py
+      default: ""
+    - name: devops_suite_name
+      type: string
+      description: Optional name for the junit suite, used to enable save-junit-to-mongo.py
+      default: ""
+    - name: devops_build_number
+      type: string
+      description: Optional identifier for the execution run, used to enable save-junit-to-mongo.py
+      default: ""
+
+  stepTemplate:
+    env:
+      - name: MAS_CHANNEL
+        value: $(params.mas_channel)
+      - name: MAS_CATALOG_SOURCE
+        value: $(params.mas_catalog_source)
+
+      - name: MAS_CONFIG_DIR
+        value: /workspace/configs
+      - name: MAS_INSTANCE_ID
+        value: $(params.mas_instance_id)
+      - name: MAS_CHANNEL
+        value: $(params.mas_channel)
+      - name: MAS_CATALOG_SOURCE
+        value: $(params.mas_catalog_source)
+
+      - name: ARTIFACTORY_USERNAME
+        value: $(params.artifactory_username)
+      - name: ARTIFACTORY_APIKEY
+        value: $(params.artifactory_apikey)
+
+      - name: MAS_ICR_CP
+        value: $(params.mas_icr_cp)
+      - name: MAS_ICR_CPOPEN
+        value: $(params.mas_icr_cpopen)
+
+      - name: MAS_ENTITLEMENT_USERNAME
+        value: $(params.mas_entitlement_username)
+      - name: IBM_ENTITLEMENT_KEY
+        value: $(params.ibm_entitlement_key)
+      - name: MAS_ENTITLEMENT_KEY
+        value: $(params.mas_entitlement_key)
+      - name: MAS_ANNOTATIONS
+        value: $(params.mas_annotations)
+      - name: MAS_DOMAIN
+        value: $(params.mas_domain)
+      - name: MAS_UPGRADE_STRATEGY
+        value: $(params.mas_upgrade_strategy)
+
+      # Optional support built into the ansible-devops image
+      # for saving task execution results to a MongoDb instance
+      - name: DEVOPS_MONGO_URI
+        value: $(params.devops_mongo_uri)
+      - name: DEVOPS_SUITE_NAME
+        value: $(params.devops_suite_name)
+      - name: DEVOPS_BUILD_NUMBER
+        value: $(params.devops_build_number)
+
+  steps:
+    - name: suite-install
+      command:
+        - /opt/app-root/src/run-role.sh
+        - suite_install
+      image: quay.io/ibmmas/ansible-devops:10.2.1-pre.master
+      imagePullPolicy: Always
+      workingDir: /workspace/configs
+
+  workspaces:
+    - name: configs
+    - name: additional-configs
+# --------------------------------------------------------------------------------
+# /home/runner/work/ansible-devops/ansible-devops/pipelines/tasks/suite-mustgather.yaml
+# --------------------------------------------------------------------------------
+---
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: mas-devops-suite-mustgather
+spec:
+  params:
+    - name: base_output_dir
+      type: string
+      description: Locaton for the output of mustgather. Set as a sub-path of /workspace/mustgather to ensure that data is persisted.
+      default: "/workspace/mustgather"
+    - name: mas_instance_id
+      type: string
+
+  stepTemplate:
+    env:
+      - name: BASE_OUTPUT_DIR
+        value: $(params.base_output_dir)
+      - name: MAS_INSTANCE_ID
+        value: $(params.mas_instance_id)
+
+  steps:
+    - name: clear-mustgather
+      command:
+        - /opt/app-root/src/clear-mustgather-workspace.sh
+      image: quay.io/ibmmas/ansible-devops:10.2.1-pre.master
+      imagePullPolicy: Always
+      workingDir: /workspace/mustgather
+    - name: suite-mustgather
+      command:
+        - /opt/app-root/src/run-role.sh
+        - suite_mustgather
+      image: quay.io/ibmmas/ansible-devops:10.2.1-pre.master
+      imagePullPolicy: Always
+      workingDir: /workspace/mustgather
+
+  workspaces:
+    - name: mustgather
+# --------------------------------------------------------------------------------
+# /home/runner/work/ansible-devops/ansible-devops/pipelines/tasks/suite-verify.yaml
+# --------------------------------------------------------------------------------
+---
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: mas-devops-suite-verify
+spec:
+  params:
+    - name: mas_instance_id
+      type: string
+
+    # Optional support built into the ansible-devops image
+    # for saving task execution results to a MongoDb instance
+    - name: devops_mongo_uri
+      type: string
+      description: Optional MongoDb connection URI, used to enable save-junit-to-mongo.py
+      default: ""
+    - name: devops_suite_name
+      type: string
+      description: Optional name for the junit suite, used to enable save-junit-to-mongo.py
+      default: ""
+    - name: devops_build_number
+      type: string
+      description: Optional identifier for the execution run, used to enable save-junit-to-mongo.py
+      default: ""
+
+  stepTemplate:
+    env:
+      - name: MAS_INSTANCE_ID
+        value: $(params.mas_instance_id)
+
+      # Optional support built into the ansible-devops image
+      # for saving task execution results to a MongoDb instance
+      - name: DEVOPS_MONGO_URI
+        value: $(params.devops_mongo_uri)
+      - name: DEVOPS_SUITE_NAME
+        value: $(params.devops_suite_name)
+      - name: DEVOPS_BUILD_NUMBER
+        value: $(params.devops_build_number)
+
+  steps:
+    - name: suite-verify
+      command:
+        - /opt/app-root/src/run-role.sh
+        - suite_verify
+      image: quay.io/ibmmas/ansible-devops:10.2.1-pre.master
+      imagePullPolicy: Always
+# --------------------------------------------------------------------------------
+# /home/runner/work/ansible-devops/ansible-devops/pipelines/tasks/uds.yaml
+# --------------------------------------------------------------------------------
+---
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: mas-devops-uds
+spec:
+  params:
+    - name: mas_instance_id
+      type: string
+      default: ""
+    - name: mas_segment_key
+      type: string
+      default: ""
+    - name: uds_contact_email
+      type: string
+      default: ""
+    - name: uds_contact_firstname
+      type: string
+      default: ""
+    - name: uds_contact_lastname
+      type: string
+      default: ""
+    - name: uds_event_scheduler_frequency
+      type: string
+      default: ""
+
+    # Optional support built into the ansible-devops image
+    # for saving task execution results to a MongoDb instance
+    - name: devops_mongo_uri
+      type: string
+      description: Optional MongoDb connection URI, used to enable save-junit-to-mongo.py
+      default: ""
+    - name: devops_suite_name
+      type: string
+      description: Optional name for the junit suite, used to enable save-junit-to-mongo.py
+      default: ""
+    - name: devops_build_number
+      type: string
+      description: Optional identifier for the execution run, used to enable save-junit-to-mongo.py
+      default: ""
+
+  stepTemplate:
+    env:
+      # Properties for generating a MAS configuration
+      - name: MAS_CONFIG_DIR
+        value: /workspace/configs
+      - name: MAS_INSTANCE_ID
+        value: $(params.mas_instance_id)
+      - name: MAS_SEGMENT_KEY
+        value: $(params.mas_segment_key)
+      - name: UDS_CONTACT_EMAIL
+        value: $(params.uds_contact_email)
+      - name: UDS_CONTACT_FIRSTNAME
+        value: $(params.uds_contact_firstname)
+      - name: UDS_CONTACT_LASTNAME
+        value: $(params.uds_contact_lastname)
+
+      # Properties to configure the UDS install
+      - name: UDS_EVENT_SCHEDULER_FREQUENCY
+        value: $(params.uds_event_scheduler_frequency)
+
+      # Optional support built into the ansible-devops image
+      # for saving task execution results to a MongoDb instance
+      - name: DEVOPS_MONGO_URI
+        value: $(params.devops_mongo_uri)
+      - name: DEVOPS_SUITE_NAME
+        value: $(params.devops_suite_name)
+      - name: DEVOPS_BUILD_NUMBER
+        value: $(params.devops_build_number)
+
+  steps:
+    - name: uds
+      command:
+        - /opt/app-root/src/run-role.sh
+        - uds
+      image: quay.io/ibmmas/ansible-devops:10.2.1-pre.master
+      imagePullPolicy: Always
+      workingDir: /workspace/configs
+
+  workspaces:
+    - name: configs

--- a/image/cli/bin/templates/pipeline.yaml
+++ b/image/cli/bin/templates/pipeline.yaml
@@ -65,10 +65,12 @@ spec:
     - name: sls_mongodb_cfg_file
       type: string
       default: "/workspace/configs/mongo-mongoce.yml"
-    - name: sls_catalog_source         # Required
+    - name: sls_catalog_source
       type: string
-    - name: sls_channel                # Required
+      default: ""
+    - name: sls_channel
       type: string
+      default: ""
     - name: sls_icr_cp
       type: string
       default: ""

--- a/image/cli/bin/templates/pipeline.yaml
+++ b/image/cli/bin/templates/pipeline.yaml
@@ -46,6 +46,11 @@ spec:
       type: string
       description: IBM Entitlement Key
 
+    # Dependencies - Foundation Services
+    - name: common_services_catalog_source
+      type: string
+      default: ""
+
     # Dependencies - CP4D
     # This will be removed once we wire up CP4D installation to the applications
     - name: temp_deploy_cp4d
@@ -63,7 +68,7 @@ spec:
     - name: sls_catalog_source         # Required
       type: string
     - name: sls_channel                # Required
-      type: string 
+      type: string
     - name: sls_icr_cp
       type: string
       default: ""
@@ -434,6 +439,9 @@ spec:
 
     - name: common-services
       params:
+        - name: common_services_catalog_source
+          value: $(params.common_services_catalog_source)
+
         - name: mas_instance_id
           value: $(params.mas_instance_id)
         - name: devops_suite_name

--- a/image/cli/bin/templates/pipelinerun.yaml
+++ b/image/cli/bin/templates/pipelinerun.yaml
@@ -23,6 +23,10 @@ spec:
     - name: ibm_entitlement_key
       value: '$IBM_ENTITLEMENT_KEY'
 
+    # Dependencies - Common Services
+    - name: common_services_catalog_source
+      value: '$COMMON_SERVICES_CATALOG_SOURCE'
+
     # Dependencies - CP4D
     - name: cpd_product_version
       value: '4.0.9'

--- a/image/cli/bin/templates/pipelinerun.yaml
+++ b/image/cli/bin/templates/pipelinerun.yaml
@@ -41,7 +41,7 @@ spec:
     - name: sls_catalog_source
       value: '$SLS_CATALOG_SOURCE'
     - name: sls_channel
-      value: '$SLS_CHANNEL'
+      value: '3.x'
     - name: sls_icr_cp
       value: '$SLS_ICR_CP'
     - name: sls_icr_cpopen


### PR DESCRIPTION
- Installer will auto-detect air gap mode by the presence/absence of `ImageContentSourcePolicy/ibm-mas-and-dependencies`
- Installer will disable the ability to install applications and CP4D when in air gap mode
- Installer will limit MAS subscription channel choice to 8.7.x when in air gap mode