### PR TITLE
[patch] Disable AppConnect in install pipeline

### DIFF
--- a/tekton/src/pipelines/install-with-fvt.yml.j2
+++ b/tekton/src/pipelines/install-with-fvt.yml.j2
@@ -146,16 +146,17 @@ spec:
         - fvt-operatormaturity
         - cos
 
+    # App Connect temporarily disabled due CVEID: CVE-2023-28521
     # 4.1 Install AppConnect
-    {{ lookup('template', 'taskdefs/dependencies/appconnect.yml.j2') | indent(4) }}
-      runAfter:
-        - ibm-catalogs
+    # {{ lookup('template', 'taskdefs/dependencies/appconnect.yml.j2') | indent(4) }}
+      # runAfter:
+        # - ibm-catalogs
 
     # 4.2 Configure AppConnect in MAS
-    {{ lookup('template', 'taskdefs/core/suite-config-appconnect.yml.j2') | indent(4) }}
-      runAfter:
-        - fvt-operatormaturity
-        - appconnect
+    # {{ lookup('template', 'taskdefs/core/suite-config-appconnect.yml.j2') | indent(4) }}
+      # runAfter:
+        # - fvt-operatormaturity
+        # - appconnect
 
     # 4.3 Nvidia GPU Operator
     {{ lookup('template', 'taskdefs/dependencies/nvidia.yml.j2') | indent(4) }}
@@ -304,7 +305,8 @@ spec:
       runAfter:
         - app-cfg-manage # Requires Health as an add-on
         - suite-config-watson-studio
-        - suite-config-appconnect
+        # App Connect temporarily disabled due CVEID: CVE-2023-28521
+        # - suite-config-appconnect
 
     # 12.2 Configure HPUtilities workspace
     {{ lookup('template', 'taskdefs/apps/hputilities-workspace.yml.j2') | indent(4) }}

--- a/tekton/src/pipelines/install.yml.j2
+++ b/tekton/src/pipelines/install.yml.j2
@@ -141,17 +141,18 @@ spec:
       runAfter:
         - suite-verify
         - cos
-
+    
+    # App Connect temporarily disabled due CVEID: CVE-2023-28521
     # 4.1 Install AppConnect
-    {{ lookup('template', 'taskdefs/dependencies/appconnect.yml.j2') | indent(4) }}
-      runAfter:
-        - ibm-catalogs
+    # {{ lookup('template', 'taskdefs/dependencies/appconnect.yml.j2') | indent(4) }}
+      # runAfter:
+        # - ibm-catalogs
 
     # 4.2 Configure AppConnect in MAS
-    {{ lookup('template', 'taskdefs/core/suite-config-appconnect.yml.j2') | indent(4) }}
-      runAfter:
-        - suite-verify
-        - appconnect
+    # {{ lookup('template', 'taskdefs/core/suite-config-appconnect.yml.j2') | indent(4) }}
+      # runAfter:
+        # - suite-verify
+        # - appconnect
 
     # 4.3 Nvidia GPU Operator
     {{ lookup('template', 'taskdefs/dependencies/nvidia.yml.j2') | indent(4) }}
@@ -300,7 +301,8 @@ spec:
       runAfter:
         - app-cfg-manage # Requires Health as an add-on
         - suite-config-watson-studio
-        - suite-config-appconnect
+        # App Connect temporarily disabled due CVEID: CVE-2023-28521
+        # - suite-config-appconnect
 
     # 12.2 Configure HPUtilities workspace
     {{ lookup('template', 'taskdefs/apps/hputilities-workspace.yml.j2') | indent(4) }}


### PR DESCRIPTION
This PR disables `appconnect` and `suite-config-appconnect` tasks from both the `mas-install` and `mas-install-with-fvt` pipelines which are the only two pipelines we have that are capable of installing and configuring appconnect prior HPU install & activation.

After pipeline run, we could verify that regardless of not having appconnect installed and configured, HPU can be installed and activated:

![image](https://user-images.githubusercontent.com/31037381/227666310-de6cf4fe-d9e1-4561-bfc8-a4beb8d5d393.png)

![image](https://user-images.githubusercontent.com/31037381/227666361-75cf141f-de16-40eb-ba80-575b3a238f99.png)
