### PR TITLE
[patch] Use "IfNotPresent" imagePullPolicy

### DIFF
--- a/image/cli/mascli/functions/pipeline_prepare
+++ b/image/cli/mascli/functions/pipeline_prepare
@@ -69,7 +69,7 @@ function pipeline_prepare() {
   echo ""
   echo -en "\033[s" # Save cursor position
   echo -n "Testing availability of $CLI_IMAGE in cluster ..."
-  EXISTING_DEPLOYMENT_IMAGE=$(oc -n default get deployment mas-cli2 -o jsonpath='{.spec.template.spec.containers[0].image}' 2>/dev/null)
+  EXISTING_DEPLOYMENT_IMAGE=$(oc -n mas-$MAS_INSTANCE_ID-pipelines get deployment mas-cli -o jsonpath='{.spec.template.spec.containers[0].image}' 2>/dev/null)
 
   if [[ "$EXISTING_DEPLOYMENT_IMAGE" != "CLI_IMAGE" ]]
   then oc -n mas-$MAS_INSTANCE_ID-pipelines apply -f $CONFIG_DIR/deployment-$MAS_INSTANCE_ID.yaml &>> $LOGFILE

--- a/image/cli/mascli/templates/deployment.yaml
+++ b/image/cli/mascli/templates/deployment.yaml
@@ -18,7 +18,7 @@ spec:
     spec:
       containers:
       - name: mas-cli
-        imagePullPolicy: Always
+        imagePullPolicy: IfNotPresent
         image: quay.io/ibmmas/cli:latest
         command: [ "/bin/bash", "-c", "--" ]
         args: [ "while true; do sleep 30; done;" ]

--- a/tekton/tasks/appconnect.yaml
+++ b/tekton/tasks/appconnect.yaml
@@ -91,7 +91,7 @@ spec:
         - /opt/app-root/src/run-role.sh
         - appconnect
       image: quay.io/ibmmas/cli:$(params.cli_version)
-      imagePullPolicy: Always
+      imagePullPolicy: IfNotPresent
       workingDir: /workspace/configs
 
   workspaces:

--- a/tekton/tasks/cert-manager.yaml
+++ b/tekton/tasks/cert-manager.yaml
@@ -54,5 +54,5 @@ spec:
         - /opt/app-root/src/run-role.sh
         - cert_manager
       image: quay.io/ibmmas/cli:$(params.cli_version)
-      imagePullPolicy: Always
+      imagePullPolicy: IfNotPresent
       workingDir: /workspace/configs

--- a/tekton/tasks/cluster-monitoring.yaml
+++ b/tekton/tasks/cluster-monitoring.yaml
@@ -99,5 +99,5 @@ spec:
         - /opt/app-root/src/run-role.sh
         - cluster_monitoring
       image: quay.io/ibmmas/cli:$(params.cli_version)
-      imagePullPolicy: Always
+      imagePullPolicy: IfNotPresent
       workingDir: /workspace/configs

--- a/tekton/tasks/common-services.yaml
+++ b/tekton/tasks/common-services.yaml
@@ -53,5 +53,5 @@ spec:
         - /opt/app-root/src/run-role.sh
         - common_services
       image: quay.io/ibmmas/cli:$(params.cli_version)
-      imagePullPolicy: Always
+      imagePullPolicy: IfNotPresent
       workingDir: /workspace/configs

--- a/tekton/tasks/cos.yaml
+++ b/tekton/tasks/cos.yaml
@@ -70,7 +70,7 @@ spec:
         - /opt/app-root/src/run-role.sh
         - cos
       image: quay.io/ibmmas/cli:$(params.cli_version)
-      imagePullPolicy: Always
+      imagePullPolicy: IfNotPresent
       workingDir: /workspace/configs
 
   workspaces:

--- a/tekton/tasks/cp4d.yaml
+++ b/tekton/tasks/cp4d.yaml
@@ -95,4 +95,4 @@ spec:
         - /opt/app-root/src/run-role.sh
         - cp4d
       image: quay.io/ibmmas/cli:$(params.cli_version)
-      imagePullPolicy: Always
+      imagePullPolicy: IfNotPresent

--- a/tekton/tasks/cp4d_service.yaml
+++ b/tekton/tasks/cp4d_service.yaml
@@ -98,7 +98,7 @@ spec:
         - /opt/app-root/src/run-role.sh
         - cp4d_service
       image: quay.io/ibmmas/cli:$(params.cli_version)
-      imagePullPolicy: Always
+      imagePullPolicy: IfNotPresent
       workingDir: /workspace/configs
 
   workspaces:

--- a/tekton/tasks/db2.yaml
+++ b/tekton/tasks/db2.yaml
@@ -207,7 +207,7 @@ spec:
         - /opt/app-root/src/run-role.sh
         - db2
       image: quay.io/ibmmas/cli:$(params.cli_version)
-      imagePullPolicy: Always
+      imagePullPolicy: IfNotPresent
       workingDir: /workspace/configs
 
   workspaces:

--- a/tekton/tasks/fvt-assist-desktop.yaml
+++ b/tekton/tasks/fvt-assist-desktop.yaml
@@ -122,168 +122,168 @@ spec:
   steps:
     - name: admin-roles
       image: '$(params.fvt_image_registry)/fvt-assist/fvt-assist-testng:$(params.fvt_image_version)'
-      imagePullPolicy: Always
+      imagePullPolicy: IfNotPresent
       timeout: 90m # Ensure bad FVTs don't run forever
       onError: continue # Ensure bad FVTs don't break the pipeline
       command: [ "FVT_TEST_SUITE=testng-desktop-admin-roles", "/bin/bash", "runner.sh" ]
 
     - name: admin-apikeys
       image: '$(params.fvt_image_registry)/fvt-assist/fvt-assist-testng:$(params.fvt_image_version)'
-      imagePullPolicy: Always
+      imagePullPolicy: IfNotPresent
       timeout: 90m # Ensure bad FVTs don't run forever
       onError: continue # Ensure bad FVTs don't break the pipeline
       command: [ "FVT_TEST_SUITE=testng-desktop-admin-apikeys", "/bin/bash", "runner.sh" ]
 
     - name: admin-field
       image: '$(params.fvt_image_registry)/fvt-assist/fvt-assist-testng:$(params.fvt_image_version)'
-      imagePullPolicy: Always
+      imagePullPolicy: IfNotPresent
       timeout: 90m # Ensure bad FVTs don't run forever
       onError: continue # Ensure bad FVTs don't break the pipeline
       command: [ "FVT_TEST_SUITE=testng-desktop-admin-field", "/bin/bash", "runner.sh" ]
 
     - name: admin-expertise
       image: '$(params.fvt_image_registry)/fvt-assist/fvt-assist-testng:$(params.fvt_image_version)'
-      imagePullPolicy: Always
+      imagePullPolicy: IfNotPresent
       timeout: 90m # Ensure bad FVTs don't run forever
       onError: continue # Ensure bad FVTs don't break the pipeline
       command: [ "FVT_TEST_SUITE=testng-desktop-admin-expertise", "/bin/bash", "runner.sh" ]
 
     - name: admin-collaboration
       image: '$(params.fvt_image_registry)/fvt-assist/fvt-assist-testng:$(params.fvt_image_version)'
-      imagePullPolicy: Always
+      imagePullPolicy: IfNotPresent
       timeout: 90m # Ensure bad FVTs don't run forever
       onError: continue # Ensure bad FVTs don't break the pipeline
       command: [ "FVT_TEST_SUITE=testng-desktop-admin-collaboration", "/bin/bash", "runner.sh" ]
 
     - name: admin-ice
       image: '$(params.fvt_image_registry)/fvt-assist/fvt-assist-testng:$(params.fvt_image_version)'
-      imagePullPolicy: Always
+      imagePullPolicy: IfNotPresent
       timeout: 90m # Ensure bad FVTs don't run forever
       onError: continue # Ensure bad FVTs don't break the pipeline
       command: [ "FVT_TEST_SUITE=testng-desktop-admin-ice", "/bin/bash", "runner.sh" ]
 
     - name: admin-search-config
       image: '$(params.fvt_image_registry)/fvt-assist/fvt-assist-testng:$(params.fvt_image_version)'
-      imagePullPolicy: Always
+      imagePullPolicy: IfNotPresent
       timeout: 90m # Ensure bad FVTs don't run forever
       onError: continue # Ensure bad FVTs don't break the pipeline
       command: [ "FVT_TEST_SUITE=testng-desktop-admin-search-config", "/bin/bash", "runner.sh" ]
 
     - name: admin-sessions
       image: '$(params.fvt_image_registry)/fvt-assist/fvt-assist-testng:$(params.fvt_image_version)'
-      imagePullPolicy: Always
+      imagePullPolicy: IfNotPresent
       timeout: 90m # Ensure bad FVTs don't run forever
       onError: continue # Ensure bad FVTs don't break the pipeline
       command: [ "FVT_TEST_SUITE=testng-desktop-admin-sessions", "/bin/bash", "runner.sh" ]
 
     - name: admin-users
       image: '$(params.fvt_image_registry)/fvt-assist/fvt-assist-testng:$(params.fvt_image_version)'
-      imagePullPolicy: Always
+      imagePullPolicy: IfNotPresent
       timeout: 90m # Ensure bad FVTs don't run forever
       onError: continue # Ensure bad FVTs don't break the pipeline
       command: [ "FVT_TEST_SUITE=testng-desktop-admin-users", "/bin/bash", "runner.sh" ]
 
     - name: diagnosis-element-relation
       image: '$(params.fvt_image_registry)/fvt-assist/fvt-assist-testng:$(params.fvt_image_version)'
-      imagePullPolicy: Always
+      imagePullPolicy: IfNotPresent
       timeout: 90m # Ensure bad FVTs don't run forever
       onError: continue # Ensure bad FVTs don't break the pipeline
       command: [ "FVT_TEST_SUITE=testng-desktop-diagnosis-element-relation", "/bin/bash", "runner.sh" ]
 
     - name: diagnosis-flow
       image: '$(params.fvt_image_registry)/fvt-assist/fvt-assist-testng:$(params.fvt_image_version)'
-      imagePullPolicy: Always
+      imagePullPolicy: IfNotPresent
       timeout: 90m # Ensure bad FVTs don't run forever
       onError: continue # Ensure bad FVTs don't break the pipeline
       command: [ "FVT_TEST_SUITE=testng-desktop-diagnosis-flow", "/bin/bash", "runner.sh" ]
 
     - name: diagnosis-library-feedback
       image: '$(params.fvt_image_registry)/fvt-assist/fvt-assist-testng:$(params.fvt_image_version)'
-      imagePullPolicy: Always
+      imagePullPolicy: IfNotPresent
       timeout: 90m # Ensure bad FVTs don't run forever
       onError: continue # Ensure bad FVTs don't break the pipeline
       command: [ "FVT_TEST_SUITE=testng-desktop-diagnosis-library-feedback", "/bin/bash", "runner.sh" ]
 
     - name: diagnosis-library-historicaldata
       image: '$(params.fvt_image_registry)/fvt-assist/fvt-assist-testng:$(params.fvt_image_version)'
-      imagePullPolicy: Always
+      imagePullPolicy: IfNotPresent
       timeout: 90m # Ensure bad FVTs don't run forever
       onError: continue # Ensure bad FVTs don't break the pipeline
       command: [ "FVT_TEST_SUITE=testng-desktop-diagnosis-library-historicaldata", "/bin/bash", "runner.sh" ]
 
     - name: technician-diagnosis
       image: '$(params.fvt_image_registry)/fvt-assist/fvt-assist-testng:$(params.fvt_image_version)'
-      imagePullPolicy: Always
+      imagePullPolicy: IfNotPresent
       timeout: 90m # Ensure bad FVTs don't run forever
       onError: continue # Ensure bad FVTs don't break the pipeline
       command: [ "FVT_TEST_SUITE=testng-desktop-technician-diagnosis", "/bin/bash", "runner.sh" ]
 
     - name: query-docpreview
       image: '$(params.fvt_image_registry)/fvt-assist/fvt-assist-testng:$(params.fvt_image_version)'
-      imagePullPolicy: Always
+      imagePullPolicy: IfNotPresent
       timeout: 90m # Ensure bad FVTs don't run forever
       onError: continue # Ensure bad FVTs don't break the pipeline
       command: [ "FVT_TEST_SUITE=testng-desktop-query-docpreview", "/bin/bash", "runner.sh" ]
 
     - name: query-maximo-integration
       image: '$(params.fvt_image_registry)/fvt-assist/fvt-assist-testng:$(params.fvt_image_version)'
-      imagePullPolicy: Always
+      imagePullPolicy: IfNotPresent
       timeout: 90m # Ensure bad FVTs don't run forever
       onError: continue # Ensure bad FVTs don't break the pipeline
       command: [ "FVT_TEST_SUITE=testng-desktop-query-maximo-integration", "/bin/bash", "runner.sh" ]
 
     - name: query-resultcard
       image: '$(params.fvt_image_registry)/fvt-assist/fvt-assist-testng:$(params.fvt_image_version)'
-      imagePullPolicy: Always
+      imagePullPolicy: IfNotPresent
       timeout: 90m # Ensure bad FVTs don't run forever
       onError: continue # Ensure bad FVTs don't break the pipeline
       command: [ "FVT_TEST_SUITE=testng-desktop-query-resultcard", "/bin/bash", "runner.sh" ]
 
     - name: query-search
       image: '$(params.fvt_image_registry)/fvt-assist/fvt-assist-testng:$(params.fvt_image_version)'
-      imagePullPolicy: Always
+      imagePullPolicy: IfNotPresent
       timeout: 90m # Ensure bad FVTs don't run forever
       onError: continue # Ensure bad FVTs don't break the pipeline
       command: [ "FVT_TEST_SUITE=testng-desktop-query-search", "/bin/bash", "runner.sh" ]
 
     - name: query-searchconfig
       image: '$(params.fvt_image_registry)/fvt-assist/fvt-assist-testng:$(params.fvt_image_version)'
-      imagePullPolicy: Always
+      imagePullPolicy: IfNotPresent
       timeout: 90m # Ensure bad FVTs don't run forever
       onError: continue # Ensure bad FVTs don't break the pipeline
       command: [ "FVT_TEST_SUITE=testng-desktop-query-searchconfig", "/bin/bash", "runner.sh" ]
 
     - name: technician-collaborate
       image: '$(params.fvt_image_registry)/fvt-assist/fvt-assist-testng:$(params.fvt_image_version)'
-      imagePullPolicy: Always
+      imagePullPolicy: IfNotPresent
       timeout: 90m # Ensure bad FVTs don't run forever
       onError: continue # Ensure bad FVTs don't break the pipeline
       command: [ "FVT_TEST_SUITE=testng-desktop-technician-collaborate", "/bin/bash", "runner.sh" ]
 
     - name: admin-attribute
       image: '$(params.fvt_image_registry)/fvt-assist/fvt-assist-testng:$(params.fvt_image_version)'
-      imagePullPolicy: Always
+      imagePullPolicy: IfNotPresent
       timeout: 90m # Ensure bad FVTs don't run forever
       onError: continue # Ensure bad FVTs don't break the pipeline
       command: [ "FVT_TEST_SUITE=testng-desktop-admin-attribute", "/bin/bash", "runner.sh" ]
 
     - name: admin-token-refresh-studio
       image: '$(params.fvt_image_registry)/fvt-assist/fvt-assist-testng:$(params.fvt_image_version)'
-      imagePullPolicy: Always
+      imagePullPolicy: IfNotPresent
       timeout: 90m # Ensure bad FVTs don't run forever
       onError: continue # Ensure bad FVTs don't break the pipeline
       command: [ "FVT_TEST_SUITE=testng-desktop-admin-token-refresh-studio", "/bin/bash", "runner.sh" ]
 
     - name: admin-token-refresh-adminconsole
       image: '$(params.fvt_image_registry)/fvt-assist/fvt-assist-testng:$(params.fvt_image_version)'
-      imagePullPolicy: Always
+      imagePullPolicy: IfNotPresent
       timeout: 90m # Ensure bad FVTs don't run forever
       onError: continue # Ensure bad FVTs don't break the pipeline
       command: [ "FVT_TEST_SUITE=testng-desktop-admin-token-refresh-adminconsole", "/bin/bash", "runner.sh" ]
 
     - name: admin-token-refresh-technician
       image: '$(params.fvt_image_registry)/fvt-assist/fvt-assist-testng:$(params.fvt_image_version)'
-      imagePullPolicy: Always
+      imagePullPolicy: IfNotPresent
       timeout: 90m # Ensure bad FVTs don't run forever
       onError: continue # Ensure bad FVTs don't break the pipeline
       command: [ "FVT_TEST_SUITE=testng-desktop-admin-token-refresh-technician", "/bin/bash", "runner.sh" ]

--- a/tekton/tasks/fvt-assist.yaml
+++ b/tekton/tasks/fvt-assist.yaml
@@ -116,7 +116,7 @@ spec:
         value: $(params.ctf_is_local)
   steps:
     - image: '$(params.fvt_image_registry)/fvt-assist/$(params.fvt_image_name):$(params.fvt_image_version)'
-      imagePullPolicy: Always
+      imagePullPolicy: IfNotPresent
       timeout: 300m # Ensure bad FVTs don't run forever
       onError: continue # Ensure bad FVTs don't break the pipeline
       resources: {}

--- a/tekton/tasks/fvt-core.yaml
+++ b/tekton/tasks/fvt-core.yaml
@@ -103,7 +103,7 @@ spec:
         value: $(params.partium_password)
   steps:
     - image: '$(params.fvt_image_registry)/mas-devops/fvt-ibm-mas:$(params.fvt_image_version)'
-      imagePullPolicy: Always
+      imagePullPolicy: IfNotPresent
       timeout: 90m # Ensure bad FVTs don't run forever
       onError: continue # Ensure bad FVTs don't break the pipeline
       resources: {}

--- a/tekton/tasks/fvt-run-suite.yaml
+++ b/tekton/tasks/fvt-run-suite.yaml
@@ -208,7 +208,7 @@ spec:
         value: $(params.ctf_is_local)
   steps:
     - image: '$(params.fvt_image_registry)/$(params.fvt_image_namespace)/$(params.fvt_image_name):$(params.fvt_image_version)'
-      imagePullPolicy: Always
+      imagePullPolicy: IfNotPresent
       timeout: 6h # Ensure bad FVTs don't run forever .. want this to be smaller, but urgh, teams have already created huge suites that run for hours instead of multiple smaller suites
       onError: continue # Ensure bad FVTs don't break the pipeline
       resources: {}

--- a/tekton/tasks/gencfg-workspace.yaml
+++ b/tekton/tasks/gencfg-workspace.yaml
@@ -60,7 +60,7 @@ spec:
         - /opt/app-root/src/run-role.sh
         - gencfg_workspace
       image: quay.io/ibmmas/cli:$(params.cli_version)
-      imagePullPolicy: Always
+      imagePullPolicy: IfNotPresent
       workingDir: /workspace/configs
 
   workspaces:

--- a/tekton/tasks/ibm-catalogs.yaml
+++ b/tekton/tasks/ibm-catalogs.yaml
@@ -68,5 +68,5 @@ spec:
         - /opt/app-root/src/run-role.sh
         - ibm_catalogs
       image: quay.io/ibmmas/cli:$(params.cli_version)
-      imagePullPolicy: Always
+      imagePullPolicy: IfNotPresent
       workingDir: /workspace/configs

--- a/tekton/tasks/kafka.yaml
+++ b/tekton/tasks/kafka.yaml
@@ -78,7 +78,7 @@ spec:
         - /opt/app-root/src/run-role.sh
         - kafka
       image: quay.io/ibmmas/cli:$(params.cli_version)
-      imagePullPolicy: Always
+      imagePullPolicy: IfNotPresent
       workingDir: /workspace/configs
 
   workspaces:

--- a/tekton/tasks/mongodb.yaml
+++ b/tekton/tasks/mongodb.yaml
@@ -76,7 +76,7 @@ spec:
         - /opt/app-root/src/run-role.sh
         - mongodb
       image: quay.io/ibmmas/cli:$(params.cli_version)
-      imagePullPolicy: Always
+      imagePullPolicy: IfNotPresent
       workingDir: /workspace/configs
 
   workspaces:

--- a/tekton/tasks/nvidia-gpu.yaml
+++ b/tekton/tasks/nvidia-gpu.yaml
@@ -73,7 +73,7 @@ spec:
         - /opt/app-root/src/run-role.sh
         - nvidia_gpu
       image: quay.io/ibmmas/cli:$(params.cli_version)
-      imagePullPolicy: Always
+      imagePullPolicy: IfNotPresent
       workingDir: /workspace/configs
 
   workspaces:

--- a/tekton/tasks/sbo.yaml
+++ b/tekton/tasks/sbo.yaml
@@ -53,5 +53,5 @@ spec:
         - /opt/app-root/src/run-role.sh
         - sbo
       image: quay.io/ibmmas/cli:$(params.cli_version)
-      imagePullPolicy: Always
+      imagePullPolicy: IfNotPresent
       workingDir: /workspace/configs

--- a/tekton/tasks/sls.yaml
+++ b/tekton/tasks/sls.yaml
@@ -116,7 +116,7 @@ spec:
         - /opt/app-root/src/run-role.sh
         - sls
       image: quay.io/ibmmas/cli:$(params.cli_version)
-      imagePullPolicy: Always
+      imagePullPolicy: IfNotPresent
       workingDir: /workspace/configs
 
   workspaces:

--- a/tekton/tasks/suite-app-config.yaml
+++ b/tekton/tasks/suite-app-config.yaml
@@ -126,7 +126,7 @@ spec:
         - /opt/app-root/src/run-role.sh
         - suite_app_config
       image: quay.io/ibmmas/cli:$(params.cli_version)
-      imagePullPolicy: Always
+      imagePullPolicy: IfNotPresent
 
   workspaces:
     - name: configs

--- a/tekton/tasks/suite-app-install.yaml
+++ b/tekton/tasks/suite-app-install.yaml
@@ -118,4 +118,4 @@ spec:
         - /opt/app-root/src/run-role.sh
         - suite_app_install
       image: quay.io/ibmmas/cli:$(params.cli_version)
-      imagePullPolicy: Always
+      imagePullPolicy: IfNotPresent

--- a/tekton/tasks/suite-app-upgrade.yaml
+++ b/tekton/tasks/suite-app-upgrade.yaml
@@ -33,4 +33,4 @@ spec:
         - /opt/app-root/src/run-role.sh
         - suite_app_upgrade
       image: quay.io/ibmmas/cli:$(params.cli_version)
-      imagePullPolicy: Always
+      imagePullPolicy: IfNotPresent

--- a/tekton/tasks/suite-config.yaml
+++ b/tekton/tasks/suite-config.yaml
@@ -50,7 +50,7 @@ spec:
         - /opt/app-root/src/run-role.sh
         - suite_config
       image: quay.io/ibmmas/cli:$(params.cli_version)
-      imagePullPolicy: Always
+      imagePullPolicy: IfNotPresent
       workingDir: /workspace/configs
 
   workspaces:

--- a/tekton/tasks/suite-db2-setup-for-manage.yaml
+++ b/tekton/tasks/suite-db2-setup-for-manage.yaml
@@ -60,4 +60,4 @@ spec:
         - /opt/app-root/src/run-role.sh
         - suite_db2_setup_for_manage
       image: quay.io/ibmmas/cli:$(params.cli_version)
-      imagePullPolicy: Always
+      imagePullPolicy: IfNotPresent

--- a/tekton/tasks/suite-dns.yaml
+++ b/tekton/tasks/suite-dns.yaml
@@ -103,4 +103,4 @@ spec:
         - /opt/app-root/src/run-role.sh
         - suite_dns
       image: quay.io/ibmmas/cli:$(params.cli_version)
-      imagePullPolicy: Always
+      imagePullPolicy: IfNotPresent

--- a/tekton/tasks/suite-install.yaml
+++ b/tekton/tasks/suite-install.yaml
@@ -152,7 +152,7 @@ spec:
         - /opt/app-root/src/run-role.sh
         - suite_install
       image: quay.io/ibmmas/cli:$(params.cli_version)
-      imagePullPolicy: Always
+      imagePullPolicy: IfNotPresent
       workingDir: /workspace/configs
 
   workspaces:

--- a/tekton/tasks/suite-mustgather.yaml
+++ b/tekton/tasks/suite-mustgather.yaml
@@ -28,14 +28,14 @@ spec:
       command:
         - /opt/app-root/src/clear-mustgather-workspace.sh
       image: quay.io/ibmmas/cli:$(params.cli_version)
-      imagePullPolicy: Always
+      imagePullPolicy: IfNotPresent
       workingDir: /workspace/mustgather
     - name: suite-mustgather
       command:
         - /opt/app-root/src/run-role.sh
         - suite_mustgather
       image: quay.io/ibmmas/cli:$(params.cli_version)
-      imagePullPolicy: Always
+      imagePullPolicy: IfNotPresent
       workingDir: /workspace/mustgather
 
   workspaces:

--- a/tekton/tasks/suite-upgrade.yaml
+++ b/tekton/tasks/suite-upgrade.yaml
@@ -28,4 +28,4 @@ spec:
         - /opt/app-root/src/run-role.sh
         - suite_upgrade
       image: quay.io/ibmmas/cli:$(params.cli_version)
-      imagePullPolicy: Always
+      imagePullPolicy: IfNotPresent

--- a/tekton/tasks/suite-verify.yaml
+++ b/tekton/tasks/suite-verify.yaml
@@ -47,4 +47,4 @@ spec:
         - /opt/app-root/src/run-role.sh
         - suite_verify
       image: quay.io/ibmmas/cli:$(params.cli_version)
-      imagePullPolicy: Always
+      imagePullPolicy: IfNotPresent

--- a/tekton/tasks/uds.yaml
+++ b/tekton/tasks/uds.yaml
@@ -83,7 +83,7 @@ spec:
         - /opt/app-root/src/run-role.sh
         - uds
       image: quay.io/ibmmas/cli:$(params.cli_version)
-      imagePullPolicy: Always
+      imagePullPolicy: IfNotPresent
       workingDir: /workspace/configs
 
   workspaces:


### PR DESCRIPTION
`Always` is a suitable `imagePullPolicy` for development, but there's no reason to ship Tekton tasks with the policy set to this value, this update chages the pull policy to `IfNotPresent` which saves unnecessary image pulls/digest comparisons needing to be performed by kubelet.