### PR TITLE
[patch] Ensure VERSION is set when running local

### DIFF
--- a/build/bin/build-cli.sh
+++ b/build/bin/build-cli.sh
@@ -9,5 +9,7 @@ else
   export GITHUB_WORKSPACE=$(pwd)
 fi
 
+sed -i "s#VERSION=latest#VERSION=${VERSION}#g" ${GITHUB_WORKSPACE}/image/cli/mascli/mas
+
 cd $GITHUB_WORKSPACE/image/cli/mascli
 tar -czvf $GITHUB_WORKSPACE/ibm-mas-cli-$VERSION.tgz --directory $GITHUB_WORKSPACE/image/cli/mascli *

--- a/image/cli/mascli/mas
+++ b/image/cli/mascli/mas
@@ -28,6 +28,8 @@ CONFIG_DIR="$HOME/.ibm-mas/config"
 LOG_DIR="$HOME/.ibm-mas/logs"
 LOGFILE=$LOG_DIR/mas.log
 
+VERSION=latest
+
 mkdir -p $LOG_DIR
 mkdir -p $CONFIG_DIR
 
@@ -65,7 +67,7 @@ mkdir -p $CONFIG_DIR
 load_config
 case $1 in
   fyre|provision-fyre)
-    echo "${TEXT_UNDERLINE}IBM Maximo Application Suite FYRE Cluster Provisioner${TEXT_RESET}"
+    echo "${TEXT_UNDERLINE}IBM Maximo Application Suite FYRE Cluster Provisioner (v${VERSION})${TEXT_RESET}"
     echo "Powered by ${COLOR_CYAN}${TEXT_UNDERLINE}https://github.com/ibm-mas/ansible-devops/${TEXT_RESET}"
     echo
     reset_colors
@@ -74,7 +76,7 @@ case $1 in
     ;;
 
   roks|provision-roks)
-    echo "${TEXT_UNDERLINE}IBM Maximo Application Suite ROKS Cluster Provisioner${TEXT_RESET}"
+    echo "${TEXT_UNDERLINE}IBM Maximo Application Suite ROKS Cluster Provisioner (v${VERSION})${TEXT_RESET}"
     echo "Powered by ${COLOR_CYAN}${TEXT_UNDERLINE}https://github.com/ibm-mas/ansible-devops/${TEXT_RESET}"
     echo
     reset_colors
@@ -83,7 +85,7 @@ case $1 in
     ;;
 
   aws|provision-aws)
-    echo "${TEXT_UNDERLINE}IBM Maximo Application Suite AWS Cluster Provisioner${TEXT_RESET}"
+    echo "${TEXT_UNDERLINE}IBM Maximo Application Suite AWS Cluster Provisioner (v${VERSION})${TEXT_RESET}"
     echo "Powered by ${COLOR_CYAN}${TEXT_UNDERLINE}https://github.com/ibm-mas/ansible-devops/${TEXT_RESET}"
     echo
     reset_colors
@@ -92,14 +94,14 @@ case $1 in
     ;;
 
   oidc|configtool-oidc)
-    echo "${TEXT_UNDERLINE}IBM Maximo Application Suite OIDC for Configuration Tool${TEXT_RESET}"
+    echo "${TEXT_UNDERLINE}IBM Maximo Application Suite OIDC for Configuration Tool (v${VERSION})${TEXT_RESET}"
     echo
     reset_colors
     configtool_oidc "$@"
     ;;
 
   registry|setup-registry|setup-mirror-registry|setup-airgap-registry)
-    echo "${TEXT_UNDERLINE}IBM Maximo Application Suite Air Gap Registry Setup${TEXT_RESET}"
+    echo "${TEXT_UNDERLINE}IBM Maximo Application Suite Air Gap Registry Setup (v${VERSION})${TEXT_RESET}"
     echo "Powered by ${COLOR_CYAN}${TEXT_UNDERLINE}https://github.com/ibm-mas/ansible-devops/${TEXT_RESET}"
     echo
     echo "${TEXT_UNDERLINE}${TEXT_DIM}Current Limitations${TEXT_RESET}"
@@ -112,7 +114,7 @@ case $1 in
     ;;
 
   mirror|mirror-images)
-    echo "${TEXT_UNDERLINE}IBM Maximo Application Suite Air Gap Image Mirror${TEXT_RESET}"
+    echo "${TEXT_UNDERLINE}IBM Maximo Application Suite Air Gap Image Mirror (v${VERSION})${TEXT_RESET}"
     echo "Powered by ${COLOR_CYAN}${TEXT_UNDERLINE}https://github.com/ibm-mas/ansible-devops/${TEXT_RESET}"
     echo
     reset_colors
@@ -121,7 +123,7 @@ case $1 in
     ;;
 
   mirror-redhat|mirror-redhat-images)
-    echo "${TEXT_UNDERLINE}IBM Maximo Application Suite Air Gap Image Mirror${TEXT_RESET}"
+    echo "${TEXT_UNDERLINE}IBM Maximo Application Suite Air Gap Image Mirror (v${VERSION})${TEXT_RESET}"
     echo "Powered by ${COLOR_CYAN}${TEXT_UNDERLINE}https://github.com/ibm-mas/ansible-devops/${TEXT_RESET}"
     echo
     reset_colors
@@ -131,7 +133,7 @@ case $1 in
 
 
   configure-ocp-for-mirror|configure-airgap|configure-mirror|config-airgap|config-mirror)
-    echo "${TEXT_UNDERLINE}IBM Maximo Application Suite Air Gap OCP Setup${TEXT_RESET}"
+    echo "${TEXT_UNDERLINE}IBM Maximo Application Suite Air Gap OCP Setup (v${VERSION})${TEXT_RESET}"
     echo "Powered by ${COLOR_CYAN}${TEXT_UNDERLINE}https://github.com/ibm-mas/ansible-devops/${TEXT_RESET}"
     echo
     reset_colors
@@ -140,7 +142,7 @@ case $1 in
     ;;
 
   install)
-    echo "${TEXT_UNDERLINE}IBM Maximo Application Suite Installer${TEXT_RESET}"
+    echo "${TEXT_UNDERLINE}IBM Maximo Application Suite Installer (v${VERSION})${TEXT_RESET}"
     echo "Powered by ${COLOR_CYAN}${TEXT_UNDERLINE}https://github.com/ibm-mas/ansible-devops/${TEXT_RESET} and ${COLOR_CYAN}${TEXT_UNDERLINE}https://tekton.dev/${TEXT_RESET}"
     echo
     echo "${TEXT_UNDERLINE}${TEXT_DIM}Current Limitations${TEXT_RESET}"
@@ -151,7 +153,7 @@ case $1 in
     ;;
 
   update)
-    echo "${TEXT_UNDERLINE}IBM Maximo Application Suite Update Manager${TEXT_RESET}"
+    echo "${TEXT_UNDERLINE}IBM Maximo Application Suite Update Manager (v${VERSION})${TEXT_RESET}"
     echo "Powered by ${COLOR_CYAN}${TEXT_UNDERLINE}https://github.com/ibm-mas/ansible-devops/${TEXT_RESET} and ${COLOR_CYAN}${TEXT_UNDERLINE}https://tekton.dev/${TEXT_RESET}"
     echo
     reset_colors
@@ -159,7 +161,7 @@ case $1 in
     ;;
 
   upgrade)
-    echo "${TEXT_UNDERLINE}IBM Maximo Application Suite Upgrade Manager${TEXT_RESET}"
+    echo "${TEXT_UNDERLINE}IBM Maximo Application Suite Upgrade Manager (v${VERSION})${TEXT_RESET}"
     echo "Powered by ${COLOR_CYAN}${TEXT_UNDERLINE}https://github.com/ibm-mas/ansible-devops/${TEXT_RESET} and ${COLOR_CYAN}${TEXT_UNDERLINE}https://tekton.dev/${TEXT_RESET}"
     echo
     reset_colors
@@ -167,7 +169,7 @@ case $1 in
     ;;
 
   uninstall)
-    echo "${TEXT_UNDERLINE}IBM Maximo Application Suite Uninstall Manager${TEXT_RESET}"
+    echo "${TEXT_UNDERLINE}IBM Maximo Application Suite Uninstall Manager (v${VERSION})${TEXT_RESET}"
     echo "Powered by ${COLOR_CYAN}${TEXT_UNDERLINE}https://github.com/ibm-mas/ansible-devops/${TEXT_RESET} and ${COLOR_CYAN}${TEXT_UNDERLINE}https://tekton.dev/${TEXT_RESET}"
     echo
     reset_colors
@@ -175,7 +177,7 @@ case $1 in
     ;;
 
   mustgather|must-gather)
-    echo "${TEXT_UNDERLINE}IBM Maximo Application Suite Must-Gather Tool${TEXT_RESET}"
+    echo "${TEXT_UNDERLINE}IBM Maximo Application Suite Must-Gather Tool (v${VERSION})${TEXT_RESET}"
     echo
     mustgather "$@"
     ;;


### PR DESCRIPTION
When running `mas install` locally (ie. not inside the ibmmas/cli container image) the `VERSION`  env var is not set.  We missed this internally as we happen to have this variable set to determine the version of the CLI to download/test, but we don't want users to have to manually set this environment variable for obvious reasons.

The version is also printed in `h1` title now as well:
![image](https://user-images.githubusercontent.com/4400618/236148100-f9716fbe-3ae1-482a-840d-00690adac339.png)
