### PR TITLE
[patch] Compatibility fix for OCP 4.8

### DIFF
--- a/image/cli/mascli/functions/install
+++ b/image/cli/mascli/functions/install
@@ -37,6 +37,32 @@ function install() {
   done
 
   connect
+
+  # Check for OCP 4.8
+  export OCP_VERSION=$(oc get clusterversion version -o jsonpath="{.status.desired.version}")
+  if [[ "$OCP_VERSION" =~ ^4\.7\.* ]]; then
+    echo
+    echo_warning "Warning: OpenShift Container Platform v${OCP_VERSION} detected!"
+    echo_warning " - This version is now out of support by Red Hat and ${TEXT_UNDERLINE}not a supported platform for IBM Maximo Application Suite"
+    echo_warning " - The installation of IBM Maximo Application Suite may not proceed, you must upgrade to OCP v4.10 before installing MAS"
+    echo
+    echo_warning "For more information refer to the Red Hat OpenShift Container Platform Life Cycle Policy:"
+    echo "  ${COLOR_CYAN}${TEXT_UNDERLINE}https://access.redhat.com/support/policy/updates/openshift/${COLOR_RESET}${TEXT_RESET}"
+    reset_colors
+    exit 1
+  elif [[ "$OCP_VERSION" =~ ^4\.8\.* ]]; then
+    echo
+    echo_warning "Warning: OpenShift Container Platform v${OCP_VERSION} detected!"
+    echo_warning " - This version is ${TEXT_UNDERLINE}now out of support by Red Hat"
+    echo_warning " - The installation of IBM Maximo Application Suite may proceed, but we strongly encourage you to upgrade to OCP v4.10 first"
+    echo
+    echo_warning "For more information refer to the Red Hat OpenShift Container Platform Life Cycle Policy:"
+    echo "  ${COLOR_CYAN}${TEXT_UNDERLINE}https://access.redhat.com/support/policy/updates/openshift/${COLOR_RESET}${TEXT_RESET}"
+    reset_colors
+    echo
+    prompt_for_confirm "Continue anyway?" || exit 0
+  fi
+
   detect_airgap
   detect_sno
   pipeline_install_operator

--- a/image/cli/mascli/functions/pipeline_install_tasks
+++ b/image/cli/mascli/functions/pipeline_install_tasks
@@ -7,6 +7,12 @@ function pipeline_install_tasks() {
   # Install the MAS Tekton definitions
   cp $DIR/templates/ibm-mas-tekton.yaml $CONFIG_DIR/ibm-mas-tekton-$MAS_INSTANCE_ID.yaml
   sed -e "s/cli:latest/cli:$VERSION/g" $DIR/templates/deployment.yaml > $CONFIG_DIR/deployment-$MAS_INSTANCE_ID.yaml
+
+  # Patch the tekton definitions to remove features not supported on OCP 4.8
+  if [[ "$OCP_VERSION" =~ ^4\.8\.* ]]; then
+    sed -i -e "s/onError: continue//g" $CONFIG_DIR/ibm-mas-tekton-$MAS_INSTANCE_ID.yaml
+  fi
+
   CLI_IMAGE=quay.io/ibmmas/cli:$VERSION
 
   if [[ "$AIRGAP_MODE" == "true" ]]; then

--- a/image/cli/mascli/functions/update
+++ b/image/cli/mascli/functions/update
@@ -21,6 +21,7 @@ EOM
 
 
 function update_noninteractive() {
+  detect_airgap
   while [[ $# -gt 0 ]]
   do
     key="$1"
@@ -50,6 +51,7 @@ function update_noninteractive() {
 
 function update_interactive() {
   connect
+  detect_airgap
 
   echo
   echo_h2 "Select IBM Maximo Operator Catalog Version"

--- a/image/cli/mascli/functions/upgrade
+++ b/image/cli/mascli/functions/upgrade
@@ -21,6 +21,7 @@ EOM
 
 
 function upgrade_noninteractive() {
+  detect_airgap
   while [[ $# -gt 0 ]]
   do
     key="$1"
@@ -50,6 +51,7 @@ function upgrade_noninteractive() {
 
 function upgrade_interactive() {
   connect
+  detect_airgap
 
   echo
   echo_h2 "Select IBM Maximo Application Suite Upgrade"


### PR DESCRIPTION
We will continue to support OCP 4.8 in the installer for now, but the install will now provide a warning about 4.8 being out of support by Red Hat and encouraging the user to upgrade.

(Ignore that the screenshot shows the version as 4.10.47 - we modified the if condition to easily test this with a 4.10 cluster)

![image](https://user-images.githubusercontent.com/4400618/219622163-da13d02a-5965-4d61-8f7d-b98a24d01aca.png)
