### PR TITLE
[patch] Include add and predict in must-gather

### DIFF
--- a/image/cli/mascli/functions/must_gather
+++ b/image/cli/mascli/functions/must_gather
@@ -160,7 +160,7 @@ function mustgather() {
   do
     echo_h2 "Maximo Application Suite Must Gather: ${MAS_INSTANCE_ID}"
 
-    for MAS_APP_ID in core assist iot monitor manage optimizer visualinspection pipelines
+    for MAS_APP_ID in core add assist iot monitor manage optimizer predict visualinspection pipelines
     do
       MAS_APP_NAMESPACE=mas-${MAS_INSTANCE_ID}-${MAS_APP_ID}
       NAMESPACE_LOOKUP=$(oc get namespace $MAS_APP_NAMESPACE --ignore-not-found)

--- a/image/cli/mascli/must-gather/mg-collect-mas-add
+++ b/image/cli/mascli/must-gather/mg-collect-mas-add
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+exit 0

--- a/image/cli/mascli/must-gather/mg-collect-mas-predict
+++ b/image/cli/mascli/must-gather/mg-collect-mas-predict
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+exit 0

--- a/image/cli/mascli/must-gather/mg-summary-mas-add
+++ b/image/cli/mascli/must-gather/mg-summary-mas-add
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+exit 0

--- a/image/cli/mascli/must-gather/mg-summary-mas-predict
+++ b/image/cli/mascli/must-gather/mg-summary-mas-predict
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+exit 0


### PR DESCRIPTION
It was reported that `mas-xxx-predict` namespace wasn't being included in the must-gather, also noticed when investigating that neither was the `mas-xxx-add` (Data Dictionary) namespace.