### PR TITLE
[patch] Ensure build only updates version of ibmmas/cli

### DIFF
--- a/build/bin/build-tekton.sh
+++ b/build/bin/build-tekton.sh
@@ -52,7 +52,7 @@ for FILE in $PIPELINE_FILES; do
   cat $FILE >> $TARGET_FILE
 done
 
-sed "s/cli:latest/cli:$VERSION/g" $TARGET_FILE > $TARGET_FILE.txt
+sed "s#quay.io/ibmmas/cli:latest#quay.io/ibmmas/cli:$VERSION#g" $TARGET_FILE > $TARGET_FILE.txt
 
 rm $TARGET_FILE
 mv $TARGET_FILE.txt $TARGET_FILE


### PR DESCRIPTION
In testing use of the openshift/cli image in a new pipeline we found that the sed command used to substitute the version of the ibmmas/cli image into tekton files is overwriting any reference to `cli:latest` ... the regex used has been updated to specifically match `quay.io/ibmmas/cli:latest` now.

This avoids the following:

```
      - name: wait-for-install
        taskSpec:
          metadata: {}
          spec: null
          steps:
            - env:
                - name: DEVOPS_BUILD_NUMBER
                  valueFrom:
                    secretKeyRef:
                      key: DEVOPS_BUILD_NUMBER
                      name: mas-devops
                      optional: true
              image: >-
                image-registry.openshift-image-registry.svc:5000/openshift/cli:4.1.0-pre.master
```