### PR TITLE
[patch] Fix invalid inputs in mas-fvt-core-ui task

### DIFF
--- a/tekton/src/pipelines/taskdefs/fvt-core/phase5.yml.j2
+++ b/tekton/src/pipelines/taskdefs/fvt-core/phase5.yml.j2
@@ -37,8 +37,6 @@
     {{ lookup('template', 'taskdefs/fvt-core/ui/params.yml.j2') | indent(4) }}
     - name: test_suite
       value: coreidp-saml-ui
-    - name: fvt_image_name
-      value: fvt-ibm-mas-ui
   runAfter:
     - fvt-coreidp-saml
 


### PR DESCRIPTION
Fix for `invalid input params for task mas-fvt-core-ui: didn't need these params but they were provided anyway: [fvt_image_name]` introduced in #163