### PR TITLE
[patch] Consolidate per-app FVT digests into common digest

### DIFF
--- a/tekton/src/params/fvt.yml.j2
+++ b/tekton/src/params/fvt.yml.j2
@@ -48,13 +48,9 @@
   type: string
   description: FVT Digest - IoT
   default: ""
-- name: fvt_digest_monitor
+- name: fvt_digest_ctf
   type: string
-  description: FVT Digest - Monitor
-  default: ""
-- name: fvt_digest_predict
-  type: string
-  description: FVT Digest - Predict
+  description: FVT Digest - Common Test Framework (Predict, Monitor, Optimizer, Visual Inspection)
   default: ""
 - name: fvt_digest_hputilities_preparedata
   type: string
@@ -67,10 +63,6 @@
 - name: fvt_digest_hputilities_python
   type: string
   description: FVT Digest - Health & Predict Utilities - Python
-  default: ""
-- name: fvt_digest_visualinspection
-  type: string
-  description: FVT Digest - Visual Inspection
   default: ""
 - name: fvt_digest_assist_cucumber
   type: string
@@ -87,10 +79,6 @@
 - name: fvt_digest_assist_testng
   type: string
   description: FVT Digest - Assist - Testng
-  default: ""
-- name: fvt_digest_optimizer
-  type: string
-  description: FVT Digest - Optimizer
   default: ""
 
 # FVT Digests - Manage, Health and Industry Solutions

--- a/tekton/src/pipelines/taskdefs/fvt-apps/monitor.yml.j2
+++ b/tekton/src/pipelines/taskdefs/fvt-apps/monitor.yml.j2
@@ -17,14 +17,14 @@
     - name: fvt_image_name
       value: common-test-framework
     - name: fvt_image_digest
-      value: $(params.fvt_digest_monitor)
+      value: $(params.fvt_digest_ctf)
     - name: fvt_test_suite
       value: monitor_fvt # pytest_marker in Common Test Framework
     - name: product_channel
       value: $(params.mas_app_channel_monitor)
     - name: product_id
       value: ibm-mas-monitor
-    
+
     - name: devops_test_type
       value: $(params.devops_test_type)
     - name: devops_test_phase
@@ -34,7 +34,7 @@
     name: mas-fvt-run-suite
   # Only if we've set a digest of the Predict FVT to run
   when:
-    - input: "$(params.fvt_digest_monitor)"
+    - input: "$(params.fvt_digest_ctf)"
       operator: notin
       values: [""]
     - input: "$(params.mas_app_channel_monitor)"

--- a/tekton/src/pipelines/taskdefs/fvt-apps/optimizer.yml.j2
+++ b/tekton/src/pipelines/taskdefs/fvt-apps/optimizer.yml.j2
@@ -17,14 +17,14 @@
     - name: fvt_image_name
       value: common-test-framework
     - name: fvt_image_digest
-      value: $(params.fvt_digest_optimizer)
+      value: $(params.fvt_digest_ctf)
     - name: fvt_test_suite
       value: optimizer_fvt # pytest_marker in Common Test Framework
     - name: product_channel
       value: $(params.mas_app_channel_optimizer)
     - name: product_id
       value: ibm-mas-optimizer
-    
+
     - name: devops_test_type
       value: $(params.devops_test_type)
     - name: devops_test_phase
@@ -34,7 +34,7 @@
     name: mas-fvt-run-suite
   # Only if we've set a digest of the Predict FVT to run
   when:
-    - input: "$(params.fvt_digest_optimizer)"
+    - input: "$(params.fvt_digest_ctf)"
       operator: notin
       values: [""]
     - input: "$(params.mas_app_channel_optimizer)"

--- a/tekton/src/pipelines/taskdefs/fvt-apps/predict.yml.j2
+++ b/tekton/src/pipelines/taskdefs/fvt-apps/predict.yml.j2
@@ -15,14 +15,14 @@
     - name: fvt_image_name
       value: common-test-framework
     - name: fvt_image_digest
-      value: $(params.fvt_digest_predict)
+      value: $(params.fvt_digest_ctf)
     - name: fvt_test_suite
       value: predict_fvt # pytest_marker in Common Test Framework
     - name: product_channel
       value: $(params.mas_app_channel_predict)
     - name: product_id
       value: ibm-mas-predict
-    
+
     - name: devops_test_type
       value: $(params.devops_test_type)
     - name: devops_test_phase
@@ -32,7 +32,7 @@
     name: mas-fvt-run-suite
   # Only if we've set a digest of the Predict FVT to run
   when:
-    - input: "$(params.fvt_digest_predict)"
+    - input: "$(params.fvt_digest_ctf)"
       operator: notin
       values: [""]
     - input: "$(params.mas_app_channel_predict)"

--- a/tekton/src/pipelines/taskdefs/fvt-apps/visualinspection.yml.j2
+++ b/tekton/src/pipelines/taskdefs/fvt-apps/visualinspection.yml.j2
@@ -17,14 +17,14 @@
     - name: fvt_image_name
       value: common-test-framework
     - name: fvt_image_digest
-      value: $(params.fvt_digest_visualinspection)
+      value: $(params.fvt_digest_ctf)
     - name: fvt_test_suite
       value: visualinspection_fvt # pytest_marker in Common Test Framework
     - name: product_channel
       value: $(params.mas_app_channel_visualinspection)
     - name: product_id
       value: ibm-mas-visualinspection
-    
+
     - name: devops_test_type
       value: $(params.devops_test_type)
     - name: devops_test_phase
@@ -34,7 +34,7 @@
     name: mas-fvt-run-suite
   # Only if we've set a digest of the MVI FVT to run
   when:
-    - input: "$(params.fvt_digest_visualinspection)"
+    - input: "$(params.fvt_digest_ctf)"
       operator: notin
       values: [""]
     - input: "$(params.mas_app_channel_visualinspection)"


### PR DESCRIPTION
Instead of requiring:
- `fvt_digest_monitor`
- `fvt_digest_predict`
- `fvt_digest_visualinspection`
- `fvt_digest_optimizer`

Consolidate to 
- `fvt_digest_ctf`

These application all use the same "common test framework" container image.