### PR TITLE
[patch] Fix GRAFANA_INSTANCE_STORAGE_CLASS|SIZE mixup

### DIFF
--- a/image/cli/mascli/templates/pipelinerun.yaml
+++ b/image/cli/mascli/templates/pipelinerun.yaml
@@ -353,7 +353,7 @@ spec:
     - name: grafana_instance_storage_class
       value: '$GRAFANA_INSTANCE_STORAGE_CLASS'
     - name: grafana_instance_storage_size
-      value: '$GRAFANA_INSTANCE_STORAGE_CLASS'
+      value: '$GRAFANA_INSTANCE_STORAGE_SIZE'
 
   workspaces:
     # The generated configuration files


### PR DESCRIPTION
Regression introduced in:

- #227 

`grafana_storage_size` is being set to the value of `grafana_storage_class`, if you customize the storage class you cannot install MAS.