### PR TITLE
[patch] update changelogs and removed 8.8 apps

### DIFF
--- a/docs/catalogs/v8-230414-amd64.md
+++ b/docs/catalogs/v8-230414-amd64.md
@@ -151,34 +151,22 @@ Package Manifest
 | ------------------------ | ---------- | --------------- |
 | ibm-mas                  | **8.10.x** | **8.10.0**      |
 | ibm-mas                  | 8.9.x      | 8.9.4           |
-| ibm-mas                  | 8.8.x      | 8.8.8           |
 | ibm-mas-assist           | **8.7.x**  | **8.7.0**       |
 | ibm-mas-assist           | 8.6.x      | 8.6.3           |
-| ibm-mas-assist           | 8.5.x      | 8.5.3           |
 | ibm-mas-hputilities      | **8.6.x**  | **8.6.0**       |
 | ibm-mas-hputilities      | 8.5.x      | 8.5.2           |
-| ibm-mas-hputilities      | 8.4.x      | 8.4.1           |
 | ibm-mas-iot              | **8.7.x**  | **8.7.0**       |
 | ibm-mas-iot              | 8.6.x      | 8.6.5           |
-| ibm-mas-iot              | 8.5.x      | 8.5.8           |
 | ibm-mas-manage           | **8.6.x**  | **8.6.0**       |
 | ibm-mas-manage           | 8.5.x      | 8.5.4           |
-| ibm-mas-manage           | 8.4.x      | 8.4.8           |
 | ibm-mas-monitor          | **8.10.x** | **8.10.0**      |
 | ibm-mas-monitor          | 8.9.x      | 8.9.4           |
-| ibm-mas-monitor          | 8.8.x      | 8.8.4           |
-| ibm-mas-mso              | 8.1.x      | 8.1.0           |
 | ibm-mas-optimizer        | **8.4.x**  | **8.4.0**       |
 | ibm-mas-optimizer        | 8.3.x      | 8.3.3           |
-| ibm-mas-optimizer        | 8.2.x      | 8.2.4           |
 | ibm-mas-predict          | **8.8.x**  | **8.8.0**       |
 | ibm-mas-predict          | 8.7.x      | 8.7.2           |
-| ibm-mas-predict          | 8.6.x      | 8.6.2           |
-| ibm-mas-safety           | 8.3.x      | 8.3.2           |
-| ibm-mas-safety           | 8.2.x      | 8.2.2           |
 | ibm-mas-visualinspection | **8.8.x**  | **8.8.0**       |
 | ibm-mas-visualinspection | 8.7.x      | 8.7.0           |
-| ibm-mas-visualinspection | 8.6.x      | 8.6.1           |
 
 ### IBM Utilities
 | Package                  | Channel | Latest Version |

--- a/docs/changes.md
+++ b/docs/changes.md
@@ -1,6 +1,8 @@
 ## Changes
 
-- [`3.21`](https://github.com/ibm-mas/cli/releases/tag/3.21.0) Support April Catalog Update (#236)
+- [`4.0`](https://github.com/ibm-mas/cli/releases/tag/4.0.0) Multiple updates:
+    - Remove HP Utilities & MAS 8.8 support (#234)
+    - Support April Catalog Update (#236)
 - [`3.20`](https://github.com/ibm-mas/cli/releases/tag/3.20.0) Multiple updates:
      - Add support for advanced settings (#227)
      - Add support for March 28th catalog update (#226)


### PR DESCRIPTION
 fix the changelog - since there is a major version available after last release.

remove 8.8 apps references from docs.