### PR TITLE
[patch] Run Cluster Monitoring before Kafka in install pipeline

### DIFF
--- a/docs/catalogs/v8-220717-amd64.md
+++ b/docs/catalogs/v8-220717-amd64.md
@@ -41,7 +41,7 @@ OpenShift Container Platform Support
 | Maximo Application Suite 8.8 | 4.8-4.10    |
 | Maximo Application Suite 8.7 | 4.6-4.8     |
 | Maximo Application Suite 8.6 | 4.6         |
-| [Cloud Pak Foundational Services 1.19.1](https://www.ibm.com/docs/en/cpfs?topic=operator-supported-openshift-versions-platforms)* | 4.6-4.10 |
+| [Cloud Pak Foundational Services 3.19.1](https://www.ibm.com/docs/en/cpfs?topic=operator-supported-openshift-versions-platforms)* | 4.6-4.10 |
 | [Cloud Pak For Data 2.0.8](https://www.ibm.com/docs/en/cloud-paks/cp-data/4.0?topic=requirements-software) | 4.6, 4.8 |
 | [AppConnect 3.0.0](https://www.ibm.com/support/pages/node/6239294) | 4.6-4.8 |
 
@@ -58,7 +58,7 @@ IBM Maximo Application Suite will run anywhere that you can run a supported Open
 
 | Provider                                                                                 | Certified |
 | ---------------------------------------------------------------------------------------- | :--------:|
-| [AWS](https://aws.amazon.com/rosa/)                                                      | ❌       |
+| [AWS](https://aws.amazon.com/rosa/)                                                      | ✔        |
 | [Azure](https://azure.microsoft.com/en-gb/services/openshift/)                           | ❌       |
 | [Google Cloud Platform](https://cloud.google.com/architecture/partners/openshift-on-gcp) | ❌       |
 | [IBM Cloud](https://www.ibm.com/cloud/openshift)                                         | ✔        |

--- a/docs/catalogs/v8-220717-amd64.md
+++ b/docs/catalogs/v8-220717-amd64.md
@@ -58,7 +58,7 @@ IBM Maximo Application Suite will run anywhere that you can run a supported Open
 
 | Provider                                                                                 | Certified |
 | ---------------------------------------------------------------------------------------- | :--------:|
-| [AWS](https://aws.amazon.com/rosa/)                                                      | ✔        |
+| [AWS](https://aws.amazon.com/rosa/)                                                      | ✔       |
 | [Azure](https://azure.microsoft.com/en-gb/services/openshift/)                           | ❌       |
 | [Google Cloud Platform](https://cloud.google.com/architecture/partners/openshift-on-gcp) | ❌       |
 | [IBM Cloud](https://www.ibm.com/cloud/openshift)                                         | ✔        |
@@ -127,5 +127,3 @@ Manifest
 | ------------------------ | --------------- |
 | ibm-appconnect           | 3.0.0           |
 | couchdb-operator         | 2.2.1           |
-
-

--- a/docs/catalogs/v8-220805-amd64.md
+++ b/docs/catalogs/v8-220805-amd64.md
@@ -41,7 +41,7 @@ OpenShift Container Platform Support
 | Maximo Application Suite 8.8 | 4.8-4.10    |
 | Maximo Application Suite 8.7 | 4.6-4.8     |
 | Maximo Application Suite 8.6 | 4.6         |
-| [Cloud Pak Foundational Services 1.19.1](https://www.ibm.com/docs/en/cpfs?topic=operator-supported-openshift-versions-platforms)* | 4.6-4.10 |
+| [Cloud Pak Foundational Services 3.19.1](https://www.ibm.com/docs/en/cpfs?topic=operator-supported-openshift-versions-platforms)* | 4.6-4.10 |
 | [Cloud Pak For Data 2.0.8](https://www.ibm.com/docs/en/cloud-paks/cp-data/4.0?topic=requirements-software) | 4.6, 4.8 |
 | [AppConnect 3.0.0](https://www.ibm.com/support/pages/node/6239294) | 4.6-4.8 |
 
@@ -58,7 +58,7 @@ IBM Maximo Application Suite will run anywhere that you can run a supported Open
 
 | Provider                                                                                 | Certified |
 | ---------------------------------------------------------------------------------------- | :--------:|
-| [AWS](https://aws.amazon.com/rosa/)                                                      | ❌       |
+| [AWS](https://aws.amazon.com/rosa/)                                                      | ✔        |
 | [Azure](https://azure.microsoft.com/en-gb/services/openshift/)                           | ❌       |
 | [Google Cloud Platform](https://cloud.google.com/architecture/partners/openshift-on-gcp) | ❌       |
 | [IBM Cloud](https://www.ibm.com/cloud/openshift)                                         | ✔        |
@@ -76,7 +76,7 @@ Manifest
 | ibm-mas                  | 8.8.0, 8.7.3, 8.6.4, 8.5.2 |
 | ibm-mas-assist           | 8.5.0, 8.4.0, 8.3.0, 8.2.0 |
 | ibm-mas-hputilities      | 8.4.0, 8.3.0, 8.2.0        |
-| ibm-mas-iot              | **v8.5.1**, **v8.4.4**     |
+| ibm-mas-iot              | **8.5.1**, **8.4.4**       |
 | ibm-mas-manage           | 8.4.0, 8.3.0, 8.2.0, 8.1.0 |
 | ibm-mas-monitor          | 8.8.0, 8.7.2, 8.6.4        |
 | ibm-mas-mso              | 8.1.0, 8.0.3               |

--- a/docs/catalogs/v8-220805-amd64.md
+++ b/docs/catalogs/v8-220805-amd64.md
@@ -58,7 +58,7 @@ IBM Maximo Application Suite will run anywhere that you can run a supported Open
 
 | Provider                                                                                 | Certified |
 | ---------------------------------------------------------------------------------------- | :--------:|
-| [AWS](https://aws.amazon.com/rosa/)                                                      | ✔        |
+| [AWS](https://aws.amazon.com/rosa/)                                                      | ✔       |
 | [Azure](https://azure.microsoft.com/en-gb/services/openshift/)                           | ❌       |
 | [Google Cloud Platform](https://cloud.google.com/architecture/partners/openshift-on-gcp) | ❌       |
 | [IBM Cloud](https://www.ibm.com/cloud/openshift)                                         | ✔        |

--- a/tekton/pipelines/install.yaml
+++ b/tekton/pipelines/install.yaml
@@ -455,7 +455,7 @@ spec:
           workspace: shared-configs
 
 
-    # 3. Install AMQStream (Kafka)
+    # 3. Install AMQStreams (Kafka)
     # -------------------------------------------------------------------------
     - name: kafka
       params:
@@ -486,6 +486,8 @@ spec:
       taskRef:
         kind: Task
         name: mas-devops-kafka
+      runAfter:
+        - cluster-monitoring
       workspaces:
         - name: configs
           workspace: shared-configs


### PR DESCRIPTION
https://github.com/ibm-mas/ansible-devops/pull/451 created a dependency between the kafka and cluster-monitoring roles.  The Kafka role will install a Grafana dashboard now, but it can not do that unless the Grafana operator has been installed, which is performed in the cluster-monitoring role.
