### PR TITLE
[patch] Update FVT pipeline to use image digests (core)

### DIFF
--- a/tekton/src/params/fvt.yml.j2
+++ b/tekton/src/params/fvt.yml.j2
@@ -36,9 +36,9 @@
   default: ""
 
 # FVT Versions
-- name: fvt_version_core
+- name: fvt_digest_core
   type: string
-  description: FVT Version - Core
+  description: FVT digest - Core
   default: ""
 - name: fvt_version_iot
   type: string

--- a/tekton/src/pipelines/taskdefs/fvt-core/common/params.yml.j2
+++ b/tekton/src/pipelines/taskdefs/fvt-core/common/params.yml.j2
@@ -10,8 +10,8 @@
   value: $(params.mas_channel)
 - name: fvt_image_registry
   value: $(params.fvt_image_registry)
-- name: fvt_image_version
-  value: $(params.fvt_version_core)
+- name: fvt_image_digest
+  value: $(params.fvt_digest_core)
 - name: devops_test_type
   value: $(params.devops_test_type)
 - name: devops_test_phase

--- a/tekton/src/pipelines/taskdefs/fvt-core/common/taskref.yml.j2
+++ b/tekton/src/pipelines/taskdefs/fvt-core/common/taskref.yml.j2
@@ -2,9 +2,9 @@ taskRef:
   kind: Task
   name: mas-fvt-core
 when:
-  - input: "$(params.fvt_version_core)"
+  - input: "$(params.fvt_digest_core)"
     operator: notin
-    values: ["skip"]
+    values: [""]
 workspaces:
   - name: configs
     workspace: shared-configs

--- a/tekton/src/pipelines/taskdefs/fvt-core/ui/params.yml.j2
+++ b/tekton/src/pipelines/taskdefs/fvt-core/ui/params.yml.j2
@@ -10,8 +10,8 @@
   value: $(params.mas_channel)
 - name: fvt_image_registry
   value: $(params.fvt_image_registry)
-- name: fvt_image_version
-  value: $(params.fvt_version_core)
+- name: fvt_image_digest
+  value: $(params.fvt_digest_core)
 - name: devops_test_type
   value: $(params.devops_test_type)
 - name: devops_test_phase

--- a/tekton/src/pipelines/taskdefs/fvt-core/ui/taskref.yml.j2
+++ b/tekton/src/pipelines/taskdefs/fvt-core/ui/taskref.yml.j2
@@ -2,9 +2,9 @@ taskRef:
   kind: Task
   name: mas-fvt-core-ui
 when:
-  - input: "$(params.fvt_version_core)"
+  - input: "$(params.fvt_digest_core)"
     operator: notin
-    values: ["skip"]
+    values: [""]
 workspaces:
   - name: configs
     workspace: shared-configs

--- a/tekton/src/tasks/fvt/fvt-core.yml.j2
+++ b/tekton/src/tasks/fvt/fvt-core.yml.j2
@@ -15,10 +15,9 @@ spec:
     - name: fvt_image_registry
       type: string
       description: FVT Container Image Registry (required)
-    - name: fvt_image_version
+    - name: fvt_image_digest
       type: string
-      description: FVT Container Image Version
-      default: latest
+      description: FVT Container Image digest
 
     # Test Framework Information
     # -------------------------------------------------------------------------
@@ -124,7 +123,7 @@ spec:
       - name: DEVOPS_TEST_PHASE
         value: $(params.devops_test_phase)
   steps:
-    - image: '$(params.fvt_image_registry)/mas-devops/fvt-ibm-mas:$(params.fvt_image_version)'
+    - image: '$(params.fvt_image_registry)/mas-devops/fvt-ibm-mas@$(params.fvt_image_digest)'
       imagePullPolicy: $(params.image_pull_policy)
       timeout: 90m # Ensure bad FVTs don't run forever
       onError: continue # Ensure bad FVTs don't break the pipeline


### PR DESCRIPTION
When we use image tags in complex pipelines we are seeing the issue raised here: https://github.com/tektoncd/pipeline/issues/6530

```
status:
  completionTime: '2023-04-12T10:33:41Z'
  conditions:
    - lastTransitionTime: '2023-04-12T10:33:41Z'
      message: >-
        The step "unnamed-0" in TaskRun "fvtnocpd-fvt-1481-fvt-optimizer" failed
        to pull the image "". The pod errored with the message: "Back-off
        pulling image
        "<someimage>@sha256:914dab53d028dbfc7012d806d36505a80a2642f53f337b9551c64756574651b7"."
      reason: TaskRunImagePullFailed
      status: 'False'
      type: Succeeded
  podName: fvtnocpd-fvt-1481-fvt-optimizer-pod
  startTime: '2023-04-12T10:28:00Z'
  steps:
    - container: step-unnamed-0
      name: unnamed-0
      terminated:
        exitCode: 1
        finishedAt: '2023-04-12T10:33:41Z'
        reason: TaskRunImagePullFailed
        startedAt: null
```

Our hope is that by replacing all params that accept image tags with digests we will stop seeing this issue.