### PR TITLE
[patch] Improve early failure detection

### DIFF
--- a/image/cli/bin/functions/pipeline_prepare
+++ b/image/cli/bin/functions/pipeline_prepare
@@ -102,7 +102,7 @@ function pipeline_prepare() {
   fi
 
   oc -n mas-$MAS_INSTANCE_ID-pipelines wait --for=condition=Available=true deployment mas-cli --timeout=3m &>> $LOGFILE
-  if [[ $1 == "0" ]]; then
+  if [[ "$?" == "0" ]]; then
     # All is good
     echo -en "\033[1K" # Clear current line
     echo -en "\033[u" # Restore cursor position

--- a/image/cli/bin/functions/pipeline_prepare
+++ b/image/cli/bin/functions/pipeline_prepare
@@ -27,20 +27,31 @@ function pipeline_prepare() {
 
   # Install the MAS Tekton definitions
   cp $DIR/templates/ibm-mas-tekton.yaml $CONFIG_DIR/ibm-mas-tekton-$MAS_INSTANCE_ID.yaml
+  sed -e "s/:latest/:$VERSION/g" $DIR/templates/deployment.yaml > $CONFIG_DIR/deployment-$MAS_INSTANCE_ID.yaml
+  CLI_IMAGE=quay.io/ibmmas/cli:$VERSION
   if [[ "$AIRGAP_MODE" == "true" ]]; then
     # If we're installing on airgap then we can't reference the images by tag, we need to prompt the user to enter the digest of
     # a specific version of the container image ... we can't do this automatically as we are inside the image.
     prompt_for_confirm_default_yes "Override image tag '$VERSION' with digest?" USE_DIGEST
     if [[ "$USE_DIGEST" == "true" ]]; then
-      prompt_for_input "Enter image digest (sha256:xxxxx) " CLI_IMAGE_DIGEST
-      # Overwrite the tekton definitions with one that uses the provided image digest
+      CLI_IMAGE_DIGEST=$(skopeo inspect docker://quay.io/ibmmas/cli:$VERSION 2>> $LOGFILE | jq -r ".Digest")
+      if [[ "$CLI_IMAGE_DIGEST" == "" ]]; then
+        echo_warning "Unable to retrieve image digest for quay.io/ibmmas/cli:$VERSION"
+        exit 1
+      fi
+      echo "Using image digest $CLI_IMAGE_DIGEST"
+      # Overwrite the tekton definitions with one that uses the looked up image digest
       sed -e "s/:$VERSION/@$CLI_IMAGE_DIGEST/g" $DIR/templates/ibm-mas-tekton.yaml > $CONFIG_DIR/ibm-mas-tekton-$MAS_INSTANCE_ID.yaml
+      sed -e "s/:latest/@$CLI_IMAGE_DIGEST/g" $DIR/templates/deployment.yaml > $CONFIG_DIR/deployment-$MAS_INSTANCE_ID.yaml
+      CLI_IMAGE=quay.io/ibmmas/cli@$CLI_IMAGE_DIGEST
     fi
   fi
 
   echo ""
   echo -en "\033[s" # Save cursor position
   echo -n "Preparing namespace 'mas-$MAS_INSTANCE_ID-pipelines' ..."
+  echo -e "\n\nPreparing namespace 'mas-$MAS_INSTANCE_ID-pipelines" >> $LOGFILE
+  echo_hr1 >> $LOGFILE
 
   oc apply -f $CONFIG_DIR/namespace-$MAS_INSTANCE_ID.yaml &>> $LOGFILE
   oc -n mas-$MAS_INSTANCE_ID-pipelines apply -f $CONFIG_DIR/ibm-mas-tekton-$MAS_INSTANCE_ID.yaml &>> $LOGFILE
@@ -57,7 +68,6 @@ function pipeline_prepare() {
   fi
 
   oc apply -f $CONFIG_DIR/rbac-$MAS_INSTANCE_ID.yaml &>> $LOGFILE
-  oc apply -f $CONFIG_DIR/pipeline-$MAS_INSTANCE_ID.yaml &>> $LOGFILE
 
   # Clean up existing secrets
   oc -n mas-$MAS_INSTANCE_ID-pipelines delete secret pipeline-additional-configs --ignore-not-found=true &>> $LOGFILE
@@ -74,4 +84,41 @@ function pipeline_prepare() {
   echo -en "\033[u" # Restore cursor position
   echo -e "${COLOR_GREEN}Namespace 'mas-$MAS_INSTANCE_ID-pipelines' is ready${COLOR_RESET}"
 
+  echo
+  echo_h2 "Installed Task Definitions"
+  oc -n mas-$MAS_INSTANCE_ID-pipelines get tasks -o=custom-columns='NAME:.metadata.name,IMAGE:.spec.steps[0].image'
+
+  echo
+  echo_h2 "Installed Pipeline Definitions"
+  oc -n mas-$MAS_INSTANCE_ID-pipelines get pipeline
+
+  echo ""
+  echo -en "\033[s" # Save cursor position
+  echo -n "Testing availability of $CLI_IMAGE in cluster ..."
+  EXISTING_DEPLOYMENT_IMAGE=$(oc -n default get deployment mas-cli2 -o jsonpath='{.spec.template.spec.containers[0].image}' 2>/dev/null)
+
+  if [[ "$EXISTING_DEPLOYMENT_IMAGE" != "CLI_IMAGE" ]]
+  then oc -n mas-$MAS_INSTANCE_ID-pipelines apply -f $CONFIG_DIR/deployment-$MAS_INSTANCE_ID.yaml &>> $LOGFILE
+  fi
+
+  oc -n mas-$MAS_INSTANCE_ID-pipelines wait --for=condition=Available=true deployment mas-cli --timeout=3m &>> $LOGFILE
+  if [[ $1 == "0" ]]; then
+    # All is good
+    echo -en "\033[1K" # Clear current line
+    echo -en "\033[u" # Restore cursor position
+    echo -e "${COLOR_GREEN}$CLI_IMAGE is available from the target OCP cluster${COLOR_RESET}"
+  else
+    echo -en "\033[1K" # Clear current line
+    echo -en "\033[u" # Restore cursor position
+    # We can't get the image, so there's no point running the pipeline
+    echo_warning "$CLI_IMAGE is unavailable from the target OCP cluster"
+    echo "This image must be accessible from your OpenShift cluster to run the installation:"
+    echo "- If you are running an offline (air gap) installation this likely means you have not mirrored this image to your private registry"
+    echo "- It could also mean that your cluster's ImageContentSourcePolicy is misconfigured and does not contain an entry for quay.io/ibmmas"
+
+    echo -e "\n\n[WARNING] $CLI_IMAGE is unavailable from the target OCP cluster" >> $LOGFILE
+    echo_hr1 >> $LOGFILE
+    oc -n mas-$MAS_INSTANCE_ID-pipelines get pods --selector="app=mas-cli" -o yaml >> $LOGFILE
+    exit 1
+  fi
 }

--- a/image/cli/bin/templates/deployment.yaml
+++ b/image/cli/bin/templates/deployment.yaml
@@ -9,6 +9,8 @@ spec:
   selector:
     matchLabels:
       app: mas-cli
+  strategy:
+    type: Recreate
   template:
     metadata:
       labels:
@@ -17,6 +19,6 @@ spec:
       containers:
       - name: mas-cli
         imagePullPolicy: Always
-        image: quay.io/ibmmas/cli:2.1.0
+        image: quay.io/ibmmas/cli:latest
         command: [ "/bin/bash", "-c", "--" ]
         args: [ "while true; do sleep 30; done;" ]


### PR DESCRIPTION
- Adds the ability to automatically determine the image digest for the `ibmmas/cli` image that is in use
- Adds the ability to fail instantly if the image does not exist
- Adds debug information about the Tekton Tasks and Pipelines install into the target namespace to aid in debugging failures
- Adds new pre-flight check which tries to run the `ibmmas/cli` container image in a new deployment in the pipelines namespace before starting the pipeline.  If this deployment can not successfully start then the install pipeline will not be started (as it will just fail).  Provides additional debug when this happens to aid in problem determination. 

## Validation Passing
![image](https://user-images.githubusercontent.com/4400618/183265314-0cacf1ff-608f-46de-bdaf-f29a943eadb3.png)

## Validation Failing
![image](https://user-images.githubusercontent.com/4400618/183265349-e597f874-b9d7-4533-9772-d6cd472f6bb5.png)

![image](https://user-images.githubusercontent.com/4400618/183265342-54d68e84-d5ee-4efe-88d9-bd1e086ccbef.png)


