### PR TITLE
[patch] Hide IBM entitlement key entry

### DIFF
--- a/image/cli/mascli/functions/pipeline_config
+++ b/image/cli/mascli/functions/pipeline_config
@@ -181,7 +181,7 @@ function pipeline_config() {
   else
     # Production Mode -- everything comes from the same registry (IBM container registry)
     echo_h2 "9. Configure IBM Container Registry"
-    prompt_for_input "IBM Entitlement Key" IBM_ENTITLEMENT_KEY $IBM_ENTITLEMENT_KEY
+    prompt_for_secret "IBM Entitlement Key" IBM_ENTITLEMENT_KEY "Re-use saved IBM Entitlement Key?"
 
     # Use defaults
     MAS_ICR_CP=cp.icr.io/cp

--- a/image/cli/mascli/functions/provision_roks
+++ b/image/cli/mascli/functions/provision_roks
@@ -98,19 +98,11 @@ function provision_roks_noninteractive() {
 
 function provision_roks_interactive() {
 
-  if [[ -z "$IBMCLOUD_APIKEY" ]]; then
-    echo ""
-    echo_h2 "IBM Cloud API Key"
-    echo "Provide your IBMCloud API key (if you have not set the IBMCLOUD_APIKEY"
-    echo "environment variable) which will be used to provision a ROKS instance."
-    echo ""
-    prompt_for_input "IBM Cloud API Key" IBMCLOUD_APIKEY && export IBMCLOUD_APIKEY
-  else
-    prompt_for_confirm_default_yes "Re-use saved IBMCloud API Key Starting '${IBMCLOUD_APIKEY:0:8}'?" REUSE_IBMCLOUD_AUTH
-    if [[ "$REUSE_IBMCLOUD_AUTH" == "false" ]]; then
-      prompt_for_input "IBM Cloud API Key" IBMCLOUD_APIKEY && export IBMCLOUD_APIKEY
-    fi
-  fi
+  echo_h2 "IBM Cloud API Key"
+  echo "Provide your IBM Cloud API key (if you have not set the IBMCLOUD_APIKEY"
+  echo "environment variable) which will be used to provision a ROKS instance."
+  echo ""
+  prompt_for_secret "IBM Cloud API Key" IBMCLOUD_APIKEY "Re-use saved IBM Cloud API Key?" && export IBMCLOUD_APIKEY
 
   echo ""
   echo_h2 "IBM Cloud ROKS Cluster Configuration"

--- a/image/cli/mascli/functions/utils
+++ b/image/cli/mascli/functions/utils
@@ -49,7 +49,7 @@ function echo_hr2() {
 # Prompt for confirmation to continue
 # -----------------------------------------------------------------------------
 confirm() {
-  read -r -p "${1:-Proceed? [y/N]} " response
+  read -r -p "${COLOR_YELLOW}${1:-Proceed? [y/N]} ${COLOR_MAGENTA}" response
   case "$response" in
     [yY][eE][sS]|[yY])
       export ALREADY_CONFIRMED="true"
@@ -65,7 +65,7 @@ confirm() {
 }
 
 confirm_default_yes() {
-  read -r -p "${1:-Proceed? [Y/n]} " response
+  read -r -p "${COLOR_YELLOW}${1:-Proceed? [Y/n]} ${COLOR_MAGENTA}" response
   case "$response" in
     [yY][eE][sS]|[yY])
       export ALREADY_CONFIRMED="true"
@@ -111,6 +111,31 @@ function prompt_for_number(){
   done
   printf -v "$varname" "%s" "$input"
 }
+
+function prompt_for_secret(){
+  msg=$1
+  varname=$2
+  # When override is set, the default provided in $3 will override the saved default
+  reuse_msg=$3
+
+  # Use the saved default
+  default=${!varname}
+
+  if [[ "${default}" != "" ]]; then
+    if ! confirm_default_yes "$reuse_msg [Y/n]"; then
+      input=$(/bin/systemd-ask-password -n --echo=masked --emoji=no "${COLOR_YELLOW}$msg ${COLOR_MAGENTA}> ")
+      echo -ne "${COLOR_RESET}\033[1K"
+      # https://stackoverflow.com/a/13717788
+      printf -v "$varname" "%s" "$input"
+    fi
+  else
+    input=$(/bin/systemd-ask-password -n --echo=masked --emoji=no "${COLOR_YELLOW}$msg ${COLOR_MAGENTA}> ")
+    echo -ne "${COLOR_RESET}\033[1K"
+    # https://stackoverflow.com/a/13717788
+    printf -v "$varname" "%s" "$input"
+  fi
+}
+
 
 function prompt_for_input(){
   msg=$1

--- a/image/cli/mascli/mas
+++ b/image/cli/mascli/mas
@@ -10,6 +10,9 @@ function trap_exit {
   save_config
 }
 function trap_int {
+  # Reset any modifications made to the terminal
+  tset
+
   echo
   echo
   save_config


### PR DESCRIPTION
Add new function `prompt_for_secret()` that uses `systemd-ask-password` to prompt for a secret information and will provide masked output so that the users' IBM Entitlement Key is not exposed on screen.

Enter the entitlement key, output is masked with asterisks
![image](https://user-images.githubusercontent.com/4400618/218474783-e033aa24-7ed7-4a0d-9950-83a19657608e.png)

Or re-use the key you entered previously (or from environment variable)
![image](https://user-images.githubusercontent.com/4400618/218474837-da83ff43-c65d-4779-b3d0-538581fe00d0.png)
