### PR TITLE
[patch] Add missing update pipeline definition

### DIFF
--- a/tekton/generate-tekton-pipelines.yml
+++ b/tekton/generate-tekton-pipelines.yml
@@ -31,3 +31,4 @@
         - fvt-assist
         - fvt-core
         - upgrade
+        - update

--- a/tekton/src/pipelines/update.yml.j2
+++ b/tekton/src/pipelines/update.yml.j2
@@ -1,0 +1,35 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: mas-update
+spec:
+  params:
+    # Catalog Version
+    - name: mas_catalog_version
+      type: string
+
+    # Development Build Support
+    - name: artifactory_username
+      default: ""
+      type: string
+      description: Required to install development MAS catalogs
+    - name: artifactory_apikey
+      default: ""
+      type: string
+      description: Required to install development MAS catalogs
+
+  tasks:
+    - name: ibm-catalogs
+      params:
+        - name: mas_catalog_version
+          value: $(params.mas_catalog_version)
+
+        # Development catalog support
+        - name: artifactory_username
+          value: $(params.artifactory_username)
+        - name: artifactory_apikey
+          value: $(params.artifactory_apikey)
+      taskRef:
+        kind: Task
+        name: mas-devops-ibm-catalogs


### PR DESCRIPTION
At some point the `mas-update` pipeline definition went AWOL .. this change restores the pipeline definition.