### PR TITLE
[patch] Rearrange coreapi-dependencies test suite

### DIFF
--- a/tekton/src/pipelines/taskdefs/fvt-core/phase2.yml.j2
+++ b/tekton/src/pipelines/taskdefs/fvt-core/phase2.yml.j2
@@ -64,8 +64,7 @@
     - name: test_suite
       value: coreapi-dependencies
   runAfter:
-    - fvt-coreapi-addons
-    - fvt-coreapi-groupmgmt
-    - fvt-coreapi-usermgmt
-    - fvt-coreapi-workspacemgmt
-    - fvt-coreapi-graphiteconfigtool
+    - fvt-coreapi-mobileapi
+    - fvt-coreapi-other
+    - fvt-coreapi-utilities
+    - fvt-coreapi-uiresources


### PR DESCRIPTION
This should fix the intermittent failures for custom User Data Model test suite and possibly other tests.
https://github.ibm.com/maximoappsuite/tracker-fvt/issues/82

Coreapi-dependencies is stressing truststore with multiple different combinations of valid and invalid certs, causing ibm-mas operator to fail and don't update status results in the Suite CR.

Tested on my fvt-personal cluster and it worked well
https://dashboard.masdev.wiotp.sl.hursley.ibm.com/tests/pfvtjpcustomdatamodel
<img width="529" alt="image" src="https://user-images.githubusercontent.com/26097641/235233089-0d9fa2ad-9295-49c8-a781-ea77d9c592f3.png">
