### PR TITLE
[patch] Increase Core FVT timeout to 2 hours

### DIFF
--- a/tekton/src/tasks/fvt/fvt-core.yml.j2
+++ b/tekton/src/tasks/fvt/fvt-core.yml.j2
@@ -65,7 +65,7 @@ spec:
       type: string
       description: Partium password (required by fvt-coreapi-workspacemgmt)
       default: ""
-    
+
     # Optional parameters to categorize result to be persisted
     # -------------------------------------------------------------------------
     - name: devops_test_type
@@ -116,7 +116,7 @@ spec:
         value: $(params.partium_username)
       - name: PARTIUM_PASSWORD
         value: $(params.partium_password)
-      
+
       # Optional parameters to categorize result to be persisted
       - name: DEVOPS_TEST_TYPE
         value: $(params.devops_test_type)
@@ -125,7 +125,7 @@ spec:
   steps:
     - image: '$(params.fvt_image_registry)/mas-devops/fvt-ibm-mas@$(params.fvt_image_digest)'
       imagePullPolicy: $(params.image_pull_policy)
-      timeout: 90m # Ensure bad FVTs don't run forever
+      timeout: 2h0m0s # Ensure bad FVTs don't run forever
       onError: continue # Ensure bad FVTs don't break the pipeline
       resources: {}
       workingDir: /opt/ibm/test/src


### PR DESCRIPTION
This is mainly for the SMTP testsuite, which is now regularly taking close to 90 minutes to run (double it's previous run time).