### PR TITLE
[patch] Fix can't read /mascli/.../subscription.yaml error

### DIFF
--- a/image/cli/mascli/functions/must_gather
+++ b/image/cli/mascli/functions/must_gather
@@ -1,5 +1,4 @@
 #!/bin/bash
-DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 MG_SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && cd "../must-gather" && pwd )"
 
 function mustgather() {


### PR DESCRIPTION
Due to the must-gather script re-using the `DIR` variable used to track the main directory of the CLI install, it results in this being variable set to  `/mascli/functions` instead of `/mascli`, and everything except the `must-gather` itself command breaks :)

```
mas install
IBM Maximo Application Suite Installer
Powered by https://github.com/ibm-mas/ansible-devops/ and https://tekton.dev/

Current Limitations
1. Support for airgap installation is limited to Core with IoT, Manage, Optimizer at present


1. Set Target OpenShift Cluster
Connected to OCP cluster:
   https://console-openshift-console.xxx
Proceed with this cluster? [Y/n] y

2. Install OpenShift Pipelines Operator
sed: can't read /mascli/functions/templates/subscription.yaml: No such file or directory
```