### PR TITLE
[patch] Fix must-gather useability issues

### DIFF
--- a/image/cli/mascli/functions/must_gather
+++ b/image/cli/mascli/functions/must_gather
@@ -1,6 +1,30 @@
 #!/bin/bash
 MG_SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && cd "../must-gather" && pwd )"
 
+function must_gather_help() {
+  [[ -n "$1" ]] && echo_warning "$1"
+  reset_colors
+  cat << EOM
+Usage:
+  mas must-gather [options]
+Where ${COLOR_YELLOW}specified${TEXT_RESET} each option may also be defined by setting the appropriate environment variable.
+
+Collection Options (Optional):
+  -d, --directory ${COLOR_YELLOW}MG_DIR${TEXT_RESET}     Directory where the must-gather will be saved, defaults to /tmp/must-gather
+  --summary-only             Perform a much faster must-gather that only gathers high level summary of resources in the cluster
+  --no-pod-logs              Skip collection of pod logs, greatly speeds up must-gather collection time when pod logs are not required
+
+Artifactory Upload (Optional):
+  --artifactory-token ${COLOR_YELLOW}ARTIFACTORY_TOKEN${TEXT_RESET}              Provide a token for Artifactory to automatically upload the file to ARTIFACTORY_UPLOAD_DIR
+  --artifactory-upload-dir ${COLOR_YELLOW}ARTIFACTORY_UPLOAD_DIR${TEXT_RESET}    Working URL to the root directory in Artifactory where the must-gather file should be uploaded
+
+Other Options:
+  -h, --help    Show this help message
+EOM
+  [[ -n "$1" ]] && exit 1 || exit 0
+}
+
+
 function mustgather() {
   # Take the first parameter off (it will be "must-gather")
   shift
@@ -28,13 +52,17 @@ function mustgather() {
     --artifactory-token)
       ARTIFACTORY_TOKEN=$1; shift
       ;;
-    --artifactory-upload-directory)
-      ARTIFACTORY_UPLOAD_DIRECTORY=$1; shift
+    --artifactory-upload-dir)
+      ARTIFACTORY_UPLOAD_DIR=$1; shift
+      ;;
+    -h|--help)
+      must_gather_help
+      exit 0
       ;;
     *)
       # unknown option
       echo -e "${COLOR_RED}Usage Error: Unsupported option \"${key}\"${COLOR_RESET}\n"
-      mirror_to_registry_help
+      must_gather_help
       exit 1
       ;;
     esac
@@ -105,10 +133,10 @@ function mustgather() {
   done
 
   tar -czf $OUTPUT_FILE -C $MG_DIR $TIMESTAMP
-  if [[ -n "$ARTIFACTORY_TOKEN" && -n "$ARTIFACTORY_UPLOAD_DIRECTORY" ]]; then
+  if [[ -n "$ARTIFACTORY_TOKEN" && -n "$ARTIFACTORY_UPLOAD_DIR" ]]; then
     set -e
     ARTIFACTORY_AUTH_HEADER="Authorization:Bearer $ARTIFACTORY_TOKEN"
-    TARGET_URL="${ARTIFACTORY_UPLOAD_DIRECTORY}/${OUTPUT_FILENAME}"
+    TARGET_URL="${ARTIFACTORY_UPLOAD_DIR}/${OUTPUT_FILENAME}"
 
     MD5_VALUE="`md5sum "$OUTPUT_FILE"`"
     MD5_VALUE="${MD5_VALUE:0:32}"

--- a/image/cli/mascli/functions/must_gather
+++ b/image/cli/mascli/functions/must_gather
@@ -121,5 +121,7 @@ function mustgather() {
     set +e
   fi
 
+  echo_green "Must gather successfully saved to: $OUTPUT_FILE"
+
   true
 }

--- a/image/cli/mascli/functions/must_gather
+++ b/image/cli/mascli/functions/must_gather
@@ -70,7 +70,7 @@ function mustgather() {
 
   # Find MAS instances
   # -----------------------------------------------------------------------------
-  MAS_INSTANCE_IDS=$(oc get suite --all-namespaces -o jsonpath='{.items[*].metadata.name}')
+  MAS_INSTANCE_IDS=$(oc get suite --all-namespaces --ignore-not-found -o jsonpath='{.items[*].metadata.name}')
 
   # Generate Detailed Report
   # -----------------------------------------------------------------------------

--- a/image/cli/mascli/functions/utils
+++ b/image/cli/mascli/functions/utils
@@ -34,6 +34,10 @@ function echo_highlight() {
   echo "${COLOR_CYAN}$1${COLOR_RESET}"
 }
 
+function echo_green() {
+  echo "${COLOR_GREEN}$1${COLOR_RESET}"
+}
+
 function echo_blue() {
   echo "${COLOR_BLUE}$1${COLOR_RESET}"
 }

--- a/tekton/src/tasks/must-gather.yml.j2
+++ b/tekton/src/tasks/must-gather.yml.j2
@@ -25,18 +25,18 @@ spec:
       image: quay.io/ibmmas/cli:latest
       imagePullPolicy: $(params.image_pull_policy)
       env:
-        # If this secret exists (with both ARTIFACTORY_TOKEN and ARTIFACTORY_UPLOAD_DIRECTORY keys set) the must-gather file will be automatically uploaded
+        # If this secret exists (with both ARTIFACTORY_TOKEN and ARTIFACTORY_UPLOAD_DIR keys set) the must-gather file will be automatically uploaded
         - name: ARTIFACTORY_TOKEN
           valueFrom:
             secretKeyRef:
               name: mas-devops
               key: ARTIFACTORY_TOKEN
               optional: true
-        - name: ARTIFACTORY_UPLOAD_DIRECTORY
+        - name: ARTIFACTORY_UPLOAD_DIR
           valueFrom:
             secretKeyRef:
               name: mas-devops
-              key: ARTIFACTORY_UPLOAD_DIRECTORY
+              key: ARTIFACTORY_UPLOAD_DIR
               optional: true
   workspaces:
     - name: mustgather


### PR DESCRIPTION
When running `mas must-gather` and no Suite instance is found there will be an error message printed:

```
IBM Maximo Application Suite Must-Gather Tool
 
Must gather will be saved to: /workspace/mustgather/pwmasdev-install-hkzkw/must-gather-20230503-151813.tgz
Generate Dependency Report
- Cluster Namespaces
- IBM CloudPak Foundation Services
- IBM CloudPak for Data
- IBM Db2 universal Operator
error: the server doesn't have a resource type "suite"

```

This is misleading and gives the impression must-gather failed; it's just we are not capturing the err from looking up whether there are any MAS instances to collect gather from.  In the case there is no MAS instance, we still want to collect the must-gather and we don't want to give the impression there was an error generating it.

An additional confirmation the must-gather was generated is also now provided:
![image](https://user-images.githubusercontent.com/4400618/236155011-62cbd37c-fd42-4cdb-aa38-70f471eb6fa5.png)

`mas must-gather --help` is also now implemented:

![image](https://user-images.githubusercontent.com/4400618/236155180-d4b8b3ca-1ca3-42b2-bb3c-b01cea4ff54b.png)
