### PR TITLE
[patch] Fix typo & upgrade to mas_devops v10.3.1

### DIFF
--- a/image/cli/Dockerfile
+++ b/image/cli/Dockerfile
@@ -12,7 +12,7 @@ RUN chmod +x /tini && \
     chmod +x /opt/app-root/src/.bashrc && \
     ln -s $ANSIBLE_COLLECTIONS_PATH/ibm/mas_airgap /mascli/airgap && \
     ln -s $ANSIBLE_COLLECTIONS_PATH/ibm/mas_devops /mascli/devops && \
-    ansible-galaxy collection install ibm.mas_devops:10.3.0 --no-deps
+    ansible-galaxy collection install ibm.mas_devops:10.3.1 --no-deps
 
 ENV PATH="/mascli/bin:${PATH}" \
     VERSION=$VERSION_LABEL

--- a/image/cli/bin/functions/channel_select
+++ b/image/cli/bin/functions/channel_select
@@ -52,7 +52,7 @@ function channel_select_iot() {
         ;;
 
       *)
-        prompt_for_input 'Custom Subscription Channel' MAS_APP_CHANNEL_IOTT
+        prompt_for_input 'Custom Subscription Channel' MAS_APP_CHANNEL_IOT
         prompt_for_input 'Custom Catalog Source' MAS_APP_SOURCE_IOT "ibm-mas-iot-operators"
         ;;
     esac


### PR DESCRIPTION
1. Update to the latest ibm.mas_devops collection to pick up bug fix for using default domain name based on OCP cluster ingress.

2. Remove the extra `T` in `MAS_APP_CHANNEL_IOTT` from **bin/functions/channel_select**:

```
prompt_for_input 'Custom Subscription Channel' MAS_APP_CHANNEL_IOTT
```