### PR TITLE
[minor] Add aws client to container image

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -1,5 +1,7 @@
 ## Changes
 
+- [`2.6`](https://github.com/ibm-mas/cli/releases/tag/2.6.0) Add aws client to container image
+- [`2.5`](https://github.com/ibm-mas/cli/releases/tag/2.5.0) Support IBM Pak and Two Phase Mirroring
 - [`2.4`](https://github.com/ibm-mas/cli/releases/tag/2.4.0) Add support for Sep 2022 catalog
 - [`2.3`](https://github.com/ibm-mas/cli/releases/tag/2.3.0) Add Update and Upgrade command support
 - [`2.2`](https://github.com/ibm-mas/cli/releases/tag/2.2.0) Catalog update for IoT airgap support fix

--- a/image/cli/Dockerfile
+++ b/image/cli/Dockerfile
@@ -29,6 +29,7 @@ RUN umask 0002 && \
     bash /tmp/install/install-ibmpak.sh && \
     bash /tmp/install/install-ibmcloud.sh && \
     bash /tmp/install/install-skopeo.sh && \
+    bash /tmp/install/install-aws.sh && \
     rm -rf /tmp/install
 
 # 4. Install tini

--- a/image/cli/install/install-aws.sh
+++ b/image/cli/install/install-aws.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+# Install AWS CLI
+set -e
+
+curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
+unzip awscliv2.zip
+./aws/install
+
+rm -rf aws
+rm  awscliv2.zip
+
+aws --version

--- a/image/cli/mascli/functions/mirror_to_registry
+++ b/image/cli/mascli/functions/mirror_to_registry
@@ -513,7 +513,10 @@ function mirror_to_registry() {
   echo
   echo_h2 "4. Run Mirror Process"
   TIMESTAMP=$(date "+%Y%m%d-%H%M%S")
-  LOG_PREFIX="$LOG_DIR/mirror-$TIMESTAMP"
+  LOG_PREFIX="$MIRROR_WORKING_DIR/logs/mirror-$TIMESTAMP"
+  if [ ! -d $MIRROR_WORKING_DIR/logs/ ]; then
+    mkdir -p $MIRROR_WORKING_DIR/logs/
+  fi
 
   mirror_one_thing $MIRROR_RH_RELEASE           "Red Hat Release"                    "$LOG_PREFIX-ocp-release.log"   mirror_openshift_release
   mirror_one_thing $MIRROR_RH_OPERATORS         "Red Hat Operators"                  "$LOG_PREFIX-ocp-operators.log" mirror_openshift_operators


### PR DESCRIPTION
This update makes the `aws` command line tool available inside the container image (https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html) and also changes the log directory used when running image mirroring from `$LOG_DIR` to `$MIRROR_WORKING_DIR/logs` so that everything associated with the mirroring process is kept together.  

This will make debugging issues during image mirroring much easier as this directory is often mounted from a local filesystem.