### PR TITLE
[patch] Update internal "latest" tekton file when GITHUB_REF_TYPE=tag

### DIFF
--- a/build/bin/artifactory-release.sh
+++ b/build/bin/artifactory-release.sh
@@ -35,8 +35,8 @@ fi
 TARGET_URL="${ARTIFACTORY_GENERIC_RELEASE_URL}/${GITHUB_REPOSITORY}/${VERSION}/${FILE_NAME}-${VERSION}.${FILE_EXT}"
 artifactory_upload $FILE_PATH $TARGET_URL
 
-# This is deliberately only done if the branch==master because we don't want to override artifacts tagged as 'latest' with backlevel releases (eg if we built a new patch of an old release level)
-if [ "${GITHUB_REF_NAME}" == "master" ]; then
+# Update latest when we publish release, and when we update master branch .. latest build is used internally in development
+if [ "${GITHUB_REF_NAME}" == "master" ] || [ "${GITHUB_REF_TYPE}" == "tag" ]; then
   LATEST_URL="${ARTIFACTORY_GENERIC_RELEASE_URL}/${GITHUB_REPOSITORY}/latest/${FILE_NAME}-latest.${FILE_EXT}"
   artifactory_upload $FILE_PATH $LATEST_URL
 fi


### PR DESCRIPTION
Currently after we build a release the `latest` version of the Tekton defintion file used internally in development is left pointing at the most recent pre.master build.  We want the latest version to be updated to point to the released version in this case.  Any future update to master will then set the latest reference back to a newer pre-release once one exists.