### PR TITLE
[patch] Support mas install from bastion without public network access

### DIFF
--- a/docs/commands/configure-airgap.md
+++ b/docs/commands/configure-airgap.md
@@ -6,6 +6,15 @@
 
 ## Usage
 
+### Interactive
 ```bash
-docker run -ti --rm -v ~:/home/local quay.io/ibmmas/cli mas configure-airgap
+docker run -ti --rm -v ~:/mnt/local quay.io/ibmmas/cli mas configure-airgap
+```
+
+### Non-Interactive
+```bash
+docker run -ti --rm -v ~:/mnt/local quay.io/ibmmas/cli mas configure-airgap \
+  -H myprivateregistry.com -P 5000 -u $REGISTRY_USERNAME -p $REGISTRY_PASSWORD \
+  --ca-file /mnt/local/registry-ca.crt \
+  --no-confirm
 ```

--- a/docs/commands/mirror-images.md
+++ b/docs/commands/mirror-images.md
@@ -57,7 +57,7 @@ Examples
 ### Interactive Image Mirroring
 ```bash
 docker pull quay.io/ibmmas/cli
-docker run -ti --rm quay.io/ibmmas/cli mas mirror-images
+docker run -ti --rm -v /mnt/registry:/mnt/registry quay.io/ibmmas/cli mas mirror-images
 ```
 
 ### Two-Phase Image Mirroring

--- a/docs/commands/update.md
+++ b/docs/commands/update.md
@@ -1,9 +1,9 @@
-Setup Private Registry
+Update
 ===============================================================================
 
 Usage
 -------------------------------------------------------------------------------
 
 ```bash
-docker run -ti --rm quay.io/ibmmas/cli mas setup-registry
+docker run -ti --rm quay.io/ibmmas/cli mas update
 ```

--- a/docs/guides/install.md
+++ b/docs/guides/install.md
@@ -1,22 +1,36 @@
 Installation
 ===============================================================================
 
-
-Pre-requisites
+Installation Overview
 -------------------------------------------------------------------------------
-### IBM Entitlement Key
+1. [Pre-requistes](#1-pre-requisites)
+    - 1.1 [IBM Entitlement Key](#11-ibm-entitlement-key)
+    - 1.2 [MAS License File](#12-mas-license-file)
+    - 1.3 [OpenShift Cluster](#13-openshift-cluster)
+    - 1.4 [Operator Catalog Selection](#14-operator-catalog-selection)
+2. [Disconnected Install Preparation](#2-disconnected-install-preparation)
+    - 2.1 [Disconnected Install Limitations](#21-disconnected-install-limitations)
+    - 2.2 [Prepare your Private Registry](#22-prepare-the-private-registry)
+    - 2.3 [Mirror Container Images](#23-mirror-container-images)
+    - 2.4 [Configure OpenShift to use your Private Registry for MAS](#24-configure-openshift-to-use-your-private-registry-for-mas)
+3. [Install MAS](#3-install-maximo-application-suite)
+
+
+1 Pre-requisites
+-------------------------------------------------------------------------------
+### 1.1 IBM Entitlement Key
 Access [Container Software Library](https://myibm.ibm.com/products-services/containerlibrary) using your IBMId to obtain your entitlement key.
 
-### MAS License File
+### 1.2 MAS License File
 Access [IBM License Key Center](https://licensing.subscribenet.com/control/ibmr/login), on the **Get Keys** menu select **IBM AppPoint Suites**.  Select `IBM MAXIMO APPLICATION SUITE AppPOINT LIC` and on the next page fill in the information as below:
 
-| Field            | Content                                           |
-| ---------------- | ------------------------------------------------- |
-| Number of Keys   | How many AppPoints to assign to the license file  |
-| Host ID Type     | Set to **Ethernet Address**                       |
-| Host ID          | Enter any 12 digit hexadecimal string             |
-| Hostname         | Set to the hostname of your OCP instance          |
-| Port             | Set to **27000**                                  |
+| Field            | Content                                                                       |
+| ---------------- | ----------------------------------------------------------------------------- |
+| Number of Keys   | How many AppPoints to assign to the license file                              |
+| Host ID Type     | Set to **Ethernet Address**                                                   |
+| Host ID          | Enter any 12 digit hexadecimal string                                         |
+| Hostname         | Set to the hostname of your OCP instance, but this can be any value really.   |
+| Port             | Set to **27000**                                                              |
 
 
 The other values can be left at their defaults.  Finally, click **Generate** and download the license file to your home directory as `entitlement.lic`.
@@ -24,7 +38,7 @@ The other values can be left at their defaults.  Finally, click **Generate** and
 !!! note
     For more information about how to access the IBM License Key Center review the [getting started documentation](https://www.ibm.com/support/pages/system/files/inline-files/GettingStartedEnglish_2020.pdf) available from the IBM support website.
 
-### OpenShift Cluster
+### 1.3 OpenShift Cluster
 You should already have a target OpenShift cluster ready to install Maximo Application suite into.  If you do not already have one then refer to the [OpenShift Container Platform installation overview](https://docs.openshift.com/container-platform/4.10/installing/index.html).
 
 The CLI also supports OpenShift provisioning in many hyperscaler providers:
@@ -34,12 +48,14 @@ The CLI also supports OpenShift provisioning in many hyperscaler providers:
 - [IBM DevIT FYRE(Internal)](../commands/provision-fyre.md)
 
 
-### Operator Catalog Selection
+### 1.4 Operator Catalog Selection
 If you have not already determined the best catalog source for your installation, refer to the information in the [choosing the right IBM Maximo Operator Catalog to meet your requirements](choosing-the-right-catalog.md) guide, or contact IBM Support for guidance.
 
 
-Disconnected Install Limitations
+2 Disconnected Install Preparation
 -------------------------------------------------------------------------------
+
+### 2.1 Disconnected Install Limitations
 Disconnected install for IBM Maximo Application Suite is supported from MAS v8.8 onwards with some restrictions:
 
 | Application                | First Version to Support Air Gap  |
@@ -56,19 +72,7 @@ Disconnected install for IBM Maximo Application Suite is supported from MAS v8.8
 | Visual Inspection          |  No support                       |
 
 
-Installation Overview
--------------------------------------------------------------------------------
-1. Disconnected Install Preparation
-    - [Prepare your Private Registry](#prepare-the-private-registry)
-    - [Mirror Container Images](#mirror-container-images)
-    - [Configure OpenShift to use your Private Registry for MAS](#configure-the-cluster)
-2. [Install MAS](#install-maximo-application-suite)
-
-
-Disconnected Install Preparation
--------------------------------------------------------------------------------
-
-### Prepare the Private Registry
+### 2.2 Prepare the Private Registry
 If you do not already have a private registry available to use as your mirror then you can use the `setup-mirror` function to deploy a private registry inside a target OpenShift cluster.
 
 ```bash
@@ -78,37 +82,69 @@ docker run -ti quay.io/ibmmas/cli mas setup-registry
 
 The registry will be setup running on port 32500.  For more details on this step, refer to the [setup-registry](../commands/setup-registry.md) command's documentation.  Regardless of whether you set up a new registry or already had one, you need to collect the following information about your private registry:
 
-| Name | Detail |
-| ---- | ------ |
-| Private Hostname | The hostname by which the registry will be accessible from the target OCP cluster. |
-| Private Port | The port number by which the registry will be accessible from the target OCP cluster. |
-| Public Hostname | The hostname by which the registry will be accessible from the machine that will be performing image mirroring. |
-| Public Port | The port number by which the registry will be accessible from the machine that will be performing image mirroring. |
-| CA certificate file | The CA certificate that the registry will present on the **private** hostname. Save this to your home directory.  |
-| Username | Optional.  Authentication username for the registry. |
-| Password | Optional.  Authentication password for the registry. |
+| Name                | Detail                                                                                                             |
+| ------------------- | ------------------------------------------------------------------------------------------------------------------ |
+| Private Hostname    | The hostname by which the registry will be accessible from the target OCP cluster.                                 |
+| Private Port        | The port number by which the registry will be accessible from the target OCP cluster.                              |
+| Public Hostname     | The hostname by which the registry will be accessible from the machine that will be performing image mirroring.    |
+| Public Port         | The port number by which the registry will be accessible from the machine that will be performing image mirroring. |
+| CA certificate file | The CA certificate that the registry will present on the **private** hostname. Save this to your home directory.   |
+| Username            | Optional.  Authentication username for the registry.                                                               |
+| Password            | Optional.  Authentication password for the registry.                                                               |
 
 
-### Mirror Container Images
-Mirroring the images is a simple but time consuming process, this step must be performed from a system with internet connectivity and network access your private registry, but does not need access to your target OpenShift cluster.
+### 2.3 Mirror Container Images
+Mirroring the images is a simple but time consuming process, this step must be performed from a system with internet connectivity and network access your private registry, but does not need access to your target OpenShift cluster.  Three modes are available for the mirror process:
 
-!!! tip
-    You can also use this command to mirror the images for OpenShift itself, but that is beyond the scope of this guide.
+- **direct** mirrors images directly from the source registry to your private registry
+- **to-filesystem** mirrors images from the source to a local directory
+- **from-filesystem** mirrors images from a local directory to your private registry
 
 ```bash
 docker pull quay.io/ibmmas/cli
 docker run -ti quay.io/ibmmas/cli mas mirror-images
 ```
 
-You will be prompted to set the target registry for the image mirroring and to [select the version of IBM Maximo Operator Catalog to mirror](choosing-the-right-catalog.md) and the subset of content that you wish to mirror  You can choose to mirror everything from the catalog, or control exactly what is mirrored to your private registry to reduce the time and bandwidth used to mirror the images, as well reducing the storage requirements of the registry.
+You will be prompted to set the target registry for the image mirroring and to [select the version of IBM Maximo Operator Catalog to mirror](choosing-the-right-catalog.md) and the subset of content that you wish to mirror.  You can choose to mirror everything from the catalog, or control exactly what is mirrored to your private registry to reduce the time and bandwidth used to mirror the images, as well reducing the storage requirements of the registry.
 
 This command can also be ran non-interactive, for full details refer to the [mirror-images](../commands/mirror-images.md) command documentation.
 
+```bash
+mas mirror-images \
+  -m direct \
+  -d /mnt/local-mirror/ \
+  -H myprivateregistry.com -P 5000 -u $REGISTRY_USERNAME -p $REGISTRY_PASSWORD \
+  -c v8-221025-amd64 --mirror-core --mirror-iot --mirror-optimizer --mirror-manage \
+  --ibm-entitlement $IBM_ENTITLEMENT_KEY \
+  --redhat-username $REDHAT_USERNAME --redhat-password $REDHAT_PASSWORD \
+  --no-confirm
+```
 
-### Configure OpenShift to use your Private Registry for MAS
-TODO: Work in progress ... basically run `mas configure-airgap`
+### 2.4 Configure OpenShift to use your Private Registry for MAS
+Your cluster must be configured to use the private registry as a mirror for the MAS container images.  An `ImageContentSourcePolicy` named `mas-and-dependencies` will be created in the cluster, this is also the resource that the MAS install will use to detect whether the installation is a disconnected install and tailor the options presented when you run the `mas install` command.
+
+```bash
+docker pull quay.io/ibmmas/cli
+docker run -ti quay.io/ibmmas/cli mas configure-airgap
+```
+
+You will be prompted to provide information about the private registry, including the CA certificate necessary to configure your cluster to trust the private registry.
+
+This command can also be ran non-interactive, for full details refer to the [configure-airgap](../commands/configure-airgap.md) command documentation.
+
+```bash
+mas configure-airgap \
+  -H myprivateregistry.com -P 5000 -u $REGISTRY_USERNAME -p $REGISTRY_PASSWORD \
+  --ca-file /mnt/local-mirror/registry-ca.crt \
+  --no-confirm
+```
 
 
-Install Maximo Application Suite
+3 Install Maximo Application Suite
 -------------------------------------------------------------------------------
-TODO: Work in progress .. basically run the install as normal: `mas install`
+Regardless of whether you are running a connected or disconnect installation, simply run the `mas install` command and follow the prompts.
+
+```bash
+docker pull quay.io/ibmmas/cli
+docker run -ti quay.io/ibmmas/cli mas install
+```

--- a/docs/guides/update.md
+++ b/docs/guides/update.md
@@ -1,0 +1,55 @@
+Update
+===============================================================================
+
+Update Overview
+-------------------------------------------------------------------------------
+This guide is specifically for environments using **static catalogs**.  If you are using the **dynamic catalog** then updates are automatically applied as soon as they are released.
+
+1. [Disconnected Update Preparation](#1-disconnected-install-preparation)
+    - 1.1 [Mirror Container Images](#11-mirror-container-images)
+2. [Update MAS](#2-update-maximo-application-suite)
+
+1 Disconnected Update Preparation
+-------------------------------------------------------------------------------
+### 1.1 Mirror Container Images
+Before you start the update, you must mirror the images for the new catalog that you wish to update to. Mirroring the images is a simple but time consuming process.  Three modes are available for the mirror process:
+
+- **direct** mirrors images directly from the source registry to your private registry
+- **to-filesystem** mirrors images from the source to a local directory
+- **from-filesystem** mirrors images from a local directory to your private registry
+
+```bash
+docker pull quay.io/ibmmas/cli
+docker run -ti quay.io/ibmmas/cli mas mirror-images
+```
+
+You will be prompted to set the target registry for the image mirroring and to [select the version of IBM Maximo Operator Catalog to mirror](choosing-the-right-catalog.md) and the subset of content that you wish to mirror.  You can choose to mirror everything from the catalog, or control exactly what is mirrored to your private registry to reduce the time and bandwidth used to mirror the images, as well reducing the storage requirements of the registry.
+
+This command can also be ran non-interactive, for full details refer to the [mirror-images](../commands/mirror-images.md) command documentation.
+
+```bash
+mas mirror-images \
+  -m direct \
+  -d /mnt/local-mirror/ \
+  -H myprivateregistry.com -P 5000 -u $REGISTRY_USERNAME -p $REGISTRY_PASSWORD \
+  -c v8-221025-amd64 --mirror-core --mirror-iot --mirror-optimizer --mirror-manage \
+  --ibm-entitlement $IBM_ENTITLEMENT_KEY \
+  --redhat-username $REDHAT_USERNAME --redhat-password $REDHAT_PASSWORD \
+  --no-confirm
+```
+
+You will be prompted to set the target registry for the image mirroring and to [select the version of IBM Maximo Operator Catalog to mirror](choosing-the-right-catalog.md) and the subset of content that you wish to mirror.  You can choose to mirror everything from the catalog, or control exactly what is mirrored to your private registry to reduce the time and bandwidth used to mirror the images, as well reducing the storage requirements of the registry.
+
+This command can also be ran non-interactive, for full details refer to the [mirror-images](../commands/mirror-images.md) command documentation.
+
+
+2 Update Maximo Application Suite
+-------------------------------------------------------------------------------
+Basically, run `mas update` and choose the catalog to update to.  This will update the operator catalog installed in your cluster, and the Operator Lifecycle Manager (OLM) will automatically update all installed operators to the newest version available on the current subscription channel.
+
+!!! important
+    You must select a newer catalog than what is already in use.  Updating to an older static catalog is not supported.
+
+```bash
+mas update -c v8-221025-amd64  --no-confirm
+```

--- a/image/cli/mascli/functions/pipeline_install_tasks
+++ b/image/cli/mascli/functions/pipeline_install_tasks
@@ -10,16 +10,21 @@ function pipeline_install_tasks() {
   CLI_IMAGE=quay.io/ibmmas/cli:$VERSION
 
   if [[ "$AIRGAP_MODE" == "true" ]]; then
-    # If we're installing on airgap then we can't reference the images by tag, we need to prompt the user to enter the digest of
-    # a specific version of the container image ... we can't do this automatically as we are inside the image.
     prompt_for_confirm_default_yes "Override image tag '$VERSION' with digest?" USE_DIGEST
     if [[ "$USE_DIGEST" == "true" ]]; then
-      CLI_IMAGE_DIGEST=$(skopeo inspect docker://quay.io/ibmmas/cli:$VERSION 2>> $LOGFILE | jq -r ".Digest")
-      if [[ "$CLI_IMAGE_DIGEST" == "" ]]; then
-        echo_warning "Unable to retrieve image digest for quay.io/ibmmas/cli:$VERSION"
-        exit 1
+      skopeo inspect docker://quay.io/ibmmas/cli:$VERSION &> /dev/null
+      if [[ "$?" == "0" ]]; then
+        CLI_IMAGE_DIGEST=$(skopeo inspect docker://quay.io/ibmmas/cli:$VERSION 2>> $LOGFILE | jq -r ".Digest")
+        if [[ "$CLI_IMAGE_DIGEST" == "" ]]; then
+          echo_warning "Unable to retrieve image digest for quay.io/ibmmas/cli:$VERSION"
+          exit 1
+        fi
+        echo "Using image digest $CLI_IMAGE_DIGEST"
+      else
+        echo "Unable to communicate with quay.io, please manually enter the digest for"
+        echo "environment variable) which will be used to provision a ROKS instance."
+        prompt_for_input "quay.io/ibmmas/cli image digest" CLI_IMAGE_DIGEST
       fi
-      echo "Using image digest $CLI_IMAGE_DIGEST"
       # Overwrite the tekton definitions with one that uses the looked up image digest
       sed -e "s/:$VERSION/@$CLI_IMAGE_DIGEST/g" $DIR/templates/ibm-mas-tekton.yaml > $CONFIG_DIR/ibm-mas-tekton-$MAS_INSTANCE_ID.yaml
       sed -e "s/:latest/@$CLI_IMAGE_DIGEST/g" $DIR/templates/deployment.yaml > $CONFIG_DIR/deployment-$MAS_INSTANCE_ID.yaml

--- a/image/cli/mascli/functions/pipeline_install_tasks
+++ b/image/cli/mascli/functions/pipeline_install_tasks
@@ -21,8 +21,7 @@ function pipeline_install_tasks() {
         fi
         echo "Using image digest $CLI_IMAGE_DIGEST"
       else
-        echo "Unable to communicate with quay.io, please manually enter the digest for"
-        echo "environment variable) which will be used to provision a ROKS instance."
+        echo "Unable to communicate with quay.io, please manually enter the digest."
         prompt_for_input "quay.io/ibmmas/cli image digest" CLI_IMAGE_DIGEST
       fi
       # Overwrite the tekton definitions with one that uses the looked up image digest

--- a/image/cli/mascli/functions/update
+++ b/image/cli/mascli/functions/update
@@ -55,18 +55,24 @@ function update_interactive() {
   echo_h2 "Select IBM Maximo Operator Catalog Version"
 
   echo -e "${COLOR_YELLOW}MAS Catalog:"
-  echo "  1. v8 (2022-08-05)"
-  echo "  2. v8 (2022-07-17)"
+  echo "  1. v8 (2022-10-25)"
+  echo "  2. v8 (2022-09-27)"
+  echo "  3. v8 (2022-08-05)"
+  echo "  4. v8 (2022-07-17)"
   prompt_for_input "Select Catalog Version" MAS_CATALOG_SELECTION "1"
 
   case $MAS_CATALOG_SELECTION in
-    1|220805|2022-08-05)
+    1|221025|2022-10-25)
+      MAS_CATALOG_VERSION=v8-221025-amd64
+      ;;
+    2|220927|2022-09-27)
+      MAS_CATALOG_VERSION=v8-220927-amd64
+      ;;
+    3|220805|2022-08-05)
       MAS_CATALOG_VERSION=v8-220805-amd64
       ;;
-    2|220717|2022-07-17)
-      MAS_CATALOG_VERSION=v8-220717
-      # We are deliberately leaving this without the -amd64 to ensure this is not a breaking change
-      # for anyone already using v8-220717
+    4|220717|2022-07-17)
+      MAS_CATALOG_VERSION=v8-220717-amd64
       ;;
     *)
       echo_warning "Invalid selection"
@@ -77,7 +83,7 @@ function update_interactive() {
 
 
 function update() {
-  # Take the first parameter off (it will be mirror-images)
+  # Take the first parameter off (it will be "update")
   shift
   if [[ $# -gt 0 ]]; then
     update_noninteractive "$@"

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -13,6 +13,7 @@ nav:
   - 'Guides':
     - 'Choosing the Right Catalog': guides/choosing-the-right-catalog.md
     - 'Installation': guides/install.md
+    - 'Update': guides/update.md
     - 'MAS Core Explained': guides/architecture/core.md
     - 'MAS Pods Explained': guides/mas-pods-explained.md
   - 'Commands':


### PR DESCRIPTION
Support use of `mas install` on a host without public internet access, today the install flow will fail when it tries to dynamically lookup the image digest of the ibmmas/cli container image from quay.io.

This update will prompt the user to manually enter the digest if it can't be automatically looked up, the new logic is:

```
  if [[ "$AIRGAP_MODE" == "true" ]]; then
    prompt_for_confirm_default_yes "Override image tag '$VERSION' with digest?" USE_DIGEST
    if [[ "$USE_DIGEST" == "true" ]]; then
      skopeo inspect docker://quay.io/ibmmas/cli:$VERSION &> /dev/null
      if [[ "$?" == "0" ]]; then
        CLI_IMAGE_DIGEST=$(skopeo inspect docker://quay.io/ibmmas/cli:$VERSION 2>> $LOGFILE | jq -r ".Digest")
        if [[ "$CLI_IMAGE_DIGEST" == "" ]]; then
          echo_warning "Unable to retrieve image digest for quay.io/ibmmas/cli:$VERSION"
          exit 1
        fi
        echo "Using image digest $CLI_IMAGE_DIGEST"
      else
        echo "Unable to communicate with quay.io, please manually enter the digest."
        prompt_for_input "quay.io/ibmmas/cli image digest" CLI_IMAGE_DIGEST
      fi
      # Overwrite the tekton definitions with one that uses the looked up image digest
      sed -e "s/:$VERSION/@$CLI_IMAGE_DIGEST/g" $DIR/templates/ibm-mas-tekton.yaml > $CONFIG_DIR/ibm-mas-tekton-$MAS_INSTANCE_ID.yaml
      sed -e "s/:latest/@$CLI_IMAGE_DIGEST/g" $DIR/templates/deployment.yaml > $CONFIG_DIR/deployment-$MAS_INSTANCE_ID.yaml
      CLI_IMAGE=quay.io/ibmmas/cli@$CLI_IMAGE_DIGEST
    fi
  fi
```

Additionally, brings a lot of documentation updates.