### PR TITLE
[patch] Conditionally wait for TektonConfig CR

### DIFF
--- a/image/cli/bin/functions/pipeline_install_operator
+++ b/image/cli/bin/functions/pipeline_install_operator
@@ -1,5 +1,23 @@
 #!/bin/bash
 
+# Array of OCP versions that do not support TektonConfig CR
+NOT_SUPPORTED_OCP_VERSIONS=("4.6")
+
+function is_tektonconfig_supported() {
+  LOCAL_OCP_VERSION=`oc version -o json | jq -r ".openshiftVersion"`
+
+  SUPPORT_TEKTONCONFIG=1
+
+  for i in "${NOT_SUPPORTED_OCP_VERSIONS[@]}"; do
+    echo "i is $i" &>> $LOGFILE
+    if [[ "$LOCAL_OCP_VERSION" == "$i"* ]]; then
+       SUPPORT_TEKTONCONFIG=0
+    fi
+  done
+
+  echo $SUPPORT_TEKTONCONFIG
+}
+
 function pipeline_install_operator() {
   # Install pipelines support
   echo
@@ -21,21 +39,22 @@ function pipeline_install_operator() {
   echo "Wait for Pipeline operator to be ready" &>> $LOGFILE
   oc wait --for=condition=Established  crd tasks.tekton.dev --timeout=30m &>> $LOGFILE
 
-
-  echo "Wait for Tekton config to be available" &>> $LOGFILE
-  oc get TektonConfig config &>> $LOGFILE
-  LOOKUP_RESULT=$?
-  while [ "$LOOKUP_RESULT" == "1" ]; do
-    echo "Waiting 5s for TektonConfig to be created before checking again ..." &>> $LOGFILE
-    sleep 5
+  if [[ "$(is_tektonconfig_supported)" == "1" ]]; then
+    echo "Wait for Tekton config to be available" &>> $LOGFILE
     oc get TektonConfig config &>> $LOGFILE
     LOOKUP_RESULT=$?
-  done
+    while [ "$LOOKUP_RESULT" == "1" ]; do
+      echo "Waiting 5s for TektonConfig to be created before checking again ..." &>> $LOGFILE
+      sleep 5
+      oc get TektonConfig config &>> $LOGFILE
+      LOOKUP_RESULT=$?
+    done
 
-  # This will have no effect on OCP 4.8 ... OpenShift Pipelines doesn't support configuration properly at this level
-  # Note: We need to use --tpye merge because it's a custom resource
-  echo "Patch Tekton config to enable alpha API fields and scope when expressions to tasks" &>> $LOGFILE
-  oc patch TektonConfig config --type merge -p '{"spec":{"pipeline":{"enable-api-fields": "alpha", "scope-when-expressions-to-task": true}}}'  &>> $LOGFILE
+    # This will have no effect on OCP 4.8 ... OpenShift Pipelines doesn't support configuration properly at this level
+    # Note: We need to use --tpye merge because it's a custom resource
+    echo "Patch Tekton config to enable alpha API fields and scope when expressions to tasks" &>> $LOGFILE
+    oc patch TektonConfig config --type merge -p '{"spec":{"pipeline":{"enable-api-fields": "alpha", "scope-when-expressions-to-task": true}}}'  &>> $LOGFILE
+  fi
 
   echo -en "\033[1K" # Clear current line
   echo -en "\033[u" # Restore cursor position

--- a/image/cli/bin/functions/pipeline_install_operator
+++ b/image/cli/bin/functions/pipeline_install_operator
@@ -15,7 +15,7 @@ function is_tektonconfig_supported() {
     fi
   done
 
-  echo $SUPPORT_TEKTONCONFIG
+  echo "$SUPPORT_TEKTONCONFIG"
 }
 
 function pipeline_install_operator() {

--- a/image/cli/bin/functions/pipeline_install_operator
+++ b/image/cli/bin/functions/pipeline_install_operator
@@ -15,7 +15,7 @@ function is_tektonconfig_supported() {
     fi
   done
 
-  echo "$SUPPORT_TEKTONCONFIG"
+  echo $SUPPORT_TEKTONCONFIG
 }
 
 function pipeline_install_operator() {


### PR DESCRIPTION
`mas install` gets in a forever loop waiting for TektonConfig resource when CLI is running against OCP 4.6. Such waiting was placed then under a conditional statement based on OCP version.