### PR TITLE
[patch] Correct UDS operator version in catalog manifests

### DIFF
--- a/docs/catalogs/v8-230616-amd64.md
+++ b/docs/catalogs/v8-230616-amd64.md
@@ -289,7 +289,7 @@ Package Manifest
 |                                     |                   | v3.21        | 3.23.0           |
 |                                     |                   | v3.22        | 3.24.0           |
 |                                     |                   | v3.23        | 3.25.0           |
-| ibm-user-data-services-operator     | alpha             | alpha        | 2.0.9            |
+| ibm-user-data-services-operator     | alpha             | alpha        | 2.0.10           |
 | ibm-zen-operator                    | v3.23             | beta         | 1.0.1            |
 |                                     |                   | v3           | 1.6.8            |
 |                                     |                   | v3.20        | 1.7.1            |

--- a/docs/catalogs/v8-230627-amd64.md
+++ b/docs/catalogs/v8-230627-amd64.md
@@ -289,7 +289,7 @@ Package Manifest
 |                                     |                   | v3.21        | 3.23.0           |
 |                                     |                   | v3.22        | 3.24.0           |
 |                                     |                   | v3.23        | 3.25.0           |
-| ibm-user-data-services-operator     | alpha             | alpha        | 2.0.9            |
+| ibm-user-data-services-operator     | alpha             | alpha        | 2.0.10           |
 | ibm-zen-operator                    | v3.23             | beta         | 1.0.1            |
 |                                     |                   | v3           | 1.6.8            |
 |                                     |                   | v3.20        | 1.7.1            |


### PR DESCRIPTION
## Incorrect UDS operator versions in 230616 and 230627 catalog manifests

The IBM Maximo Operator Catalog manifests for versions:

- v8-230616-amd64
- v8-230627-amd64

Incorrectly list:

```
| ibm-user-data-services-operator | alpha | alpha | 2.0.9 |
```

This has been correct to accurately reflect version `2.0.10`

```
| ibm-user-data-services-operator | alpha | alpha | 2.0.10 |
```
