### PR TITLE
[patch] More missing refs to fvt_image_registry

### DIFF
--- a/tekton/pipelines/install-with-fvt.yaml
+++ b/tekton/pipelines/install-with-fvt.yaml
@@ -3799,6 +3799,8 @@ spec:
         - name: devops_build_number
           value: $(params.devops_build_number)
 
+        - name: fvt_image_registry
+          value: $(params.fvt_image_registry)
         - name: fvt_image_namespace
           value: mas-devops
         - name: fvt_image_name
@@ -3847,6 +3849,8 @@ spec:
         - name: ibmcloud_apikey
           value: $(params.ibmcloud_apikey)
 
+        - name: fvt_image_registry
+          value: $(params.fvt_image_registry)
         - name: fvt_image_namespace
           value: fvt-manage
         - name: fvt_image_name
@@ -3895,6 +3899,8 @@ spec:
         - name: ibmcloud_apikey
           value: $(params.ibmcloud_apikey)
 
+        - name: fvt_image_registry
+          value: $(params.fvt_image_registry)
         - name: fvt_image_namespace
           value: fvt-manage
         - name: fvt_image_name
@@ -3943,6 +3949,8 @@ spec:
         - name: ibmcloud_apikey
           value: $(params.ibmcloud_apikey)
 
+        - name: fvt_image_registry
+          value: $(params.fvt_image_registry)
         - name: fvt_image_namespace
           value: fvt-manage
         - name: fvt_image_name
@@ -3991,6 +3999,8 @@ spec:
         - name: ibmcloud_apikey
           value: $(params.ibmcloud_apikey)
 
+        - name: fvt_image_registry
+          value: $(params.fvt_image_registry)
         - name: fvt_image_namespace
           value: fvt-manage
         - name: fvt_image_name
@@ -4039,6 +4049,8 @@ spec:
         - name: ibmcloud_apikey
           value: $(params.ibmcloud_apikey)
 
+        - name: fvt_image_registry
+          value: $(params.fvt_image_registry)
         - name: fvt_image_namespace
           value: fvt-manage
         - name: fvt_image_name
@@ -4087,6 +4099,8 @@ spec:
         - name: ibmcloud_apikey
           value: $(params.ibmcloud_apikey)
 
+        - name: fvt_image_registry
+          value: $(params.fvt_image_registry)
         - name: fvt_image_namespace
           value: fvt-manage
         - name: fvt_image_name
@@ -4135,6 +4149,8 @@ spec:
         - name: ibmcloud_apikey
           value: $(params.ibmcloud_apikey)
 
+        - name: fvt_image_registry
+          value: $(params.fvt_image_registry)
         - name: fvt_image_namespace
           value: fvt-manage
         - name: fvt_image_name
@@ -4183,6 +4199,8 @@ spec:
         - name: ibmcloud_apikey
           value: $(params.ibmcloud_apikey)
 
+        - name: fvt_image_registry
+          value: $(params.fvt_image_registry)
         - name: fvt_image_namespace
           value: fvt-manage
         - name: fvt_image_name
@@ -4231,6 +4249,8 @@ spec:
         - name: ibmcloud_apikey
           value: $(params.ibmcloud_apikey)
 
+        - name: fvt_image_registry
+          value: $(params.fvt_image_registry)
         - name: fvt_image_namespace
           value: fvt-civil
         - name: fvt_image_name
@@ -4279,6 +4299,8 @@ spec:
         - name: ibmcloud_apikey
           value: $(params.ibmcloud_apikey)
 
+        - name: fvt_image_registry
+          value: $(params.fvt_image_registry)
         - name: fvt_image_namespace
           value: fvt-manage
         - name: fvt_image_name
@@ -4420,6 +4442,8 @@ spec:
         - name: devops_build_number
           value: $(params.devops_build_number)
 
+        - name: fvt_image_registry
+          value: $(params.fvt_image_registry)
         - name: fvt_image_namespace
           value: fvt-mobilefoundation
         - name: fvt_image_name
@@ -4464,6 +4488,8 @@ spec:
         - name: devops_build_number
           value: $(params.devops_build_number)
 
+        - name: fvt_image_registry
+          value: $(params.fvt_image_registry)
         - name: fvt_image_namespace
           value: fvt-mobilefoundation
         - name: fvt_image_name
@@ -4514,6 +4540,8 @@ spec:
         - name: devops_build_number
           value: $(params.devops_build_number)
 
+        - name: fvt_image_registry
+          value: $(params.fvt_image_registry)
         - name: fvt_image_namespace
           value: ai-solutions
         - name: fvt_image_name
@@ -4556,6 +4584,8 @@ spec:
           value: $(params.devops_mongo_uri)
         - name: devops_build_number
           value: $(params.devops_build_number)
+        - name: fvt_image_registry
+          value: $(params.fvt_image_registry)
         - name: fvt_image_namespace
           value: ai-solutions
         - name: fvt_image_name
@@ -4600,6 +4630,8 @@ spec:
         - name: devops_build_number
           value: $(params.devops_build_number)
 
+        - name: fvt_image_registry
+          value: $(params.fvt_image_registry)
         - name: fvt_image_namespace
           value: fvt-safety
         - name: fvt_image_name
@@ -4646,6 +4678,8 @@ spec:
         - name: devops_build_number
           value: $(params.devops_build_number)
 
+        - name: fvt_image_registry
+          value: $(params.fvt_image_registry)
         - name: fvt_image_namespace
           value: ai-solutions
         - name: fvt_image_name

--- a/tekton/pipelines/taskdefs/fvt-apps/iot.yml.j2
+++ b/tekton/pipelines/taskdefs/fvt-apps/iot.yml.j2
@@ -11,6 +11,8 @@
     - name: devops_build_number
       value: $(params.devops_build_number)
 
+    - name: fvt_image_registry
+      value: $(params.fvt_image_registry)
     - name: fvt_image_namespace
       value: mas-devops
     - name: fvt_image_name

--- a/tekton/pipelines/taskdefs/fvt-apps/manage.yml.j2
+++ b/tekton/pipelines/taskdefs/fvt-apps/manage.yml.j2
@@ -15,6 +15,8 @@
     - name: ibmcloud_apikey
       value: $(params.ibmcloud_apikey)
 
+    - name: fvt_image_registry
+      value: $(params.fvt_image_registry)
     - name: fvt_image_namespace
       value: fvt-manage
     - name: fvt_image_name
@@ -63,6 +65,8 @@
     - name: ibmcloud_apikey
       value: $(params.ibmcloud_apikey)
 
+    - name: fvt_image_registry
+      value: $(params.fvt_image_registry)
     - name: fvt_image_namespace
       value: fvt-manage
     - name: fvt_image_name
@@ -111,6 +115,8 @@
     - name: ibmcloud_apikey
       value: $(params.ibmcloud_apikey)
 
+    - name: fvt_image_registry
+      value: $(params.fvt_image_registry)
     - name: fvt_image_namespace
       value: fvt-manage
     - name: fvt_image_name
@@ -159,6 +165,8 @@
     - name: ibmcloud_apikey
       value: $(params.ibmcloud_apikey)
 
+    - name: fvt_image_registry
+      value: $(params.fvt_image_registry)
     - name: fvt_image_namespace
       value: fvt-manage
     - name: fvt_image_name
@@ -207,6 +215,8 @@
     - name: ibmcloud_apikey
       value: $(params.ibmcloud_apikey)
 
+    - name: fvt_image_registry
+      value: $(params.fvt_image_registry)
     - name: fvt_image_namespace
       value: fvt-manage
     - name: fvt_image_name
@@ -255,6 +265,8 @@
     - name: ibmcloud_apikey
       value: $(params.ibmcloud_apikey)
 
+    - name: fvt_image_registry
+      value: $(params.fvt_image_registry)
     - name: fvt_image_namespace
       value: fvt-manage
     - name: fvt_image_name
@@ -303,6 +315,8 @@
     - name: ibmcloud_apikey
       value: $(params.ibmcloud_apikey)
 
+    - name: fvt_image_registry
+      value: $(params.fvt_image_registry)
     - name: fvt_image_namespace
       value: fvt-manage
     - name: fvt_image_name
@@ -351,6 +365,8 @@
     - name: ibmcloud_apikey
       value: $(params.ibmcloud_apikey)
 
+    - name: fvt_image_registry
+      value: $(params.fvt_image_registry)
     - name: fvt_image_namespace
       value: fvt-manage
     - name: fvt_image_name
@@ -399,6 +415,8 @@
     - name: ibmcloud_apikey
       value: $(params.ibmcloud_apikey)
 
+    - name: fvt_image_registry
+      value: $(params.fvt_image_registry)
     - name: fvt_image_namespace
       value: fvt-civil
     - name: fvt_image_name
@@ -447,6 +465,8 @@
     - name: ibmcloud_apikey
       value: $(params.ibmcloud_apikey)
 
+    - name: fvt_image_registry
+      value: $(params.fvt_image_registry)
     - name: fvt_image_namespace
       value: fvt-manage
     - name: fvt_image_name

--- a/tekton/pipelines/taskdefs/fvt-apps/mobile.yml.j2
+++ b/tekton/pipelines/taskdefs/fvt-apps/mobile.yml.j2
@@ -11,6 +11,8 @@
     - name: devops_build_number
       value: $(params.devops_build_number)
 
+    - name: fvt_image_registry
+      value: $(params.fvt_image_registry)
     - name: fvt_image_namespace
       value: fvt-mobilefoundation
     - name: fvt_image_name
@@ -55,6 +57,8 @@
     - name: devops_build_number
       value: $(params.devops_build_number)
 
+    - name: fvt_image_registry
+      value: $(params.fvt_image_registry)
     - name: fvt_image_namespace
       value: fvt-mobilefoundation
     - name: fvt_image_name

--- a/tekton/pipelines/taskdefs/fvt-apps/monitor.yml.j2
+++ b/tekton/pipelines/taskdefs/fvt-apps/monitor.yml.j2
@@ -10,6 +10,8 @@
     - name: devops_build_number
       value: $(params.devops_build_number)
 
+    - name: fvt_image_registry
+      value: $(params.fvt_image_registry)
     - name: fvt_image_namespace
       value: ai-solutions
     - name: fvt_image_name

--- a/tekton/pipelines/taskdefs/fvt-apps/optimizer.yml.j2
+++ b/tekton/pipelines/taskdefs/fvt-apps/optimizer.yml.j2
@@ -10,6 +10,8 @@
     - name: devops_build_number
       value: $(params.devops_build_number)
 
+    - name: fvt_image_registry
+      value: $(params.fvt_image_registry)
     - name: fvt_image_namespace
       value: ai-solutions
     - name: fvt_image_name

--- a/tekton/pipelines/taskdefs/fvt-apps/predict.yml.j2
+++ b/tekton/pipelines/taskdefs/fvt-apps/predict.yml.j2
@@ -8,6 +8,8 @@
       value: $(params.devops_mongo_uri)
     - name: devops_build_number
       value: $(params.devops_build_number)
+    - name: fvt_image_registry
+      value: $(params.fvt_image_registry)
     - name: fvt_image_namespace
       value: ai-solutions
     - name: fvt_image_name

--- a/tekton/pipelines/taskdefs/fvt-apps/safety.yml.j2
+++ b/tekton/pipelines/taskdefs/fvt-apps/safety.yml.j2
@@ -10,6 +10,8 @@
     - name: devops_build_number
       value: $(params.devops_build_number)
 
+    - name: fvt_image_registry
+      value: $(params.fvt_image_registry)
     - name: fvt_image_namespace
       value: fvt-safety
     - name: fvt_image_name

--- a/tekton/pipelines/taskdefs/fvt-apps/visualinspection.yml.j2
+++ b/tekton/pipelines/taskdefs/fvt-apps/visualinspection.yml.j2
@@ -10,6 +10,8 @@
     - name: devops_build_number
       value: $(params.devops_build_number)
 
+    - name: fvt_image_registry
+      value: $(params.fvt_image_registry)
     - name: fvt_image_namespace
       value: ai-solutions
     - name: fvt_image_name


### PR DESCRIPTION
Forgot that templating is only partial at the moment, not everything uses the common params, so many taskdefs need this added as well.