### PR TITLE
[minor] Add update-after-install pipeline

### DIFF
--- a/image/cli/app-root/save-junit-to-mongo.py
+++ b/image/cli/app-root/save-junit-to-mongo.py
@@ -135,6 +135,8 @@ if __name__ == "__main__":
                 resultDoc,
                 upsert=True
             )
-            print ("Pipeline results saved to MongoDb (v2 data model)")
+            print("Pipeline results saved to MongoDb (v2 data model)")
+            print(result1)
+            print(result2)
         else:
             print("Pipeline results not recorded as DEVOPS_MONGO_URI is not defined")

--- a/tekton/generate-tekton-pipelines.yml
+++ b/tekton/generate-tekton-pipelines.yml
@@ -34,3 +34,4 @@
         - fvt-manage-regr
         - upgrade
         - update
+        - update-after-install

--- a/tekton/src/pipelines/update-after-install.yml.j2
+++ b/tekton/src/pipelines/update-after-install.yml.j2
@@ -19,6 +19,10 @@ spec:
       type: string
       description: Required to install development MAS catalogs
 
+    # Required to save results to the FVT database and to know what install to wait for
+    - name: mas_instance_id
+      type: string
+
   tasks:
     - name: wait-for-install
       taskSpec:
@@ -31,11 +35,11 @@ spec:
               echo ''
               echo 'Status of install pipeline'
               echo '--------------------------'
-              oc -n $(context.pipelineRun.namespace) get pipelinerun/fvtupdate-install-${DEVOPS_BUILD_NUMBER}
+              oc -n $(context.pipelineRun.namespace) get pipelinerun/$(params.mas_instance_id)-install-${DEVOPS_BUILD_NUMBER}
               echo ''
-              echo 'Waiting for pipelinerun/fvtupdate-install-${DEVOPS_BUILD_NUMBER} to complete'
+              echo 'Waiting for pipelinerun/$(params.mas_instance_id)-install-${DEVOPS_BUILD_NUMBER} to complete'
               echo '------------------------------------------------------------------'
-              oc -n $(context.pipelineRun.namespace) wait pipelinerun/fvtupdate-install-${DEVOPS_BUILD_NUMBER} --for=condition=Succeeded --timeout=12h
+              oc -n $(context.pipelineRun.namespace) wait pipelinerun/$(params.mas_instance_id)-install-${DEVOPS_BUILD_NUMBER} --for=condition=Succeeded --timeout=12h
             env:
               - name: DEVOPS_BUILD_NUMBER
                 valueFrom:
@@ -48,6 +52,9 @@ spec:
       params:
         - name: devops_suite_name
           value: update-catalog
+        - name: mas_instance_id
+          value: $(params.mas_instance_id)
+
         - name: mas_catalog_version
           value: $(params.mas_catalog_version)
 

--- a/tekton/src/pipelines/update-after-install.yml.j2
+++ b/tekton/src/pipelines/update-after-install.yml.j2
@@ -39,14 +39,14 @@ spec:
             script: |
               #!/usr/bin/env bash
 
-              echo 'Updating to $(params.mas_catalog_version) after install completes'
-              echo ''
-              echo 'Status of install pipeline'
-              echo '--------------------------'
+              echo "Updating to $(params.mas_catalog_version) after install completes"
+              echo ""
+              echo "Status of install pipeline"
+              echo "--------------------------"
               oc -n $(context.pipelineRun.namespace) get pipelinerun/$(params.mas_instance_id)-install-${DEVOPS_BUILD_NUMBER}
-              echo ''
-              echo 'Waiting for pipelinerun/$(params.mas_instance_id)-install-${DEVOPS_BUILD_NUMBER} to complete'
-              echo '------------------------------------------------------------------'
+              echo ""
+              echo "Waiting for pipelinerun/$(params.mas_instance_id)-install-${DEVOPS_BUILD_NUMBER} to complete"
+              echo "------------------------------------------------------------------"
               oc -n $(context.pipelineRun.namespace) wait pipelinerun/$(params.mas_instance_id)-install-${DEVOPS_BUILD_NUMBER} --for=condition=Succeeded --timeout=12h
             env:
               - name: DEVOPS_BUILD_NUMBER

--- a/tekton/src/pipelines/update-after-install.yml.j2
+++ b/tekton/src/pipelines/update-after-install.yml.j2
@@ -1,0 +1,63 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: mas-update-after-install
+spec:
+  params:
+    # Catalog Version
+    - name: mas_catalog_version
+      type: string
+
+    # Development Build Support
+    - name: artifactory_username
+      default: ""
+      type: string
+      description: Required to install development MAS catalogs
+    - name: artifactory_token
+      default: ""
+      type: string
+      description: Required to install development MAS catalogs
+
+  tasks:
+    - name: wait-for-install
+      taskSpec:
+        steps:
+          - image: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
+            script: |
+              #!/usr/bin/env bash
+
+              echo 'Updating to $(params.mas_catalog_version) after install completes'
+              echo ''
+              echo 'Status of install pipeline'
+              echo '--------------------------'
+              oc -n $(context.pipelineRun.namespace) get pipelinerun/fvtupdate-install-${DEVOPS_BUILD_NUMBER}
+              echo ''
+              echo 'Waiting for pipelinerun/fvtupdate-install-${DEVOPS_BUILD_NUMBER} to complete'
+              echo '------------------------------------------------------------------'
+              oc -n $(context.pipelineRun.namespace) wait pipelinerun/fvtupdate-install-${DEVOPS_BUILD_NUMBER} --for=condition=Succeeded --timeout=12h
+            env:
+              - name: DEVOPS_BUILD_NUMBER
+                valueFrom:
+                  secretKeyRef:
+                    name: mas-devops
+                    key: DEVOPS_BUILD_NUMBER
+                    optional: true
+
+    - name: update-catalog
+      params:
+        - name: devops_suite_name
+          value: update-catalog
+        - name: mas_catalog_version
+          value: $(params.mas_catalog_version)
+
+        # Development catalog support
+        - name: artifactory_username
+          value: $(params.artifactory_username)
+        - name: artifactory_token
+          value: $(params.artifactory_token)
+      taskRef:
+        kind: Task
+        name: mas-devops-ibm-catalogs
+      runAfter:
+        - wait-for-install

--- a/tekton/src/pipelines/update-after-install.yml.j2
+++ b/tekton/src/pipelines/update-after-install.yml.j2
@@ -5,9 +5,13 @@ metadata:
   name: mas-update-after-install
 spec:
   params:
-    # Catalog Version
-    - name: mas_catalog_version
+    # Common Parameters
+    # -------------------------------------------------------------------------
+    # Tekton Pipeline image pull policy (for CLI & FVT images)
+    - name: image_pull_policy
       type: string
+      default: IfNotPresent
+      description: Pull policy for pipeline container images
 
     # Development Build Support
     - name: artifactory_username
@@ -18,6 +22,10 @@ spec:
       default: ""
       type: string
       description: Required to install development MAS catalogs
+
+    # Catalog Version
+    - name: mas_catalog_version
+      type: string
 
     # Required to save results to the FVT database and to know what install to wait for
     - name: mas_instance_id
@@ -50,6 +58,9 @@ spec:
 
     - name: update-catalog
       params:
+        - name: image_pull_policy
+          value: $(params.image_pull_policy)
+
         - name: devops_suite_name
           value: update-catalog
         - name: mas_instance_id

--- a/tekton/src/pipelines/update.yml.j2
+++ b/tekton/src/pipelines/update.yml.j2
@@ -20,7 +20,7 @@ spec:
       description: Required to install development MAS catalogs
 
   tasks:
-    - name: ibm-catalogs
+    - name: update-catalog
       params:
         - name: mas_catalog_version
           value: $(params.mas_catalog_version)


### PR DESCRIPTION
Creation of a new pipeline that will queue the update action to be performed after the completion of the install action targeting the same environment.  This will be used in automated update testing.