### PR TITLE
[patch] Fix incorrect values for devops_suite_name

### DIFF
--- a/tekton/pipelines/install.yaml
+++ b/tekton/pipelines/install.yaml
@@ -1026,7 +1026,7 @@ spec:
     - name: suite-config-watson-studio
       params:
         - name: devops_suite_name
-          value: cfg-suite-appconnect
+          value: cfg-suite-watson-studio
         - name: devops_build_number
           value: $(params.devops_build_number)
         - name: devops_mongo_uri
@@ -1055,7 +1055,7 @@ spec:
     - name: suite-config-discovery
       params:
         - name: devops_suite_name
-          value: cfg-suite-appconnect
+          value: cfg-suite-discovery
         - name: devops_build_number
           value: $(params.devops_build_number)
         - name: devops_mongo_uri
@@ -1114,7 +1114,7 @@ spec:
     - name: suite-config-cos
       params:
         - name: devops_suite_name
-          value: cfg-suite-appconnect
+          value: cfg-suite-cos
         - name: devops_build_number
           value: $(params.devops_build_number)
         - name: devops_mongo_uri


### PR DESCRIPTION
The pipeline has multiple steps carrying the wrong value for `devops_suite_name`, this looks like the result of a previous bad merge.  There is minimal impact, but anyoneusing the "save pipeline results" feature will lose results for a number of steps due to duplicated suite names.