### PR TITLE
[patch] Fix "ARTIFACTORY_token" env var

### DIFF
--- a/tekton/src/tasks/suite-app-install.yml.j2
+++ b/tekton/src/tasks/suite-app-install.yml.j2
@@ -65,7 +65,7 @@ spec:
       # Pre-Release Support
       - name: ARTIFACTORY_USERNAME
         value: $(params.artifactory_username)
-      - name: ARTIFACTORY_token
+      - name: ARTIFACTORY_TOKEN
         value: $(params.artifactory_token)
 
       # Entitlement


### PR DESCRIPTION
Env vars are case sensitive, this is preventing the token being passed to the app install role