### PR TITLE
[patch] Remove must-gather from install and update pipelines

### DIFF
--- a/image/cli/mascli/functions/update
+++ b/image/cli/mascli/functions/update
@@ -74,7 +74,7 @@ function update() {
   echo_h2 "Review Settings"
 
   echo "${TEXT_DIM}"
-  echo_h2 "IBM Operator Catalog" "    "
+  echo_h4 "IBM Operator Catalog" "    "
   echo_reset_dim "Catalog Version ..................... ${COLOR_MAGENTA}${MAS_CATALOG_VERSION}"
 
   echo

--- a/image/cli/mascli/templates/deployment.yaml
+++ b/image/cli/mascli/templates/deployment.yaml
@@ -25,12 +25,7 @@ spec:
           volumeMounts:
             - mountPath: /mnt/config
               name: config
-            - mountPath: /mnt/mustgather
-              name: mustgather
       volumes:
         - name: config
           persistentVolumeClaim:
             claimName: config-pvc
-        - name: mustgather
-          persistentVolumeClaim:
-            claimName: shared-mustgather-storage

--- a/image/cli/mascli/templates/pipelinerun.yaml
+++ b/image/cli/mascli/templates/pipelinerun.yaml
@@ -422,10 +422,3 @@ spec:
     - name: shared-entitlement
       secret:
         secretName: pipeline-sls-entitlement
-
-    # Pipeline must-gather storage
-    # -------------------------------------------------------------------------
-    # The storage to hold mustgather output after the pipeline has completed
-    - name: shared-mustgather
-      persistentVolumeClaim:
-        claimName: shared-mustgather-storage

--- a/image/cli/mascli/templates/pvc.yaml
+++ b/image/cli/mascli/templates/pvc.yaml
@@ -13,18 +13,3 @@ spec:
   resources:
     requests:
       storage: 500Mi
----
-# 2. Set up a PVC for shared storage for mustgather
-apiVersion: v1
-kind: PersistentVolumeClaim
-metadata:
-  name: shared-mustgather-storage
-  namespace: mas-{{mas_instance_id}}-pipelines
-spec:
-  accessModes:
-    - {{pipeline_storage_accessmode}}
-  volumeMode: Filesystem
-  storageClassName: {{pipeline_storage_class}}
-  resources:
-    requests:
-      storage: 1Gi

--- a/tekton/src/pipelines/install.yml.j2
+++ b/tekton/src/pipelines/install.yml.j2
@@ -12,8 +12,6 @@ spec:
     - name: shared-additional-configs
     # The SLS entitlement key file that will be installed during install-sls.
     - name: shared-entitlement
-    # Shared storage to hold mustgather output for tasks
-    - name: shared-mustgather
 
   params:
     # 1. Common Parameters
@@ -343,18 +341,3 @@ spec:
         - app-cfg-predict # infers Manage completed
         - app-cfg-monitor # infers IoT completed
         - app-cfg-visualinspection
-
-
-  # Perform must-gather after the install
-  # ---------------------------------------------------------------------------
-  finally:
-    - name: must-gather
-      params:
-        - name: base_output_dir
-          value: "/workspace/mustgather/$(context.pipelineRun.name)"
-      taskRef:
-        kind: Task
-        name: mas-devops-must-gather
-      workspaces:
-        - name: mustgather
-          workspace: shared-mustgather

--- a/tekton/src/pipelines/update.yml.j2
+++ b/tekton/src/pipelines/update.yml.j2
@@ -8,9 +8,11 @@ metadata:
   name: mas-update
 {% endif %}
 spec:
+{% if wait_for_install == true %}
   workspaces:
     # Shared storage to hold mustgather output for tasks
     - name: shared-mustgather
+{% endif %}
 
   params:
 {% if wait_for_install == true %}
@@ -130,7 +132,7 @@ spec:
       runAfter:
         - post-update-verify-subscriptions
 
-
+{% if wait_for_install == true %}
   # Perform must-gather after the update
   # ---------------------------------------------------------------------------
   finally:
@@ -144,3 +146,4 @@ spec:
       workspaces:
         - name: mustgather
           workspace: shared-mustgather
+{% endif %}


### PR DESCRIPTION
Disable the must-gather step at the end of the update and install, it is now easy for customers to run must-gather on demand directly from the mas-cli, this reduces the footprint of the pipeline.