### PR TITLE
[patch] Fix IVT Core taskdef

### DIFF
--- a/tekton/src/pipelines/taskdefs/ivt-core/all-apps.yml.j2
+++ b/tekton/src/pipelines/taskdefs/ivt-core/all-apps.yml.j2
@@ -72,7 +72,7 @@
     - name: product_channel
       value: $(params.mas_app_channel_monitor)
   when:
-    - input: "$(params.digest)"
+    - input: "$(params.ivt_digest_core)"
       operator: notin
       values: [""]
     - input: "$(params.mas_app_channel_monitor)"
@@ -135,7 +135,7 @@
     - name: product_channel
       value: $(params.mas_app_channel_safety)
   when:
-    - input: "$(params.digest)"
+    - input: "$(params.ivt_digest_core)"
       operator: notin
       values: [""]
     - input: "$(params.mas_app_channel_safety)"


### PR DESCRIPTION
Fixes the following error in the 4.0.2 install-with-fvt tekton pipeline:

```
non-existent variable in "$(params.digest)": spec.tasks[75].when[0].input, spec.tasks[78].when[0].input
```