### PR TITLE
[patch] Update CLI version refs in doc

### DIFF
--- a/docs/commands/mirror-redhat-images.md
+++ b/docs/commands/mirror-redhat-images.md
@@ -47,7 +47,7 @@ docker run -ti --rm -v /mnt/storage:/mnt/local --pull always quay.io/ibmmas/cli 
 Two-Phase image mirroring is required when you do not have a single system with both access to the public registries containing the source container images **and** your internal private registry.  In this case you will require a system with internet connectivity and another with access to your private network, along with a means to transfer data from one to the other (for example, a portable drive).
 
 !!! important
-    The examples here use a specific version of the container image (3.3.0).  You should always use the latest available container image, but because we are working in a disconnected environment we need to be specific about the version we are using.  Replace `3.3.0` with the appropriate version.
+    The examples here use a specific version of the container image (6.0.0).  You should always use the latest available container image, but because we are working in a disconnected environment we need to be specific about the version we are using.  Replace `6.0.0` with the appropriate version.
 
 #### Phase 1: Mirror to Filesystem
 First, download the latest version of the container image and start up a terminal session inside the container image, we are going to mount a local directory into the running container to persist the mirror filesystem.
@@ -56,8 +56,8 @@ First, download the latest version of the container image and start up a termina
     Mirroring images for Core, Manage and all dependencies will require approximately 62Gb available capacity.
 
 ```bash
-docker pull quay.io/ibmmas/cli:3.3.0
-docker run -ti --rm -v /mnt/storage:/mnt/workspace quay.io/ibmmas/cli:3.3.0 mas mirror-redhat-images \
+docker pull quay.io/ibmmas/cli:6.0.0
+docker run -ti --rm -v /mnt/storage:/mnt/workspace quay.io/ibmmas/cli:6.0.0 mas mirror-redhat-images \
   --mode to-filesystem \
   --dir /mnt/workspace \
   --pull-secret /mnt/local/pull-secret.json
@@ -70,7 +70,7 @@ docker run -ti --rm -v /mnt/storage:/mnt/workspace quay.io/ibmmas/cli:3.3.0 mas 
 You must now transfer the content of `/mnt/storage` on your local filesystem to a system inside your disconnected network on which we will perform phase 2 of this operator.  However, before we can do that we also need to mirror the CLI image to your registry so that it's available on the disconnected host system.
 
 ```bash
-oc image mirror --dir /mnt/workspace quay.io/ibmmas/cli:3.3.0 file://ibmmas/cli:3.3.0
+oc image mirror --dir /mnt/workspace quay.io/ibmmas/cli:6.0.0 file://ibmmas/cli:6.0.0
 ```
 
 
@@ -79,14 +79,14 @@ Transfer the content of `/mnt/storage` to your system in the disconnected networ
 
 ```bash
 docker login mirror.mydomain.com:32500 -u admin -p password
-oc image mirror --dir /mnt/storage file://ibmmas/cli:3.3.0 mirror.mydomain.com:32500/ibmmas/cli:3.3.0
+oc image mirror --dir /mnt/storage file://ibmmas/cli:6.0.0 mirror.mydomain.com:32500/ibmmas/cli:6.0.0
 ```
 
 Now we are ready to mirror the images to your registry using the CLI image in the same way we mirrored the images to the local disk in the first place:
 
 ```bash
-docker pull mirror.mydomain.com:32500/ibmmas/cli:3.3.0
-docker run -ti --rm -v /mnt/storage:/mnt/workspace mirror.mydomain.com:32500/ibmmas/cli:3.3.0 mas mirror-redhat-images \
+docker pull mirror.mydomain.com:32500/ibmmas/cli:6.0.0
+docker run -ti --rm -v /mnt/storage:/mnt/workspace mirror.mydomain.com:32500/ibmmas/cli:6.0.0 mas mirror-redhat-images \
   --mode from-filesystem \
   --dir /mnt/workspace \
   -H mirror.mydomain.com -P 32500 \

--- a/docs/index.md
+++ b/docs/index.md
@@ -15,18 +15,18 @@ Installation
 The best way to use the CLI is to not install it at all and use the container image we publish:
 
 ```bash
-docker run -ti -v ~:/mnt/home --pull always quay.io/ibmmas/cli
+docker run -ti --rm -v ~:/mnt/home --pull always quay.io/ibmmas/cli
 ```
 
 !!! tip
     Running `docker pull` before `docker run` will ensure you are using the latest release of the container image.
 
-    If you want to stick with a specific release of the image you can attach a specific version tag to the docker run command: `docker run -ti -v ~:/mnt/home quay.io/ibmmas/cli:x.y.z`
+    If you want to stick with a specific release of the image you can attach a specific version tag to the docker run command: `docker run -ti --rm -v ~:/mnt/home quay.io/ibmmas/cli:x.y.z`
 
 If you prefer to install the client it can be obtained from the [GitHub releases page](https://github.com/ibm-mas/cli/releases).
 
 ```bash
-wget https://github.com/ibm-mas/cli/releases/download/2.3.1/ibm-mas-cli-2.3.1.tgz
-tar -xvf ibm-mas-cli-2.3.1.tgz
+wget https://github.com/ibm-mas/cli/releases/download/6.0.0/ibm-mas-cli-6.0.0.tgz
+tar -xvf ibm-mas-cli-6.0.0.tgz
 ./mas mirror-images
 ```


### PR DESCRIPTION
Simple doc update to remove references to older v3.3.0 CLI release.