### PR TITLE
[patch] Fix version strings for December catalog in mirror-images

### DIFF
--- a/image/cli/mascli/functions/mirror_to_registry
+++ b/image/cli/mascli/functions/mirror_to_registry
@@ -27,7 +27,7 @@ Source Registry Entitlements (Required based on what content you choose to mirro
       --redhat-password ${COLOR_YELLOW}REDHAT_CONNECT_PASSWORD${TEXT_RESET}   Red Hat Connect Password
 
 Maximo Operator Catalog Selection (Optional):
-  -c, --catalog ${COLOR_YELLOW}MAS_CATALOG_VERSION${TEXT_RESET}               Maximo Operator Catalog Version to mirror (e.g. v8-deccat-amd64)
+  -c, --catalog ${COLOR_YELLOW}MAS_CATALOG_VERSION${TEXT_RESET}               Maximo Operator Catalog Version to mirror (e.g. v8-221228-amd64)
   -C, --channel ${COLOR_YELLOW}MAS_CHANNEL${TEXT_RESET}                       Maximo Application Suite Channel to mirror (e.g. 8.9.x)
       --mirror-core                               Mirror images for IBM Maximo Application Suite Core & dependencies
       --mirror-assist                             Mirror images for IBM Maximo Assist
@@ -245,41 +245,47 @@ function mirror_to_registry_interactive() {
   echo_h2 "3. Configure Static Catalog Version"
 
   echo -e "${COLOR_YELLOW}MAS Version:"
-  echo "  1. 8.8.4 (2022-12-14)"
-  echo "  2. 8.9.0 (2022-11-29)"
-  echo "  3. 8.8.3 (2022-11-29)"
-  echo "  4. 8.8.2 (2022-10-25)"
-  echo "  5. 8.8.1 (2022-09-27)"
-  echo "  6. 8.8.0 (2022-08-05)"
+  echo "  1. 8.9.0 (2022-12-28)"
+  echo "  2. 8.8.4 (2022-12-28)"
+  echo "  3. 8.9.0 (2022-11-29)"
+  echo "  4. 8.8.3 (2022-11-29)"
+  echo "  5. 8.8.2 (2022-10-25)"
+  echo "  6. 8.8.1 (2022-09-27)"
+  echo "  7. 8.8.0 (2022-08-05)"
   prompt_for_input "Select Catalog Source" MAS_CHANNEL_SELECTION "1"
 
   case $MAS_CHANNEL_SELECTION in
-    1|8.8.4)
+    1)
+      MAS_CHANNEL=8.9.x
+      MAS_CATALOG_SOURCE=ibm-operator-catalog
+      MAS_CATALOG_VERSION=v8-221228-amd64
+      ;;
+    1)
       MAS_CHANNEL=8.8.x
       MAS_CATALOG_SOURCE=ibm-operator-catalog
       MAS_CATALOG_VERSION=v8-221228-amd64
       ;;
-    2|8.9.0)
+    2)
       MAS_CHANNEL=8.9.x
       MAS_CATALOG_SOURCE=ibm-operator-catalog
       MAS_CATALOG_VERSION=v8-221129-amd64
       ;;
-    3|8.8.3)
+    3)
       MAS_CHANNEL=8.8.x
       MAS_CATALOG_SOURCE=ibm-operator-catalog
       MAS_CATALOG_VERSION=v8-221129-amd64
       ;;
-    4|8.8.2)
+    4)
       MAS_CHANNEL=8.8.x
       MAS_CATALOG_SOURCE=ibm-operator-catalog
       MAS_CATALOG_VERSION=v8-221025-amd64
       ;;
-    5|8.8.1)
+    5)
       MAS_CHANNEL=8.8.x
       MAS_CATALOG_SOURCE=ibm-operator-catalog
       MAS_CATALOG_VERSION=v8-220927-amd64
       ;;
-    6|8.8.0)
+    6)
       MAS_CHANNEL=8.8.x
       MAS_CATALOG_SOURCE=ibm-operator-catalog
       MAS_CATALOG_VERSION=v8-220805-amd64

--- a/image/cli/mascli/functions/mirror_to_registry
+++ b/image/cli/mascli/functions/mirror_to_registry
@@ -257,7 +257,7 @@ function mirror_to_registry_interactive() {
     1|8.8.4)
       MAS_CHANNEL=8.8.x
       MAS_CATALOG_SOURCE=ibm-operator-catalog
-      MAS_CATALOG_VERSION=v8-deccat-amd64
+      MAS_CATALOG_VERSION=v8-221228-amd64
       ;;
     2|8.9.0)
       MAS_CHANNEL=8.9.x

--- a/image/cli/mascli/functions/mirror_to_registry
+++ b/image/cli/mascli/functions/mirror_to_registry
@@ -260,32 +260,32 @@ function mirror_to_registry_interactive() {
       MAS_CATALOG_SOURCE=ibm-operator-catalog
       MAS_CATALOG_VERSION=v8-221228-amd64
       ;;
-    1)
+    2)
       MAS_CHANNEL=8.8.x
       MAS_CATALOG_SOURCE=ibm-operator-catalog
       MAS_CATALOG_VERSION=v8-221228-amd64
       ;;
-    2)
-      MAS_CHANNEL=8.9.x
-      MAS_CATALOG_SOURCE=ibm-operator-catalog
-      MAS_CATALOG_VERSION=v8-221129-amd64
-      ;;
     3)
-      MAS_CHANNEL=8.8.x
+      MAS_CHANNEL=8.9.x
       MAS_CATALOG_SOURCE=ibm-operator-catalog
       MAS_CATALOG_VERSION=v8-221129-amd64
       ;;
     4)
       MAS_CHANNEL=8.8.x
       MAS_CATALOG_SOURCE=ibm-operator-catalog
-      MAS_CATALOG_VERSION=v8-221025-amd64
+      MAS_CATALOG_VERSION=v8-221129-amd64
       ;;
     5)
       MAS_CHANNEL=8.8.x
       MAS_CATALOG_SOURCE=ibm-operator-catalog
-      MAS_CATALOG_VERSION=v8-220927-amd64
+      MAS_CATALOG_VERSION=v8-221025-amd64
       ;;
     6)
+      MAS_CHANNEL=8.8.x
+      MAS_CATALOG_SOURCE=ibm-operator-catalog
+      MAS_CATALOG_VERSION=v8-220927-amd64
+      ;;
+    7)
       MAS_CHANNEL=8.8.x
       MAS_CATALOG_SOURCE=ibm-operator-catalog
       MAS_CATALOG_VERSION=v8-220805-amd64

--- a/image/cli/mascli/functions/utils
+++ b/image/cli/mascli/functions/utils
@@ -181,7 +181,7 @@ function update_ansible_collections() {
     else
       echo
       echo_h2 "Updating ansible collections from Galaxy"
-      ansible-galaxy collection install ibm.mas_devops-12.4.0-pre.deccat --force || exit 1
+      ansible-galaxy collection install ibm.mas_devops --force || exit 1
     fi
   fi
 }


### PR DESCRIPTION
the version for december catalog was v8-deccat-amd64 instead of v8-221228-amd64. This was failing the mirroring because it does not match the file in the ansible-devops