### PR TITLE
[patch] Input validation for provision-fyre

### DIFF
--- a/docs/commands/provision-fyre.md
+++ b/docs/commands/provision-fyre.md
@@ -12,7 +12,7 @@ Usage
 ### Cluster Configuration
 - `-p|--product-id FYRE_PRODUCT_ID` FYRE product group ID that will own the cluster
 - `-q|--quota-type FYRE_QUOTA_TYPE` Declare the quota to use when provisioning the cluster ("quick_burn" or "product_group")
-- `-c|--cluster-name CLUSTER_NAME` Name of the cluster to be provisioned
+- `-c|--cluster-name CLUSTER_NAME` Name of the cluster to be provisioned (lowercase only)
 - `-v|--ocp-version OCP_VERSION` OCP version to use (e.g 4.8, 4.10)
 - `-d|--description FYRE_DESCRIPTION` Description of the OCP cluster
 

--- a/image/cli/mascli/functions/provision_fyre
+++ b/image/cli/mascli/functions/provision_fyre
@@ -17,7 +17,7 @@ FYRE Credentials (Required):
 Cluster Configuration (Required):
   -p, --product-id ${COLOR_YELLOW}FYRE_PRODUCT_ID${TEXT_RESET}        FYRE product group ID that will own the cluster
   -q, --quota-type ${COLOR_YELLOW}FYRE_QUOTA_TYPE${TEXT_RESET}        Declare the quota to use when provisioning the cluster ("quick_burn" or "product_group")
-  -c, --cluster-name ${COLOR_YELLOW}CLUSTER_NAME${TEXT_RESET}         Name of the cluster to be provisioned
+  -c, --cluster-name ${COLOR_YELLOW}CLUSTER_NAME${TEXT_RESET}         Name of the cluster to be provisioned (lowercase only)
   -v, --ocp-version ${COLOR_YELLOW}OCP_VERSION${TEXT_RESET}           OCP version to use (e.g 4.8, 4.10)
   -d, --description ${COLOR_YELLOW}FYRE_DESCRIPTION${TEXT_RESET}      Description of the OCP cluster
 
@@ -132,6 +132,8 @@ function provision_fyre_interactive() {
       ;;
 
     *)
+      # Print out a warning as there could be a typo
+      echo_warning "    Using custom OCP version ($OCP_VERSION_SELECTION)"
       export OCP_VERSION=$OCP_VERSION_SELECTION
       ;;
   esac
@@ -144,9 +146,9 @@ function provision_fyre_interactive() {
   prompt_for_confirm "Use Product Group Quota?" USE_PRODUCT_GROUP_QUOTA
   if [[ "$USE_PRODUCT_GROUP_QUOTA" == "true" ]]; then
     FYRE_QUOTA_TYPE=product_group
-    prompt_for_input "Number of Worker Nodes (min 3)" FYRE_WORKER_COUNT
-    prompt_for_input "Worker Node CPU (max 16)" FYRE_WORKER_CPU
-    prompt_for_input "Worker Node Memory (max 64)" FYRE_WORKER_MEMORY
+    prompt_for_number "Number of Worker Nodes (min 3)" FYRE_WORKER_COUNT
+    prompt_for_number "Worker Node CPU (max 16)" FYRE_WORKER_CPU
+    prompt_for_number "Worker Node Memory (max 64)" FYRE_WORKER_MEMORY
   else
     FYRE_QUOTA_TYPE=product_group
   fi
@@ -162,6 +164,15 @@ function provision_fyre() {
     provision_fyre_noninteractive "$@"
   else
     provision_fyre_interactive
+  fi
+
+  # Fyre will provision a cluster with lowercase name so force to lowercase now
+  old=$CLUSTER_NAME
+  declare -l new=$CLUSTER_NAME
+  if [[ $old != $new ]] ; then
+    echo
+    echo_warning "Cluster name converted to lowercase"
+    CLUSTER_NAME=$new
   fi
 
   # Ensure all environment variables are available to ansible-playbook

--- a/image/cli/mascli/functions/utils
+++ b/image/cli/mascli/functions/utils
@@ -77,6 +77,39 @@ confirm_default_yes() {
   esac
 }
 
+
+function prompt_for_number(){
+  msg=$1
+  varname=$2
+  # When override is set, the default provided in $3 will override the saved default
+  override=$4
+
+  if [[ -z "${!varname}" || "$override" == "override" ]]; then
+    # Use the script default
+    default=$3
+  else
+    # Use the saved default
+    default=${!varname}
+  fi
+
+  while :; do
+
+    if [[ "${default}" != "" ]]; then
+      read -e -p "${COLOR_YELLOW}$msg ${COLOR_MAGENTA}> " -i "${default}" input
+    else
+      read -p "${COLOR_YELLOW}$msg ${COLOR_MAGENTA}> " input
+    fi
+    echo -ne "${COLOR_RESET}\033[1K"
+    # https://stackoverflow.com/a/13717788
+    re='^[1-9][0-9]*$'
+    if [[ $input =~ $re ]] ; then
+      break
+    fi
+  done
+  printf -v "$varname" "%s" "$input"
+}
+
+
 function prompt_for_input(){
   msg=$1
   varname=$2


### PR DESCRIPTION
- Add warning if cluster name has uppercase (and automatically change to lower)
- Add warning if specifying a custom OCP version
- Add function for inputing numbers that will rety if a number wasn't entered

