### PR TITLE
[patch] Fix missing parameter in fvt-assist-desktop

### DIFF
--- a/tekton/tasks/fvt-assist-desktop.yaml
+++ b/tekton/tasks/fvt-assist-desktop.yaml
@@ -7,6 +7,9 @@ spec:
   params:
     # Test Container Information
     # -------------------------------------------------------------------------
+    - name: fvt_image_registry
+      type: string
+      description: FVT Container Image Registry (required)
     - name: fvt_image_version
       type: string
       description: FVT Container Image Version


### PR DESCRIPTION
As title, looks like we missed declaring a parameter (`fvt_image_registry`) in the task definition for fvt-assist-desktop.