### PR TITLE
[patch] Support for clusters without a RWX storage class

### DIFF
--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -1,9 +1,9 @@
 name: Build CLI
 on:
   push:
-    branches:
+    branches-ignore:
       - '**'
-    tags-ignore:
+    tags:
       - '**'
 jobs:
   build-cli:
@@ -23,22 +23,25 @@ jobs:
           $GITHUB_WORKSPACE/build/bin/build-cli.sh
 
       - name: Upload the cli
-        uses: actions/upload-artifact@v2
+        uses: svenstaro/upload-release-action@v2
         with:
-          name: ibm-mas-cli-${{ env.VERSION }}.tgz
-          path: ${{ github.workspace }}/ibm-mas-cli-${{ env.VERSION }}.tgz
-          retention-days: 30
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: ${{ github.workspace }}/ibm-mas-cli-${{ env.VERSION }}.tgz
+          asset_name: ibm-mas-cli-${{ env.VERSION }}.yaml
+          tag: ${{ github.ref }}
+          overwrite: true
 
       - name: Build the docker image
         run: |
           $GITHUB_WORKSPACE/build/bin/docker-build.sh -n ibmmas -i cli
           docker tag ibmmas/cli quay.io/ibmmas/cli:${{ env.DOCKER_TAG }}
+          docker tag ibmmas/cli quay.io/ibmmas/cli:latest
 
       # https://github.com/marketplace/actions/push-to-registry
       - name: Push the docker image
         id: push_to_quay
         uses: redhat-actions/push-to-registry@v2
         with:
-          tags: quay.io/ibmmas/cli:${{ env.DOCKER_TAG }}
+          tags: quay.io/ibmmas/cli:${{ env.DOCKER_TAG }} quay.io/ibmmas/cli:latest
           username: ${{ secrets.QUAYIO_USERNAME }}
           password: ${{ secrets.QUAYIO_PASSWORD }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 
 *.DS_Store*
 .env
+.vscode
 image/cli/bin/configs/*.yaml
 image/cli/bin/*.log
 image/cli/bin/mas.env

--- a/image/cli/Dockerfile
+++ b/image/cli/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/ibmmas/ansible-airgap:1.3.1
+FROM quay.io/ibmmas/ansible-airgap:latest
 
 ARG VERSION_LABEL
 

--- a/image/cli/bin/functions/pipeline_config_storage_classes
+++ b/image/cli/bin/functions/pipeline_config_storage_classes
@@ -7,7 +7,6 @@
 # - Db2 (data, logs, and temp volumes)
 # - Kafka, MongoDb, and User Data Services
 #
-# - prometheus_alertmgr_storage_class [ibmc-file-gold-gid, ocs-storagecluster-cephfs, azurefiles-premium]
 # - db2_meta_storage_class [ibmc-file-gold, ocs-storagecluster-cephfs, azurefiles-premium]
 # - db2_backup_storage_class [ibmc-file-gold, ocs-storagecluster-cephfs, azurefiles-premium]
 
@@ -18,6 +17,7 @@
 # - Db2 (meta and backup volumes)
 #
 # - prometheus_storage_class [ibmc-block-gold, ocs-storagecluster-ceph-rbd, managed-premium]
+# - prometheus_alertmgr_storage_class [ibmc-block-gold, ocs-storagecluster-ceph-rbd, managed-premium]
 # - prometheus_userworkload_storage_class [ibmc-block-gold, ocs-storagecluster-ceph-rbd, managed-premium]
 # - grafana_instance_storage_class [ibmc-block-gold, ocs-storagecluster-ceph-rbd, managed-premium]
 # - db2_data_storage_class [ibmc-block-gold, ocs-storagecluster-ceph-rbd, managed-premium]
@@ -91,10 +91,18 @@ function config_pipeline_storage_classes() {
   if [[ "$STORAGE_CLASS_RWX" == "" || "$OVERRIDE_STORAGE_CLASSES" == "true" ]]; then
     STORAGE_CLASS_PROVIDER=custom
     echo ""
-    echo "${COLOR_YELLOW}Select the ReadWriteOnce and ReadWriteMany storage classes to use from the list below:"
+    echo "${COLOR_YELLOW}Select the ReadWriteOnce and ReadWriteMany storage classes to use from the list below (enter 'none' for the ReadWriteMany storage class if you do not have a suitable class available in the cluster, however this will limit what software can be installed in your cluster):"
     oc get storageclasses -o jsonpath='{range .items[*]}{" - "}{.metadata.name}{"\n"}{end}'
     echo ""
-    prompt_for_input "ReadWriteOnce storage class" STORAGE_CLASS_RWO
-    prompt_for_input "ReadWriteMany storage class" STORAGE_CLASS_RWX
+    prompt_for_input "ReadWriteOnce (RWO) storage class" STORAGE_CLASS_RWO
+    prompt_for_input "ReadWriteMany (RWX) storage class" STORAGE_CLASS_RWX
+
+    # We prefer to use ReadWriteMany, but we can cope with ReadWriteOnce if necessary
+    PIPELINE_STORAGE_CLASS=$STORAGE_CLASS_RWX
+    PIPELINE_STORAGE_ACCESSMODE="ReadWriteMany"
+    if [[ "$STORAGE_CLASS_RWX" == "none" ]]; then
+      PIPELINE_STORAGE_CLASS=$STORAGE_CLASS_RWO
+      PIPELINE_STORAGE_ACCESSMODE="ReadWriteOnce"
+    fi
   fi
 }

--- a/image/cli/bin/functions/pipeline_config_storage_classes
+++ b/image/cli/bin/functions/pipeline_config_storage_classes
@@ -91,8 +91,10 @@ function config_pipeline_storage_classes() {
   if [[ "$STORAGE_CLASS_RWX" == "" || "$OVERRIDE_STORAGE_CLASSES" == "true" ]]; then
     STORAGE_CLASS_PROVIDER=custom
     echo ""
-    echo "${COLOR_YELLOW}Select the ReadWriteOnce and ReadWriteMany storage classes to use from the list below (enter 'none' for the ReadWriteMany storage class if you do not have a suitable class available in the cluster, however this will limit what software can be installed in your cluster):"
+    echo "${COLOR_YELLOW}Select the ReadWriteOnce and ReadWriteMany storage classes to use from the list below:"
     oc get storageclasses -o jsonpath='{range .items[*]}{" - "}{.metadata.name}{"\n"}{end}'
+    echo ""
+    echo "${COLOR_YELLOW}Enter 'none' for the ReadWriteMany storage class if you do not have a suitable class available in the cluster, however this will limit what can be installed"
     echo ""
     prompt_for_input "ReadWriteOnce (RWO) storage class" STORAGE_CLASS_RWO
     prompt_for_input "ReadWriteMany (RWX) storage class" STORAGE_CLASS_RWX

--- a/image/cli/bin/functions/pipeline_prepare
+++ b/image/cli/bin/functions/pipeline_prepare
@@ -23,6 +23,10 @@ function pipeline_prepare() {
   fi
 
   echo -en "\033[s" # Save cursor position
+  echo "${COLOR_YELLOW}If you are using using storage classes that utilize 'WaitForFirstConsumer' binding mode choose 'No' at the prompt below"
+  echo ""
+  prompt_for_confirm "Wait for PVCs to bind?" WAIT_FOR_PVCS
+  echo ""
   echo -n "Preparing namespace 'mas-$MAS_INSTANCE_ID-pipelines' ..."
 
   PIPELINE_VERSION=10.6.1
@@ -35,8 +39,6 @@ function pipeline_prepare() {
 
   oc apply -f $DIR/configs/pvc-$MAS_INSTANCE_ID.yaml &>> $LOGFILE
   # Wait for PVC
-  echo "If you are using using storage classes that utilize 'WaitForFirstConsumer' binding mode choose 'No' at the prompt below"
-  prompt_for_confirm "Wait for PVCs to bind?" WAIT_FOR_PVCS
   if [[ "$WAIT_FOR_PVCS" == "true" ]]; then
     LOOKUP_RESULT=$(oc -n mas-$MAS_INSTANCE_ID-pipelines get pvc config-pvc -o jsonpath='{.status.phase}')
     while [ "$LOOKUP_RESULT" != "Bound" ]; do

--- a/image/cli/bin/functions/pipeline_prepare
+++ b/image/cli/bin/functions/pipeline_prepare
@@ -10,7 +10,8 @@ function pipeline_prepare() {
   # Replace mas_instance_id and pipeline_storage_class in templates
   sed "s/{{mas_instance_id}}/$MAS_INSTANCE_ID/g" $DIR/templates/namespace.yaml > $DIR/configs/namespace-$MAS_INSTANCE_ID.yaml
   sed -e "s/{{mas_instance_id}}/$MAS_INSTANCE_ID/g" \
-      -e "s/{{pipeline_storage_class}}/$STORAGE_CLASS_RWX/g" \
+      -e "s/{{pipeline_storage_class}}/$PIPELINE_STORAGE_CLASS/g" \
+      -e "s/{{pipeline_storage_accessmode}}/$PIPELINE_STORAGE_ACCESSMODE/g" \
       $DIR/templates/pvc.yaml > $DIR/configs/pvc-$MAS_INSTANCE_ID.yaml
   sed "s/{{mas_instance_id}}/$MAS_INSTANCE_ID/g" $DIR/templates/rbac.yaml > $DIR/configs/rbac-$MAS_INSTANCE_ID.yaml
   sed "s/{{mas_instance_id}}/$MAS_INSTANCE_ID/g" $DIR/templates/pipeline.yaml > $DIR/configs/pipeline-$MAS_INSTANCE_ID.yaml
@@ -34,12 +35,16 @@ function pipeline_prepare() {
 
   oc apply -f $DIR/configs/pvc-$MAS_INSTANCE_ID.yaml &>> $LOGFILE
   # Wait for PVC
-  LOOKUP_RESULT=$(oc -n mas-$MAS_INSTANCE_ID-pipelines get pvc config-pvc -o jsonpath='{.status.phase}')
-  while [ "$LOOKUP_RESULT" != "Bound" ]; do
-    echo "Waiting 5s for PVC to be bound before checking again ..."  &>> $LOGFILE
-    sleep 5
+  echo "If you are using using storage classes that utilize 'WaitForFirstConsumer' binding mode choose 'No' at the prompt below"
+  prompt_for_confirm "Wait for PVCs to bind?" WAIT_FOR_PVCS
+  if [[ "$WAIT_FOR_PVCS" == "true" ]]; then
     LOOKUP_RESULT=$(oc -n mas-$MAS_INSTANCE_ID-pipelines get pvc config-pvc -o jsonpath='{.status.phase}')
-  done
+    while [ "$LOOKUP_RESULT" != "Bound" ]; do
+      echo "Waiting 5s for PVC to be bound before checking again ..."  &>> $LOGFILE
+      sleep 5
+      LOOKUP_RESULT=$(oc -n mas-$MAS_INSTANCE_ID-pipelines get pvc config-pvc -o jsonpath='{.status.phase}')
+    done
+  fi
 
   oc apply -f $DIR/configs/rbac-$MAS_INSTANCE_ID.yaml &>> $LOGFILE
   oc apply -f $DIR/configs/pipeline-$MAS_INSTANCE_ID.yaml &>> $LOGFILE

--- a/image/cli/bin/templates/pipeline.yaml
+++ b/image/cli/bin/templates/pipeline.yaml
@@ -536,6 +536,11 @@ spec:
         - input: "$(params.mas_app_channel_iot)$(params.mas_app_channel_manage)"
           operator: notin
           values: [""]
+        # If there is no RWX storage class available then we can't deploy Db2.
+        # TODO: Test Db2 install using RWO storage only
+        - input: "$(params.storage_class_rwx)"
+          operator: notin
+          values: ["none"]
       taskRef:
         name: mas-devops-db2
         kind: Task

--- a/image/cli/bin/templates/pvc.yaml
+++ b/image/cli/bin/templates/pvc.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: mas-{{mas_instance_id}}-pipelines
 spec:
   accessModes:
-    - ReadWriteMany
+    - {{pipeline_storage_accessmode}}
   volumeMode: Filesystem
   storageClassName: {{pipeline_storage_class}}
   resources:
@@ -21,10 +21,10 @@ metadata:
   name: shared-mustgather-storage
   namespace: mas-{{mas_instance_id}}-pipelines
 spec:
+  accessModes:
+    - ReadWriteOnce
+  volumeMode: Filesystem
+  storageClassName: {{pipeline_storage_class}}
   resources:
     requests:
       storage: 1Gi
-  volumeMode: Filesystem
-  storageClassName: {{pipeline_storage_class}}
-  accessModes:
-    - ReadWriteOnce

--- a/image/cli/dev.Dockerfile
+++ b/image/cli/dev.Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/ibmmas/ansible-airgap:1.3.1
+FROM quay.io/ibmmas/ansible-airgap:latest
 
 ARG VERSION_LABEL
 


### PR DESCRIPTION
We still won't be able to run the entire pipeline without a RWX storage class, but this update allows the user to set the RWX class name to "none" to trigger limited support for RWO-only storage classes.

![image](https://user-images.githubusercontent.com/4400618/179247256-8bfad70c-ee17-489b-9d16-c1701203d2b4.png)
