### PR TITLE
[patch] Fix Manage install runAfter condition

### DIFF
--- a/tekton/src/pipelines/install-with-fvt.yml.j2
+++ b/tekton/src/pipelines/install-with-fvt.yml.j2
@@ -261,7 +261,7 @@ spec:
     # 9.2 Manage Install
     {{ lookup('template', 'taskdefs/apps/manage-app.yml.j2') | indent(4) }}
       runAfter:
-        - suite-db2-setup-manage
+        - suite-db2-setup-system
         - suite-db2-setup-manage
 
     # 9.3 Configure Manage workspace


### PR DESCRIPTION
This update adjusts the `install-with-fvt` pipeline to correctly set the `runAfter` for the installation of the Manage application, which incorrectly listed `suite-db2-setup-manage` twice, instead of including `suite-db2-setup-system` as a dependency.