### PR TITLE
[patch] Mark scripts in the CLI tgz executable

### DIFF
--- a/build/bin/build-cli.sh
+++ b/build/bin/build-cli.sh
@@ -12,4 +12,6 @@ fi
 sed -i "s#VERSION=latest#VERSION=${VERSION}#g" ${GITHUB_WORKSPACE}/image/cli/mascli/mas
 
 cd $GITHUB_WORKSPACE/image/cli/mascli
+chmod +x $GITHUB_WORKSPACE/image/cli/mascli/mas
+chmod +x $GITHUB_WORKSPACE/image/cli/mascli/must-gather/*
 tar -czvf $GITHUB_WORKSPACE/ibm-mas-cli-$VERSION.tgz --directory $GITHUB_WORKSPACE/image/cli/mascli *

--- a/build/bin/build-cli.sh
+++ b/build/bin/build-cli.sh
@@ -12,6 +12,6 @@ fi
 sed -i "s#VERSION=latest#VERSION=${VERSION}#g" ${GITHUB_WORKSPACE}/image/cli/mascli/mas
 
 cd $GITHUB_WORKSPACE/image/cli/mascli
-chmod +x $GITHUB_WORKSPACE/image/cli/mascli/mas
-chmod +x $GITHUB_WORKSPACE/image/cli/mascli/must-gather/*
+chmod ug+x $GITHUB_WORKSPACE/image/cli/mascli/mas
+chmod ug+x $GITHUB_WORKSPACE/image/cli/mascli/must-gather/*
 tar -czvf $GITHUB_WORKSPACE/ibm-mas-cli-$VERSION.tgz --directory $GITHUB_WORKSPACE/image/cli/mascli *


### PR DESCRIPTION
We've made scripts executable in the CLI container image, but we have not done this for the installer tgz package:

```
bash ./mas must-gather -d /tmp/must-gather
IBM Maximo Application Suite Must-Gather Tool (v4.2.0)
 
Must gather will be saved to: /tmp/must-gather/must-gather-20230509-071807.tgz
Generate OCP Report
- Cluster Resources
/root/pwmasdev/functions/must_gather: line 94: /root/pwmasdev/must-gather/mg-collect-resources: Permission denied
/root/pwmasdev/functions/must_gather: line 94: /root/pwmasdev/must-gather/mg-collect-resources: Permission denied
/root/pwmasdev/functions/must_gather: line 94: /root/pwmasdev/must-gather/mg-collect-resources: Permission denied
/root/pwmasdev/functions/must_gather: line 94: /root/pwmasdev/must-gather/mg-collect-resources: Permission denied
/root/pwmasdev/functions/must_gather: line 94: /root/pwmasdev/must-gather/mg-collect-resources: Permission denied
/root/pwmasdev/functions/must_gather: line 94: /root/pwmasdev/must-gather/mg-collect-resources: Permission denied
/root/pwmasdev/functions/must_gather: line 94: /root/pwmasdev/must-gather/mg-collect-resources: Permission denied
- OpenShift Marketplace
/root/pwmasdev/functions/must_gather: line 100: /root/pwmasdev/must-gather/mg-collect-resources: Permission denied
/root/pwmasdev/functions/must_gather: line 100: /root/pwmasdev/must-gather/mg-collect-resources: Permission denied
- Operator Conditions
```
