### PR TITLE
[patch] Fix January catalog version string

### DIFF
--- a/image/cli/mascli/functions/pipeline_config
+++ b/image/cli/mascli/functions/pipeline_config
@@ -105,11 +105,11 @@ function pipeline_config() {
     case $MAS_CHANNEL_SELECTION in
       1)
         MAS_CHANNEL=8.9.x
-        MAS_CATALOG_VERSION=v8-20230111-amd64
+        MAS_CATALOG_VERSION=v8-230111-amd64
         ;;
       2)
         MAS_CHANNEL=8.8.x
-        MAS_CATALOG_VERSION=v8-20230111-amd64
+        MAS_CATALOG_VERSION=v8-230111-amd64
         ;;
       3)
         MAS_CHANNEL=8.8.x


### PR DESCRIPTION
The CLI incorrectly refers to the Jan catalog as `v8-20230111-amd64` instead of `v8-230111-amd64`

- Fixes https://github.com/ibm-mas/cli/issues/151