### PR TITLE
[patch] Reference supported architecture

### DIFF
--- a/docs/catalogs/v8-220717-amd64.md
+++ b/docs/catalogs/v8-220717-amd64.md
@@ -36,7 +36,7 @@ spec:
 
 OpenShift Container Platform Support
 -------------------------------------------------------------------------------
-IBM Maximo Application Suite will run anywhere that you can run a supported OpenShift release, including:
+IBM Maximo Application Suite will run anywhere that you can run a supported OpenShift release on AMD64 architecture, including:
 
 - [AWS](https://aws.amazon.com/rosa/)
 - [Azure](https://azure.microsoft.com/en-gb/services/openshift/)

--- a/docs/catalogs/v8-220805-amd64.md
+++ b/docs/catalogs/v8-220805-amd64.md
@@ -36,7 +36,7 @@ spec:
 
 OpenShift Container Platform Support
 -------------------------------------------------------------------------------
-IBM Maximo Application Suite will run anywhere that you can run a supported OpenShift release, including:
+IBM Maximo Application Suite will run anywhere that you can run a supported OpenShift release on AMD64 architecture, including:
 
 - [AWS](https://aws.amazon.com/rosa/)
 - [Azure](https://azure.microsoft.com/en-gb/services/openshift/)

--- a/docs/catalogs/v8-220927-amd64.md
+++ b/docs/catalogs/v8-220927-amd64.md
@@ -37,7 +37,7 @@ spec:
 
 OpenShift Container Platform Support
 -------------------------------------------------------------------------------
-IBM Maximo Application Suite will run anywhere that you can run a supported OpenShift release, including:
+IBM Maximo Application Suite will run anywhere that you can run a supported OpenShift release on AMD64 architecture, including:
 
 - [AWS](https://aws.amazon.com/rosa/)
 - [Azure](https://azure.microsoft.com/en-gb/services/openshift/)

--- a/docs/catalogs/v8-221025-amd64.md
+++ b/docs/catalogs/v8-221025-amd64.md
@@ -37,7 +37,7 @@ spec:
 
 OpenShift Container Platform Support
 -------------------------------------------------------------------------------
-IBM Maximo Application Suite will run anywhere that you can run a supported OpenShift release, including:
+IBM Maximo Application Suite will run anywhere that you can run a supported OpenShift release on AMD64 architecture, including:
 
 - [AWS](https://aws.amazon.com/rosa/)
 - [Azure](https://azure.microsoft.com/en-gb/services/openshift/)

--- a/docs/catalogs/v8-221129-amd64.md
+++ b/docs/catalogs/v8-221129-amd64.md
@@ -44,7 +44,7 @@ spec:
 
 OpenShift Container Platform Support
 -------------------------------------------------------------------------------
-IBM Maximo Application Suite will run anywhere that you can run a supported OpenShift release, including:
+IBM Maximo Application Suite will run anywhere that you can run a supported OpenShift release on AMD64 architecture, including:
 
 - [AWS](https://aws.amazon.com/rosa/)
 - [Azure](https://azure.microsoft.com/en-gb/services/openshift/)

--- a/docs/catalogs/v8-221228-amd64.md
+++ b/docs/catalogs/v8-221228-amd64.md
@@ -41,7 +41,7 @@ spec:
 
 OpenShift Container Platform Support
 -------------------------------------------------------------------------------
-IBM Maximo Application Suite will run anywhere that you can run a supported OpenShift release, including:
+IBM Maximo Application Suite will run anywhere that you can run a supported OpenShift release on AMD64 architecture, including:
 
 - [AWS](https://aws.amazon.com/rosa/)
 - [Azure](https://azure.microsoft.com/en-gb/services/openshift/)

--- a/docs/catalogs/v8-230111-amd64.md
+++ b/docs/catalogs/v8-230111-amd64.md
@@ -37,7 +37,7 @@ spec:
 
 Red Hat OpenShift Container Platform Support
 -------------------------------------------------------------------------------
-IBM Maximo Application Suite will run anywhere that you can run a supported OpenShift release, including:
+IBM Maximo Application Suite will run anywhere that you can run a supported OpenShift release on AMD64 architecture, including:
 
 - [AWS](https://aws.amazon.com/rosa/)
 - [Azure](https://azure.microsoft.com/en-gb/services/openshift/)

--- a/docs/catalogs/v8-230217-amd64.md
+++ b/docs/catalogs/v8-230217-amd64.md
@@ -36,7 +36,7 @@ spec:
 
 Red Hat OpenShift Container Platform Support
 -------------------------------------------------------------------------------
-IBM Maximo Application Suite will run anywhere that you can run a supported OpenShift release, including:
+IBM Maximo Application Suite will run anywhere that you can run a supported OpenShift release on AMD64 architecture, including:
 
 - [AWS](https://aws.amazon.com/rosa/)
 - [Azure](https://azure.microsoft.com/en-gb/services/openshift/)

--- a/docs/catalogs/v8-230314-amd64.md
+++ b/docs/catalogs/v8-230314-amd64.md
@@ -36,7 +36,7 @@ spec:
 
 Red Hat OpenShift Container Platform Support
 -------------------------------------------------------------------------------
-IBM Maximo Application Suite will run anywhere that you can run a supported OpenShift release, including:
+IBM Maximo Application Suite will run anywhere that you can run a supported OpenShift release on AMD64 architecture, including:
 
 - [AWS](https://aws.amazon.com/rosa/)
 - [Azure](https://azure.microsoft.com/en-gb/services/openshift/)

--- a/docs/catalogs/v8-230414-amd64.md
+++ b/docs/catalogs/v8-230414-amd64.md
@@ -34,7 +34,7 @@ spec:
 
 Red Hat OpenShift Container Platform Support
 -------------------------------------------------------------------------------
-IBM Maximo Application Suite will run anywhere that you can run a supported OpenShift release, including:
+IBM Maximo Application Suite will run anywhere that you can run a supported OpenShift release on AMD64 architecture, including:
 
 - [AWS](https://aws.amazon.com/rosa/)
 - [Azure](https://azure.microsoft.com/en-gb/services/openshift/)

--- a/docs/catalogs/v8-230518-amd64.md
+++ b/docs/catalogs/v8-230518-amd64.md
@@ -37,7 +37,7 @@ spec:
 
 Red Hat OpenShift Container Platform Support
 -------------------------------------------------------------------------------
-IBM Maximo Application Suite will run anywhere that you can run a supported OpenShift release, including:
+IBM Maximo Application Suite will run anywhere that you can run a supported OpenShift release on AMD64 architecture, including:
 
 - [AWS](https://aws.amazon.com/rosa/)
 - [Azure](https://azure.microsoft.com/en-gb/services/openshift/)

--- a/docs/catalogs/v8-230526-amd64.md
+++ b/docs/catalogs/v8-230526-amd64.md
@@ -34,7 +34,7 @@ spec:
 
 Red Hat OpenShift Container Platform Support
 -------------------------------------------------------------------------------
-IBM Maximo Application Suite will run anywhere that you can run a supported OpenShift release, including:
+IBM Maximo Application Suite will run anywhere that you can run a supported OpenShift release on AMD64 architecture, including:
 
 - [AWS](https://aws.amazon.com/rosa/)
 - [Azure](https://azure.microsoft.com/en-gb/services/openshift/)

--- a/docs/catalogs/v8-230616-amd64.md
+++ b/docs/catalogs/v8-230616-amd64.md
@@ -34,7 +34,7 @@ spec:
 
 Red Hat OpenShift Container Platform Support
 -------------------------------------------------------------------------------
-IBM Maximo Application Suite will run anywhere that you can run a supported OpenShift release, including:
+IBM Maximo Application Suite will run anywhere that you can run a supported OpenShift release on AMD64 architecture, including:
 
 - [AWS](https://aws.amazon.com/rosa/)
 - [Azure](https://azure.microsoft.com/en-gb/services/openshift/)


### PR DESCRIPTION
This is a simple update to change `IBM Maximo Application Suite will run anywhere that you can run a supported OpenShift release` to `IBM Maximo Application Suite will run anywhere that you can run a supported OpenShift release on AMD64 architecture`.

- Fixes #320