### PR TITLE
[patch] Update build to support ARTIFACTORY_TOKEN

### DIFF
--- a/.github/workflows/build-cli.yml
+++ b/.github/workflows/build-cli.yml
@@ -36,14 +36,14 @@ jobs:
       - name: Upload definition to Artifactory
         env:
           ARTIFACTORY_GENERIC_RELEASE_URL: ${{ secrets.ARTIFACTORY_GENERIC_RELEASE_URL }}
-          ARTIFACTORY_APIKEY: ${{ secrets.ARTIFACTORY_APIKEY }}
+          ARTIFACTORY_TOKEN: ${{ secrets.ARTIFACTORY_TOKEN }}
         run: |
           $GITHUB_WORKSPACE/build/bin/artifactory-release.sh $GITHUB_WORKSPACE/tekton/target/ibm-mas-tekton.yaml
 
       - name: Upload PipelineRun templates to Artifactory
         env:
           ARTIFACTORY_GENERIC_RELEASE_URL: ${{ secrets.ARTIFACTORY_GENERIC_RELEASE_URL }}
-          ARTIFACTORY_APIKEY: ${{ secrets.ARTIFACTORY_APIKEY }}
+          ARTIFACTORY_TOKEN: ${{ secrets.ARTIFACTORY_TOKEN }}
         run: |
           $GITHUB_WORKSPACE/build/bin/artifactory-release.sh $GITHUB_WORKSPACE/tekton/target/pipelineruns/fvt-core.yml.j2
           $GITHUB_WORKSPACE/build/bin/artifactory-release.sh $GITHUB_WORKSPACE/tekton/target/pipelineruns/install-with-fvt.yml.j2

--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -35,14 +35,14 @@ jobs:
       - name: Upload definition to Artifactory
         env:
           ARTIFACTORY_GENERIC_RELEASE_URL: ${{ secrets.ARTIFACTORY_GENERIC_RELEASE_URL }}
-          ARTIFACTORY_APIKEY: ${{ secrets.ARTIFACTORY_APIKEY }}
+          ARTIFACTORY_TOKEN: ${{ secrets.ARTIFACTORY_TOKEN }}
         run: |
           $GITHUB_WORKSPACE/build/bin/artifactory-release.sh $GITHUB_WORKSPACE/tekton/target/ibm-mas-tekton.yaml
 
       - name: Upload PipelineRun templates to Artifactory
         env:
           ARTIFACTORY_GENERIC_RELEASE_URL: ${{ secrets.ARTIFACTORY_GENERIC_RELEASE_URL }}
-          ARTIFACTORY_APIKEY: ${{ secrets.ARTIFACTORY_APIKEY }}
+          ARTIFACTORY_TOKEN: ${{ secrets.ARTIFACTORY_TOKEN }}
         run: |
           $GITHUB_WORKSPACE/build/bin/artifactory-release.sh $GITHUB_WORKSPACE/tekton/target/pipelineruns/fvt-core.yml.j2
           $GITHUB_WORKSPACE/build/bin/artifactory-release.sh $GITHUB_WORKSPACE/tekton/target/pipelineruns/install-with-fvt.yml.j2

--- a/build/bin/.functions.sh
+++ b/build/bin/.functions.sh
@@ -76,5 +76,5 @@ function artifactory_upload() {
   sha1Value="${sha1Value:0:40}"
 
   echo "Uploading $1 to $2"
-  curl -H "X-JFrog-Art-Api:$ARTIFACTORY_APIKEY"  -H "X-Checksum-Md5: $md5Value" -H "X-Checksum-Sha1: $sha1Value" -T $1 $2 || exit 1
+  curl -H "Authorization:Bearer $ARTIFACTORY_TOKEN"  -H "X-Checksum-Md5: $md5Value" -H "X-Checksum-Sha1: $sha1Value" -T $1 $2 || exit 1
 }


### PR DESCRIPTION
This PR is a subset of #224, only changing the build system to use `ARTIFACTORY_TOKEN`.  We have more work to do before we can integrate the rest of the changes.