### PR TITLE
[patch] Add redirects for content moved to product doc

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -14,7 +14,7 @@ jobs:
 
       - name: Install and Build
         run: |
-          python -m pip install -q mkdocs
+          python -m pip install -q mkdocs mkdocs-redirects
           mkdocs build --verbose --clean --strict
 
       - name: Deploy

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -19,7 +19,7 @@ jobs:
 
       - name: Deploy
         uses: JamesIves/github-pages-deploy-action@4.1.7
-        if: github.ref == 'refs/heads/redirect'
+        if: github.ref == 'refs/heads/master'
         with:
           branch: gh-pages
           folder: site

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -19,7 +19,7 @@ jobs:
 
       - name: Deploy
         uses: JamesIves/github-pages-deploy-action@4.1.7
-        if: github.ref == 'refs/heads/master'
+        if: github.ref == 'refs/heads/redirect'
         with:
           branch: gh-pages
           folder: site

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -46,6 +46,11 @@ markdown_extensions:
   - admonition
   # Add this to support expandable sections
   #- pymdownx.details
+plugins:
+  - redirects:
+      redirect_maps:
+        "guides/architecture/core.md": "https://www.ibm.com/docs/en/mas-cd/continuous-delivery?topic=reference-maximo-application-suite-core-services"
+        "guides/mas-pods-explained.md": "https://www.ibm.com/docs/en/mas-cd/continuous-delivery?topic=reference-maximo-application-suite-pod-details"
 
 # https://squidfunk.github.io/mkdocs-material/extensions/admonition/
 # Note


### PR DESCRIPTION
Adds redirects for content moved to the product documentation:

- guides/architecture/core to https://www.ibm.com/docs/en/mas-cd/continuous-delivery?topic=reference-maximo-application-suite-core-services
- guides/mas-pods-explained to https://www.ibm.com/docs/en/mas-cd/continuous-delivery?topic=reference-maximo-application-suite-pod-details
