### PR TITLE
[patch] Fix catalog selections in update prompt

### DIFF
--- a/image/cli/mascli/functions/update
+++ b/image/cli/mascli/functions/update
@@ -55,23 +55,31 @@ function update_interactive() {
   echo_h2 "Select IBM Maximo Operator Catalog Version"
 
   echo -e "${COLOR_YELLOW}MAS Catalog:"
-  echo "  1. v8 (2022-11-29)"
-  echo "  2. v8 (2022-10-25)"
-  echo "  3. v8 (2022-09-27)"
-  echo "  4. v8 (2022-08-05)"
+  echo "  1. v8 (2023-01-11)"
+  echo "  2. v8 (2022-12-28)"
+  echo "  3. v8 (2022-11-29)"
+  echo "  4. v8 (2022-10-25)"
+  echo "  5. v8 (2022-09-27)"
+  echo "  6. v8 (2022-08-05)"
   prompt_for_input "Select Catalog Version" MAS_CATALOG_SELECTION "1"
 
   case $MAS_CATALOG_SELECTION in
-    1|221129|2022-11-29)
+    1|230111|2023-01-11)
+      MAS_CATALOG_VERSION=v8-230111-amd64
+      ;;
+    2|221228|2022-12-28)
+      MAS_CATALOG_VERSION=v8-221228-amd64
+      ;;
+    3|221129|2022-11-29)
       MAS_CATALOG_VERSION=v8-221129-amd64
       ;;
-    2|221025|2022-10-25)
+    4|221025|2022-10-25)
       MAS_CATALOG_VERSION=v8-221025-amd64
       ;;
-    3|220927|2022-09-27)
+    5|220927|2022-09-27)
       MAS_CATALOG_VERSION=v8-220927-amd64
       ;;
-    4|220805|2022-08-05)
+    6|220805|2022-08-05)
       MAS_CATALOG_VERSION=v8-220805-amd64
       ;;
     *)


### PR DESCRIPTION
The December and January catalog versions were missing as options in the interactive prompts for `mas update` command.