### PR TITLE
[patch] Fix pipeline install on OCP 4.11

### DIFF
--- a/image/cli/mascli/functions/pipeline_install_operator
+++ b/image/cli/mascli/functions/pipeline_install_operator
@@ -22,10 +22,12 @@ function pipeline_install_operator() {
   # Install pipelines support
   echo
   echo_h2 "2. Install OpenShift Pipelines Operator"
-  oc apply -f $DIR/templates/subscription.yaml &>> $LOGFILE
+  PIPELINES_CHANNEL=$(oc get packagemanifests openshift-pipelines-operator-rh -o jsonpath="{.status.defaultChannel}")
+
+  sed -e "s/{{pipelines_channel}}/$PIPELINES_CHANNEL/g" $DIR/templates/subscription.yaml | oc apply -f - &>> $LOGFILE
 
   echo -en "\033[s" # Save cursor position
-  echo -n "Installing OpenShift Pipelines Operator ..."
+  echo -n "Installing OpenShift Pipelines Operator ($PIPELINES_CHANNEL) ..."
 
   oc get crd tasks.tekton.dev &>> $LOGFILE
   LOOKUP_RESULT=$?

--- a/image/cli/mascli/templates/subscription.yaml
+++ b/image/cli/mascli/templates/subscription.yaml
@@ -5,7 +5,7 @@ metadata:
     name: openshift-pipelines-operator
     namespace: openshift-operators
 spec:
-    channel: stable
+    channel: {{pipelines_channel}}
     name: openshift-pipelines-operator-rh
     source: redhat-operators
     sourceNamespace: openshift-marketplace


### PR DESCRIPTION
Operator catalog on 4.11 uses different naming conventions for the channels in the Pipelines package.  Dynamically look up the default channel for OpenShift Pipelines and use that.