### PR TITLE
[patch] Fix UI test suite conflict error

### DIFF
--- a/tekton/src/pipelines/taskdefs/fvt-core/phase5.yml.j2
+++ b/tekton/src/pipelines/taskdefs/fvt-core/phase5.yml.j2
@@ -36,7 +36,7 @@
   params:
     {{ lookup('template', 'taskdefs/fvt-core/ui/params.yml.j2') | indent(4) }}
     - name: test_suite
-      value: coreidp-saml
+      value: coreidp-saml-ui
     - name: fvt_image_name
       value: fvt-ibm-mas-ui
   runAfter:


### PR DESCRIPTION
This change will prevent the current coreidp-saml test results in mongo to be replaced.
Test Suite names in fvt-ibm-mas must be unique as we are using same product_id