### PR TITLE
[patch] Remove mas_channel from cert-manager taskdef

### DIFF
--- a/tekton/src/pipelines/taskdefs/cluster-setup/cert-manager.yml.j2
+++ b/tekton/src/pipelines/taskdefs/cluster-setup/cert-manager.yml.j2
@@ -3,9 +3,6 @@
     {{ lookup('template', 'taskdefs/common/cli-params.yml.j2') | indent(4) }}
     - name: devops_suite_name
       value: setup-cert-manager
-
-    - name: mas_channel
-      value: $(params.mas_channel)
   taskRef:
     kind: Task
     name: mas-devops-cert-manager


### PR DESCRIPTION
Presumably a bad merge somewhere in yesterday's commits as this was working previously.

```
invalid input params for task mas-devops-cert-manager: didn't need these params but they were provided anyway: [mas_channel]
```