### PR TITLE
[patch] Remove unsupported systemd-ask-password params

### DIFF
--- a/image/cli/mascli/functions/utils
+++ b/image/cli/mascli/functions/utils
@@ -123,13 +123,13 @@ function prompt_for_secret(){
 
   if [[ "${default}" != "" && "${reuse_msg}" != "" ]]; then
     if ! confirm_default_yes "$reuse_msg [Y/n]"; then
-      input=$(/bin/systemd-ask-password -n --echo=masked --emoji=no "${COLOR_YELLOW}$msg ${COLOR_MAGENTA}> ")
+      input=$(/bin/systemd-ask-password "${COLOR_YELLOW}$msg ${COLOR_MAGENTA}> ")
       echo -ne "${COLOR_RESET}\033[1K"
       # https://stackoverflow.com/a/13717788
       printf -v "$varname" "%s" "$input"
     fi
   else
-    input=$(/bin/systemd-ask-password -n --echo=masked --emoji=no "${COLOR_YELLOW}$msg ${COLOR_MAGENTA}> ")
+    input=$(/bin/systemd-ask-password "${COLOR_YELLOW}$msg ${COLOR_MAGENTA}> ")
     echo -ne "${COLOR_RESET}\033[1K"
     # https://stackoverflow.com/a/13717788
     printf -v "$varname" "%s" "$input"


### PR DESCRIPTION
The version of systemd-ask-password included in the base image does not support the params used in local development (`-n --echo=masked --emoji=no`)