### PR TITLE
[patch] Correct OCP support statement

### DIFF
--- a/docs/catalogs/v8-230616-amd64.md
+++ b/docs/catalogs/v8-230616-amd64.md
@@ -56,11 +56,28 @@ For more information about the OCP lifecycle refer to the [Red Hat OpenShift Con
     <td>September 10, 2023</td>
     <td>8.9 - 8.10</td>
   </tr>
+  <tr>
+    <td class="firstColumn">4.11<sup>1</sup></td>
+    <td>August 10, 2022</td>
+    <td>February 10, 2024</td>
+    <td>8.9 - 8.10</td>
+  </tr>
+  <tr>
+    <td class="firstColumn">4.12</td>
+    <td>January 17, 2023</td>
+    <td>January 17, 2025</td>
+    <td>8.9 - 8.10</td>
+  </tr>
 </table>
+
+ 1. Note that **IBM App Connect** and **IBM Cloud Pak for Data** do not support odd-numbered OpenShift releases, so if you intend to use Predict, HP Utilities, or Assist you are limited to use of the even numbered OCP releases.
+
 
 
 ### Certified Operators
 - `registry.redhat.io/redhat/certified-operator-index:v4.10`
+- `registry.redhat.io/redhat/certified-operator-index:v4.11`
+- `registry.redhat.io/redhat/certified-operator-index:v4.12`
 
 The following packages from this catalog are used in the Maximo Application Suite install:
 
@@ -71,6 +88,8 @@ The following packages from this catalog are used in the Maximo Application Suit
 
 ### Community Operators
 - `registry.redhat.io/redhat/community-operator-index:v4.10`
+- `registry.redhat.io/redhat/community-operator-index:v4.11`
+- `registry.redhat.io/redhat/community-operator-index:v4.12`
 
 The following packages from this catalog are used in the Maximo Application Suite install:
 
@@ -80,6 +99,8 @@ The following packages from this catalog are used in the Maximo Application Suit
 
 ### Red Hat Operators
 - `registry.redhat.io/redhat/redhat-operator-index:v4.10`
+- `registry.redhat.io/redhat/redhat-operator-index:v4.11`
+- `registry.redhat.io/redhat/redhat-operator-index:v4.12`
 
 The following packages from this catalog are used in the Maximo Application Suite install:
 
@@ -90,9 +111,6 @@ The following packages from this catalog are used in the Maximo Application Suit
 - **local-storage-operator**  required by `ibm.mas_devops.ocs` role
 - **ocs-operator**  required by `ibm.mas_devops.ocs` role (OCP 4.10)
 - **odf-operator**  required by `ibm.mas_devops.ocs` role (OCP 4.11+)
-
-
-<!-- 1. Note that **IBM App Connect** and **IBM Cloud Pak for Data** do not support odd-numbered OpenShift releases, so if you intend to use Predict, HP Utilities, or Assist you are limited to use of the even numbered OCP releases. -->
 
 
 IBM Cloud Pak for Data Compatibility


### PR DESCRIPTION
The June catalog documentation was not correctly updated to include new OCP 4.12 support in MAS 8.9 and 8.10.