### PR TITLE
[patch] Fix release asset name & pipeline version

### DIFF
--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -27,7 +27,7 @@ jobs:
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           file: ${{ github.workspace }}/ibm-mas-cli-${{ env.VERSION }}.tgz
-          asset_name: ibm-mas-cli-${{ env.VERSION }}.yaml
+          asset_name: ibm-mas-cli-${{ env.VERSION }}.tgz
           tag: ${{ github.ref }}
           overwrite: true
 

--- a/image/cli/bin/functions/pipeline_prepare
+++ b/image/cli/bin/functions/pipeline_prepare
@@ -29,7 +29,7 @@ function pipeline_prepare() {
   echo ""
   echo -n "Preparing namespace 'mas-$MAS_INSTANCE_ID-pipelines' ..."
 
-  PIPELINE_VERSION=10.6.1
+  PIPELINE_VERSION=10.6.2
   if [ ! -e $DIR/templates/ibm-mas-devops-tasks-$PIPELINE_VERSION.yaml ]; then
     wget https://github.com/ibm-mas/ansible-devops/releases/download/$PIPELINE_VERSION/ibm-mas-devops-tasks-$PIPELINE_VERSION.yaml -O $DIR/templates/ibm-mas-devops-tasks-$PIPELINE_VERSION.yaml  &>> $LOGFILE
   fi


### PR DESCRIPTION
A couple of small fixes:

- Installer tgz artifact was uploaded to GitHub release with yaml extension instead of tgz
- 10.6.1 task definitions were being installed instead of the 10.6.2 versions