### PR TITLE
[patch] Remove fvt_version_manage criteria from setup tasks

### DIFF
--- a/tekton/src/pipelines/taskdefs/fvt-apps/common/taskref-manage-setup.yml.j2
+++ b/tekton/src/pipelines/taskdefs/fvt-apps/common/taskref-manage-setup.yml.j2
@@ -1,0 +1,10 @@
+taskRef:
+  kind: Task
+  name: mas-fvt-manage
+when:
+  - input: "$(params.mas_app_channel_manage)"
+    operator: notin
+    values: [""]
+workspaces:
+  - name: configs
+    workspace: shared-configs

--- a/tekton/src/pipelines/taskdefs/fvt-apps/manage-industry-solutions.yml.j2
+++ b/tekton/src/pipelines/taskdefs/fvt-apps/manage-industry-solutions.yml.j2
@@ -44,8 +44,10 @@
     - fvt-manage-acm-user
 
 # Manage FVT - Aviation Setup
+# Note: Manage Setup and Aviation Setup has a special taskref defintion without fvt_digest_manage criteria. We want to run that even when
+# not running the entire FVT suite as applications like Predict depends on it
 - name: fvt-manage-aviation-setup
-  {{ lookup('template', 'taskdefs/fvt-apps/common/taskref-manage.yml.j2') | indent(2) }}
+  {{ lookup('template', 'taskdefs/fvt-apps/common/taskref-manage-setup.yml.j2') | indent(2) }}
   params:
     {{ lookup('template', 'taskdefs/fvt-apps/common/params-manage.yml.j2') | indent(4) }}
     - name: fvt_test_suite

--- a/tekton/src/pipelines/taskdefs/fvt-apps/manage-industry-solutions.yml.j2
+++ b/tekton/src/pipelines/taskdefs/fvt-apps/manage-industry-solutions.yml.j2
@@ -45,7 +45,7 @@
 
 # Manage FVT - Aviation Setup
 # Note: Manage Setup and Aviation Setup has a special taskref defintion without fvt_digest_manage criteria. We want to run that even when
-# not running the entire FVT suite as applications like Predict depends on it
+# not running the entire FVT suite as applications like Predict and Mobile apps depend on it
 - name: fvt-manage-aviation-setup
   {{ lookup('template', 'taskdefs/fvt-apps/common/taskref-manage-setup.yml.j2') | indent(2) }}
   params:

--- a/tekton/src/pipelines/taskdefs/fvt-apps/manage.yml.j2
+++ b/tekton/src/pipelines/taskdefs/fvt-apps/manage.yml.j2
@@ -21,8 +21,10 @@
 # -------------------------------------------------------------
 
 # Manage FVT Setup
+# Note: Manage Setup and Aviation Setup has a special taskref defintion without fvt_digest_manage criteria. We want to run that even when
+# not running the entire FVT suite as applications like Predict depends on it
 - name: fvt-manage-setup # convention: use fvt-manage-<keyword>, as the value of fvt_test_suite parameter
-  {{ lookup('template', 'taskdefs/fvt-apps/common/taskref-manage.yml.j2') | indent(2) }}
+  {{ lookup('template', 'taskdefs/fvt-apps/common/taskref-manage-setup.yml.j2') | indent(2) }}
   params:
     {{ lookup('template', 'taskdefs/fvt-apps/common/params-manage.yml.j2') | indent(4) }}
     - name: fvt_test_suite

--- a/tekton/src/pipelines/taskdefs/fvt-apps/manage.yml.j2
+++ b/tekton/src/pipelines/taskdefs/fvt-apps/manage.yml.j2
@@ -22,7 +22,7 @@
 
 # Manage FVT Setup
 # Note: Manage Setup and Aviation Setup has a special taskref defintion without fvt_digest_manage criteria. We want to run that even when
-# not running the entire FVT suite as applications like Predict depends on it
+# not running the entire FVT suite as applications like Predict and Mobile apps depend on it
 - name: fvt-manage-setup # convention: use fvt-manage-<keyword>, as the value of fvt_test_suite parameter
   {{ lookup('template', 'taskdefs/fvt-apps/common/taskref-manage-setup.yml.j2') | indent(2) }}
   params:


### PR DESCRIPTION
We will remove manage fvt tasks from fvtcpd, but just setting fvt_version_manage=skip is not enough because `fvt-manage-setup`is still required by Mobile applicaitons and Predict.|


last lines of `'tekton/test.sh` to validate resources updates are good:

```
(...)
 - Adding Pipeline: /Users/alequint/Documents/projects/mas/tasks/cpdnomanage/cli/tekton/target/pipelines/update-after-install.yaml
pipeline.tekton.dev/mas-update-after-install created
 - Adding Pipeline: /Users/alequint/Documents/projects/mas/tasks/cpdnomanage/cli/tekton/target/pipelines/update.yaml
pipeline.tekton.dev/mas-update created
 - Adding Pipeline: /Users/alequint/Documents/projects/mas/tasks/cpdnomanage/cli/tekton/target/pipelines/upgrade-after-install.yaml
pipeline.tekton.dev/mas-upgrade-after-install created
 - Adding Pipeline: /Users/alequint/Documents/projects/mas/tasks/cpdnomanage/cli/tekton/target/pipelines/upgrade.yaml
pipeline.tekton.dev/mas-upgrade created
```