### PR TITLE
[minor] Support for workload scale customization

### DIFF
--- a/tekton/pipelines/fvt-assist.yaml
+++ b/tekton/pipelines/fvt-assist.yaml
@@ -294,6 +294,11 @@ spec:
       type: string
       default: ""
       description: Override IBM Entitlement key for MAS installation
+    - name: mas_customize_scaling
+      type: string
+      default: ""
+      description: Workload Scaling Custom ConfigMap Name
+
 
     # MAS Configuration - Workspace
     - name: mas_workspace_id

--- a/tekton/pipelines/fvt-core.yaml
+++ b/tekton/pipelines/fvt-core.yaml
@@ -1388,3 +1388,35 @@ spec:
           value: fvt-smtp
       runAfter:
         - fvt-licensingapi
+
+    # FVT5.6 core-scaling ~25m
+    - name: fvt-core-scaling
+      taskRef:
+        kind: Task
+        name: mas-fvt-core
+      when:
+        - input: "$(params.fvt_version_core)"
+          operator: notin
+          values: [""]
+      workspaces:
+        - name: configs
+          workspace: shared-configs
+      params:
+        - name: mas_instance_id
+          value: $(params.mas_instance_id)
+        - name: mas_workspace_id
+          value: $(params.mas_workspace_id)
+        - name: devops_mongo_uri
+          value: $(params.devops_mongo_uri)
+        - name: devops_build_number
+          value: $(params.devops_build_number)
+        - name: product_channel
+          value: $(params.mas_channel)
+        - name: fvt_image_registry
+          value: $(params.fvt_image_registry)
+        - name: fvt_image_version
+          value: $(params.fvt_version_core)
+        - name: fvt_image_name
+          value: fvt-core-scaling
+      runAfter:
+        - fvt-smtp

--- a/tekton/pipelines/fvt-core.yaml
+++ b/tekton/pipelines/fvt-core.yaml
@@ -294,6 +294,11 @@ spec:
       type: string
       default: ""
       description: Override IBM Entitlement key for MAS installation
+    - name: mas_customize_scaling
+      type: string
+      default: ""
+      description: Workload Scaling Custom ConfigMap Name
+
 
     # MAS Configuration - Workspace
     - name: mas_workspace_id

--- a/tekton/pipelines/install-with-fvt.yaml
+++ b/tekton/pipelines/install-with-fvt.yaml
@@ -300,6 +300,11 @@ spec:
       type: string
       default: ""
       description: Override IBM Entitlement key for MAS installation
+    - name: mas_customize_scaling
+      type: string
+      default: ""
+      description: Workload Scaling Custom ConfigMap Name
+
 
     # MAS Configuration - Workspace
     - name: mas_workspace_id

--- a/tekton/pipelines/install-with-fvt.yaml
+++ b/tekton/pipelines/install-with-fvt.yaml
@@ -1470,6 +1470,9 @@ spec:
           value: $(params.ibm_entitlement_key)
         - name: mas_entitlement_key
           value: $(params.mas_entitlement_key)
+        - name: mas_customize_scaling
+          value: $(params.mas_customize_scaling)
+
       taskRef:
         kind: Task
         name: mas-devops-suite-install
@@ -3213,6 +3216,38 @@ spec:
           value: fvt-smtp
       runAfter:
         - fvt-licensingapi
+
+    # FVT5.6 core-scaling ~25m
+    - name: fvt-core-scaling
+      taskRef:
+        kind: Task
+        name: mas-fvt-core
+      when:
+        - input: "$(params.fvt_version_core)"
+          operator: notin
+          values: [""]
+      workspaces:
+        - name: configs
+          workspace: shared-configs
+      params:
+        - name: mas_instance_id
+          value: $(params.mas_instance_id)
+        - name: mas_workspace_id
+          value: $(params.mas_workspace_id)
+        - name: devops_mongo_uri
+          value: $(params.devops_mongo_uri)
+        - name: devops_build_number
+          value: $(params.devops_build_number)
+        - name: product_channel
+          value: $(params.mas_channel)
+        - name: fvt_image_registry
+          value: $(params.fvt_image_registry)
+        - name: fvt_image_version
+          value: $(params.fvt_version_core)
+        - name: fvt_image_name
+          value: fvt-core-scaling
+      runAfter:
+        - fvt-smtp
 
 
     # 16. MAS Core IVT

--- a/tekton/pipelines/install.yaml
+++ b/tekton/pipelines/install.yaml
@@ -300,6 +300,11 @@ spec:
       type: string
       default: ""
       description: Override IBM Entitlement key for MAS installation
+    - name: mas_customize_scaling
+      type: string
+      default: ""
+      description: Workload Scaling Custom ConfigMap Name
+
 
     # MAS Configuration - Workspace
     - name: mas_workspace_id

--- a/tekton/pipelines/install.yaml
+++ b/tekton/pipelines/install.yaml
@@ -1341,6 +1341,9 @@ spec:
           value: $(params.ibm_entitlement_key)
         - name: mas_entitlement_key
           value: $(params.mas_entitlement_key)
+        - name: mas_customize_scaling
+          value: $(params.mas_customize_scaling)
+
       taskRef:
         kind: Task
         name: mas-devops-suite-install

--- a/tekton/pipelines/params/install.yml.j2
+++ b/tekton/pipelines/params/install.yml.j2
@@ -224,6 +224,11 @@
   type: string
   default: ""
   description: Override IBM Entitlement key for MAS installation
+- name: mas_customize_scaling
+  type: string
+  default: ""
+  description: Workload Scaling Custom ConfigMap Name
+
 
 # MAS Configuration - Workspace
 - name: mas_workspace_id

--- a/tekton/pipelines/taskdefs/core/suite-install.yml.j2
+++ b/tekton/pipelines/taskdefs/core/suite-install.yml.j2
@@ -35,6 +35,9 @@
       value: $(params.ibm_entitlement_key)
     - name: mas_entitlement_key
       value: $(params.mas_entitlement_key)
+    - name: mas_customize_scaling
+      value: $(params.mas_customize_scaling)
+
   taskRef:
     kind: Task
     name: mas-devops-suite-install

--- a/tekton/pipelines/taskdefs/fvt-core/phase5.yml.j2
+++ b/tekton/pipelines/taskdefs/fvt-core/phase5.yml.j2
@@ -59,3 +59,13 @@
       value: fvt-smtp
   runAfter:
     - fvt-licensingapi
+
+# FVT5.6 core-scaling ~25m
+- name: fvt-core-scaling
+  {{ lookup('template', 'taskdefs/fvt-core/common/taskref.yml.j2') | indent(2) }}
+  params:
+    {{ lookup('template', 'taskdefs/fvt-core/common/params.yml.j2') | indent(4) }}
+    - name: fvt_image_name
+      value: fvt-core-scaling
+  runAfter:
+    - fvt-smtp

--- a/tekton/tasks/suite-install.yaml
+++ b/tekton/tasks/suite-install.yaml
@@ -54,6 +54,11 @@ spec:
       default: ""
       description: "Optional MAS-specific override for the IBM entitlement key"
 
+    - name: mas_customize_scaling
+      type: string
+      default: ""
+      description: Optional Workload Scaling Custom ConfigMap Name
+
     - name: artifactory_username
       default: ''
       type: string
@@ -124,6 +129,9 @@ spec:
         value: $(params.ibm_entitlement_key)
       - name: MAS_ENTITLEMENT_KEY
         value: $(params.mas_entitlement_key)
+
+      - name: MAS_CUSTOMIZE_SCALING
+        value: $(params.mas_customize_scaling)
 
       # Optional support built into the ansible-devops image
       # for saving task execution results to a MongoDb instance


### PR DESCRIPTION
Adding support for the new var, used to host the custom workload configMap name.
This will allow us to include it in different pipelines.