### PR TITLE
[patch] Fetch new fvt_digest_coreui

### DIFF
--- a/tekton/src/pipelines/taskdefs/fvt-core/ui/params.yml.j2
+++ b/tekton/src/pipelines/taskdefs/fvt-core/ui/params.yml.j2
@@ -11,7 +11,7 @@
 - name: fvt_image_registry
   value: $(params.fvt_image_registry)
 - name: fvt_image_digest
-  value: $(params.fvt_digest_core)
+  value: $(params.fvt_digest_coreui)
 - name: devops_test_type
   value: $(params.devops_test_type)
 - name: devops_test_phase

--- a/tekton/src/pipelines/taskdefs/fvt-core/ui/taskref.yml.j2
+++ b/tekton/src/pipelines/taskdefs/fvt-core/ui/taskref.yml.j2
@@ -2,7 +2,7 @@ taskRef:
   kind: Task
   name: mas-fvt-core-ui
 when:
-  - input: "$(params.fvt_digest_core)"
+  - input: "$(params.fvt_digest_coreui)"
     operator: notin
     values: [""]
 workspaces:


### PR DESCRIPTION
**IBM internal links**:
Following on from this [slack thread](https://ibm-watson-iot.slack.com/archives/C031Q7W21FZ/p1681892442219969) fetching the new `fvt_digest_coreui` variable created by https://github.ibm.com/maximoappsuite/ansible-fvt/pull/177

Relevant issue: https://github.ibm.com/wiotp/tracker/issues/11846