### PR TITLE
[patch] Add namespace context to wait Task

### DIFF
--- a/tekton/src/tasks/fvt/fvt-wait-for-pipelinerun.yml.j2
+++ b/tekton/src/tasks/fvt/fvt-wait-for-pipelinerun.yml.j2
@@ -31,21 +31,21 @@ spec:
 
         IGNORE_FAILURE=$(params.ignore_failure)
         PIPELINERUN_NAME=$(params.pipelinerun_name)
-        COMPLETION_TIME=$(oc get pipelinerun/$PIPELINERUN_NAME -o jsonpath='{.status.completionTime}')
+        COMPLETION_TIME=$(oc -n $(context.taskRun.namespace) get pipelinerun/$PIPELINERUN_NAME -o jsonpath='{.status.completionTime}')
         # 30 seconds * 1440 = ~12 hours
         MAX_RETRIES=1440
         RETRIES_USED=0
         DELAY=30
-        while [[ "$COMPLETION_TIME" == "" && "$RETRIES_USED" < "$MAX_RETRIES" ]]; do
+        while [[ "$COMPLETION_TIME" == "" && "$RETRIES_USED" -lt "$MAX_RETRIES" ]]; do
           echo "[$RETRIES_USED/$MAX_RETRIES] pipelinerun/$PIPELINERUN_NAME is still running.  Waiting $DELAY seconds before checking again"
           sleep $DELAY
-          COMPLETION_TIME=$(oc get pipelinerun/$PIPELINERUN_NAME -o jsonpath='{.status.completionTime}')
+          COMPLETION_TIME=$(oc -n $(context.taskRun.namespace) get pipelinerun/$PIPELINERUN_NAME -o jsonpath='{.status.completionTime}')
           RETRIES_USED=$((RETRIES_USED + 1))
         done
 
         echo "Completion Time = $COMPLETION_TIME"
         echo "Retries Used    = $RETRIES_USED"
-        RESULT=$(oc get pipelinerun/$PIPELINERUN_NAME -o jsonpath='{.status.conditions[0].status}')
+        RESULT=$(oc -n $(context.taskRun.namespace) get pipelinerun/$PIPELINERUN_NAME -o jsonpath='{.status.conditions[0].status}')
 
         if [[ "$RESULT" == "True" ]]; then
           echo "Result          = PipelineRun completed successfully"

--- a/tekton/src/tasks/fvt/fvt-wait-for-pipelinerun.yml.j2
+++ b/tekton/src/tasks/fvt/fvt-wait-for-pipelinerun.yml.j2
@@ -32,10 +32,10 @@ spec:
         IGNORE_FAILURE=$(params.ignore_failure)
         PIPELINERUN_NAME=$(params.pipelinerun_name)
         COMPLETION_TIME=$(oc -n $(context.taskRun.namespace) get pipelinerun/$PIPELINERUN_NAME -o jsonpath='{.status.completionTime}')
-        # 30 seconds * 1440 = ~12 hours
-        MAX_RETRIES=1440
+        # 1 minute * 720 = ~12 hours
+        MAX_RETRIES=720
         RETRIES_USED=0
-        DELAY=30
+        DELAY=60
         while [[ "$COMPLETION_TIME" == "" && "$RETRIES_USED" -lt "$MAX_RETRIES" ]]; do
           echo "[$RETRIES_USED/$MAX_RETRIES] pipelinerun/$PIPELINERUN_NAME is still running.  Waiting $DELAY seconds before checking again"
           sleep $DELAY


### PR DESCRIPTION
The `fvt-wait-for-pipelinerun` Task was not setting the namespace when running `oc` commands, therefore only worked when used in the default namespace.