### PR TITLE
[patch] Correct supported CP4D versions

### DIFF
--- a/image/cli/bin/functions/config_pipeline
+++ b/image/cli/bin/functions/config_pipeline
@@ -333,13 +333,14 @@ function config_pipeline() {
     if [[ "$DEPLOY_CP4D" == "run" ]]; then
       case $MAS_CHANNEL in
         8.7.x)
+          # Predict 8.5  was tested on 4.0.6 and 4.0.7
           # Breaking changes introduced in CP4D v4.0.8 prevent use of a newer version of CP4D
           CP4D_VERSION=4.0.7
           ;;
 
         8.6.x)
-          # Breaking changes introduced in CP4D v4.0.6 prevent use of a newer version of CP4D
-          CP4D_VERSION=4.0.5
+          # Predict 8.4 was tested on 4.0.3
+          CP4D_VERSION=4.0.3
           ;;
 
         *)


### PR DESCRIPTION
This update corrects the version of CP4D supported by MAS 8.6.x to `4.0.3`

- MAS 8.8: (not yet available) Predict 8.6 was tested on `4.0.7` and `4.0.8`, Assuming cp4d does not make any more breaking changes in 4.0.x we can say Predict 8.6 supports `4.0.8` or newer
- MAS 8.7: Predict 8.5 was tested on `4.0.6` and `4.0.7`
- MAS 8.6: Predict 8.4 was tested on `4.0.3`