### PR TITLE
[patch] Manage FVT pipeline adjustments

### DIFF
--- a/tekton/src/pipelines/taskdefs/fvt-apps/manage.yml.j2
+++ b/tekton/src/pipelines/taskdefs/fvt-apps/manage.yml.j2
@@ -78,3 +78,23 @@
       value: security-audit-logging
   runAfter:
     - fvt-manage-setup
+
+# Manage FVT Inactive User Authentication
+- name: fvt-manage-security-inactive-auth
+  {{ lookup('template', 'taskdefs/fvt-apps/common/taskref-manage.yml.j2') | indent(2) }}
+  params:
+    {{ lookup('template', 'taskdefs/fvt-apps/common/params-manage.yml.j2') | indent(4) }}
+    - name: fvt_test_suite
+      value: security-inactiveuser-authentication
+  runAfter:
+    - fvt-manage-setup
+
+# Manage FVT Work Order Basic Scenario
+- name: fvt-manage-wobasic
+  {{ lookup('template', 'taskdefs/fvt-apps/common/taskref-manage.yml.j2') | indent(2) }}
+  params:
+    {{ lookup('template', 'taskdefs/fvt-apps/common/params-manage.yml.j2') | indent(4) }}
+    - name: fvt_test_suite
+      value: workorderbasic
+  runAfter:
+    - fvt-manage-setup

--- a/tekton/src/pipelines/taskdefs/fvt-apps/manage.yml.j2
+++ b/tekton/src/pipelines/taskdefs/fvt-apps/manage.yml.j2
@@ -69,8 +69,8 @@
   runAfter:
     - fvt-manage-setup
   
-  # Manage FVT Pytest Tests
-- name: fvt-manage-pytest-metrics
+  # Manage Monitoring Tests
+- name: fvt-manage-monitoring
   {{ lookup('template', 'taskdefs/fvt-apps/common/taskref-manage.yml.j2') | indent(2) }}
   params:
     {{ lookup('template', 'taskdefs/fvt-apps/common/params-manage.yml.j2') | indent(4) }}

--- a/tekton/src/pipelines/taskdefs/fvt-apps/manage.yml.j2
+++ b/tekton/src/pipelines/taskdefs/fvt-apps/manage.yml.j2
@@ -68,6 +68,16 @@
       value: metrics-api
   runAfter:
     - fvt-manage-setup
+  
+  # Manage FVT Pytest Tests
+- name: fvt-manage-pytest-metrics
+  {{ lookup('template', 'taskdefs/fvt-apps/common/taskref-manage.yml.j2') | indent(2) }}
+  params:
+    {{ lookup('template', 'taskdefs/fvt-apps/common/params-manage.yml.j2') | indent(4) }}
+    - name: fvt_test_suite
+      value: monitoring
+  runAfter:
+    - ivtcore-manage
 
 # Manage FVT Security Audit Logging
 - name: fvt-manage-security-audit-logging

--- a/tekton/src/pipelines/taskdefs/fvt-apps/manage.yml.j2
+++ b/tekton/src/pipelines/taskdefs/fvt-apps/manage.yml.j2
@@ -108,3 +108,13 @@
       value: workorderbasic
   runAfter:
     - fvt-manage-setup
+    
+  # Manage FVT Masnavigation Scenarion 
+- name: fvt-manage-masnavigation
+  {{ lookup('template', 'taskdefs/fvt-apps/common/taskref-manage.yml.j2') | indent(2) }}
+  params:
+    {{ lookup('template', 'taskdefs/fvt-apps/common/params-manage.yml.j2') | indent(4) }}
+    - name: fvt_test_suite
+      value: masnavigation
+  runAfter:
+    - fvt-manage-setup

--- a/tekton/src/pipelines/taskdefs/fvt-apps/manage.yml.j2
+++ b/tekton/src/pipelines/taskdefs/fvt-apps/manage.yml.j2
@@ -118,3 +118,13 @@
       value: masnavigation
   runAfter:
     - fvt-manage-setup
+    
+    # Manage FVT Create Workflow Design & Approve WO Assignments
+- name: fvt-manage-workflow-designer
+  {{ lookup('template', 'taskdefs/fvt-apps/common/taskref-manage.yml.j2') | indent(2) }}
+  params:
+    {{ lookup('template', 'taskdefs/fvt-apps/common/params-manage.yml.j2') | indent(4) }}
+    - name: fvt_test_suite
+      value: workflow-designer
+  runAfter:
+    - fvt-manage-setup


### PR DESCRIPTION
Test Evidencies:

<img width="598" alt="image" src="https://github.com/ibm-mas/cli/assets/15021471/2baef7b6-e977-4110-8258-0317d87ef773">

Note `monitoring` tests failed in the first attempt, but we fixed problem by including the right test suite export (leveraing hook in ubi-fvt pytest_runner), which result in a success:

<img width="560" alt="image" src="https://github.com/ibm-mas/cli/assets/15021471/9261f7bd-31df-4a0e-989a-4624bf0b5316">

The remaining tests are being worked by Scheduler team, not part of this PR