### PR TITLE
[patch] Creating a new productID for ibm-mas UI tests

### DIFF
--- a/tekton/src/tasks/fvt/fvt-core-ui.yml.j2
+++ b/tekton/src/tasks/fvt/fvt-core-ui.yml.j2
@@ -83,7 +83,7 @@ spec:
     env:
       # What are we testing?
       - name: PRODUCT_ID
-        value: ibm-mas
+        value: ibm-mas-ui
       - name: PRODUCT_CHANNEL
         value: $(params.product_channel)
       - name: NAMESPACE


### PR DESCRIPTION
ibm-mas tests results are being overwritten by UI tests in mongodb.

We need to give it a different product_id to differentiate it in the database.

For example coreidp-saml test Suite exists on both fvt-ibm-mas and fvt-ibm-mas-ui. So the conflict occurs.