### PR TITLE
[minor] Support for MAS 8.10 SUDS-based install

### DIFF
--- a/image/cli/mascli/functions/pipeline_config
+++ b/image/cli/mascli/functions/pipeline_config
@@ -155,7 +155,7 @@ function pipeline_config() {
     esac
   fi
   true
-  
+
   echo
   echo_h2 "3.1. License Terms"
   echo -e "${COLOR_YELLOW} For information about your license, see "$MAS_LICENSE_LINK " To continue with the installation, you must accept the license terms."
@@ -245,8 +245,17 @@ function pipeline_config() {
 
   echo
   echo_h2 "12. Configure UDS"
-  prompt_for_input "UDS Contact Email" UDS_CONTACT_EMAIL
-  prompt_for_input "UDS Contact First Name" UDS_CONTACT_FIRSTNAME
-  prompt_for_input "UDS Contact Last Name" UDS_CONTACT_LASTNAME
-
+  if [[ -n "$DEV_MODE" ]]; then
+    echo "${TEXT_DIM}Maximo Application Suite version v8.10+ no longer requires IBM User Data Services as a dependency."
+    echo
+    reset_colors
+    UDS_CONTACT_EMAIL=""
+    UDS_CONTACT_FIRSTNAME=""
+    UDS_CONTACT_LASTNAME=""
+    UDS_ACTION="install_suds"
+  else
+    prompt_for_input "UDS Contact Email" UDS_CONTACT_EMAIL
+    prompt_for_input "UDS Contact First Name" UDS_CONTACT_FIRSTNAME
+    prompt_for_input "UDS Contact Last Name" UDS_CONTACT_LASTNAME
+  fi
 }

--- a/image/cli/mascli/templates/pipelinerun.yaml
+++ b/image/cli/mascli/templates/pipelinerun.yaml
@@ -112,6 +112,8 @@ spec:
       value: '$UDS_CONTACT_FIRSTNAME'
     - name: uds_contact_lastname
       value: '$UDS_CONTACT_LASTNAME'
+    - name: uds_action
+      value: '$UDS_ACTION'
 
     # Dependencies - AppConnect
     # -------------------------------------------------------------------------

--- a/tekton/src/params/install.yml.j2
+++ b/tekton/src/params/install.yml.j2
@@ -136,6 +136,9 @@
 - name: uds_event_scheduler_frequency
   type: string
   default: ""
+- name: uds_action
+  type: string
+  default: "install"
 - name: mas_segment_key
   type: string
   default: ""

--- a/tekton/src/pipelines/taskdefs/dependencies/uds.yml.j2
+++ b/tekton/src/pipelines/taskdefs/dependencies/uds.yml.j2
@@ -4,6 +4,9 @@
     - name: devops_suite_name
       value: dependencies-uds
 
+    - name: uds_action
+      value: "$(params.uds_action)"
+
     - name: uds_contact_email
       value: "$(params.uds_contact_email)"
     - name: uds_contact_firstname


### PR DESCRIPTION
Initially only available under the `DEV_MODE` flag, this will eventually allow us to support a MAS 8.10 install without UDS by exposing the `uds_action` parameter to the pipeline and the cli.