### PR TITLE
[patch] Small doc formatting fix

### DIFF
--- a/docs/catalogs/v8-230721-amd64.md
+++ b/docs/catalogs/v8-230721-amd64.md
@@ -10,10 +10,10 @@ Details
   <tr><td>Digest</td><td>sha256:200df0fe4723d2ec40433be5793ee3afe341f966f66b7acaa1fb43b412c90848</tr></tr>
 </table>
 
-!!! Note: 
-  This catalog is a republish of the [v8-230627-amd64](v8-230627-amd64.md) catalog, it introduces only one new package; IBM User Data Services 2.0.11 to fix a critical defect related to support for a recent update of Crunchy Postgres in the Red Hat Certified Operator Catalog.  For more information refer to [ibm-mas/ansible-devops#916](https://github.com/ibm-mas/ansible-devops/issues/916)
+!!! note
+    This catalog is a republish of the [v8-230627-amd64](v8-230627-amd64.md) catalog, it introduces only one new package - IBM User Data Services v2.0.11 - to fix a critical defect related to support for a recent update of Crunchy Postgres in the Red Hat Certified Operator Catalog.  For more information refer to [ibm-mas/ansible-devops#916](https://github.com/ibm-mas/ansible-devops/issues/916).
 
-  It is recommended that all customers using earlier catalogs switch to this catalog as soon as possible to prevent potential issues when updating to newer Red Hat Certified Operator Catalog version.  Customers running in a disconnected environment already using the [v8-230627-amd64](v8-230627-amd64.md) catalog will only need to mirror the new UDS images, because nothing else has changed.
+    It is recommended that all customers using earlier catalogs switch to this catalog as soon as possible to prevent potential issues when updating to newer Red Hat Certified Operator Catalog versions.  Customers running in a disconnected environment already using the [v8-230627-amd64](v8-230627-amd64.md) catalog will only need to mirror the new UDS images, because nothing else has changed.
 
 Manual Installation
 -------------------------------------------------------------------------------


### PR DESCRIPTION
The formatting for the "note" annotation was not correct.

![image](https://github.com/ibm-mas/cli/assets/4400618/237c693a-bdea-4574-89bb-7e36fed32a1d)
