### PR TITLE
[patch] Fix AppConnect removal from the pipeline

### DIFF
--- a/tekton/src/pipelines/install.yml.j2
+++ b/tekton/src/pipelines/install.yml.j2
@@ -150,18 +150,6 @@ spec:
         - suite-verify
         - cos
 
-    # App Connect temporarily disabled due CVEID: CVE-2023-28521
-    # 4.1 Install AppConnect
-    # {{ lookup('template', 'taskdefs/dependencies/appconnect.yml.j2') | indent(4) }}
-      # runAfter:
-        # - ibm-catalogs
-
-    # 4.2 Configure AppConnect in MAS
-    # {{ lookup('template', 'taskdefs/core/suite-config-appconnect.yml.j2') | indent(4) }}
-      # runAfter:
-        # - suite-verify
-        # - appconnect
-
     # 4.3 Nvidia GPU Operator
     {{ lookup('template', 'taskdefs/dependencies/nvidia.yml.j2') | indent(4) }}
       runAfter:
@@ -298,8 +286,6 @@ spec:
       runAfter:
         - app-cfg-manage # Requires Health as an add-on
         - suite-config-watson-studio
-        # App Connect temporarily disabled due CVEID: CVE-2023-28521
-        # - suite-config-appconnect
 
     # 11.2 Configure HPUtilities workspace
     {{ lookup('template', 'taskdefs/apps/hputilities-workspace.yml.j2') | indent(4) }}


### PR DESCRIPTION
AppConnect wasn't properly removed from the pipeline, resulting in some tasks in the pipeline becoming corrupted.