### PR TITLE
[patch] Update FVT pipeline to use image digests (global)

### DIFF
--- a/tekton/src/params/fvt.yml.j2
+++ b/tekton/src/params/fvt.yml.j2
@@ -35,93 +35,93 @@
   type: string
   default: ""
 
-# FVT Versions
+# FVT Digests
 - name: fvt_digest_core
   type: string
   description: FVT digest - Core
   default: ""
-- name: fvt_version_iot
+- name: fvt_digest_iot
   type: string
-  description: FVT Version - IoT
+  description: FVT Digest - IoT
   default: ""
-- name: fvt_version_safety
+- name: fvt_digest_safety
   type: string
-  description: FVT Version - Safety
+  description: FVT Digest - Safety
   default: ""
-- name: fvt_version_monitor
+- name: fvt_digest_monitor
   type: string
-  description: FVT Version - Monitor
+  description: FVT Digest - Monitor
   default: ""
-- name: fvt_version_predict
+- name: fvt_digest_predict
   type: string
-  description: FVT Version - Predict
+  description: FVT Digest - Predict
   default: ""
-- name: fvt_version_hputilities
+- name: fvt_digest_hputilities
   type: string
-  description: FVT Version - Health & Predict Utilities
+  description: FVT Digest - Health & Predict Utilities
   default: ""
-- name: fvt_version_visualinspection
+- name: fvt_digest_visualinspection
   type: string
-  description: FVT Version - Visual Inspection
+  description: FVT Digest - Visual Inspection
   default: ""
-- name: fvt_version_assist
+- name: fvt_digest_assist
   type: string
-  description: FVT Version - Assist
+  description: FVT Digest - Assist
   default: ""
-- name: fvt_version_optimizer
+- name: fvt_digest_optimizer
   type: string
-  description: FVT Version - Optimizer
+  description: FVT Digest - Optimizer
   default: ""
 
-# FVT Versions - Manage, Health and Industry Solutions
-- name: fvt_version_manage
+# FVT Digests - Manage, Health and Industry Solutions
+- name: fvt_digest_manage
   type: string
-  description: FVT Version - Manage
+  description: FVT Digest - Manage
   default: ""
-- name: fvt_version_manage_multi_is
+- name: fvt_digest_manage_multi_is
   type: string
-  description: FVT Version - Manage Multi IS
+  description: FVT Digest - Manage Multi IS
   default: ""
 - name: fvt_test_driver
   type: string
   description: FVT Driver for Manage - graphite/tpae
   default: ""
 
-# FVT Versions - Civil Selenium, Cypress and Defects (mobile)
-- name: fvt_version_manage_civil
+# FVT Digests - Civil Selenium, Cypress and Defects (mobile)
+- name: fvt_digest_manage_civil
   type: string
-  description: FVT Version - Civil
+  description: FVT Digest - Civil
   default: ""
 
-# FVT Versions - Mobile Tests
-- name: fvt_version_mobilefoundation
+# FVT Digests - Mobile Tests
+- name: fvt_digest_mobilefoundation
   type: string
-  description: FVT Version - Mobile Foundation
+  description: FVT Digest - Mobile Foundation
   default: ""
-- name: fvt_version_servicerequests
+- name: fvt_digest_servicerequests
   type: string
-  description: FVT Version - Mobile Service Requests
+  description: FVT Digest - Mobile Service Requests
   default: ""
-- name: fvt_version_technician
+- name: fvt_digest_technician
   type: string
-  description: FVT Version - Mobile Technician
+  description: FVT Digest - Mobile Technician
   default: ""
-- name: fvt_version_inspection
+- name: fvt_digest_inspection
   type: string
-  description: FVT Version - Mobile Inspection
+  description: FVT Digest - Mobile Inspection
   default: ""
-- name: fvt_version_asset_manager
+- name: fvt_digest_asset_manager
   type: string
-  description: FVT Version - Mobile Asset Manager
+  description: FVT Digest - Mobile Asset Manager
   default: ""
-- name: fvt_version_inventorycounting
+- name: fvt_digest_inventorycounting
   type: string
-  description: FVT Version - Mobile IC
+  description: FVT Digest - Mobile IC
   default: ""
 
 
-# IVT Versions
-- name: ivt_version_core
+# IVT Digests
+- name: ivt_digest_core
   type: string
-  description: IVT Version - Core
+  description: IVT Digest - Core
   default: ""

--- a/tekton/src/pipelines/fvt-assist.yml.j2
+++ b/tekton/src/pipelines/fvt-assist.yml.j2
@@ -35,7 +35,7 @@ spec:
         - name: product_channel
           value: $(params.mas_app_channel_assist)
       when:
-        - input: "$(params.ivt_version_core)"
+        - input: "$(params.ivt_digest_core)"
           operator: notin
           values: [""]
         - input: "$(params.mas_app_channel_assist)"

--- a/tekton/src/pipelines/taskdefs/fvt-apps/common/params-assist-cucumber.yml.j2
+++ b/tekton/src/pipelines/taskdefs/fvt-apps/common/params-assist-cucumber.yml.j2
@@ -10,8 +10,8 @@
   value: $(params.fvt_image_registry)
 - name: fvt_image_name
   value: fvt-assist-cucumber
-- name: fvt_image_version
-  value: $(params.fvt_version_assist)
+- name: fvt_image_digest
+  value: $(params.fvt_digest_assist)
 - name: product_channel
   value: $(params.mas_app_channel_assist)
 - name: devops_test_type

--- a/tekton/src/pipelines/taskdefs/fvt-apps/common/params-assist-prepare.yml.j2
+++ b/tekton/src/pipelines/taskdefs/fvt-apps/common/params-assist-prepare.yml.j2
@@ -10,8 +10,8 @@
   value: $(params.fvt_image_registry)
 - name: fvt_image_name
   value: fvt-assist-preparedata
-- name: fvt_image_version
-  value: $(params.fvt_version_assist)
+- name: fvt_image_digest
+  value: $(params.fvt_digest_assist)
 - name: product_channel
   value: $(params.mas_app_channel_assist)
 - name: devops_test_type

--- a/tekton/src/pipelines/taskdefs/fvt-apps/common/params-assist-python.yml.j2
+++ b/tekton/src/pipelines/taskdefs/fvt-apps/common/params-assist-python.yml.j2
@@ -10,8 +10,8 @@
   value: $(params.fvt_image_registry)
 - name: fvt_image_name
   value: fvt-assist-python
-- name: fvt_image_version
-  value: $(params.fvt_version_assist)
+- name: fvt_image_digest
+  value: $(params.fvt_digest_assist)
 - name: product_channel
   value: $(params.mas_app_channel_assist)
 - name: devops_test_type

--- a/tekton/src/pipelines/taskdefs/fvt-apps/common/params-assist-testng.yml.j2
+++ b/tekton/src/pipelines/taskdefs/fvt-apps/common/params-assist-testng.yml.j2
@@ -10,8 +10,8 @@
   value: $(params.fvt_image_registry)
 - name: fvt_image_name
   value: fvt-assist-testng
-- name: fvt_image_version
-  value: $(params.fvt_version_assist)
+- name: fvt_image_digest
+  value: $(params.fvt_digest_assist)
 - name: product_channel
   value: $(params.mas_app_channel_assist)
 - name: devops_test_type

--- a/tekton/src/pipelines/taskdefs/fvt-apps/common/params-manage-civil.yml.j2
+++ b/tekton/src/pipelines/taskdefs/fvt-apps/common/params-manage-civil.yml.j2
@@ -14,8 +14,8 @@
   value: $(params.fvt_image_registry)
 - name: fvt_image_namespace
   value: fvt-manage-civil
-- name: fvt_image_version
-  value: $(params.fvt_version_manage_civil)
+- name: fvt_image_digest
+  value: $(params.fvt_digest_manage_civil)
 - name: product_channel
   value: $(params.mas_app_channel_manage)
 - name: product_id

--- a/tekton/src/pipelines/taskdefs/fvt-apps/common/params-manage-multi-is.yml.j2
+++ b/tekton/src/pipelines/taskdefs/fvt-apps/common/params-manage-multi-is.yml.j2
@@ -12,8 +12,8 @@
   value: $(params.devops_ibmcloud_apikey)
 - name: fvt_image_registry
   value: $(params.fvt_image_registry)
-- name: fvt_image_version
-  value: $(params.fvt_version_manage_multi_is)
+- name: fvt_image_digest
+  value: $(params.fvt_digest_manage_multi_is)
 - name: product_channel
   value: $(params.mas_app_channel_manage)
 - name: product_id

--- a/tekton/src/pipelines/taskdefs/fvt-apps/common/params-manage.yml.j2
+++ b/tekton/src/pipelines/taskdefs/fvt-apps/common/params-manage.yml.j2
@@ -16,8 +16,8 @@
   value: fvt-manage
 - name: fvt_image_name
   value: fvt-ibm-mas-manage
-- name: fvt_image_version
-  value: $(params.fvt_version_manage)
+- name: fvt_image_digest
+  value: $(params.fvt_digest_manage)
 - name: product_channel
   value: $(params.mas_app_channel_manage)
 - name: product_id

--- a/tekton/src/pipelines/taskdefs/fvt-apps/common/taskref-assist.yml.j2
+++ b/tekton/src/pipelines/taskdefs/fvt-apps/common/taskref-assist.yml.j2
@@ -2,9 +2,9 @@ taskRef:
   kind: Task
   name: mas-fvt-assist
 when:
-  - input: "$(params.fvt_version_assist)"
+  - input: "$(params.fvt_digest_assist)"
     operator: notin
-    values: ["skip"]
+    values: [""]
   - input: "$(params.mas_app_channel_assist)"
     operator: notin
     values: [""]

--- a/tekton/src/pipelines/taskdefs/fvt-apps/common/taskref-manage-civil.yml.j2
+++ b/tekton/src/pipelines/taskdefs/fvt-apps/common/taskref-manage-civil.yml.j2
@@ -2,9 +2,9 @@ taskRef:
   kind: Task
   name: mas-fvt-manage
 when:
-  - input: "$(params.fvt_version_manage_civil)"
+  - input: "$(params.fvt_digest_manage_civil)"
     operator: notin
-    values: ["skip"]
+    values: [""]
   - input: "$(params.mas_app_channel_manage)"
     operator: notin
     values: [""]

--- a/tekton/src/pipelines/taskdefs/fvt-apps/common/taskref-manage-multi-is.yml.j2
+++ b/tekton/src/pipelines/taskdefs/fvt-apps/common/taskref-manage-multi-is.yml.j2
@@ -2,9 +2,9 @@ taskRef:
   kind: Task
   name: mas-fvt-manage
 when:
-  - input: "$(params.fvt_version_manage_multi_is)"
+  - input: "$(params.fvt_digest_manage_multi_is)"
     operator: notin
-    values: ["skip"]
+    values: [""]
   - input: "$(params.mas_app_channel_manage)"
     operator: notin
     values: [""]

--- a/tekton/src/pipelines/taskdefs/fvt-apps/common/taskref-manage.yml.j2
+++ b/tekton/src/pipelines/taskdefs/fvt-apps/common/taskref-manage.yml.j2
@@ -2,9 +2,9 @@ taskRef:
   kind: Task
   name: mas-fvt-manage
 when:
-  - input: "$(params.fvt_version_manage)"
+  - input: "$(params.fvt_digest_manage)"
     operator: notin
-    values: ["skip"]
+    values: [""]
   - input: "$(params.mas_app_channel_manage)"
     operator: notin
     values: [""]

--- a/tekton/src/pipelines/taskdefs/fvt-apps/hputilities.yml.j2
+++ b/tekton/src/pipelines/taskdefs/fvt-apps/hputilities.yml.j2
@@ -17,8 +17,8 @@
       value: fvt-hputilities
     - name: fvt_image_name
       value: fvt-hputilities-preparedata
-    - name: fvt_image_version
-      value: $(params.fvt_version_hputilities)
+    - name: fvt_image_digest
+      value: $(params.fvt_digest_hputilities)
     - name: fvt_test_suite
       value: prepare
     - name: product_channel
@@ -35,11 +35,11 @@
   taskRef:
     kind: Task
     name: mas-fvt-run-suite
-  # Only if we've set a version of the HPUtilities FVT to run
+  # Only if we've set a digest of the HPUtilities FVT to run
   when:
-    - input: "$(params.fvt_version_hputilities)"
+    - input: "$(params.fvt_digest_hputilities)"
       operator: notin
-      values: ["skip"]
+      values: [""]
     - input: "$(params.mas_app_channel_hputilities)"
       operator: notin
       values: [""]
@@ -68,8 +68,8 @@
       value: fvt-hputilities
     - name: fvt_image_name
       value: fvt-hputilities-testng
-    - name: fvt_image_version
-      value: $(params.fvt_version_hputilities)
+    - name: fvt_image_digest
+      value: $(params.fvt_digest_hputilities)
     - name: fvt_test_suite
       value: testng-hputilities-minimal
     - name: product_channel
@@ -86,11 +86,11 @@
   taskRef:
     kind: Task
     name: mas-fvt-run-suite
-  # Only if we've set a version of the HPUtilities FVT to run
+  # Only if we've set a digest of the HPUtilities FVT to run
   when:
-    - input: "$(params.fvt_version_hputilities)"
+    - input: "$(params.fvt_digest_hputilities)"
       operator: notin
-      values: ["skip"]
+      values: [""]
     - input: "$(params.mas_app_channel_hputilities)"
       operator: notin
       values: [""]
@@ -119,8 +119,8 @@
       value: fvt-hputilities
     - name: fvt_image_name
       value: fvt-hputilities-python
-    - name: fvt_image_version
-      value: $(params.fvt_version_hputilities)
+    - name: fvt_image_digest
+      value: $(params.fvt_digest_hputilities)
     - name: product_channel
       value: $(params.mas_app_channel_hputilities)
     - name: product_id
@@ -133,11 +133,11 @@
   taskRef:
     kind: Task
     name: mas-fvt-run-suite
-  # Only if we've set a version of the HPUtilities FVT to run
+  # Only if we've set a digest of the HPUtilities FVT to run
   when:
-    - input: "$(params.fvt_version_hputilities)"
+    - input: "$(params.fvt_digest_hputilities)"
       operator: notin
-      values: ["skip"]
+      values: [""]
     - input: "$(params.mas_app_channel_hputilities)"
       operator: notin
       values: [""]

--- a/tekton/src/pipelines/taskdefs/fvt-apps/iot.yml.j2
+++ b/tekton/src/pipelines/taskdefs/fvt-apps/iot.yml.j2
@@ -17,8 +17,8 @@
       value: mas-devops
     - name: fvt_image_name
       value: fvt-iot
-    - name: fvt_image_version
-      value: $(params.fvt_version_iot)
+    - name: fvt_image_digest
+      value: $(params.fvt_digest_iot)
     - name: product_channel
       value: $(params.mas_app_channel_iot)
     - name: product_id
@@ -34,9 +34,9 @@
     kind: Task
     name: mas-fvt-run-suite
   when:
-    - input: "$(params.fvt_version_iot)"
+    - input: "$(params.fvt_digest_iot)"
       operator: notin
-      values: ["skip"]
+      values: [""]
     - input: "$(params.mas_app_channel_iot)"
       operator: notin
       values: [""]

--- a/tekton/src/pipelines/taskdefs/fvt-apps/mobile.yml.j2
+++ b/tekton/src/pipelines/taskdefs/fvt-apps/mobile.yml.j2
@@ -21,8 +21,8 @@
       value: fvt-mobilefoundation
     - name: fvt_image_name
       value: fvt-mobilefoundation-manage-setup
-    - name: fvt_image_version
-      value: $(params.fvt_version_mobilefoundation)
+    - name: fvt_image_digest
+      value: $(params.fvt_digest_mobilefoundation)
     - name: fvt_mas_appws_component
       value: base
     - name: mas_appws_components
@@ -43,11 +43,11 @@
   taskRef:
     kind: Task
     name: mas-fvt-manage
-  # Only if we've set a version of the Manage Transportation FVT to run
+  # Only if we've set a digest of the Manage Transportation FVT to run
   when:
-    - input: "$(params.fvt_version_mobilefoundation)"
+    - input: "$(params.fvt_digest_mobilefoundation)"
       operator: notin
-      values: ["skip"]
+      values: [""]
     - input: "$(params.mas_app_channel_manage)"
       operator: notin
       values: [""]
@@ -76,8 +76,8 @@
       value: fvt-mobilefoundation
     - name: fvt_image_name
       value: fvt-mobilefoundation-preparedata
-    - name: fvt_image_version
-      value: $(params.fvt_version_mobilefoundation)
+    - name: fvt_image_digest
+      value: $(params.fvt_digest_mobilefoundation)
     - name: fvt_test_suite
       value: prepare
     - name: product_channel
@@ -94,11 +94,11 @@
   taskRef:
     kind: Task
     name: mas-fvt-run-suite
-  # Only if we've set a version of the Mobile Foundation FVT to run
+  # Only if we've set a digest of the Mobile Foundation FVT to run
   when:
-    - input: "$(params.fvt_version_mobilefoundation)"
+    - input: "$(params.fvt_digest_mobilefoundation)"
       operator: notin
-      values: ["skip"]
+      values: [""]
     - input: "$(params.mas_app_channel_manage)"
       operator: notin
       values: [""]
@@ -128,8 +128,8 @@
       value: fvt-mobilefoundation
     - name: fvt_image_name
       value: fvt-mobilefoundation-testng
-    - name: fvt_image_version
-      value: $(params.fvt_version_mobilefoundation)
+    - name: fvt_image_digest
+      value: $(params.fvt_digest_mobilefoundation)
     - name: fvt_test_suite
       value: testng-all
     - name: product_channel
@@ -150,11 +150,11 @@
   taskRef:
     kind: Task
     name: mas-fvt-run-suite
-  # Only if we've set a version of the Mobile Foundation FVT to run
+  # Only if we've set a digest of the Mobile Foundation FVT to run
   when:
-    - input: "$(params.fvt_version_mobilefoundation)"
+    - input: "$(params.fvt_digest_mobilefoundation)"
       operator: notin
-      values: ["skip"]
+      values: [""]
     - input: "$(params.mas_app_channel_manage)"
       operator: notin
       values: [""]
@@ -182,8 +182,8 @@
       value: fvt-mobilefoundation
     - name: fvt_image_name
       value: fvt-mobilefoundation-testng
-    - name: fvt_image_version
-      value: $(params.fvt_version_mobilefoundation)
+    - name: fvt_image_digest
+      value: $(params.fvt_digest_mobilefoundation)
     - name: fvt_test_suite
       value: testng-all
     - name: product_channel
@@ -204,11 +204,11 @@
   taskRef:
     kind: Task
     name: mas-fvt-run-suite
-  # Only if we've set a version of the Mobile Foundation FVT to run
+  # Only if we've set a digest of the Mobile Foundation FVT to run
   when:
-    - input: "$(params.fvt_version_mobilefoundation)"
+    - input: "$(params.fvt_digest_mobilefoundation)"
       operator: notin
-      values: ["skip"]
+      values: [""]
     - input: "$(params.mas_app_channel_manage)"
       operator: notin
       values: [""]
@@ -241,8 +241,8 @@
       value: fvt-servicerequests
     - name: fvt_image_name
       value: fvt-servicerequests-manage-setup
-    - name: fvt_image_version
-      value: $(params.fvt_version_servicerequests)
+    - name: fvt_image_digest
+      value: $(params.fvt_digest_servicerequests)
     - name: artifactory_token
       value: $(params.fvt_artifactory_token)
     - name: fvt_test_suite
@@ -259,11 +259,11 @@
   taskRef:
     kind: Task
     name: mas-fvt-manage
-  # Only if we've set a version of the Mobile Foundation FVT to run
+  # Only if we've set a digest of the Mobile Foundation FVT to run
   when:
-    - input: "$(params.fvt_version_servicerequests)"
+    - input: "$(params.fvt_digest_servicerequests)"
       operator: notin
-      values: ["skip"]
+      values: [""]
     - input: "$(params.mas_app_channel_manage)"
       operator: notin
       values: [""]
@@ -292,8 +292,8 @@
       value: fvt-servicerequests
     - name: fvt_image_name
       value: fvt-servicerequests-testng
-    - name: fvt_image_version
-      value: $(params.fvt_version_servicerequests)
+    - name: fvt_image_digest
+      value: $(params.fvt_digest_servicerequests)
     - name: fvt_test_suite
       value: mas-android-MVT-SR
     - name: product_channel
@@ -314,11 +314,11 @@
   taskRef:
     kind: Task
     name: mas-fvt-run-suite
-  # Only if we've set a version of the Mobile Service Request FVT to run
+  # Only if we've set a digest of the Mobile Service Request FVT to run
   when:
-    - input: "$(params.fvt_version_servicerequests)"
+    - input: "$(params.fvt_digest_servicerequests)"
       operator: notin
-      values: ["skip"]
+      values: [""]
     - input: "$(params.mas_app_channel_manage)"
       operator: notin
       values: [""]
@@ -347,8 +347,8 @@
       value: fvt-servicerequests
     - name: fvt_image_name
       value: fvt-servicerequests-testng
-    - name: fvt_image_version
-      value: $(params.fvt_version_servicerequests)
+    - name: fvt_image_digest
+      value: $(params.fvt_digest_servicerequests)
     - name: fvt_test_suite
       value: mas-ios-MVT-SR
     - name: product_channel
@@ -369,11 +369,11 @@
   taskRef:
     kind: Task
     name: mas-fvt-run-suite
-  # Only if we've set a version of the Mobile Service Request FVT to run
+  # Only if we've set a digest of the Mobile Service Request FVT to run
   when:
-    - input: "$(params.fvt_version_servicerequests)"
+    - input: "$(params.fvt_digest_servicerequests)"
       operator: notin
-      values: ["skip"]
+      values: [""]
     - input: "$(params.mas_app_channel_manage)"
       operator: notin
       values: [""]
@@ -402,8 +402,8 @@
       value: fvt-technician
     - name: fvt_image_name
       value: fvt-technician-preparedata
-    - name: fvt_image_version
-      value: $(params.fvt_version_technician)
+    - name: fvt_image_digest
+      value: $(params.fvt_digest_technician)
     - name: fvt_test_suite
       value: prepare-test-data-testng-mas
     - name: product_channel
@@ -413,11 +413,11 @@
   taskRef:
     kind: Task
     name: mas-fvt-run-suite
-  # Only if we've set a version of the Mobile Foundation FVT to run
+  # Only if we've set a digest of the Mobile Foundation FVT to run
   when:
-    - input: "$(params.fvt_version_technician)"
+    - input: "$(params.fvt_digest_technician)"
       operator: notin
-      values: ["skip"]
+      values: [""]
     - input: "$(params.mas_app_channel_manage)"
       operator: notin
       values: [""]
@@ -446,8 +446,8 @@
       value: fvt-technician
     - name: fvt_image_name
       value: fvt-technician-testng
-    - name: fvt_image_version
-      value: $(params.fvt_version_technician)
+    - name: fvt_image_digest
+      value: $(params.fvt_digest_technician)
     - name: fvt_test_suite
       value: mas-android-MVT-Technician
     - name: product_channel
@@ -463,11 +463,11 @@
   taskRef:
     kind: Task
     name: mas-fvt-run-suite
-  # Only if we've set a version of the Mobile Technician FVT to run
+  # Only if we've set a digest of the Mobile Technician FVT to run
   when:
-    - input: "$(params.fvt_version_technician)"
+    - input: "$(params.fvt_digest_technician)"
       operator: notin
-      values: ["skip"]
+      values: [""]
     - input: "$(params.mas_app_channel_manage)"
       operator: notin
       values: [""]
@@ -496,8 +496,8 @@
       value: fvt-technician
     - name: fvt_image_name
       value: fvt-technician-testng
-    - name: fvt_image_version
-      value: $(params.fvt_version_technician)
+    - name: fvt_image_digest
+      value: $(params.fvt_digest_technician)
     - name: fvt_test_suite
       value: mas-ios-MVT-Technician
     - name: product_channel
@@ -513,11 +513,11 @@
   taskRef:
     kind: Task
     name: mas-fvt-run-suite
-  # Only if we've set a version of the Mobile Technician FVT to run
+  # Only if we've set a digest of the Mobile Technician FVT to run
   when:
-    - input: "$(params.fvt_version_technician)"
+    - input: "$(params.fvt_digest_technician)"
       operator: notin
-      values: ["skip"]
+      values: [""]
     - input: "$(params.mas_app_channel_manage)"
       operator: notin
       values: [""]
@@ -546,8 +546,8 @@
       value: fvt-inspections
     - name: fvt_image_name
       value: fvt-inspections-preparedata
-    - name: fvt_image_version
-      value: $(params.fvt_version_inspection)
+    - name: fvt_image_digest
+      value: $(params.fvt_digest_inspection)
     - name: fvt_test_suite
       value: prepare-test-data-testng-mas
     - name: product_channel
@@ -557,11 +557,11 @@
   taskRef:
     kind: Task
     name: mas-fvt-run-suite
-  # Only if we've set a version of the Mobile Foundation FVT to run
+  # Only if we've set a digest of the Mobile Foundation FVT to run
   when:
-    - input: "$(params.fvt_version_inspection)"
+    - input: "$(params.fvt_digest_inspection)"
       operator: notin
-      values: ["skip"]
+      values: [""]
     - input: "$(params.mas_app_channel_manage)"
       operator: notin
       values: [""]
@@ -590,8 +590,8 @@
       value: fvt-inspections
     - name: fvt_image_name
       value: fvt-inspections-testng
-    - name: fvt_image_version
-      value: $(params.fvt_version_inspection)
+    - name: fvt_image_digest
+      value: $(params.fvt_digest_inspection)
     - name: fvt_test_suite
       value: mas-android-MVT-Inspections
     - name: product_channel
@@ -607,11 +607,11 @@
   taskRef:
     kind: Task
     name: mas-fvt-run-suite
-  # Only if we've set a version of the Mobile Inspection FVT to run
+  # Only if we've set a digest of the Mobile Inspection FVT to run
   when:
-    - input: "$(params.fvt_version_inspection)"
+    - input: "$(params.fvt_digest_inspection)"
       operator: notin
-      values: ["skip"]
+      values: [""]
     - input: "$(params.mas_app_channel_manage)"
       operator: notin
       values: [""]
@@ -640,8 +640,8 @@
       value: fvt-inspections
     - name: fvt_image_name
       value: fvt-inspections-testng
-    - name: fvt_image_version
-      value: $(params.fvt_version_inspection)
+    - name: fvt_image_digest
+      value: $(params.fvt_digest_inspection)
     - name: fvt_test_suite
       value: mas-ios-MVT-Inspections
     - name: product_channel
@@ -657,11 +657,11 @@
   taskRef:
     kind: Task
     name: mas-fvt-run-suite
-  # Only if we've set a version of the Mobile Inspection FVT to run
+  # Only if we've set a digest of the Mobile Inspection FVT to run
   when:
-    - input: "$(params.fvt_version_inspection)"
+    - input: "$(params.fvt_digest_inspection)"
       operator: notin
-      values: ["skip"]
+      values: [""]
     - input: "$(params.mas_app_channel_manage)"
       operator: notin
       values: [""]
@@ -690,8 +690,8 @@
       value: fvt-manage-civil
     - name: fvt_image_name
       value: fvt-ibm-mas-manage-civil-defects-preparedata
-    - name: fvt_image_version
-      value: $(params.fvt_version_manage_civil)
+    - name: fvt_image_digest
+      value: $(params.fvt_digest_manage_civil)
     - name: fvt_test_suite
       value: prepare-test-data-testng-mas
     - name: product_channel
@@ -701,11 +701,11 @@
   taskRef:
     kind: Task
     name: mas-fvt-run-suite
-  # Only if we've set a version of the Mobile Foundation FVT to run
+  # Only if we've set a digest of the Mobile Foundation FVT to run
   when:
-    - input: "$(params.fvt_version_manage_civil)"
+    - input: "$(params.fvt_digest_manage_civil)"
       operator: notin
-      values: ["skip"]
+      values: [""]
     - input: "$(params.mas_app_channel_manage)"
       operator: notin
       values: [""]
@@ -734,8 +734,8 @@
       value: fvt-manage-civil
     - name: fvt_image_name
       value: fvt-ibm-mas-manage-civil-defects-testng
-    - name: fvt_image_version
-      value: $(params.fvt_version_manage_civil)
+    - name: fvt_image_digest
+      value: $(params.fvt_digest_manage_civil)
     - name: fvt_test_suite
       value: testng-mas-mobile-andorid
     - name: product_channel
@@ -751,11 +751,11 @@
   taskRef:
     kind: Task
     name: mas-fvt-run-suite
-  # Only if we've set a version of the Mobile Defects FVT to run
+  # Only if we've set a digest of the Mobile Defects FVT to run
   when:
-    - input: "$(params.fvt_version_manage_civil)"
+    - input: "$(params.fvt_digest_manage_civil)"
       operator: notin
-      values: ["skip"]
+      values: [""]
     - input: "$(params.mas_app_channel_manage)"
       operator: notin
       values: [""]
@@ -784,8 +784,8 @@
       value: fvt-manage-civil
     - name: fvt_image_name
       value: fvt-ibm-mas-manage-civil-defects-testng
-    - name: fvt_image_version
-      value: $(params.fvt_version_manage_civil)
+    - name: fvt_image_digest
+      value: $(params.fvt_digest_manage_civil)
     - name: fvt_test_suite
       value: testng-mas-mobile-ios
     - name: product_channel
@@ -801,11 +801,11 @@
   taskRef:
     kind: Task
     name: mas-fvt-run-suite
-  # Only if we've set a version of the Mobile Defects FVT to run
+  # Only if we've set a digest of the Mobile Defects FVT to run
   when:
-    - input: "$(params.fvt_version_manage_civil)"
+    - input: "$(params.fvt_digest_manage_civil)"
       operator: notin
-      values: ["skip"]
+      values: [""]
     - input: "$(params.mas_app_channel_manage)"
       operator: notin
       values: [""]
@@ -834,8 +834,8 @@
       value: fvt-asset-manager
     - name: fvt_image_name
       value: fvt-asset-manager-preparedata
-    - name: fvt_image_version
-      value: $(params.fvt_version_asset_manager)
+    - name: fvt_image_digest
+      value: $(params.fvt_digest_asset_manager)
     - name: fvt_test_suite
       value: prepare-test-data-testng-mas
     - name: product_channel
@@ -850,11 +850,11 @@
   taskRef:
     kind: Task
     name: mas-fvt-run-suite
-  # Only if we've set a version of the Mobile Foundation FVT to run
+  # Only if we've set a digest of the Mobile Foundation FVT to run
   when:
-    - input: "$(params.fvt_version_asset_manager)"
+    - input: "$(params.fvt_digest_asset_manager)"
       operator: notin
-      values: ["skip"]
+      values: [""]
     - input: "$(params.mas_app_channel_manage)"
       operator: notin
       values: [""]
@@ -883,8 +883,8 @@
       value: fvt-asset-manager
     - name: fvt_image_name
       value: fvt-asset-manager-testng
-    - name: fvt_image_version
-      value: $(params.fvt_version_asset_manager)
+    - name: fvt_image_digest
+      value: $(params.fvt_digest_asset_manager)
     - name: fvt_test_suite
       value: mas-android-MVT-AssetManager
     - name: product_channel
@@ -905,11 +905,11 @@
   taskRef:
     kind: Task
     name: mas-fvt-run-suite
-  # Only if we've set a version of the Mobile Asset Manager FVT to run
+  # Only if we've set a digest of the Mobile Asset Manager FVT to run
   when:
-    - input: "$(params.fvt_version_asset_manager)"
+    - input: "$(params.fvt_digest_asset_manager)"
       operator: notin
-      values: ["skip"]
+      values: [""]
     - input: "$(params.mas_app_channel_manage)"
       operator: notin
       values: [""]
@@ -938,8 +938,8 @@
       value: fvt-asset-manager
     - name: fvt_image_name
       value: fvt-asset-manager-testng
-    - name: fvt_image_version
-      value: $(params.fvt_version_asset_manager)
+    - name: fvt_image_digest
+      value: $(params.fvt_digest_asset_manager)
     - name: fvt_test_suite
       value: mas-ios-MVT-AssetManager
     - name: product_channel
@@ -960,11 +960,11 @@
   taskRef:
     kind: Task
     name: mas-fvt-run-suite
-  # Only if we've set a version of the Mobile Asset Manager FVT to run
+  # Only if we've set a digest of the Mobile Asset Manager FVT to run
   when:
-    - input: "$(params.fvt_version_asset_manager)"
+    - input: "$(params.fvt_digest_asset_manager)"
       operator: notin
-      values: ["skip"]
+      values: [""]
     - input: "$(params.mas_app_channel_manage)"
       operator: notin
       values: [""]
@@ -997,8 +997,8 @@
       value: fvt-inventorycounting
     - name: fvt_image_name
       value: fvt-inventorycounting-manage-setup
-    - name: fvt_image_version
-      value: $(params.fvt_version_inventorycounting)
+    - name: fvt_image_digest
+      value: $(params.fvt_digest_inventorycounting)
     - name: fvt_mas_appws_component
       value: base
     - name: mas_appws_components
@@ -1019,11 +1019,11 @@
   taskRef:
     kind: Task
     name: mas-fvt-manage
-  # Only if we've set a version of the IC FVT to run
+  # Only if we've set a digest of the IC FVT to run
   when:
-    - input: "$(params.fvt_version_inventorycounting)"
+    - input: "$(params.fvt_digest_inventorycounting)"
       operator: notin
-      values: ["skip"]
+      values: [""]
     - input: "$(params.mas_app_channel_manage)"
       operator: notin
       values: [""]
@@ -1056,8 +1056,8 @@
       value: fvt-inventorycounting
     - name: fvt_image_name
       value: fvt-inventorycounting-testng
-    - name: fvt_image_version
-      value: $(params.fvt_version_inventorycounting)
+    - name: fvt_image_digest
+      value: $(params.fvt_digest_inventorycounting)
     - name: fvt_mas_appws_component
       value: base
     - name: mas_appws_components
@@ -1078,11 +1078,11 @@
   taskRef:
     kind: Task
     name: mas-fvt-manage
-  # Only if we've set a version of the Mobile IC FVT to run
+  # Only if we've set a digest of the Mobile IC FVT to run
   when:
-    - input: "$(params.fvt_version_inventorycounting)"
+    - input: "$(params.fvt_digest_inventorycounting)"
       operator: notin
-      values: ["skip"]
+      values: [""]
     - input: "$(params.mas_app_channel_manage)"
       operator: notin
       values: [""]

--- a/tekton/src/pipelines/taskdefs/fvt-apps/monitor.yml.j2
+++ b/tekton/src/pipelines/taskdefs/fvt-apps/monitor.yml.j2
@@ -16,8 +16,8 @@
       value: ai-solutions
     - name: fvt_image_name
       value: common-test-framework
-    - name: fvt_image_version
-      value: $(params.fvt_version_monitor)
+    - name: fvt_image_digest
+      value: $(params.fvt_digest_monitor)
     - name: fvt_test_suite
       value: monitor_fvt # pytest_marker in Common Test Framework
     - name: product_channel
@@ -32,11 +32,11 @@
   taskRef:
     kind: Task
     name: mas-fvt-run-suite
-  # Only if we've set a version of the Predict FVT to run
+  # Only if we've set a digest of the Predict FVT to run
   when:
-    - input: "$(params.fvt_version_monitor)"
+    - input: "$(params.fvt_digest_monitor)"
       operator: notin
-      values: ["skip"]
+      values: [""]
     - input: "$(params.mas_app_channel_monitor)"
       operator: notin
       values: [""]

--- a/tekton/src/pipelines/taskdefs/fvt-apps/optimizer.yml.j2
+++ b/tekton/src/pipelines/taskdefs/fvt-apps/optimizer.yml.j2
@@ -16,8 +16,8 @@
       value: ai-solutions
     - name: fvt_image_name
       value: common-test-framework
-    - name: fvt_image_version
-      value: $(params.fvt_version_optimizer)
+    - name: fvt_image_digest
+      value: $(params.fvt_digest_optimizer)
     - name: fvt_test_suite
       value: optimizer_fvt # pytest_marker in Common Test Framework
     - name: product_channel
@@ -32,11 +32,11 @@
   taskRef:
     kind: Task
     name: mas-fvt-run-suite
-  # Only if we've set a version of the Predict FVT to run
+  # Only if we've set a digest of the Predict FVT to run
   when:
-    - input: "$(params.fvt_version_optimizer)"
+    - input: "$(params.fvt_digest_optimizer)"
       operator: notin
-      values: ["skip"]
+      values: [""]
     - input: "$(params.mas_app_channel_optimizer)"
       operator: notin
       values: [""]

--- a/tekton/src/pipelines/taskdefs/fvt-apps/predict.yml.j2
+++ b/tekton/src/pipelines/taskdefs/fvt-apps/predict.yml.j2
@@ -14,8 +14,8 @@
       value: ai-solutions
     - name: fvt_image_name
       value: common-test-framework
-    - name: fvt_image_version
-      value: $(params.fvt_version_predict)
+    - name: fvt_image_digest
+      value: $(params.fvt_digest_predict)
     - name: fvt_test_suite
       value: predict_fvt # pytest_marker in Common Test Framework
     - name: product_channel
@@ -30,11 +30,11 @@
   taskRef:
     kind: Task
     name: mas-fvt-run-suite
-  # Only if we've set a version of the Predict FVT to run
+  # Only if we've set a digest of the Predict FVT to run
   when:
-    - input: "$(params.fvt_version_predict)"
+    - input: "$(params.fvt_digest_predict)"
       operator: notin
-      values: ["skip"]
+      values: [""]
     - input: "$(params.mas_app_channel_predict)"
       operator: notin
       values: [""]

--- a/tekton/src/pipelines/taskdefs/fvt-apps/safety.yml.j2
+++ b/tekton/src/pipelines/taskdefs/fvt-apps/safety.yml.j2
@@ -16,8 +16,8 @@
       value: fvt-safety
     - name: fvt_image_name
       value: fvt-ibm-mas-safety
-    - name: fvt_image_version
-      value: $(params.fvt_version_safety)
+    - name: fvt_image_digest
+      value: $(params.fvt_digest_safety)
     - name: product_channel
       value: $(params.mas_app_channel_safety)
     - name: product_id
@@ -34,11 +34,11 @@
   taskRef:
     kind: Task
     name: mas-fvt-run-suite
-  # Only if we've set a version of the Satety FVT to run
+  # Only if we've set a digest of the Satety FVT to run
   when:
-    - input: "$(params.fvt_version_safety)"
+    - input: "$(params.fvt_digest_safety)"
       operator: notin
-      values: ["skip"]
+      values: [""]
     - input: "$(params.mas_app_channel_safety)"
       operator: notin
       values: [""]

--- a/tekton/src/pipelines/taskdefs/fvt-apps/visualinspection.yml.j2
+++ b/tekton/src/pipelines/taskdefs/fvt-apps/visualinspection.yml.j2
@@ -16,8 +16,8 @@
       value: ai-solutions
     - name: fvt_image_name
       value: common-test-framework
-    - name: fvt_image_version
-      value: $(params.fvt_version_visualinspection)
+    - name: fvt_image_digest
+      value: $(params.fvt_digest_visualinspection)
     - name: fvt_test_suite
       value: visualinspection_fvt # pytest_marker in Common Test Framework
     - name: product_channel
@@ -32,11 +32,11 @@
   taskRef:
     kind: Task
     name: mas-fvt-run-suite
-  # Only if we've set a version of the MVI FVT to run
+  # Only if we've set a digest of the MVI FVT to run
   when:
-    - input: "$(params.fvt_version_visualinspection)"
+    - input: "$(params.fvt_digest_visualinspection)"
       operator: notin
-      values: ["skip"]
+      values: [""]
     - input: "$(params.mas_app_channel_visualinspection)"
       operator: notin
       values: [""]

--- a/tekton/src/pipelines/taskdefs/ivt-core/all-apps.yml.j2
+++ b/tekton/src/pipelines/taskdefs/ivt-core/all-apps.yml.j2
@@ -9,9 +9,9 @@
     - name: product_channel
       value: $(params.mas_app_channel_assist)
   when:
-    - input: "$(params.ivt_version_core)"
+    - input: "$(params.ivt_digest_core)"
       operator: notin
-      values: ["skip"]
+      values: [""]
     - input: "$(params.mas_app_channel_assist)"
       operator: notin
       values: [""]
@@ -30,9 +30,9 @@
     - name: product_channel
       value: $(params.mas_app_channel_hputilities)
   when:
-    - input: "$(params.ivt_version_core)"
+    - input: "$(params.ivt_digest_core)"
       operator: notin
-      values: ["skip"]
+      values: [""]
     - input: "$(params.mas_app_channel_hputilities)"
       operator: notin
       values: [""]
@@ -51,9 +51,9 @@
     - name: product_channel
       value: $(params.mas_app_channel_iot)
   when:
-    - input: "$(params.ivt_version_core)"
+    - input: "$(params.ivt_digest_core)"
       operator: notin
-      values: ["skip"]
+      values: [""]
     - input: "$(params.mas_app_channel_iot)"
       operator: notin
       values: [""]
@@ -72,9 +72,9 @@
     - name: product_channel
       value: $(params.mas_app_channel_monitor)
   when:
-    - input: "$(params.ivt_version_core)"
+    - input: "$(params.digest)"
       operator: notin
-      values: ["skip"]
+      values: [""]
     - input: "$(params.mas_app_channel_monitor)"
       operator: notin
       values: [""]
@@ -93,9 +93,9 @@
     - name: product_channel
       value: $(params.mas_app_channel_optimizer)
   when:
-    - input: "$(params.ivt_version_core)"
+    - input: "$(params.ivt_digest_core)"
       operator: notin
-      values: ["skip"]
+      values: [""]
     - input: "$(params.mas_app_channel_optimizer)"
       operator: notin
       values: [""]
@@ -114,9 +114,9 @@
     - name: product_channel
       value: $(params.mas_app_channel_predict)
   when:
-    - input: "$(params.ivt_version_core)"
+    - input: "$(params.ivt_digest_core)"
       operator: notin
-      values: ["skip"]
+      values: [""]
     - input: "$(params.mas_app_channel_predict)"
       operator: notin
       values: [""]
@@ -135,9 +135,9 @@
     - name: product_channel
       value: $(params.mas_app_channel_safety)
   when:
-    - input: "$(params.ivt_version_core)"
+    - input: "$(params.digest)"
       operator: notin
-      values: ["skip"]
+      values: [""]
     - input: "$(params.mas_app_channel_safety)"
       operator: notin
       values: [""]
@@ -156,9 +156,9 @@
     - name: product_channel
       value: $(params.mas_app_channel_visualinspection)
   when:
-    - input: "$(params.ivt_version_core)"
+    - input: "$(params.ivt_digest_core)"
       operator: notin
-      values: ["skip"]
+      values: [""]
     - input: "$(params.mas_app_channel_visualinspection)"
       operator: notin
       values: [""]

--- a/tekton/src/pipelines/taskdefs/ivt-core/common/params.yml.j2
+++ b/tekton/src/pipelines/taskdefs/ivt-core/common/params.yml.j2
@@ -10,8 +10,8 @@
   value: $(params.fvt_image_registry)
 - name: fvt_image_name
   value: ivt-core
-- name: fvt_image_version
-  value: $(params.ivt_version_core)
+- name: fvt_image_digest
+  value: $(params.ivt_digest_core)
 - name: devops_test_type
   value: $(params.devops_test_type)
 - name: devops_test_phase

--- a/tekton/src/pipelines/taskdefs/ivt-core/manage.yml.j2
+++ b/tekton/src/pipelines/taskdefs/ivt-core/manage.yml.j2
@@ -9,9 +9,9 @@
     - name: product_channel
       value: $(params.mas_app_channel_manage)
   when:
-    - input: "$(params.ivt_version_core)"
+    - input: "$(params.ivt_digest_core)"
       operator: notin
-      values: ["skip"]
+      values: [""]
     - input: "$(params.mas_app_channel_manage)"
       operator: notin
       values: [""]

--- a/tekton/src/tasks/fvt/fvt-assist-desktop.yml.j2
+++ b/tekton/src/tasks/fvt/fvt-assist-desktop.yml.j2
@@ -15,10 +15,9 @@ spec:
     - name: fvt_image_registry
       type: string
       description: FVT Container Image Registry (required)
-    - name: fvt_image_version
+    - name: fvt_image_digest
       type: string
-      description: FVT Container Image Version
-      default: latest
+      description: FVT Container Image Digest
 
     # Test Framework Information
     # -------------------------------------------------------------------------
@@ -142,168 +141,168 @@ spec:
     - name: configs
   steps:
     - name: admin-roles
-      image: '$(params.fvt_image_registry)/fvt-assist/fvt-assist-testng:$(params.fvt_image_version)'
+      image: '$(params.fvt_image_registry)/fvt-assist/fvt-assist-testng:$(params.fvt_image_digest)'
       imagePullPolicy: $(params.image_pull_policy)
       timeout: 90m # Ensure bad FVTs don't run forever
       onError: continue # Ensure bad FVTs don't break the pipeline
       command: [ "FVT_TEST_SUITE=testng-desktop-admin-roles", "/bin/bash", "runner.sh" ]
 
     - name: admin-apikeys
-      image: '$(params.fvt_image_registry)/fvt-assist/fvt-assist-testng:$(params.fvt_image_version)'
+      image: '$(params.fvt_image_registry)/fvt-assist/fvt-assist-testng:$(params.fvt_image_digest)'
       imagePullPolicy: $(params.image_pull_policy)
       timeout: 90m # Ensure bad FVTs don't run forever
       onError: continue # Ensure bad FVTs don't break the pipeline
       command: [ "FVT_TEST_SUITE=testng-desktop-admin-apikeys", "/bin/bash", "runner.sh" ]
 
     - name: admin-field
-      image: '$(params.fvt_image_registry)/fvt-assist/fvt-assist-testng:$(params.fvt_image_version)'
+      image: '$(params.fvt_image_registry)/fvt-assist/fvt-assist-testng:$(params.fvt_image_digest)'
       imagePullPolicy: $(params.image_pull_policy)
       timeout: 90m # Ensure bad FVTs don't run forever
       onError: continue # Ensure bad FVTs don't break the pipeline
       command: [ "FVT_TEST_SUITE=testng-desktop-admin-field", "/bin/bash", "runner.sh" ]
 
     - name: admin-expertise
-      image: '$(params.fvt_image_registry)/fvt-assist/fvt-assist-testng:$(params.fvt_image_version)'
+      image: '$(params.fvt_image_registry)/fvt-assist/fvt-assist-testng:$(params.fvt_image_digest)'
       imagePullPolicy: $(params.image_pull_policy)
       timeout: 90m # Ensure bad FVTs don't run forever
       onError: continue # Ensure bad FVTs don't break the pipeline
       command: [ "FVT_TEST_SUITE=testng-desktop-admin-expertise", "/bin/bash", "runner.sh" ]
 
     - name: admin-collaboration
-      image: '$(params.fvt_image_registry)/fvt-assist/fvt-assist-testng:$(params.fvt_image_version)'
+      image: '$(params.fvt_image_registry)/fvt-assist/fvt-assist-testng:$(params.fvt_image_digest)'
       imagePullPolicy: $(params.image_pull_policy)
       timeout: 90m # Ensure bad FVTs don't run forever
       onError: continue # Ensure bad FVTs don't break the pipeline
       command: [ "FVT_TEST_SUITE=testng-desktop-admin-collaboration", "/bin/bash", "runner.sh" ]
 
     - name: admin-ice
-      image: '$(params.fvt_image_registry)/fvt-assist/fvt-assist-testng:$(params.fvt_image_version)'
+      image: '$(params.fvt_image_registry)/fvt-assist/fvt-assist-testng:$(params.fvt_image_digest)'
       imagePullPolicy: $(params.image_pull_policy)
       timeout: 90m # Ensure bad FVTs don't run forever
       onError: continue # Ensure bad FVTs don't break the pipeline
       command: [ "FVT_TEST_SUITE=testng-desktop-admin-ice", "/bin/bash", "runner.sh" ]
 
     - name: admin-search-config
-      image: '$(params.fvt_image_registry)/fvt-assist/fvt-assist-testng:$(params.fvt_image_version)'
+      image: '$(params.fvt_image_registry)/fvt-assist/fvt-assist-testng:$(params.fvt_image_digest)'
       imagePullPolicy: $(params.image_pull_policy)
       timeout: 90m # Ensure bad FVTs don't run forever
       onError: continue # Ensure bad FVTs don't break the pipeline
       command: [ "FVT_TEST_SUITE=testng-desktop-admin-search-config", "/bin/bash", "runner.sh" ]
 
     - name: admin-sessions
-      image: '$(params.fvt_image_registry)/fvt-assist/fvt-assist-testng:$(params.fvt_image_version)'
+      image: '$(params.fvt_image_registry)/fvt-assist/fvt-assist-testng:$(params.fvt_image_digest)'
       imagePullPolicy: $(params.image_pull_policy)
       timeout: 90m # Ensure bad FVTs don't run forever
       onError: continue # Ensure bad FVTs don't break the pipeline
       command: [ "FVT_TEST_SUITE=testng-desktop-admin-sessions", "/bin/bash", "runner.sh" ]
 
     - name: admin-users
-      image: '$(params.fvt_image_registry)/fvt-assist/fvt-assist-testng:$(params.fvt_image_version)'
+      image: '$(params.fvt_image_registry)/fvt-assist/fvt-assist-testng:$(params.fvt_image_digest)'
       imagePullPolicy: $(params.image_pull_policy)
       timeout: 90m # Ensure bad FVTs don't run forever
       onError: continue # Ensure bad FVTs don't break the pipeline
       command: [ "FVT_TEST_SUITE=testng-desktop-admin-users", "/bin/bash", "runner.sh" ]
 
     - name: diagnosis-element-relation
-      image: '$(params.fvt_image_registry)/fvt-assist/fvt-assist-testng:$(params.fvt_image_version)'
+      image: '$(params.fvt_image_registry)/fvt-assist/fvt-assist-testng:$(params.fvt_image_digest)'
       imagePullPolicy: $(params.image_pull_policy)
       timeout: 90m # Ensure bad FVTs don't run forever
       onError: continue # Ensure bad FVTs don't break the pipeline
       command: [ "FVT_TEST_SUITE=testng-desktop-diagnosis-element-relation", "/bin/bash", "runner.sh" ]
 
     - name: diagnosis-flow
-      image: '$(params.fvt_image_registry)/fvt-assist/fvt-assist-testng:$(params.fvt_image_version)'
+      image: '$(params.fvt_image_registry)/fvt-assist/fvt-assist-testng:$(params.fvt_image_digest)'
       imagePullPolicy: $(params.image_pull_policy)
       timeout: 90m # Ensure bad FVTs don't run forever
       onError: continue # Ensure bad FVTs don't break the pipeline
       command: [ "FVT_TEST_SUITE=testng-desktop-diagnosis-flow", "/bin/bash", "runner.sh" ]
 
     - name: diagnosis-library-feedback
-      image: '$(params.fvt_image_registry)/fvt-assist/fvt-assist-testng:$(params.fvt_image_version)'
+      image: '$(params.fvt_image_registry)/fvt-assist/fvt-assist-testng:$(params.fvt_image_digest)'
       imagePullPolicy: $(params.image_pull_policy)
       timeout: 90m # Ensure bad FVTs don't run forever
       onError: continue # Ensure bad FVTs don't break the pipeline
       command: [ "FVT_TEST_SUITE=testng-desktop-diagnosis-library-feedback", "/bin/bash", "runner.sh" ]
 
     - name: diagnosis-library-historicaldata
-      image: '$(params.fvt_image_registry)/fvt-assist/fvt-assist-testng:$(params.fvt_image_version)'
+      image: '$(params.fvt_image_registry)/fvt-assist/fvt-assist-testng:$(params.fvt_image_digest)'
       imagePullPolicy: $(params.image_pull_policy)
       timeout: 90m # Ensure bad FVTs don't run forever
       onError: continue # Ensure bad FVTs don't break the pipeline
       command: [ "FVT_TEST_SUITE=testng-desktop-diagnosis-library-historicaldata", "/bin/bash", "runner.sh" ]
 
     - name: technician-diagnosis
-      image: '$(params.fvt_image_registry)/fvt-assist/fvt-assist-testng:$(params.fvt_image_version)'
+      image: '$(params.fvt_image_registry)/fvt-assist/fvt-assist-testng:$(params.fvt_image_digest)'
       imagePullPolicy: $(params.image_pull_policy)
       timeout: 90m # Ensure bad FVTs don't run forever
       onError: continue # Ensure bad FVTs don't break the pipeline
       command: [ "FVT_TEST_SUITE=testng-desktop-technician-diagnosis", "/bin/bash", "runner.sh" ]
 
     - name: query-docpreview
-      image: '$(params.fvt_image_registry)/fvt-assist/fvt-assist-testng:$(params.fvt_image_version)'
+      image: '$(params.fvt_image_registry)/fvt-assist/fvt-assist-testng:$(params.fvt_image_digest)'
       imagePullPolicy: $(params.image_pull_policy)
       timeout: 90m # Ensure bad FVTs don't run forever
       onError: continue # Ensure bad FVTs don't break the pipeline
       command: [ "FVT_TEST_SUITE=testng-desktop-query-docpreview", "/bin/bash", "runner.sh" ]
 
     - name: query-maximo-integration
-      image: '$(params.fvt_image_registry)/fvt-assist/fvt-assist-testng:$(params.fvt_image_version)'
+      image: '$(params.fvt_image_registry)/fvt-assist/fvt-assist-testng:$(params.fvt_image_digest)'
       imagePullPolicy: $(params.image_pull_policy)
       timeout: 90m # Ensure bad FVTs don't run forever
       onError: continue # Ensure bad FVTs don't break the pipeline
       command: [ "FVT_TEST_SUITE=testng-desktop-query-maximo-integration", "/bin/bash", "runner.sh" ]
 
     - name: query-resultcard
-      image: '$(params.fvt_image_registry)/fvt-assist/fvt-assist-testng:$(params.fvt_image_version)'
+      image: '$(params.fvt_image_registry)/fvt-assist/fvt-assist-testng:$(params.fvt_image_digest)'
       imagePullPolicy: $(params.image_pull_policy)
       timeout: 90m # Ensure bad FVTs don't run forever
       onError: continue # Ensure bad FVTs don't break the pipeline
       command: [ "FVT_TEST_SUITE=testng-desktop-query-resultcard", "/bin/bash", "runner.sh" ]
 
     - name: query-search
-      image: '$(params.fvt_image_registry)/fvt-assist/fvt-assist-testng:$(params.fvt_image_version)'
+      image: '$(params.fvt_image_registry)/fvt-assist/fvt-assist-testng:$(params.fvt_image_digest)'
       imagePullPolicy: $(params.image_pull_policy)
       timeout: 90m # Ensure bad FVTs don't run forever
       onError: continue # Ensure bad FVTs don't break the pipeline
       command: [ "FVT_TEST_SUITE=testng-desktop-query-search", "/bin/bash", "runner.sh" ]
 
     - name: query-searchconfig
-      image: '$(params.fvt_image_registry)/fvt-assist/fvt-assist-testng:$(params.fvt_image_version)'
+      image: '$(params.fvt_image_registry)/fvt-assist/fvt-assist-testng:$(params.fvt_image_digest)'
       imagePullPolicy: $(params.image_pull_policy)
       timeout: 90m # Ensure bad FVTs don't run forever
       onError: continue # Ensure bad FVTs don't break the pipeline
       command: [ "FVT_TEST_SUITE=testng-desktop-query-searchconfig", "/bin/bash", "runner.sh" ]
 
     - name: technician-collaborate
-      image: '$(params.fvt_image_registry)/fvt-assist/fvt-assist-testng:$(params.fvt_image_version)'
+      image: '$(params.fvt_image_registry)/fvt-assist/fvt-assist-testng:$(params.fvt_image_digest)'
       imagePullPolicy: $(params.image_pull_policy)
       timeout: 90m # Ensure bad FVTs don't run forever
       onError: continue # Ensure bad FVTs don't break the pipeline
       command: [ "FVT_TEST_SUITE=testng-desktop-technician-collaborate", "/bin/bash", "runner.sh" ]
 
     - name: admin-attribute
-      image: '$(params.fvt_image_registry)/fvt-assist/fvt-assist-testng:$(params.fvt_image_version)'
+      image: '$(params.fvt_image_registry)/fvt-assist/fvt-assist-testng:$(params.fvt_image_digest)'
       imagePullPolicy: $(params.image_pull_policy)
       timeout: 90m # Ensure bad FVTs don't run forever
       onError: continue # Ensure bad FVTs don't break the pipeline
       command: [ "FVT_TEST_SUITE=testng-desktop-admin-attribute", "/bin/bash", "runner.sh" ]
 
     - name: admin-token-refresh-studio
-      image: '$(params.fvt_image_registry)/fvt-assist/fvt-assist-testng:$(params.fvt_image_version)'
+      image: '$(params.fvt_image_registry)/fvt-assist/fvt-assist-testng:$(params.fvt_image_digest)'
       imagePullPolicy: $(params.image_pull_policy)
       timeout: 90m # Ensure bad FVTs don't run forever
       onError: continue # Ensure bad FVTs don't break the pipeline
       command: [ "FVT_TEST_SUITE=testng-desktop-admin-token-refresh-studio", "/bin/bash", "runner.sh" ]
 
     - name: admin-token-refresh-adminconsole
-      image: '$(params.fvt_image_registry)/fvt-assist/fvt-assist-testng:$(params.fvt_image_version)'
+      image: '$(params.fvt_image_registry)/fvt-assist/fvt-assist-testng:$(params.fvt_image_digest)'
       imagePullPolicy: $(params.image_pull_policy)
       timeout: 90m # Ensure bad FVTs don't run forever
       onError: continue # Ensure bad FVTs don't break the pipeline
       command: [ "FVT_TEST_SUITE=testng-desktop-admin-token-refresh-adminconsole", "/bin/bash", "runner.sh" ]
 
     - name: admin-token-refresh-technician
-      image: '$(params.fvt_image_registry)/fvt-assist/fvt-assist-testng:$(params.fvt_image_version)'
+      image: '$(params.fvt_image_registry)/fvt-assist/fvt-assist-testng:$(params.fvt_image_digest)'
       imagePullPolicy: $(params.image_pull_policy)
       timeout: 90m # Ensure bad FVTs don't run forever
       onError: continue # Ensure bad FVTs don't break the pipeline

--- a/tekton/src/tasks/fvt/fvt-assist-desktop.yml.j2
+++ b/tekton/src/tasks/fvt/fvt-assist-desktop.yml.j2
@@ -64,7 +64,7 @@ spec:
       type: string
       description: Boolean value to check if tests are runninng locally or on fvt
       default: "false"
-    
+
     # Optional parameters to categorize result to be persisted
     - name: devops_test_type
       type: string
@@ -127,7 +127,7 @@ spec:
       # Common Test Framework Specific information
       - name: CTF_IS_LOCAL
         value: $(params.ctf_is_local)
-      
+
       # Optional parameters to categorize result to be persisted
       - name: DEVOPS_TEST_TYPE
         value: $(params.devops_test_type)
@@ -141,168 +141,168 @@ spec:
     - name: configs
   steps:
     - name: admin-roles
-      image: '$(params.fvt_image_registry)/fvt-assist/fvt-assist-testng:$(params.fvt_image_digest)'
+      image: '$(params.fvt_image_registry)/fvt-assist/fvt-assist-testng@$(params.fvt_image_digest)'
       imagePullPolicy: $(params.image_pull_policy)
       timeout: 90m # Ensure bad FVTs don't run forever
       onError: continue # Ensure bad FVTs don't break the pipeline
       command: [ "FVT_TEST_SUITE=testng-desktop-admin-roles", "/bin/bash", "runner.sh" ]
 
     - name: admin-apikeys
-      image: '$(params.fvt_image_registry)/fvt-assist/fvt-assist-testng:$(params.fvt_image_digest)'
+      image: '$(params.fvt_image_registry)/fvt-assist/fvt-assist-testng@$(params.fvt_image_digest)'
       imagePullPolicy: $(params.image_pull_policy)
       timeout: 90m # Ensure bad FVTs don't run forever
       onError: continue # Ensure bad FVTs don't break the pipeline
       command: [ "FVT_TEST_SUITE=testng-desktop-admin-apikeys", "/bin/bash", "runner.sh" ]
 
     - name: admin-field
-      image: '$(params.fvt_image_registry)/fvt-assist/fvt-assist-testng:$(params.fvt_image_digest)'
+      image: '$(params.fvt_image_registry)/fvt-assist/fvt-assist-testng@$(params.fvt_image_digest)'
       imagePullPolicy: $(params.image_pull_policy)
       timeout: 90m # Ensure bad FVTs don't run forever
       onError: continue # Ensure bad FVTs don't break the pipeline
       command: [ "FVT_TEST_SUITE=testng-desktop-admin-field", "/bin/bash", "runner.sh" ]
 
     - name: admin-expertise
-      image: '$(params.fvt_image_registry)/fvt-assist/fvt-assist-testng:$(params.fvt_image_digest)'
+      image: '$(params.fvt_image_registry)/fvt-assist/fvt-assist-testng@$(params.fvt_image_digest)'
       imagePullPolicy: $(params.image_pull_policy)
       timeout: 90m # Ensure bad FVTs don't run forever
       onError: continue # Ensure bad FVTs don't break the pipeline
       command: [ "FVT_TEST_SUITE=testng-desktop-admin-expertise", "/bin/bash", "runner.sh" ]
 
     - name: admin-collaboration
-      image: '$(params.fvt_image_registry)/fvt-assist/fvt-assist-testng:$(params.fvt_image_digest)'
+      image: '$(params.fvt_image_registry)/fvt-assist/fvt-assist-testng@$(params.fvt_image_digest)'
       imagePullPolicy: $(params.image_pull_policy)
       timeout: 90m # Ensure bad FVTs don't run forever
       onError: continue # Ensure bad FVTs don't break the pipeline
       command: [ "FVT_TEST_SUITE=testng-desktop-admin-collaboration", "/bin/bash", "runner.sh" ]
 
     - name: admin-ice
-      image: '$(params.fvt_image_registry)/fvt-assist/fvt-assist-testng:$(params.fvt_image_digest)'
+      image: '$(params.fvt_image_registry)/fvt-assist/fvt-assist-testng@$(params.fvt_image_digest)'
       imagePullPolicy: $(params.image_pull_policy)
       timeout: 90m # Ensure bad FVTs don't run forever
       onError: continue # Ensure bad FVTs don't break the pipeline
       command: [ "FVT_TEST_SUITE=testng-desktop-admin-ice", "/bin/bash", "runner.sh" ]
 
     - name: admin-search-config
-      image: '$(params.fvt_image_registry)/fvt-assist/fvt-assist-testng:$(params.fvt_image_digest)'
+      image: '$(params.fvt_image_registry)/fvt-assist/fvt-assist-testng@$(params.fvt_image_digest)'
       imagePullPolicy: $(params.image_pull_policy)
       timeout: 90m # Ensure bad FVTs don't run forever
       onError: continue # Ensure bad FVTs don't break the pipeline
       command: [ "FVT_TEST_SUITE=testng-desktop-admin-search-config", "/bin/bash", "runner.sh" ]
 
     - name: admin-sessions
-      image: '$(params.fvt_image_registry)/fvt-assist/fvt-assist-testng:$(params.fvt_image_digest)'
+      image: '$(params.fvt_image_registry)/fvt-assist/fvt-assist-testng@$(params.fvt_image_digest)'
       imagePullPolicy: $(params.image_pull_policy)
       timeout: 90m # Ensure bad FVTs don't run forever
       onError: continue # Ensure bad FVTs don't break the pipeline
       command: [ "FVT_TEST_SUITE=testng-desktop-admin-sessions", "/bin/bash", "runner.sh" ]
 
     - name: admin-users
-      image: '$(params.fvt_image_registry)/fvt-assist/fvt-assist-testng:$(params.fvt_image_digest)'
+      image: '$(params.fvt_image_registry)/fvt-assist/fvt-assist-testng@$(params.fvt_image_digest)'
       imagePullPolicy: $(params.image_pull_policy)
       timeout: 90m # Ensure bad FVTs don't run forever
       onError: continue # Ensure bad FVTs don't break the pipeline
       command: [ "FVT_TEST_SUITE=testng-desktop-admin-users", "/bin/bash", "runner.sh" ]
 
     - name: diagnosis-element-relation
-      image: '$(params.fvt_image_registry)/fvt-assist/fvt-assist-testng:$(params.fvt_image_digest)'
+      image: '$(params.fvt_image_registry)/fvt-assist/fvt-assist-testng@$(params.fvt_image_digest)'
       imagePullPolicy: $(params.image_pull_policy)
       timeout: 90m # Ensure bad FVTs don't run forever
       onError: continue # Ensure bad FVTs don't break the pipeline
       command: [ "FVT_TEST_SUITE=testng-desktop-diagnosis-element-relation", "/bin/bash", "runner.sh" ]
 
     - name: diagnosis-flow
-      image: '$(params.fvt_image_registry)/fvt-assist/fvt-assist-testng:$(params.fvt_image_digest)'
+      image: '$(params.fvt_image_registry)/fvt-assist/fvt-assist-testng@$(params.fvt_image_digest)'
       imagePullPolicy: $(params.image_pull_policy)
       timeout: 90m # Ensure bad FVTs don't run forever
       onError: continue # Ensure bad FVTs don't break the pipeline
       command: [ "FVT_TEST_SUITE=testng-desktop-diagnosis-flow", "/bin/bash", "runner.sh" ]
 
     - name: diagnosis-library-feedback
-      image: '$(params.fvt_image_registry)/fvt-assist/fvt-assist-testng:$(params.fvt_image_digest)'
+      image: '$(params.fvt_image_registry)/fvt-assist/fvt-assist-testng@$(params.fvt_image_digest)'
       imagePullPolicy: $(params.image_pull_policy)
       timeout: 90m # Ensure bad FVTs don't run forever
       onError: continue # Ensure bad FVTs don't break the pipeline
       command: [ "FVT_TEST_SUITE=testng-desktop-diagnosis-library-feedback", "/bin/bash", "runner.sh" ]
 
     - name: diagnosis-library-historicaldata
-      image: '$(params.fvt_image_registry)/fvt-assist/fvt-assist-testng:$(params.fvt_image_digest)'
+      image: '$(params.fvt_image_registry)/fvt-assist/fvt-assist-testng@$(params.fvt_image_digest)'
       imagePullPolicy: $(params.image_pull_policy)
       timeout: 90m # Ensure bad FVTs don't run forever
       onError: continue # Ensure bad FVTs don't break the pipeline
       command: [ "FVT_TEST_SUITE=testng-desktop-diagnosis-library-historicaldata", "/bin/bash", "runner.sh" ]
 
     - name: technician-diagnosis
-      image: '$(params.fvt_image_registry)/fvt-assist/fvt-assist-testng:$(params.fvt_image_digest)'
+      image: '$(params.fvt_image_registry)/fvt-assist/fvt-assist-testng@$(params.fvt_image_digest)'
       imagePullPolicy: $(params.image_pull_policy)
       timeout: 90m # Ensure bad FVTs don't run forever
       onError: continue # Ensure bad FVTs don't break the pipeline
       command: [ "FVT_TEST_SUITE=testng-desktop-technician-diagnosis", "/bin/bash", "runner.sh" ]
 
     - name: query-docpreview
-      image: '$(params.fvt_image_registry)/fvt-assist/fvt-assist-testng:$(params.fvt_image_digest)'
+      image: '$(params.fvt_image_registry)/fvt-assist/fvt-assist-testng@$(params.fvt_image_digest)'
       imagePullPolicy: $(params.image_pull_policy)
       timeout: 90m # Ensure bad FVTs don't run forever
       onError: continue # Ensure bad FVTs don't break the pipeline
       command: [ "FVT_TEST_SUITE=testng-desktop-query-docpreview", "/bin/bash", "runner.sh" ]
 
     - name: query-maximo-integration
-      image: '$(params.fvt_image_registry)/fvt-assist/fvt-assist-testng:$(params.fvt_image_digest)'
+      image: '$(params.fvt_image_registry)/fvt-assist/fvt-assist-testng@$(params.fvt_image_digest)'
       imagePullPolicy: $(params.image_pull_policy)
       timeout: 90m # Ensure bad FVTs don't run forever
       onError: continue # Ensure bad FVTs don't break the pipeline
       command: [ "FVT_TEST_SUITE=testng-desktop-query-maximo-integration", "/bin/bash", "runner.sh" ]
 
     - name: query-resultcard
-      image: '$(params.fvt_image_registry)/fvt-assist/fvt-assist-testng:$(params.fvt_image_digest)'
+      image: '$(params.fvt_image_registry)/fvt-assist/fvt-assist-testng@$(params.fvt_image_digest)'
       imagePullPolicy: $(params.image_pull_policy)
       timeout: 90m # Ensure bad FVTs don't run forever
       onError: continue # Ensure bad FVTs don't break the pipeline
       command: [ "FVT_TEST_SUITE=testng-desktop-query-resultcard", "/bin/bash", "runner.sh" ]
 
     - name: query-search
-      image: '$(params.fvt_image_registry)/fvt-assist/fvt-assist-testng:$(params.fvt_image_digest)'
+      image: '$(params.fvt_image_registry)/fvt-assist/fvt-assist-testng@$(params.fvt_image_digest)'
       imagePullPolicy: $(params.image_pull_policy)
       timeout: 90m # Ensure bad FVTs don't run forever
       onError: continue # Ensure bad FVTs don't break the pipeline
       command: [ "FVT_TEST_SUITE=testng-desktop-query-search", "/bin/bash", "runner.sh" ]
 
     - name: query-searchconfig
-      image: '$(params.fvt_image_registry)/fvt-assist/fvt-assist-testng:$(params.fvt_image_digest)'
+      image: '$(params.fvt_image_registry)/fvt-assist/fvt-assist-testng@$(params.fvt_image_digest)'
       imagePullPolicy: $(params.image_pull_policy)
       timeout: 90m # Ensure bad FVTs don't run forever
       onError: continue # Ensure bad FVTs don't break the pipeline
       command: [ "FVT_TEST_SUITE=testng-desktop-query-searchconfig", "/bin/bash", "runner.sh" ]
 
     - name: technician-collaborate
-      image: '$(params.fvt_image_registry)/fvt-assist/fvt-assist-testng:$(params.fvt_image_digest)'
+      image: '$(params.fvt_image_registry)/fvt-assist/fvt-assist-testng@$(params.fvt_image_digest)'
       imagePullPolicy: $(params.image_pull_policy)
       timeout: 90m # Ensure bad FVTs don't run forever
       onError: continue # Ensure bad FVTs don't break the pipeline
       command: [ "FVT_TEST_SUITE=testng-desktop-technician-collaborate", "/bin/bash", "runner.sh" ]
 
     - name: admin-attribute
-      image: '$(params.fvt_image_registry)/fvt-assist/fvt-assist-testng:$(params.fvt_image_digest)'
+      image: '$(params.fvt_image_registry)/fvt-assist/fvt-assist-testng@$(params.fvt_image_digest)'
       imagePullPolicy: $(params.image_pull_policy)
       timeout: 90m # Ensure bad FVTs don't run forever
       onError: continue # Ensure bad FVTs don't break the pipeline
       command: [ "FVT_TEST_SUITE=testng-desktop-admin-attribute", "/bin/bash", "runner.sh" ]
 
     - name: admin-token-refresh-studio
-      image: '$(params.fvt_image_registry)/fvt-assist/fvt-assist-testng:$(params.fvt_image_digest)'
+      image: '$(params.fvt_image_registry)/fvt-assist/fvt-assist-testng@$(params.fvt_image_digest)'
       imagePullPolicy: $(params.image_pull_policy)
       timeout: 90m # Ensure bad FVTs don't run forever
       onError: continue # Ensure bad FVTs don't break the pipeline
       command: [ "FVT_TEST_SUITE=testng-desktop-admin-token-refresh-studio", "/bin/bash", "runner.sh" ]
 
     - name: admin-token-refresh-adminconsole
-      image: '$(params.fvt_image_registry)/fvt-assist/fvt-assist-testng:$(params.fvt_image_digest)'
+      image: '$(params.fvt_image_registry)/fvt-assist/fvt-assist-testng@$(params.fvt_image_digest)'
       imagePullPolicy: $(params.image_pull_policy)
       timeout: 90m # Ensure bad FVTs don't run forever
       onError: continue # Ensure bad FVTs don't break the pipeline
       command: [ "FVT_TEST_SUITE=testng-desktop-admin-token-refresh-adminconsole", "/bin/bash", "runner.sh" ]
 
     - name: admin-token-refresh-technician
-      image: '$(params.fvt_image_registry)/fvt-assist/fvt-assist-testng:$(params.fvt_image_digest)'
+      image: '$(params.fvt_image_registry)/fvt-assist/fvt-assist-testng@$(params.fvt_image_digest)'
       imagePullPolicy: $(params.image_pull_policy)
       timeout: 90m # Ensure bad FVTs don't run forever
       onError: continue # Ensure bad FVTs don't break the pipeline

--- a/tekton/src/tasks/fvt/fvt-assist.yml.j2
+++ b/tekton/src/tasks/fvt/fvt-assist.yml.j2
@@ -18,10 +18,9 @@ spec:
     - name: fvt_image_name
       type: string
       description: FVT Container Image Name (required)
-    - name: fvt_image_version
+    - name: fvt_image_digest
       type: string
-      description: FVT Container Image Version
-      default: latest
+      description: FVT Container Image Digest
 
     # Test Framework Information
     # -------------------------------------------------------------------------
@@ -139,7 +138,7 @@ spec:
       - name: DEVOPS_TEST_PHASE
         value: $(params.devops_test_phase)
   steps:
-    - image: '$(params.fvt_image_registry)/fvt-assist/$(params.fvt_image_name):$(params.fvt_image_version)'
+    - image: '$(params.fvt_image_registry)/fvt-assist/$(params.fvt_image_name):$(params.fvt_image_digest)'
       imagePullPolicy: $(params.image_pull_policy)
       timeout: 300m # Ensure bad FVTs don't run forever
       onError: continue # Ensure bad FVTs don't break the pipeline

--- a/tekton/src/tasks/fvt/fvt-assist.yml.j2
+++ b/tekton/src/tasks/fvt/fvt-assist.yml.j2
@@ -69,7 +69,7 @@ spec:
       type: string
       description: Boolean value to check if tests are runninng locally or on fvt
       default: "false"
-    
+
     # Optional parameters to categorize result to be persisted
     # -------------------------------------------------------------------------
     - name: devops_test_type
@@ -138,7 +138,7 @@ spec:
       - name: DEVOPS_TEST_PHASE
         value: $(params.devops_test_phase)
   steps:
-    - image: '$(params.fvt_image_registry)/fvt-assist/$(params.fvt_image_name):$(params.fvt_image_digest)'
+    - image: '$(params.fvt_image_registry)/fvt-assist/$(params.fvt_image_name)@$(params.fvt_image_digest)'
       imagePullPolicy: $(params.image_pull_policy)
       timeout: 300m # Ensure bad FVTs don't run forever
       onError: continue # Ensure bad FVTs don't break the pipeline

--- a/tekton/src/tasks/fvt/fvt-core-ui.yml.j2
+++ b/tekton/src/tasks/fvt/fvt-core-ui.yml.j2
@@ -65,7 +65,7 @@ spec:
       type: string
       description: Partium password (required by fvt-coreapi-workspacemgmt)
       default: ""
-    
+
     # Optional parameters to categorize result to be persisted
     # -------------------------------------------------------------------------
     - name: devops_test_type
@@ -116,14 +116,14 @@ spec:
         value: $(params.partium_username)
       - name: PARTIUM_PASSWORD
         value: $(params.partium_password)
-      
+
       # Optional parameters to categorize result to be persisted
       - name: DEVOPS_TEST_TYPE
         value: $(params.devops_test_type)
       - name: DEVOPS_TEST_PHASE
         value: $(params.devops_test_phase)
   steps:
-    - image: '$(params.fvt_image_registry)/mas-devops/fvt-ibm-mas-ui:$(params.fvt_image_digest)'
+    - image: '$(params.fvt_image_registry)/mas-devops/fvt-ibm-mas-ui@$(params.fvt_image_digest)'
       imagePullPolicy: $(params.image_pull_policy)
       timeout: 90m # Ensure bad FVTs don't run forever
       onError: continue # Ensure bad FVTs don't break the pipeline

--- a/tekton/src/tasks/fvt/fvt-core-ui.yml.j2
+++ b/tekton/src/tasks/fvt/fvt-core-ui.yml.j2
@@ -15,10 +15,9 @@ spec:
     - name: fvt_image_registry
       type: string
       description: FVT Container Image Registry (required)
-    - name: fvt_image_version
+    - name: fvt_image_digest
       type: string
-      description: FVT Container Image Version
-      default: latest
+      description: FVT Container Image Digest
 
     # Test Framework Information
     # -------------------------------------------------------------------------
@@ -124,7 +123,7 @@ spec:
       - name: DEVOPS_TEST_PHASE
         value: $(params.devops_test_phase)
   steps:
-    - image: '$(params.fvt_image_registry)/mas-devops/fvt-ibm-mas-ui:$(params.fvt_image_version)'
+    - image: '$(params.fvt_image_registry)/mas-devops/fvt-ibm-mas-ui:$(params.fvt_image_digest)'
       imagePullPolicy: $(params.image_pull_policy)
       timeout: 90m # Ensure bad FVTs don't run forever
       onError: continue # Ensure bad FVTs don't break the pipeline

--- a/tekton/src/tasks/fvt/fvt-core.yml.j2
+++ b/tekton/src/tasks/fvt/fvt-core.yml.j2
@@ -17,7 +17,7 @@ spec:
       description: FVT Container Image Registry (required)
     - name: fvt_image_digest
       type: string
-      description: FVT Container Image digest
+      description: FVT Container Image Digest
 
     # Test Framework Information
     # -------------------------------------------------------------------------

--- a/tekton/src/tasks/fvt/fvt-manage.yml.j2
+++ b/tekton/src/tasks/fvt/fvt-manage.yml.j2
@@ -100,7 +100,7 @@ spec:
       type: string
       description: Artifactory API Key (required by fvt-ibm-mas-manage and fvt-ibm-mas-safety to pull test container content)
       default: ""
-    
+
     # Optional parameters to categorize result to be persisted
     # -------------------------------------------------------------------------
     - name: devops_test_type
@@ -162,14 +162,14 @@ spec:
         value: $(params.devops_cos_upload_folder)
       - name: DEVOPS_IBMCLOUD_APIKEY
         value: $(params.devops_ibmcloud_apikey)
-      
+
       # Optional parameters to categorize result to be persisted
       - name: DEVOPS_TEST_TYPE
         value: $(params.devops_test_type)
       - name: DEVOPS_TEST_PHASE
         value: $(params.devops_test_phase)
   steps:
-    - image: '$(params.fvt_image_registry)/$(params.fvt_image_namespace)/$(params.fvt_image_name):$(params.fvt_image_digest)'
+    - image: '$(params.fvt_image_registry)/$(params.fvt_image_namespace)/$(params.fvt_image_name)@$(params.fvt_image_digest)'
       imagePullPolicy: $(params.image_pull_policy)
       timeout: 6h # Ensure bad FVTs don't run forever .. want this to be smaller, but urgh, teams have already created huge suites that run for hours instead of multiple smaller suites
       onError: continue # Ensure bad FVTs don't break the pipeline

--- a/tekton/src/tasks/fvt/fvt-manage.yml.j2
+++ b/tekton/src/tasks/fvt/fvt-manage.yml.j2
@@ -22,10 +22,9 @@ spec:
     - name: fvt_image_name
       type: string
       description: FVT Container Image
-    - name: fvt_image_version
+    - name: fvt_image_digest
       type: string
-      description: FVT Container Image Version
-      default: latest
+      description: FVT Container Image Digest
 
     # Test Framework Information
     # -------------------------------------------------------------------------
@@ -170,7 +169,7 @@ spec:
       - name: DEVOPS_TEST_PHASE
         value: $(params.devops_test_phase)
   steps:
-    - image: '$(params.fvt_image_registry)/$(params.fvt_image_namespace)/$(params.fvt_image_name):$(params.fvt_image_version)'
+    - image: '$(params.fvt_image_registry)/$(params.fvt_image_namespace)/$(params.fvt_image_name):$(params.fvt_image_digest)'
       imagePullPolicy: $(params.image_pull_policy)
       timeout: 6h # Ensure bad FVTs don't run forever .. want this to be smaller, but urgh, teams have already created huge suites that run for hours instead of multiple smaller suites
       onError: continue # Ensure bad FVTs don't break the pipeline

--- a/tekton/src/tasks/fvt/fvt-run-suite.yml.j2
+++ b/tekton/src/tasks/fvt/fvt-run-suite.yml.j2
@@ -138,7 +138,7 @@ spec:
       type: string
       description: Boolean value to check if tests are runninng locally or on fvt
       default: "false"
-    
+
     # Optional parameters to categorize result to be persisted
     # -------------------------------------------------------------------------
     - name: devops_test_type
@@ -221,14 +221,14 @@ spec:
       # Common Test Framework Specific information
       - name: CTF_IS_LOCAL
         value: $(params.ctf_is_local)
-      
+
       # Optional parameters to categorize result to be persisted
       - name: DEVOPS_TEST_TYPE
         value: $(params.devops_test_type)
       - name: DEVOPS_TEST_PHASE
         value: $(params.devops_test_phase)
   steps:
-    - image: '$(params.fvt_image_registry)/$(params.fvt_image_namespace)/$(params.fvt_image_name):$(params.fvt_image_digest)'
+    - image: '$(params.fvt_image_registry)/$(params.fvt_image_namespace)/$(params.fvt_image_name)@$(params.fvt_image_digest)'
       imagePullPolicy: $(params.image_pull_policy)
       timeout: 6h # Ensure bad FVTs don't run forever .. want this to be smaller, but urgh, teams have already created huge suites that run for hours instead of multiple smaller suites
       onError: continue # Ensure bad FVTs don't break the pipeline

--- a/tekton/src/tasks/fvt/fvt-run-suite.yml.j2
+++ b/tekton/src/tasks/fvt/fvt-run-suite.yml.j2
@@ -22,10 +22,9 @@ spec:
     - name: fvt_image_name
       type: string
       description: FVT Container Image
-    - name: fvt_image_version
+    - name: fvt_image_digest
       type: string
-      description: FVT Container Image Version
-      default: latest
+      description: FVT Container Image Digest
 
     # Test Framework Information
     # -------------------------------------------------------------------------
@@ -229,7 +228,7 @@ spec:
       - name: DEVOPS_TEST_PHASE
         value: $(params.devops_test_phase)
   steps:
-    - image: '$(params.fvt_image_registry)/$(params.fvt_image_namespace)/$(params.fvt_image_name):$(params.fvt_image_version)'
+    - image: '$(params.fvt_image_registry)/$(params.fvt_image_namespace)/$(params.fvt_image_name):$(params.fvt_image_digest)'
       imagePullPolicy: $(params.image_pull_policy)
       timeout: 6h # Ensure bad FVTs don't run forever .. want this to be smaller, but urgh, teams have already created huge suites that run for hours instead of multiple smaller suites
       onError: continue # Ensure bad FVTs don't break the pipeline


### PR DESCRIPTION
This change continues the changes made for core in https://github.com/ibm-mas/cli/pull/237 but now it covers every application's fvt version usage and swaps it to a digest.

Relevant issue: https://github.ibm.com/wiotp/tracker/issues/11846

From  https://github.com/ibm-mas/cli/pull/237:

> When we use image tags in complex pipelines we are seeing the issue raised here: https://github.com/tektoncd/pipeline/issues/6530
> 
> ```
> status:
>   completionTime: '2023-04-12T10:33:41Z'
>   conditions:
>     - lastTransitionTime: '2023-04-12T10:33:41Z'
>       message: >-
>         The step "unnamed-0" in TaskRun "fvtnocpd-fvt-1481-fvt-optimizer" failed
>         to pull the image "". The pod errored with the message: "Back-off
>         pulling image
>         "<someimage>@sha256:914dab53d028dbfc7012d806d36505a80a2642f53f337b9551c64756574651b7"."
>       reason: TaskRunImagePullFailed
>       status: 'False'
>       type: Succeeded
>   podName: fvtnocpd-fvt-1481-fvt-optimizer-pod
>   startTime: '2023-04-12T10:28:00Z'
>   steps:
>     - container: step-unnamed-0
>       name: unnamed-0
>       terminated:
>         exitCode: 1
>         finishedAt: '2023-04-12T10:33:41Z'
>         reason: TaskRunImagePullFailed
>         startedAt: null
> ```
> 
> Our hope is that by replacing all params that accept image tags with digests we will stop seeing this issue.