### PR TITLE
[patch] Fix default output directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,18 @@
 # IBM Maximo Application Suite CLI Utility
+![GitHub release](https://img.shields.io/github/v/release/ibm-mas/cli)
 
 ## Introduction
 
 There are minimal dependencies to meet on your own computer to use the CLI:
+
 - Bash (v4)
 - OpenShift client
+- IBMCloud client with container plugin enabled
+- Ansible
+- Python
 - Network access to the OpenShift cluster
 
 The best way to use the CLI is via the container image: `docker run -ti -v ~:/mnt/home --pull always quay.io/ibmmas/cli`.
-
-The install is designed to work on any OCP cluster, but has been specifically tested in these environments:
-- IBMCloud ROKS
-- Microsoft Azure
-- IBM DevIT Fyre (internal)
 
 All settings can be controlled via environment variables to avoid needing to manually type them out, for example if you `export IBM_ENTITLEMENT_KEY=xxxx` then when you run the install that input will be prefilled with the value from the environment variable, allowing you to press Enter to continue, or modify the value if you need to.
 

--- a/docs/commands/must-gather.md
+++ b/docs/commands/must-gather.md
@@ -6,7 +6,7 @@ Usage
 `mas must-gather [options]`
 
 ### Options
-- `-d|--directory MG_DIR` Directory where the must-gather will be saved, defaults to `/must-gather`
+- `-d|--directory MG_DIR` Directory where the must-gather will be saved, defaults to `/tmp/must-gather` (or `/must-gather` if the directory exists)
 - `-k|--keep-files` Do not delete individual files after creating the must-gather compressed tar archive
 - `--summary-only` Perform a much faster must-gather that only gathers high level summary of resources in the cluster
 - `--no-pod-logs` Skip collection of pod logs, greatly speeds up must-gather collection time when pod logs are not required

--- a/image/cli/mascli/functions/must_gather
+++ b/image/cli/mascli/functions/must_gather
@@ -33,7 +33,12 @@ function mustgather() {
   # Set defaults
   SUMMARY_ONLY=false
   POD_LOGS=true
-  MG_DIR=/must-gather
+  MG_DIR=/tmp/must-gather
+
+  # If a /must-gather directory exists, default to that as the output directory instead
+  if [[ -d "/must-gather" ]]; then
+    MG_DIR=/must-gather
+  fi
 
   # Process command flags
   while [[ $# -gt 0 ]]
@@ -78,6 +83,11 @@ function mustgather() {
   OUTPUT_DIR=${MG_DIR}/${TIMESTAMP}
   mkdir -p $OUTPUT_DIR
 
+  if [[ "$?" != "0" ]]; then
+    echo_warning "Unable to create must-gather output directory '${MG_DIR}/${TIMESTAMP}'"
+    exit 1
+  fi
+
   # The final destination for the must-gather is a tgz
   OUTPUT_FILENAME=must-gather-${TIMESTAMP}.tgz
   OUTPUT_FILE=${MG_DIR}/${OUTPUT_FILENAME}
@@ -101,20 +111,20 @@ function mustgather() {
   done
 
   echo "- Operator Conditions"
-  oc get operatorconditions --all-namespaces 2&> ${OUTPUT_DIR}/operatorconditions.txt
+  oc get operatorconditions --all-namespaces &> ${OUTPUT_DIR}/operatorconditions.txt
 
   # Generate Dependency Report
   # -----------------------------------------------------------------------------
   echo ""
   echo_h2 "Generate Dependency Report"
   echo "- IBM CloudPak Foundation Services"
-  $MG_SCRIPT_DIR/mg-summary-ibm-common-services 2&> ${OUTPUT_DIR}/ibm-common-services.txt
+  $MG_SCRIPT_DIR/mg-summary-ibm-common-services &> ${OUTPUT_DIR}/ibm-common-services.txt
 
   echo "- IBM CloudPak for Data"
-  $MG_SCRIPT_DIR/mg-summary-cp4d 2&> ${OUTPUT_DIR}/cp4d.txt
+  $MG_SCRIPT_DIR/mg-summary-cp4d &> ${OUTPUT_DIR}/cp4d.txt
 
-  echo "- IBM Db2 universal Operator"
-  $MG_SCRIPT_DIR/mg-summary-db2u 2&> ${OUTPUT_DIR}/db2u.txt
+  echo "- IBM Db2 Universal Operator"
+  $MG_SCRIPT_DIR/mg-summary-db2u &> ${OUTPUT_DIR}/db2u.txt
 
   # Find MAS instances
   # -----------------------------------------------------------------------------
@@ -127,7 +137,7 @@ function mustgather() {
   do
     echo_h2 "Maximo Application Suite Must Gather: ${MAS_INSTANCE_ID}"
 
-    for MAS_APP_ID in core assist iot monitor manage optimizer visualinspection
+    for MAS_APP_ID in core assist iot monitor manage optimizer visualinspection pipelines
     do
       MAS_APP_NAMESPACE=mas-${MAS_INSTANCE_ID}-${MAS_APP_ID}
       NAMESPACE_LOOKUP=$(oc get namespace $MAS_APP_NAMESPACE --ignore-not-found)
@@ -136,7 +146,7 @@ function mustgather() {
       then
         echo -e "- Performing must-gather in namespace ${MAS_APP_NAMESPACE}"
         # MAS-specific must-gather
-        $MG_SCRIPT_DIR/mg-summary-mas-${MAS_APP_ID} $MAS_APP_NAMESPACE 2&> ${OUTPUT_DIR}/mas-${MAS_INSTANCE_ID}-${MAS_APP_ID}.txt
+        $MG_SCRIPT_DIR/mg-summary-mas-${MAS_APP_ID} $MAS_APP_NAMESPACE &> ${OUTPUT_DIR}/mas-${MAS_INSTANCE_ID}-${MAS_APP_ID}.txt
         $MG_SCRIPT_DIR/mg-collect-mas-${MAS_APP_ID} $MAS_APP_NAMESPACE $OUTPUT_DIR
 
         # Generic Kubernetes must-gather

--- a/image/cli/mascli/must-gather/mg-collect-mas-pipelines
+++ b/image/cli/mascli/must-gather/mg-collect-mas-pipelines
@@ -1,0 +1,19 @@
+#!/bin/bash
+set -e
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+NAMESPACE=$1
+OUTPUT_DIR=$2
+
+# Collect Tekton Resources
+# -----------------------------------------------------------------------------
+if [[ "$SUMMARY_ONLY" == false ]]
+then
+  $MG_SCRIPT_DIR/mg-collect-pods $NAMESPACE $POD_LOGS $OUTPUT_DIR/resources
+  for RESOURCE in tasks taskruns pipelines pipelineruns
+  do
+    $MG_SCRIPT_DIR/mg-collect-resources -n $NAMESPACE -r $RESOURCE -d $OUTPUT_DIR/resources
+  done
+fi
+
+exit 0

--- a/image/cli/mascli/must-gather/mg-collect-reconcile-logs
+++ b/image/cli/mascli/must-gather/mg-collect-reconcile-logs
@@ -16,12 +16,13 @@ set -e
 TMP_DIR=${OUTPUT_DIR}/tmp-$CONTROL_PLANE
 mkdir -p $TMP_DIR
 
-oc -n $NAMESPACE exec $POD -- tar -czf - $LOGFILES > $TMP_DIR/ansible-logs-$KIND.tgz 2> /dev/null
-tar -xf $TMP_DIR/ansible-logs-$KIND.tgz -C $TMP_DIR 2> /dev/null
+echo "  - Collecting reconcile logs from control plane '$CONTROL_PLANE'"
+oc -n $NAMESPACE exec $POD -- tar -czf - $LOGFILES > $TMP_DIR/ansible-logs-$CONTROL_PLANE.tgz 2> /dev/null
+tar -xf $TMP_DIR/ansible-logs-$CONTROL_PLANE.tgz -C $TMP_DIR 2> /dev/null
 if [[ "$?" == "0" ]]; then
-  rm $TMP_DIR/ansible-logs-$KIND.tgz
+  rm $TMP_DIR/ansible-logs-$CONTROL_PLANE.tgz
 else
-  echo_warning "    - Unable to get Reconcile logs from $POD"
+  echo_warning "    - Unable to get reconcile logs from $POD"
 fi
 
 for API_DIR in $TMP_DIR/tmp/ansible-operator/runner/*
@@ -36,7 +37,7 @@ do
       RLOG_DIR=${OUTPUT_DIR}/reconcile-logs/$NAMESPACE/$KIND
       mkdir -p $RLOG_DIR
 
-      echo "  - Collecting reconcile logs for $KIND.$API/$VERSION"
+      echo "    - $KIND.$API/$VERSION"
       for INSTANCE_DIR in $KIND_DIR/$NAMESPACE/*/
       do
         INSTANCE_NAME=$(basename $INSTANCE_DIR)

--- a/image/cli/mascli/must-gather/mg-summary-mas-core
+++ b/image/cli/mascli/must-gather/mg-summary-mas-core
@@ -1,32 +1,40 @@
 #!/bin/bash
 
+NAMESPACE=$1
+
 echo "IBM Maximo Application Suite - Core Platform"
 echo "--------------------------------------------------------------------------------"
-oc get suite --all-namespaces
+oc -n $NAMESPACE get suite
+echo ""
+
+echo ""
+echo "IBM Maximo Application Suite - Workspace Configurations"
+echo "--------------------------------------------------------------------------------"
+oc -n $NAMESPACE get workspace
 echo ""
 
 echo ""
 echo "IBM Maximo Application Suite - Mongo Configurations"
 echo "--------------------------------------------------------------------------------"
-oc get mongocfg --all-namespaces
+oc -n $NAMESPACE get mongocfg
 echo ""
 
 echo ""
 echo "IBM Maximo Application Suite - SLS Configurations"
 echo "--------------------------------------------------------------------------------"
-oc get slscfg --all-namespaces
+oc -n $NAMESPACE get slscfg
 echo ""
 
 echo ""
 echo "IBM Maximo Application Suite - BAS (UDS) Configurations"
 echo "--------------------------------------------------------------------------------"
-oc get bascfg --all-namespaces
+oc -n $NAMESPACE get bascfg
 echo ""
 
 echo ""
 echo "IBM Maximo Application Suite - JDBC Configurations"
 echo "--------------------------------------------------------------------------------"
-oc get jdbccfg --all-namespaces
+oc -n $NAMESPACE get jdbccfg
 echo ""
 
 exit 0

--- a/image/cli/mascli/must-gather/mg-summary-mas-pipelines
+++ b/image/cli/mascli/must-gather/mg-summary-mas-pipelines
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+NAMESPACE=$1
+
+echo "OpenShift Pipelines - Pipelines"
+echo "--------------------------------------------------------------------------------"
+oc -n $NAMESPACE get pipelines -o wide
+echo ""
+
+echo "OpenShift Pipelines - Tasks"
+echo "--------------------------------------------------------------------------------"
+oc -n $NAMESPACE get tasks -o wide
+echo ""
+
+echo "OpenShift Pipelines - PipelineRuns"
+echo "--------------------------------------------------------------------------------"
+oc -n $NAMESPACE get pipelineruns -o wide
+echo ""
+
+echo "OpenShift Pipelines - TaskRuns"
+echo "--------------------------------------------------------------------------------"
+oc -n $NAMESPACE get taskruns -o wide
+echo ""
+
+exit 0

--- a/image/cli/usr/bin/gather
+++ b/image/cli/usr/bin/gather
@@ -1,4 +1,10 @@
 #!/bin/bash
 
 # https://github.com/openshift/enhancements/blob/89bbe226db20573f8f489eacb558a9f011072737/enhancements/oc/must-gather.md#must-gather-images
+
+# Creating a directory named /must-gather will change the default output directory from /tmp/must-gather to /must-gather, which is
+# the directory that the oc must-gather command expects to collect the must-gather files from
+mkdir -p /must-gather
+
+# Run full MAS must-gather
 mas must-gather


### PR DESCRIPTION
Various small tweaks/improvements to `must-gather`:
- Changed default must-gather output directory to `/tmp/must-gather` to be more use friendly, if an existing `/must-gather` directory exists then that will be the default, this allows us to have a more sensible default for `mas must-gather`, but still have a way to set the default to `/must-gather` when invoked via the `gather` script (which pre-creates `/must-gather`
- `must-gather` now exits if the output directory cannot be created
- Added support for resource collection from MAS `pipelines` namespaces to aid in debugging install failures