### PR TITLE
[patch] Fix missing variable exports for RH image mirroring

### DIFF
--- a/deployment.yaml
+++ b/deployment.yaml
@@ -17,6 +17,6 @@ spec:
       containers:
       - name: mas-cli
         imagePullPolicy: Always
-        image: quay.io/ibmmas/cli:1.0.0-pre.master
+        image: quay.io/ibmmas/cli:1.0.0-pre.fixrhmirror
         command: [ "/bin/bash", "-c", "--" ]
         args: [ "while true; do sleep 30; done;" ]

--- a/image/cli/Dockerfile
+++ b/image/cli/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/ibmmas/ansible-airgap:1.2.0
+FROM quay.io/ibmmas/ansible-airgap:1.2.1-pre.fixrhmirror
 
 ARG VERSION_LABEL
 

--- a/image/cli/bin/functions/mirror_to_registry
+++ b/image/cli/bin/functions/mirror_to_registry
@@ -48,10 +48,14 @@ function mirror_to_registry() {
     MIRROR_THIRDPARTY=true
   else
     prompt_for_confirm "Red Hat OpenShift Container Platform Release (x minutes)" MIRROR_RH_RELEASE
-    prompt_for_input "Release Version (x.y)" OPENSHIFT_RELEASE_VERSION "4.10"
+    if [[ "$MIRROR_RH_RELEASE" == "true" ]]; then
+      prompt_for_input "Release Version (x.y)" OPENSHIFT_RELEASE_VERSION "4.10"
+    fi
 
     prompt_for_confirm "Red Hat OpenShift Container Platform Operators (x minutes)" MIRROR_RH_OPERATORS
-    prompt_for_input "Operator Version (x.y.z)" OPENSHIFT_OPERATORS_VERSION "4.10.18"
+    if [[ "$MIRROR_RH_OPERATORS" == "true" ]]; then
+      prompt_for_input "Operator Version (x.y.z)" OPENSHIFT_OPERATORS_VERSION "4.10.18"
+    fi
 
     prompt_for_confirm "IBM Foundational Services (10 minutes)" MIRROR_COMMONSERVICES
     prompt_for_confirm "IBM Db2 Universal Operator (5 minutes)" MIRROR_DB2
@@ -80,15 +84,14 @@ function mirror_to_registry() {
     export REDHAT_CONNECT_PASSWORD
   fi
 
+  export OPENSHIFT_RELEASE_VERSION
+  export OPENSHIFT_OPERATORS_VERSION
+
   echo
   prompt_for_confirm "Proceed with these settings" || exit 0
 
   echo
   echo_h2 "4. Run Mirror Process"
-  # These playbooks aren't available in ansible-airgap repository so we can't use there here yet
-  # prompt_for_confirm "Mirror OpenShift Release Images" MIRROR_OPENSHIFT_RELEASE
-  # [ "$MIRROR_OPENSHIFT_RELEASE" == "true" ] && ansible-playbook ibm.mas_airgap.mirror_openshift_release
-  # [ "$MIRROR_OPENSHIFT_OPERATORS" == "true" ] && ansible-playbook ibm.mas_airgap.mirror_openshift_operators
   TIMESTAMP=$(date "+%Y%m%d-%H%M%S")
   LOG_PREFIX="$DIR/mirror-$TIMESTAMP"
   [ "$MIRROR_RH_RELEASE" == "true" ]      && echo "Mirroring Red Hat OCP Release Images ..." && ansible-playbook ibm.mas_airgap.mirror_openshift_release &> $LOG_PREFIX-ocp-release.log

--- a/image/cli/bin/functions/mirror_to_registry
+++ b/image/cli/bin/functions/mirror_to_registry
@@ -31,10 +31,10 @@ function mirror_to_registry() {
 
   if [[ "$MIRROR_EVERYTHING" == "true" ]]; then
     MIRROR_RH_RELEASE=true
-    prompt_for_input "Red Hat Openshift Release Version (x.y)" OPENSHIFT_RELEASE_VERSION "4.10"
+    prompt_for_input "Red Hat Openshift Release Version (x.y.z)" OPENSHIFT_RELEASE_VERSION "4.10"
 
     MIRROR_RH_OPERATORS=true
-    prompt_for_input "Red Hat Openshift Operators Version (x.y.z)" OPENSHIFT_OPERATORS_VERSION "4.10.18"
+    prompt_for_input "Red Hat Openshift Operator Catalog Version (x.y)" OPENSHIFT_OPERATORS_VERSION "4.10.18"
 
     MIRROR_COMMONSERVICES=true
     MIRROR_UDS=true
@@ -49,12 +49,12 @@ function mirror_to_registry() {
   else
     prompt_for_confirm "Red Hat OpenShift Container Platform Release (x minutes)" MIRROR_RH_RELEASE
     if [[ "$MIRROR_RH_RELEASE" == "true" ]]; then
-      prompt_for_input "Release Version (x.y)" OPENSHIFT_RELEASE_VERSION "4.10"
+      prompt_for_input "Release Version (x.y.z)" OPENSHIFT_RELEASE_VERSION "4.10.18"
     fi
 
-    prompt_for_confirm "Red Hat OpenShift Container Platform Operators (x minutes)" MIRROR_RH_OPERATORS
+    prompt_for_confirm "Red Hat OpenShift Container Platform Operator Catalog (x minutes)" MIRROR_RH_OPERATORS
     if [[ "$MIRROR_RH_OPERATORS" == "true" ]]; then
-      prompt_for_input "Operator Version (x.y.z)" OPENSHIFT_OPERATORS_VERSION "4.10.18"
+      prompt_for_input "Operator Catalog Version (x.y)" OPENSHIFT_OPERATORS_VERSION "4.10"
     fi
 
     prompt_for_confirm "IBM Foundational Services (10 minutes)" MIRROR_COMMONSERVICES


### PR DESCRIPTION
`OPENSHIFT_RELEASE_VERSION` & `OPENSHIFT_OPERATORS_VERSION` need to be exported, otherwise they will not be available to the Ansible playbooks