### PR TITLE
[patch] Fix runAfter config for MVI install

### DIFF
--- a/image/cli/bin/templates/pipeline.yaml
+++ b/image/cli/bin/templates/pipeline.yaml
@@ -1881,7 +1881,6 @@ spec:
           operator: notin
           values: [""]
       runAfter:
-        - nvidia
         - suite-verify
 
     # 28.2 Configure MVI workspace


### PR DESCRIPTION
The `nvidia` step was removed from the pipeline, but the MVI install step was not updated to remove the dependency.