### PR TITLE
[patch] Fix support for custom storage classes in Kafka

### DIFF
--- a/tekton/pipeline-templates/taskdefs/dependencies/kafka.yml.j2
+++ b/tekton/pipeline-templates/taskdefs/dependencies/kafka.yml.j2
@@ -14,6 +14,8 @@
       value: "$(params.kafka_user_name)"
     - name: kafka_storage_class
       value: $(params.storage_class_rwo)
+    - name: zookeeper_storage_class
+      value: $(params.storage_class_rwo)
   # Only install Kafka if the IoT application is being installed
   when:
     - input: "$(params.mas_app_channel_iot)"

--- a/tekton/tasks/kafka.yaml
+++ b/tekton/tasks/kafka.yaml
@@ -29,6 +29,9 @@ spec:
     - name: kafka_storage_class
       type: string
       default: ""
+    - name: zookeeper_storage_class
+      type: string
+      default: ""
 
     # Optional support built into the ansible-devops image
     # for saving task execution results to a MongoDb instance
@@ -62,6 +65,8 @@ spec:
         value: $(params.kafka_user_name)
       - name: KAFKA_STORAGE_CLASS
         value: $(params.kafka_storage_class)
+      - name: ZOOKEEPER_STORAGE_CLASS
+        value: $(params.zookeeper_storage_class)
 
       # Optional support built into the ansible-devops image
       # for saving task execution results to a MongoDb instance


### PR DESCRIPTION
Only the main Kafka storage class was being set, leaving zookeeper_storage_class undefined & reliant on the built-in default supported storage classes list, this meant that in an install with storage classes other than those in the known list we can not complete the install via the pipeline.