### PR TITLE
[patch] Set the default task timeout to 12 hours

### DIFF
--- a/image/cli/mascli/functions/pipeline_install_operator
+++ b/image/cli/mascli/functions/pipeline_install_operator
@@ -56,6 +56,10 @@ function pipeline_install_operator() {
     # Note: We need to use --tpye merge because it's a custom resource
     echo "Patch Tekton config to enable alpha API fields and scope when expressions to tasks" &>> $LOGFILE
     oc patch TektonConfig config --type merge -p '{"spec":{"pipeline":{"enable-api-fields": "alpha", "scope-when-expressions-to-task": true}}}'  &>> $LOGFILE
+
+    # Set the default task timeout, which will take effect in OCP 4.11 and newer
+    echo "Set the default pipeline tasks timeout to 12 hours" &>> $LOGFILE
+    oc patch cm config-defaults -n openshift-pipelines --type merge -p '{"data":{"default-timeout-minutes": "720"}}' &>> $LOGFILE
   fi
 
   echo -en "\033[1K" # Clear current line


### PR DESCRIPTION
Backport support into cli for setting default pipeline tasks timeout to 12 hours.

Tested with pre release version of cli:

<img width="437" alt="image" src="https://user-images.githubusercontent.com/31037381/230440202-e38ebe7e-0cf5-45a8-8b4b-a2437e27378c.png">

<img width="238" alt="image" src="https://user-images.githubusercontent.com/31037381/230440323-445ca8be-8594-4c06-ac81-d5a34c9a39e6.png">
