### PR TITLE
[patch] COLOR_BLUE is unreadable on some terminals

### DIFF
--- a/image/cli/bin/functions/configure_ocp_for_mirror
+++ b/image/cli/bin/functions/configure_ocp_for_mirror
@@ -118,14 +118,14 @@ function configure_ocp_for_mirror() {
   echo_h2 "Review Settings"
   echo "${TEXT_DIM}"
   echo_h2 "Private Registry Connection" "    "
-  echo_reset_dim "Host ...................... ${COLOR_BLUE}${REGISTRY_PRIVATE_HOST}"
-  echo_reset_dim "Port ...................... ${COLOR_BLUE}${REGISTRY_PRIVATE_PORT}"
-  echo_reset_dim "CA File ................... ${COLOR_BLUE}${REGISTRY_PRIVATE_CA_FILE}"
+  echo_reset_dim "Host ...................... ${COLOR_MAGENTA}${REGISTRY_PRIVATE_HOST}"
+  echo_reset_dim "Port ...................... ${COLOR_MAGENTA}${REGISTRY_PRIVATE_PORT}"
+  echo_reset_dim "CA File ................... ${COLOR_MAGENTA}${REGISTRY_PRIVATE_CA_FILE}"
   reset_colors
   echo "${TEXT_DIM}"
   echo_h2 "Private Registry Authentication" "    "
-  echo_reset_dim "Username .................. ${COLOR_BLUE}${REGISTRY_USERNAME}"
-  echo_reset_dim "Password .................. ${COLOR_BLUE}${REGISTRY_PASSWORD:0:8}<snip>"
+  echo_reset_dim "Username .................. ${COLOR_MAGENTA}${REGISTRY_USERNAME}"
+  echo_reset_dim "Password .................. ${COLOR_MAGENTA}${REGISTRY_PASSWORD:0:8}<snip>"
   reset_colors
 
   echo

--- a/image/cli/bin/functions/connect
+++ b/image/cli/bin/functions/connect
@@ -17,8 +17,8 @@ function connect() {
   fi
 
   if [[ $PROMPT_FOR_LOGIN == "true" ]]; then
-    read -e -p "$COLOR_YELLOW  Server URL ..... $COLOR_BLUE> " -i "$OCP_LOGIN_URL" OCP_LOGIN_URL
-    read -e -p "$COLOR_YELLOW  Login Token  ... $COLOR_BLUE> " -i "$OCP_LOGIN_TOKEN" OCP_LOGIN_TOKEN
+    read -e -p "$COLOR_YELLOW  Server URL ..... $COLOR_MAGENTA> " -i "$OCP_LOGIN_URL" OCP_LOGIN_URL
+    read -e -p "$COLOR_YELLOW  Login Token  ... $COLOR_MAGENTA> " -i "$OCP_LOGIN_TOKEN" OCP_LOGIN_TOKEN
     echo -ne "${COLOR_RESET}\033[1K"
 
     oc login --token=$OCP_LOGIN_TOKEN --server=$OCP_LOGIN_URL &>> $LOGFILE

--- a/image/cli/bin/functions/mirror_to_registry
+++ b/image/cli/bin/functions/mirror_to_registry
@@ -265,7 +265,7 @@ function mirror_one_thing() {
     else echo -e "${COLOR_RED}[FAILURE] ${MOT_NAME}: ${MOT_LOGFILE}${COLOR_RESET}"
     fi
   else
-    echo -e "${COLOR_BLUE}[SKIPPED] ${MOT_NAME}${COLOR_RESET}"
+    echo -e "${COLOR_MAGENTA}[SKIPPED] ${MOT_NAME}${COLOR_RESET}"
   fi
 }
 
@@ -311,22 +311,22 @@ function mirror_to_registry() {
 
   echo "${TEXT_DIM}"
   echo_h2 "Target Registry Connection" "    "
-  echo_reset_dim "Registry Host ......................... ${COLOR_BLUE}${REGISTRY_PUBLIC_HOST}"
-  echo_reset_dim "Registry Port ......................... ${COLOR_BLUE}${REGISTRY_PUBLIC_PORT}"
+  echo_reset_dim "Registry Host ......................... ${COLOR_MAGENTA}${REGISTRY_PUBLIC_HOST}"
+  echo_reset_dim "Registry Port ......................... ${COLOR_MAGENTA}${REGISTRY_PUBLIC_PORT}"
   reset_colors
 
   echo "${TEXT_DIM}"
   echo_h2 "Target Registry Authentication" "    "
-  echo_reset_dim "Registry Username ..................... ${COLOR_BLUE}${REGISTRY_USERNAME}"
-  echo_reset_dim "Registry Password ..................... ${COLOR_BLUE}${REGISTRY_PASSWORD:0:4}<snip>"
+  echo_reset_dim "Registry Username ..................... ${COLOR_MAGENTA}${REGISTRY_USERNAME}"
+  echo_reset_dim "Registry Password ..................... ${COLOR_MAGENTA}${REGISTRY_PASSWORD:0:4}<snip>"
   reset_colors
 
   echo "${TEXT_DIM}"
   echo_h2 "Red Hat Release Catalog" "    "
   if [[ "$MIRROR_RH_RELEASE" == "true" ]]
   then
-    echo_reset_dim "Catalog Version ....................... ${COLOR_BLUE}${OPENSHIFT_RELEASE_VERSION}"
-    echo_reset_dim "Authentication ........................ ${COLOR_BLUE}${REDHAT_CONNECT_USERNAME}/${REDHAT_CONNECT_PASSWORD:0:4}<snip>"
+    echo_reset_dim "Catalog Version ....................... ${COLOR_MAGENTA}${OPENSHIFT_RELEASE_VERSION}"
+    echo_reset_dim "Authentication ........................ ${COLOR_MAGENTA}${REDHAT_CONNECT_USERNAME}/${REDHAT_CONNECT_PASSWORD:0:4}<snip>"
   else
     echo_reset_dim "${COLOR_RED}Skip"
   fi
@@ -336,8 +336,8 @@ function mirror_to_registry() {
   echo_h2 "Red Hat Operator Catalog" "    "
   if [[ "$MIRROR_RH_OPERATORS" == "true" ]]
   then
-    echo_reset_dim "Catalog Version ....................... ${COLOR_BLUE}${OPENSHIFT_OPERATORS_VERSION}"
-    echo_reset_dim "Red Hat Connect Authentication ........ ${COLOR_BLUE}${REDHAT_CONNECT_USERNAME}/${REDHAT_CONNECT_PASSWORD:0:4}<snip>"
+    echo_reset_dim "Catalog Version ....................... ${COLOR_MAGENTA}${OPENSHIFT_OPERATORS_VERSION}"
+    echo_reset_dim "Red Hat Connect Authentication ........ ${COLOR_MAGENTA}${REDHAT_CONNECT_USERNAME}/${REDHAT_CONNECT_PASSWORD:0:4}<snip>"
   else
     echo_reset_dim "${COLOR_RED}Skip"
   fi
@@ -347,8 +347,8 @@ function mirror_to_registry() {
   echo_h2 "IBM Operator Catalog" "    "
   if [[ "$MIRROR_MAS_CORE" == "true" || "$MIRROR_MAS_IOT" == "true" || "$MIRROR_MAS_MANAGE" == "true" ]]
   then
-    echo_reset_dim "Catalog Version ..................... ${COLOR_BLUE}${MAS_CATALOG_VERSION}"
-    echo_reset_dim "IBM Authentication .................. ${COLOR_BLUE}cp/${IBM_ENTITLEMENT_KEY:0:4}<snip>"
+    echo_reset_dim "Catalog Version ..................... ${COLOR_MAGENTA}${MAS_CATALOG_VERSION}"
+    echo_reset_dim "IBM Authentication .................. ${COLOR_MAGENTA}cp/${IBM_ENTITLEMENT_KEY:0:4}<snip>"
     if [[ "$MIRROR_MAS_CORE" == "true" ]]
     then echo_reset_dim "IBM Maximo Application Suite Core ... ${COLOR_GREEN}Mirror"
     else echo_reset_dim "IBM Maximo Application Suite Core ... ${COLOR_RED}Skip"

--- a/image/cli/bin/functions/pipeline_show_config
+++ b/image/cli/bin/functions/pipeline_show_config
@@ -14,107 +14,107 @@ function pipeline_show_config() {
   echo_h2 "\n11. Review Settings"
   echo "${TEXT_DIM}"
   echo_h2 "IBM Maximo Application Suite" "    "
-  echo_reset_dim "Instance ID ............... ${COLOR_BLUE}${MAS_INSTANCE_ID}"
+  echo_reset_dim "Instance ID ............... ${COLOR_MAGENTA}${MAS_INSTANCE_ID}"
   if [[ "${MAS_DOMAIN}" != "" ]]; then
-    echo_reset_dim "Domain Name ............... ${COLOR_BLUE}${MAS_DOMAIN}"
-    echo_reset_dim "DNS Provider .............. ${COLOR_BLUE}${DNS_PROVIDER:-Manually configured}"
-    echo_reset_dim "Certificate Issuer ........ ${COLOR_BLUE}${MAS_CLUSTER_ISSUER:-Self-Signed}"
+    echo_reset_dim "Domain Name ............... ${COLOR_MAGENTA}${MAS_DOMAIN}"
+    echo_reset_dim "DNS Provider .............. ${COLOR_MAGENTA}${DNS_PROVIDER:-Manually configured}"
+    echo_reset_dim "Certificate Issuer ........ ${COLOR_MAGENTA}${MAS_CLUSTER_ISSUER:-Self-Signed}"
   fi
-  echo_reset_dim "Catalog Source ............ ${COLOR_BLUE}${MAS_CATALOG_SOURCE}"
-  echo_reset_dim "Subscription Channel ...... ${COLOR_BLUE}${MAS_CHANNEL}"
-  echo_reset_dim "IBM Entitled Registry ..... ${COLOR_BLUE}${MAS_ICR_CP}"
-  echo_reset_dim "IBM Open Registry ......... ${COLOR_BLUE}${MAS_ICR_CPOPEN}"
-  echo_reset_dim "Entitlement Username ...... ${COLOR_BLUE}${MAS_ENTITLEMENT_USERNAME}"
-  echo_reset_dim "Entitlement Key ........... ${COLOR_BLUE}${MAS_ENTITLEMENT_KEY:0:8}<snip>"
+  echo_reset_dim "Catalog Source ............ ${COLOR_MAGENTA}${MAS_CATALOG_SOURCE}"
+  echo_reset_dim "Subscription Channel ...... ${COLOR_MAGENTA}${MAS_CHANNEL}"
+  echo_reset_dim "IBM Entitled Registry ..... ${COLOR_MAGENTA}${MAS_ICR_CP}"
+  echo_reset_dim "IBM Open Registry ......... ${COLOR_MAGENTA}${MAS_ICR_CPOPEN}"
+  echo_reset_dim "Entitlement Username ...... ${COLOR_MAGENTA}${MAS_ENTITLEMENT_USERNAME}"
+  echo_reset_dim "Entitlement Key ........... ${COLOR_MAGENTA}${MAS_ENTITLEMENT_KEY:0:8}<snip>"
 
   reset_colors
   echo "${TEXT_DIM}"
   echo_h2 "IBM Maximo Application Suite Applications" "    "
   if [[ "${MAS_APP_CHANNEL_IOT}" == '' ]]
   then echo_reset_dim "IoT ...................... ${COLOR_RED}Skip Installation"
-  else echo_reset_dim "IoT ...................... ${COLOR_BLUE}${MAS_APP_SOURCE_IOT}/${MAS_APP_CHANNEL_IOT}"
+  else echo_reset_dim "IoT ...................... ${COLOR_MAGENTA}${MAS_APP_SOURCE_IOT}/${MAS_APP_CHANNEL_IOT}"
   fi
 
   if [[ "${MAS_APP_CHANNEL_MONITOR}" == '' ]]
   then echo_reset_dim " - Monitor ............... ${COLOR_RED}Skip Installation"
-  else echo_reset_dim " - Monitor ............... ${COLOR_BLUE}${MAS_APP_SOURCE_MONITOR}/${MAS_APP_CHANNEL_MONITOR}"
+  else echo_reset_dim " - Monitor ............... ${COLOR_MAGENTA}${MAS_APP_SOURCE_MONITOR}/${MAS_APP_CHANNEL_MONITOR}"
   fi
 
   if [[ "${MAS_APP_CHANNEL_SAFETY}" == '' ]]
   then echo_reset_dim " - Safety ................ ${COLOR_RED}Skip Installation"
-  else echo_reset_dim " - Safety ................ ${COLOR_BLUE}${MAS_APP_SOURCE_SAFETY}/${MAS_APP_CHANNEL_SAFETY}"
+  else echo_reset_dim " - Safety ................ ${COLOR_MAGENTA}${MAS_APP_SOURCE_SAFETY}/${MAS_APP_CHANNEL_SAFETY}"
   fi
 
   if [[ "${MAS_APP_CHANNEL_MANAGE}" == '' ]]
   then echo_reset_dim "Manage ................... ${COLOR_RED}Skip Installation"
-  else echo_reset_dim "Manage ................... ${COLOR_BLUE}${MAS_APP_SOURCE_MANAGE}/${MAS_APP_CHANNEL_MANAGE}"
+  else echo_reset_dim "Manage ................... ${COLOR_MAGENTA}${MAS_APP_SOURCE_MANAGE}/${MAS_APP_CHANNEL_MANAGE}"
   fi
 
   if [[ "${MAS_APP_CHANNEL_PREDICT}" == '' ]]
   then echo_reset_dim " - Predict ............... ${COLOR_RED}Skip Installation"
-  else echo_reset_dim " - Predict ............... ${COLOR_BLUE}${MAS_APP_SOURCE_PREDICT}/${MAS_APP_CHANNEL_PREDICT}"
+  else echo_reset_dim " - Predict ............... ${COLOR_MAGENTA}${MAS_APP_SOURCE_PREDICT}/${MAS_APP_CHANNEL_PREDICT}"
   fi
 
   if [[ "${MAS_CHANNEL}" == '8.8.x' ]]; then
     if [[ "${MAS_APP_CHANNEL_OPTIMIZER}" == '' ]]
     then echo_reset_dim "Optimizer ................ ${COLOR_RED}Skip Installation"
-    else echo_reset_dim "Optimizer ................ ${COLOR_BLUE}${MAS_APP_SOURCE_OPTIMIZER}/${MAS_APP_CHANNEL_OPTIMIZER} (${MAS_APP_PLAN_OPTIMIZER})"
+    else echo_reset_dim "Optimizer ................ ${COLOR_MAGENTA}${MAS_APP_SOURCE_OPTIMIZER}/${MAS_APP_CHANNEL_OPTIMIZER} (${MAS_APP_PLAN_OPTIMIZER})"
     fi
   fi
 
   if [[ "${MAS_APP_CHANNEL_HPUTILITIES}" == '' ]]
   then echo_reset_dim "H & P Utilities .......... ${COLOR_RED}Skip Installation"
-  else echo_reset_dim "H & P Utilities .......... ${COLOR_BLUE}${MAS_APP_SOURCE_HPUTILITIES}/${MAS_APP_CHANNEL_HPUTILITIES}"
+  else echo_reset_dim "H & P Utilities .......... ${COLOR_MAGENTA}${MAS_APP_SOURCE_HPUTILITIES}/${MAS_APP_CHANNEL_HPUTILITIES}"
   fi
 
   if [[ "${MAS_APP_CHANNEL_ASSIST}" == '' ]]
   then echo_reset_dim "Assist ................... ${COLOR_RED}Skip Installation"
-  else echo_reset_dim "Assist ................... ${COLOR_BLUE}${MAS_APP_SOURCE_ASSIST}/${MAS_APP_CHANNEL_ASSIST}"
+  else echo_reset_dim "Assist ................... ${COLOR_MAGENTA}${MAS_APP_SOURCE_ASSIST}/${MAS_APP_CHANNEL_ASSIST}"
   fi
 
   if [[ "${MAS_APP_CHANNEL_VISUALINSPECTION}" == '' ]]
   then echo_reset_dim "MVI ...................... ${COLOR_RED}Skip Installation"
-  else echo_reset_dim "MVI ...................... ${COLOR_BLUE}${MAS_APP_SOURCE_VISUALINSPECTION}/${MAS_APP_CHANNEL_VISUALINSPECTION}"
+  else echo_reset_dim "MVI ...................... ${COLOR_MAGENTA}${MAS_APP_SOURCE_VISUALINSPECTION}/${MAS_APP_CHANNEL_VISUALINSPECTION}"
   fi
 
   reset_colors
   echo "${TEXT_DIM}"
   echo_h2 "IBM Suite License Service" "    "
-  echo_reset_dim "Catalog Source ............ ${COLOR_BLUE}${SLS_CATALOG_SOURCE}"
-  echo_reset_dim "License ID ................ ${COLOR_BLUE}${SLS_LICENSE_ID}"
-  echo_reset_dim "License File .............. ${COLOR_BLUE}${SLS_LICENSE_FILE}"
-  echo_reset_dim "IBM Entitled Registry ..... ${COLOR_BLUE}${SLS_ICR_CP}"
-  echo_reset_dim "IBM Open Registry ......... ${COLOR_BLUE}${SLS_ICR_CPOPEN}"
-  echo_reset_dim "Entitlement Username ...... ${COLOR_BLUE}${SLS_ENTITLEMENT_USERNAME}"
-  echo_reset_dim "Entitlement Key ........... ${COLOR_BLUE}${SLS_ENTITLEMENT_KEY:0:8}<snip>"
+  echo_reset_dim "Catalog Source ............ ${COLOR_MAGENTA}${SLS_CATALOG_SOURCE}"
+  echo_reset_dim "License ID ................ ${COLOR_MAGENTA}${SLS_LICENSE_ID}"
+  echo_reset_dim "License File .............. ${COLOR_MAGENTA}${SLS_LICENSE_FILE}"
+  echo_reset_dim "IBM Entitled Registry ..... ${COLOR_MAGENTA}${SLS_ICR_CP}"
+  echo_reset_dim "IBM Open Registry ......... ${COLOR_MAGENTA}${SLS_ICR_CPOPEN}"
+  echo_reset_dim "Entitlement Username ...... ${COLOR_MAGENTA}${SLS_ENTITLEMENT_USERNAME}"
+  echo_reset_dim "Entitlement Key ........... ${COLOR_MAGENTA}${SLS_ENTITLEMENT_KEY:0:8}<snip>"
 
   reset_colors
   echo "${TEXT_DIM}"
   echo_h2 "IBM User Data Services" "    "
-  echo_reset_dim "Contact Email ............. ${COLOR_BLUE}${UDS_CONTACT_EMAIL}"
-  echo_reset_dim "First Name ................ ${COLOR_BLUE}${UDS_CONTACT_FIRSTNAME}"
-  echo_reset_dim "Last Name ................. ${COLOR_BLUE}${UDS_CONTACT_LASTNAME}"
+  echo_reset_dim "Contact Email ............. ${COLOR_MAGENTA}${UDS_CONTACT_EMAIL}"
+  echo_reset_dim "First Name ................ ${COLOR_MAGENTA}${UDS_CONTACT_FIRSTNAME}"
+  echo_reset_dim "Last Name ................. ${COLOR_MAGENTA}${UDS_CONTACT_LASTNAME}"
 
   reset_colors
   echo "${TEXT_DIM}"
   echo_h2 "IBM Cloud Pak Foundation Services" "    "
-  echo_reset_dim "Catalog Source ............ ${COLOR_BLUE}${COMMON_SERVICES_CATALOG_SOURCE}"
+  echo_reset_dim "Catalog Source ............ ${COLOR_MAGENTA}${COMMON_SERVICES_CATALOG_SOURCE}"
 
   if [[ "$DEPLOY_CP4D" == "run" ]]; then
     reset_colors
     echo "${TEXT_DIM}"
     echo_h2 "IBM Cloud Pak for Data" "    "
-    echo_reset_dim "Entitlement Key ........... ${COLOR_BLUE}${IBM_ENTITLEMENT_KEY:0:8}<snip>"
-    echo_reset_dim "Product Version ........... ${COLOR_BLUE}${CP4D_VERSION}"
+    echo_reset_dim "Entitlement Key ........... ${COLOR_MAGENTA}${IBM_ENTITLEMENT_KEY:0:8}<snip>"
+    echo_reset_dim "Product Version ........... ${COLOR_MAGENTA}${CP4D_VERSION}"
   fi
 
   reset_colors
   echo "${TEXT_DIM}"
   echo_h2 "Storage Class Configuration" "    "
-  echo_reset_dim "Storage Class Provider ... ${COLOR_BLUE}${STORAGE_CLASS_PROVIDER}"
+  echo_reset_dim "Storage Class Provider ... ${COLOR_MAGENTA}${STORAGE_CLASS_PROVIDER}"
   if [[ "$STORAGE_CLASS_PROVIDER" == "custom" ]]; then
-    echo_reset_dim "ReadWriteOnce ............ ${COLOR_BLUE}${STORAGE_CLASS_RWO}"
-    echo_reset_dim "ReadWriteMany ............ ${COLOR_BLUE}${STORAGE_CLASS_RWX}"
+    echo_reset_dim "ReadWriteOnce ............ ${COLOR_MAGENTA}${STORAGE_CLASS_RWO}"
+    echo_reset_dim "ReadWriteMany ............ ${COLOR_MAGENTA}${STORAGE_CLASS_RWX}"
   fi
 
   reset_colors

--- a/image/cli/bin/functions/provision_fyre
+++ b/image/cli/bin/functions/provision_fyre
@@ -183,27 +183,27 @@ function provision_fyre() {
   echo_h2 "Review Settings"
   echo "${TEXT_DIM}"
   echo_h2 "FYRE Authentication" "    "
-  echo_reset_dim "Username .................. ${COLOR_BLUE}${FYRE_USERNAME}"
-  echo_reset_dim "API Key ................... ${COLOR_BLUE}${FYRE_APIKEY:0:8}<snip>"
+  echo_reset_dim "Username .................. ${COLOR_MAGENTA}${FYRE_USERNAME}"
+  echo_reset_dim "API Key ................... ${COLOR_MAGENTA}${FYRE_APIKEY:0:8}<snip>"
   reset_colors
   echo "${TEXT_DIM}"
   echo_h2 "FYRE Accounting" "    "
-  echo_reset_dim "Product Group ID .......... ${COLOR_BLUE}${FYRE_PRODUCT_ID}"
-  echo_reset_dim "Quota Type ................ ${COLOR_BLUE}${FYRE_QUOTA_TYPE}"
+  echo_reset_dim "Product Group ID .......... ${COLOR_MAGENTA}${FYRE_PRODUCT_ID}"
+  echo_reset_dim "Quota Type ................ ${COLOR_MAGENTA}${FYRE_QUOTA_TYPE}"
   reset_colors
   echo "${TEXT_DIM}"
   echo_h2 "Cluster Configuration" "    "
-  echo_reset_dim "Name ...................... ${COLOR_BLUE}${CLUSTER_NAME}"
-  echo_reset_dim "Description ............... ${COLOR_BLUE}${FYRE_CLUSTER_DESCRIPTION}"
-  echo_reset_dim "OCP Version ............... ${COLOR_BLUE}${OCP_VERSION}"
+  echo_reset_dim "Name ...................... ${COLOR_MAGENTA}${CLUSTER_NAME}"
+  echo_reset_dim "Description ............... ${COLOR_MAGENTA}${FYRE_CLUSTER_DESCRIPTION}"
+  echo_reset_dim "OCP Version ............... ${COLOR_MAGENTA}${OCP_VERSION}"
 
   if [[ "${FYRE_QUOTA_TYPE}" == "product_group" ]]; then
     reset_colors
     echo "${TEXT_DIM}"
     echo_h2 "Worker Configuration" "    "
-    echo_reset_dim "Worker Node Count ......... ${COLOR_BLUE}${FYRE_WORKER_COUNT:-Default}"
-    echo_reset_dim "Worker Node CPU ........... ${COLOR_BLUE}${FYRE_WORKER_CPU:-Default}"
-    echo_reset_dim "Worker Node Memory ........ ${COLOR_BLUE}${FYRE_WORKER_MEMORY:-Default}"
+    echo_reset_dim "Worker Node Count ......... ${COLOR_MAGENTA}${FYRE_WORKER_COUNT:-Default}"
+    echo_reset_dim "Worker Node CPU ........... ${COLOR_MAGENTA}${FYRE_WORKER_CPU:-Default}"
+    echo_reset_dim "Worker Node Memory ........ ${COLOR_MAGENTA}${FYRE_WORKER_MEMORY:-Default}"
   fi
 
   echo

--- a/image/cli/bin/functions/utils
+++ b/image/cli/bin/functions/utils
@@ -92,9 +92,9 @@ function prompt_for_input(){
   fi
 
   if [[ "${default}" != "" ]]; then
-    read -e -p "${COLOR_YELLOW}$msg ${COLOR_BLUE}> " -i "${default}" input
+    read -e -p "${COLOR_YELLOW}$msg ${COLOR_MAGENTA}> " -i "${default}" input
   else
-    read -p "${COLOR_YELLOW}$msg ${COLOR_BLUE}> " input
+    read -p "${COLOR_YELLOW}$msg ${COLOR_MAGENTA}> " input
   fi
   echo -ne "${COLOR_RESET}\033[1K"
   # https://stackoverflow.com/a/13717788
@@ -104,7 +104,7 @@ function prompt_for_input(){
 function prompt_for_confirm() {
   msg=$1
   varname=$2
-  if confirm "${COLOR_YELLOW}$msg ${COLOR_BLUE}[y/N]"; then
+  if confirm "${COLOR_YELLOW}$msg ${COLOR_MAGENTA}[y/N]"; then
     echo -ne "${COLOR_RESET}\033[1K"
     if [[ "$varname" != "" ]]; then
       printf -v "$varname" "%s" "true"
@@ -122,7 +122,7 @@ function prompt_for_confirm() {
 function prompt_for_confirm_default_yes() {
   msg=$1
   varname=$2
-  if confirm_default_yes "${COLOR_YELLOW}$msg ${COLOR_BLUE}[Y/n]"; then
+  if confirm_default_yes "${COLOR_YELLOW}$msg ${COLOR_MAGENTA}[Y/n]"; then
     echo -ne "${COLOR_RESET}\033[1K"
     if [[ "$varname" != "" ]]; then
       printf -v "$varname" "%s" "true"


### PR DESCRIPTION
On my terminal setting `tput setaf 4` privides a nice light blue text easily readable on a black terminal.  On every customer's terminal I have worked with in the last month it results in a horrible dark blue text that is barely visible on a black background.  The defaults for this mode are clearly not a great choice for text input, so we will try `tput setaf 5`  (aka magenta).