### PR TITLE
[patch] Fix sed syntax to substitute in image digest

### DIFF
--- a/image/cli/mascli/functions/pipeline_install_tasks
+++ b/image/cli/mascli/functions/pipeline_install_tasks
@@ -25,7 +25,7 @@ function pipeline_install_tasks() {
         prompt_for_input "quay.io/ibmmas/cli image digest" CLI_IMAGE_DIGEST
       fi
       # Overwrite the tekton definitions with one that uses the looked up image digest
-      sed -e "s/cli:\$\(params\.cli_version\)/cli@$CLI_IMAGE_DIGEST/g" $DIR/templates/ibm-mas-tekton.yaml > $CONFIG_DIR/ibm-mas-tekton-$MAS_INSTANCE_ID.yaml
+      sed -e "s/cli:\$(params.cli_version)/cli@${CLI_IMAGE_DIGEST}/g" $DIR/templates/ibm-mas-tekton.yaml > $CONFIG_DIR/ibm-mas-tekton-$MAS_INSTANCE_ID.yaml
       sed -e "s/:latest/@$CLI_IMAGE_DIGEST/g" $DIR/templates/deployment.yaml > $CONFIG_DIR/deployment-$MAS_INSTANCE_ID.yaml
       CLI_IMAGE=quay.io/ibmmas/cli@$CLI_IMAGE_DIGEST
     fi


### PR DESCRIPTION
This update fixes a bug in the CLI code that prevents the CLI image digest being inserted into the Tekton TaskDefinition files to enable them to be used with image mirroring.