### PR TITLE
[patch] Integrate OWASP dependency check

### DIFF
--- a/.github/workflows/build-cli.yml
+++ b/.github/workflows/build-cli.yml
@@ -61,3 +61,23 @@ jobs:
           tags: quay.io/ibmmas/cli:${{ env.DOCKER_TAG }}
           username: ${{ secrets.QUAYIO_USERNAME }}
           password: ${{ secrets.QUAYIO_PASSWORD }}
+
+      # 4. OWASP Dependency Check
+      # -------------------------------------------------------------------------------------------
+      - name: Perform dependency check
+        uses: dependency-check/Dependency-Check_Action@main
+        id: owasp-depcheck
+        with:
+          project: 'cli'
+          path: '.'
+          format: 'HTML'
+          args: >
+            --failOnCVSS 7
+            --enableRetired
+
+      - name: Upload dependency check results
+        uses: actions/upload-artifact@v2
+        with:
+           name: OWASP dependency check report
+           path: ${{github.workspace}}/reports
+           retention-days: 30

--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -63,3 +63,23 @@ jobs:
           tags: quay.io/ibmmas/cli:${{ env.DOCKER_TAG }} quay.io/ibmmas/cli:latest
           username: ${{ secrets.QUAYIO_USERNAME }}
           password: ${{ secrets.QUAYIO_PASSWORD }}
+
+      # 4. OWASP Dependency Check
+      # -------------------------------------------------------------------------------------------
+      - name: Perform dependency check
+        uses: dependency-check/Dependency-Check_Action@main
+        id: owasp-depcheck
+        with:
+          project: 'cli'
+          path: '.'
+          format: 'HTML'
+          args: >
+            --failOnCVSS 7
+            --enableRetired
+
+      - name: Upload dependency check results
+        uses: actions/upload-artifact@v2
+        with:
+           name: OWASP dependency check report
+           path: ${{github.workspace}}/reports
+           retention-days: 90


### PR DESCRIPTION
We're being asked to run [OWASP dependency checker](https://owasp.org/www-project-dependency-check/) against our open source repositories.  It doesn't seem to do much for this repository, but it ticks another box in a spreadsheet somewhere that we are running it anyway :)

We are running the GitHub Action available here: https://github.com/dependency-check/Dependency-Check_Action