### PR TITLE
[patch] Install missing jq

### DIFF
--- a/docs/commands/install.md
+++ b/docs/commands/install.md
@@ -45,14 +45,17 @@ Access [IBM License Key Center](https://licensing.subscribenet.com/control/ibmr/
 
 | Field            | Content                                           |
 | ---------------- | ------------------------------------------------- |
-| Number of Keys 	 | How many AppPoints to assign to the license file  |
-| Host ID Type 	   | Set to **Ethernet Address**                       |
-| Host ID 	       | Enter any 12 digit hexadecimal string             |
-| Hostname 	       | Set to the hostname of your OCP instance          |
-| Port 	           | Set to **27000**                                  |
+| Number of Keys   | How many AppPoints to assign to the license file  |
+| Host ID Type     | Set to **Ethernet Address**                       |
+| Host ID          | Enter any 12 digit hexadecimal string             |
+| Hostname         | Set to the hostname of your OCP instance          |
+| Port             | Set to **27000**                                  |
 
 
 The other values can be left at their defaults.  Finally, click **Generate** and download the license file to your home directory as `entitlement.lic`.
+
+!!! note
+    For more information about how to access the IBM License Key Center review the [getting started documentation](https://www.ibm.com/support/pages/system/files/inline-files/GettingStartedEnglish_2020.pdf) available from the IBM support website.
 
 
 ## Usage

--- a/docs/commands/mirror-images.md
+++ b/docs/commands/mirror-images.md
@@ -3,37 +3,50 @@
 ## Usage
 `mas mirror-images [options]`
 
-### Registry Details (Required):
+### Registry Details
+Required
+
 - `-H|--host REGISTRY_PUBLIC_HOST` Hostname of the target registry
 - `-P|--port REGISTRY_PUBLIC_PORT` Port number for the target registry
 
-### Registry Authentication (Optional):
+### Registry Authentication
+Optional
+
 - `-u|--username REGISTRY_USERNAME` Username to authenticate to the target registry
 - `-p|--password REGISTRY_PASSWORD` Password to authenticate to the target registry
 
-### Source Registry Entitlements (Required):
+### Source Registry Entitlements
+Required
+
 - `--ibm-entitlement IBM_ENTITLEMENT_KEY` IBM Entitlement Key
 - `--redhat-username REDHAT_CONNECT_USERNAME` Red Hat Connect Username
 - `--redhat-password REDHAT_CONNECT_PASSWORD` Red Hat Connect Password
 
-### Maximo Operator Catalog Selection (Required):
+### Maximo Operator Catalog Selection
+Required
+
 - `-c|--catalog MAS_CATALOG_VERSION` Maximo Operator Catalog Version to mirror (e.g. v8-220717)
 - `--mirror-core` Mirror images for IBM Maximo Application Suite Core & dependencies
 - `--mirror-iot` Mirror images for IBM Maximo IoT & dependencies
 
-### Maximo Core Image Mirroring Configuration (Optional):
+### Maximo Core Image Mirroring Configuration
+Optional
+
 - `--skip-cfs` Skip mirroring images for IBM Cloud Pak Foundation Services
 - `--skip-uds` Skip mirroring images for IBM User Data Services
 - `--skip-sls` Skip mirroring images for IBM Suite License Service
 - `--skip-tsm` Skip mirroring images for IBM Truststore Manager
 - `--skip-mongo` Skip mirroring images for MongoDb Community Edition
 
-### Maximo IoT Image Mirroring Configuration (Optional):
+### Maximo IoT Image Mirroring Configuration
+Optional
+
 - `--skip-db2` Skip mirroring images for IBM Db2
 
-### Other Commands:
+### Other Commands
 - `--no-confirm` Mirror images without prompting for confirmation
 - `-h|--help` Show help message
+
 
 ## Examples
 ### Interactive Mode

--- a/docs/commands/provision-fyre.md
+++ b/docs/commands/provision-fyre.md
@@ -3,23 +3,29 @@
 ## Usage
 `mas provision-fyre [options]`
 
-### FYRE Credentials (Required):
+### FYRE Credentials
+Required
+
 - `-u|--username FYRE_USERNAME` FYRE username
 - `-a|--apikey FYRE_APIKEY` FYRE API key
 
-### Cluster Configuration (Required):
+### Cluster Configuration
+Required
+
 - `-p|--product-id FYRE_PRODUCT_ID` FYRE product group ID that will own the cluster
 - `-q|--quota-type FYRE_QUOTA_TYPE` Declare the quota to use when provisioning the cluster ("quick_burn" or "product_group")
 - `-c|--cluster-name CLUSTER_NAME` Name of the cluster to be provisioned
 - `-v|--ocp-version OCP_VERSION` OCP version to use (e.g 4.8, 4.10)
 - `-d|--description FYRE_DESCRIPTION` Description of the OCP cluster
 
-### Worker Node Configuration (Optional, only takes effect when quota-type is set to "product_group"):
+### Worker Node Configuration
+Optional, only takes effect when quota-type is set to "product_group"
+
 - `--worker-count FYRE_WORKER_COUNT` Number of worker nodes to provision
 - `--worker-cpu FYRE_WORKER_CPU` How many CPUs to allocate per worker node
 - `--worker-memory FYRE_WORKER_MEMORY` How much memory to allocate per worker node
 
-### Other Commands:
+### Other Commands
 - `-s|--simulate-airgap` Set flag to apply the simulated airgap network configuration to the cluster after provisioning
 - `--no-confirm` Provision the cluster without prompting for confirmation
 - `-h|--help` Show this help message

--- a/docs/commands/provision-roks.md
+++ b/docs/commands/provision-roks.md
@@ -3,24 +3,32 @@
 ## Usage
 `mas provision-roks [options]`
 
-### IBMCloud Credentials (Required):
+### IBMCloud Credentials
+Required
+
 - `-a|--apikey IBMCLOUD_APIKEY` IBMCloud API key
 
-### Cluster Configuration (Required):
+### Cluster Configuration
+Required
+
 - `-r|--resource-group IBMCLOUD_RESOURCEGROUP` IBMCloud resource group to deploy the cluster in
 - `-c|--cluster-name CLUSTER_NAME` Name of the cluster to be provisioned
 - `-v|--ocp-version OCP_VERSION` OCP version to use (e.g 4.8_openshift, 4.10_openshift)
 
-### Worker Node Configuration (Required):
+### Worker Node Configuration
+Required
+
 - `--worker-count ROKS_WORKERS` Number of worker nodes to provision
 - `--worker-flavor ROKS_FLAVOR` The flavour of worker node to use (e.g. b3c.16x64.300gb)
 - `--worker-zone ROKS_ZONE` IBM Cloud zone where the cluster should be provisioned. (e.g. dal10)
 
-### GPU Support (Optional):
+### GPU Support
+Optional
+
 - `--gpu-worker-count GPU_WORKERS` Number of GPU worker nodes to provision
 - `--gpu-workerpool-name GPU_WORKERPOOL_NAME` Name of the GPU workerpool
 
-### Other Commands:
+### Other Commands
 - `--no-confirm` Provision the cluster without prompting for confirmation
 - `-h|--help` Show help message
 

--- a/image/cli/Dockerfile
+++ b/image/cli/Dockerfile
@@ -13,7 +13,7 @@ USER root
 # 1. Upgrade system packages
 RUN dnf update -y --skip-broken --nobest &&\
     dnf upgrade -y --skip-broken --nobest &&\
-    dnf install nano -y &&\
+    dnf install nano jq -y &&\
     dnf clean all
 
 # 2. Copy basics


### PR DESCRIPTION
In testing 2.1.2 we found that `jq` is missing from the container image, which prevents one path in `mas install` running to completion; specifically the path whereby the install script tries to lookup the image digest of the ibmmas/cli container image.

![image](https://user-images.githubusercontent.com/4400618/183627453-8b1e9b9c-f7c3-4a55-9d5b-9f4f86fa7dd0.png)
