### PR TITLE
[patch] Remove .bluemix directory generated during build

### DIFF
--- a/image/cli/install/install-ibmcloud.sh
+++ b/image/cli/install/install-ibmcloud.sh
@@ -9,3 +9,5 @@ mv Bluemix_CLI/bin/ibmcloud /usr/local/bin/
 rm -rf Bluemix_CLI IBM_Cloud_CLI_2.3.0_amd64.tar.gz
 ibmcloud plugin repo-plugins -r 'IBM Cloud'
 ibmcloud plugin install container-service
+
+rm -rf /opt/app-root/src/.bluemix

--- a/image/cli/install/install-ibmpak.sh
+++ b/image/cli/install/install-ibmpak.sh
@@ -6,6 +6,7 @@ set -e
 curl -L https://github.com/IBM/ibm-pak-plugin/releases/download/v1.3.1/oc-ibm_pak-linux-amd64.tar.gz -o oc-ibm_pak-linux-amd64.tar.gz
 tar -xvf oc-ibm_pak-linux-amd64.tar.gz
 mv oc-ibm_pak-linux-amd64 /usr/local/bin/oc-ibm_pak
+rm oc-ibm_pak-linux-amd64.tar.gz
 
 oc ibm-pak --version
 rm -rf /opt/app-root/src/.ibm-pak


### PR DESCRIPTION
Bug reported internally.

The ~/.bluemix directory used by the ibmcloud tool is not writeable in the container image because it is generated at build time while verifying the install of ibmcloud.  This fix removes the directory after verifying the ibmcloud install, so that it is not part of the final image, and can be created at runtime with the right permissions.