### PR TITLE
[patch] Generate additional debug for RBAC

### DIFF
--- a/image/cli/app-root/run-playbook.sh
+++ b/image/cli/app-root/run-playbook.sh
@@ -8,7 +8,11 @@ if [ -e "/workspace/entitlement/entitlement.lic" ]; then
   cp /workspace/entitlement/entitlement.lic /workspace/configs/entitlement.lic
 fi
 
+# Debug
 source /opt/app-root/src/env.sh
+oc whoami
+oc auth can-i --list
+
 ansible-playbook "$@"
 rc=$?
 python3 /opt/app-root/src/save-junit-to-mongo.py

--- a/image/cli/app-root/run-role.sh
+++ b/image/cli/app-root/run-role.sh
@@ -4,7 +4,11 @@ if [ -e "/workspace/additional-configs" ]; then
   cp /workspace/additional-configs/* /workspace/configs/
 fi
 
+# Debug
 source /opt/app-root/src/env.sh
+oc whoami
+oc auth can-i --list
+
 export ROLE_NAME=$1
 ansible-playbook ibm.mas_devops.run_role
 rc=$?


### PR DESCRIPTION
Additional debug will be generated when the `run-playbook.sh` and `run-role.sh` scripts are used, this is intended to aid debugging permissions issues seen when running pipelines in OCP 4.10.40 with Pipelines 1.8.2.