### PR TITLE
[patch] Update pipeline logic to handle BYO manage database

### DIFF
--- a/image/cli/mascli/functions/pipeline_config_db2
+++ b/image/cli/mascli/functions/pipeline_config_db2
@@ -145,6 +145,7 @@ function config_pipeline_storage_db2() {
           export LOCAL_MAS_CONFIG_DIR_ALREADY_CHOSEN=yes
           jdbc_cfg_file=$LOCAL_MAS_CONFIG_DIR/jdbc-$MAS_INSTANCE_ID-system.yaml
           python3 $DIR/functions/gencfg jdbc $MAS_INSTANCE_ID system $jdbc_cfg_file
+          DB2_ACTION_SYSTEM=byo
         else
           echo_highlight "In the next section you MUST ensure that a system database configuration is included in your local MAS configuration directory"
         fi
@@ -172,6 +173,7 @@ function config_pipeline_storage_db2() {
           fi
           jdbc_cfg_file=$LOCAL_MAS_CONFIG_DIR/jdbc-$MAS_INSTANCE_ID-wsapp.yaml
           python3 $DIR/functions/gencfg jdbc $MAS_INSTANCE_ID workspace-application $jdbc_cfg_file --workspace-id $MAS_WORKSPACE_ID --application-id manage
+          DB2_ACTION_SYSTEM=byo
         else
           echo_highlight "In the next section you MUST ensure that a dedicated database configuration for Manage is included in your local MAS configuration directory"
         fi
@@ -192,6 +194,7 @@ function config_pipeline_storage_db2() {
               fi
               jdbc_cfg_file=$LOCAL_MAS_CONFIG_DIR/jdbc-$MAS_INSTANCE_ID-wsapp.yaml
               python3 $DIR/functions/gencfg jdbc $MAS_INSTANCE_ID $MAS_WORKSPACE_ID $MAS_APP_ID workspace-application $jdbc_cfg_file --workspace-id $MAS_WORKSPACE_ID --application-id manage
+              DB2_ACTION_MANAGE=byo
             else
               echo_highlight "In the next section you MUST ensure that a dedicated database configuration for Manage is included in your local MAS configuration directory"
             fi

--- a/tekton/src/pipelines/taskdefs/apps/db2-setup-system.yml.j2
+++ b/tekton/src/pipelines/taskdefs/apps/db2-setup-system.yml.j2
@@ -6,14 +6,17 @@
 
     - name: db2_instance_name
       value: "mas-$(params.mas_instance_id)-system"
-  # Only perform the hack if Manage is being installed and if we're not using a dedicated Db2 instance for Manage
+  # Only perform the hack if Manage is being installed, if we're using in-cluster system db and we're not using a dedicated Db2 instance for Manage (in-cluster or BYO)
   when:
     - input: "$(params.mas_app_channel_manage)"
       operator: notin
       values: [""]
+    - input: "$(params.db2_action_system)"
+      operator: in
+      values: ["install"]
     - input: "$(params.db2_action_manage)"
       operator: notin
-      values: ["install"]
+      values: ["install", "byo"]
   taskRef:
     name: mas-devops-suite-db2-setup-for-manage
     kind: Task


### PR DESCRIPTION
Add logic to ensure the Db2 setup scripts do not run when we are using an external database.