### PR TITLE
[patch] Missing parameter in install pipeline for cp4d

### DIFF
--- a/tekton/pipelines/install.yaml
+++ b/tekton/pipelines/install.yaml
@@ -857,8 +857,11 @@ spec:
         - name: ibm_entitlement_key
           value: $(params.ibm_entitlement_key)
 
+        - name: cpd_product_version
+          value: $(params.cpd_product_version)
         - name: mas_instance_id
           value: $(params.mas_instance_id)
+
         - name: devops_suite_name
           value: setup-cp4d
         - name: devops_build_number


### PR DESCRIPTION
Parameter has been added in task but not in pipeline, got the issue when using CLI to install some environment with CPD 4.5.