### PR TITLE
[patch] Make Watson OpenScale install optional

### DIFF
--- a/image/cli/mascli/functions/pipeline_config_applications
+++ b/image/cli/mascli/functions/pipeline_config_applications
@@ -184,9 +184,15 @@ function config_pipeline_applications() {
       if [[ "$MAS_APP_CHANNEL_MANAGE" != '' ]]; then
         # Predict
         if prompt_for_confirm "Install Predict"; then
+          echo ""
+          echo "Optional Cloud Pak for Data Services for Predict:"
+          echo ""
           channel_select_predict || exit 1
-          if prompt_for_confirm "+ Install SPSS (Optional Cloud Pak for Data service)"; then
-          CPD_INSTALL_SPSS=true
+          if prompt_for_confirm "+ Install IBM SPSS Statistics"; then
+            CPD_INSTALL_SPSS=true
+          fi
+          if prompt_for_confirm "+ Install Watson OpenScale"; then
+            CPD_INSTALL_OPENSCALE=true
           fi
         fi
       fi

--- a/image/cli/mascli/functions/pipeline_config_applications
+++ b/image/cli/mascli/functions/pipeline_config_applications
@@ -184,9 +184,6 @@ function config_pipeline_applications() {
       if [[ "$MAS_APP_CHANNEL_MANAGE" != '' ]]; then
         # Predict
         if prompt_for_confirm "Install Predict"; then
-          echo ""
-          echo "Optional Cloud Pak for Data Services for Predict:"
-          echo ""
           channel_select_predict || exit 1
           if prompt_for_confirm "+ Install IBM SPSS Statistics"; then
             CPD_INSTALL_SPSS=true

--- a/image/cli/mascli/templates/pipelinerun.yaml
+++ b/image/cli/mascli/templates/pipelinerun.yaml
@@ -137,6 +137,8 @@ spec:
       value: '$CP4D_VERSION'
     - name: cpd_install_spss
       value: '$CPD_INSTALL_SPSS'
+    - name: cpd_install_openscale
+      value: '$CPD_INSTALL_OPENSCALE'
 
     # Dependencies - SLS
     # -------------------------------------------------------------------------

--- a/tekton/src/params/install.yml.j2
+++ b/tekton/src/params/install.yml.j2
@@ -177,6 +177,9 @@
 - name: cpd_install_spss
   type: string
   default: "False"
+- name: cpd_install_openscale
+  type: string
+  default: "False"
 
 # Dependencies - UDS
 # -----------------------------------------------------------------------------

--- a/tekton/src/pipelines/taskdefs/cp4d/cp4d-aiopenscale.yml.j2
+++ b/tekton/src/pipelines/taskdefs/cp4d/cp4d-aiopenscale.yml.j2
@@ -12,6 +12,8 @@
       value: "$(params.cpd_aiopenscale_storage_class)"
     - name: mas_workspace_id
       value: $(params.mas_workspace_id)
+    - name: cpd_install_openscale
+      value: $(params.cpd_install_openscale)
   taskRef:
     kind: Task
     name: mas-devops-cp4d-service
@@ -20,6 +22,9 @@
     - input: "$(params.mas_app_channel_predict)"
       operator: notin
       values: [""]
+    - input: "$(params.cpd_install_openscale)"
+      operator: in
+      values: ["True","true"]
   workspaces:
     - name: configs
       workspace: shared-configs

--- a/tekton/src/tasks/dependencies/cp4d_service.yml.j2
+++ b/tekton/src/tasks/dependencies/cp4d_service.yml.j2
@@ -40,6 +40,10 @@ spec:
     - name: cpd_install_spss
       type: string
       default: "False"
+    # Whether to install Watson OpenScale or not (Optional for Predict app)
+    - name: cpd_install_openscale
+      type: string
+      default: "False"
 
     - name: mas_instance_id
       type: string
@@ -85,6 +89,8 @@ spec:
         value: $(params.cpd_wsl_project_name)
       - name: CPD_INSTALL_SPSS
         value: $(params.cpd_install_spss)
+      - name: CPD_INSTALL_OPENSCALE
+        value: $(params.cpd_install_openscale)
   steps:
     - name: cp4d-service
       command:


### PR DESCRIPTION
This PR adds optional cpd services to be installed as part of predict app: spss and openscale.

<img width="180" alt="image" src="https://github.com/ibm-mas/cli/assets/31037381/623baa70-c789-4d91-b39f-1c1c6123d1e9">


Only when `CPD_INSTALL_SPSS` and `CPD_INSTALL_OPENSCALE` are set to `'True'` then these will be installed, otherwise they won't be installed by default.

**When `CPD_INSTALL_SPSS` and `CPD_INSTALL_OPENSCALE` are set to `'True'`:**

<img width="305" alt="image" src="https://github.com/ibm-mas/cli/assets/31037381/b596aeee-44fe-467f-82ef-d67e8cd49ecf">

When **`CPD_INSTALL_SPSS` and `CPD_INSTALL_OPENSCALE` are set to `'False'`:**

<img width="315" alt="image" src="https://github.com/ibm-mas/cli/assets/31037381/3a28b9ca-48c8-4c14-9e86-b3a54de1858c">

This change goes hand in hand with: https://github.ibm.com/maximoappsuite/ansible-fvt/pull/225