### PR TITLE
[patch] Add OCP version support to catalog overview

### DIFF
--- a/docs/catalogs/index.md
+++ b/docs/catalogs/index.md
@@ -38,16 +38,23 @@ The static operator catalogs provide a fixed reference point, if you use a stati
 To receive security updates and bug fixes you must periodically update the version of the static catalog that you have installed in the cluster.  Once you do this all operators that you have installed from the catalog will automatically update to the newer version.  We aim to release a catalog update monthly.
 
 #### 2023
-- [v8-230725-amd64](v8-230725-amd64.md)
-- [v8-230721-amd64](v8-230721-amd64.md)
-- [v8-230616-amd64](v8-230616-amd64.md)
-- [v8-230526-amd64](v8-230526-amd64.md)
-- [v8-230518-amd64](v8-230518-amd64.md)
-- [v8-230414-amd64](v8-230414-amd64.md)
+| Catalog                               | OCP Support | End of Support                  |
+| ------------------------------------- | ----------- | ------------------------------- |
+| [v8-230725-amd64](v8-230725-amd64.md) | 4.10 - 4.12 | OCP 4.12 EOS January 17, 2025   |
+| [v8-230721-amd64](v8-230721-amd64.md) | 4.10 - 4.12 | OCP 4.12 EOS January 17, 2025   |
+| [v8-230616-amd64](v8-230616-amd64.md) | 4.10 - 4.12 | OCP 4.12 EOS January 17, 2025   |
+| [v8-230526-amd64](v8-230526-amd64.md) | 4.10        | OCP 4.10 EOS September 10, 2023 |
+| [v8-230518-amd64](v8-230518-amd64.md) | 4.10        | OCP 4.10 EOS September 10, 2023 |
+| [v8-230414-amd64](v8-230414-amd64.md) | 4.8 - 4.10  | OCP 4.10 EOS September 10, 2023 |
+| [v8-230314-amd64](v8-230314-amd64.md) | 4.8 - 4.10  | OCP 4.10 EOS September 10, 2023 |
+| [v8-230217-amd64](v8-230217-amd64.md) | 4.8 - 4.10  | OCP 4.10 EOS September 10, 2023 |
+| [v8-230111-amd64](v8-230111-amd64.md) | 4.8 - 4.10  | OCP 4.10 EOS September 10, 2023 |
 
 #### 2022
-- [v8-221228-amd64](v8-221228-amd64.md)
-- [v8-221129-amd64](v8-221129-amd64.md)
-- [v8-221025-amd64](v8-221025-amd64.md)
-- [v8-220927-amd64](v8-220927-amd64.md)
-- [v8-220805-amd64](v8-220805-amd64.md)
+| Catalog                               | OCP Support | End of Support                  |
+| ------------------------------------- | ----------- | ------------------------------- |
+| [v8-221228-amd64](v8-221228-amd64.md) | 4.6 - 4.10  | OCP 4.10 EOS September 10, 2023 |
+| [v8-221129-amd64](v8-221129-amd64.md) | 4.6 - 4.10  | OCP 4.10 EOS September 10, 2023 |
+| [v8-221025-amd64](v8-221025-amd64.md) | 4.6 - 4.10  | OCP 4.10 EOS September 10, 2023 |
+| [v8-220927-amd64](v8-220927-amd64.md) | 4.6 - 4.10  | OCP 4.10 EOS September 10, 2023 |
+| [v8-220805-amd64](v8-220805-amd64.md) | 4.6 - 4.10  | OCP 4.10 EOS September 10, 2023 |

--- a/docs/commands/install.md
+++ b/docs/commands/install.md
@@ -144,6 +144,24 @@ Provide the basic information about your MAS instance:
 - Workspace ID
 - Workspace Display Name
 
+!!! important
+    Instance ID restrictions:
+
+    - Must be 3-12 characters long
+    - Must only use lowercase letters, numbers, and hypen (`-`) symbol
+    - Must start with a lowercase letter
+    - Must end with a lowercase letter or a number
+
+    Workspace ID restrictions:
+
+    - Must be 3-12 characters long
+    - Must only use lowercase letters and numbers
+    - Must start with a lowercase letter
+
+    Workspace display name restrictions:
+    - Must be 3-300 characters long
+    - Only the space (` `) whitespace character may be used
+    - Must not start or end with a whitespace character
 
 ### Step 6: Configure Operation Mode
 The install will default to a production mode installation, but by choosing "y" at the prompt you will be able to install MAS in non-production mode.

--- a/image/cli/mascli/functions/pipeline_config
+++ b/image/cli/mascli/functions/pipeline_config
@@ -108,7 +108,19 @@ function pipeline_config() {
     echo_warning "Workspace ID (${MAS_WORKSPACE_ID}) does not meet requirements"
     exit 1
   fi
+  echo
+
+  # Workspace display name regex: ^[^\ \t\n\r\f\v][^\t\n\r\f\v]{1,298}[^\ \t\n\r\f\v]$
+  echo "${TEXT_DIM}Workspace display name restrictions:"
+  echo " - Must be 3-300 characters long"
+  echo " - Only the space ( ) whitespace character may be used"
+  echo " - Must not start or end with a whitespace character"
+  reset_colors
   prompt_for_input "MAS Workspace Display Name" MAS_WORKSPACE_NAME
+  if [[ ! "${MAS_WORKSPACE_NAME}" =~ ^[^\ \t\n\r\f\v][^\t\n\r\f\v]{1,298}[^\ \t\n\r\f\v]$ ]]; then
+    echo_warning "Workspace name (${MAS_WORKSPACE_NAME}) does not meet requirements"
+    exit 1
+  fi
 
   echo
   echo_h2 "Configure Operation Mode"

--- a/image/cli/mascli/functions/pipeline_config
+++ b/image/cli/mascli/functions/pipeline_config
@@ -77,17 +77,38 @@ function pipeline_config() {
     exit 1
   fi
 
+  echo
   echo_h2 "Configure MAS Instance"
 
-  # MAS instance ID
+  # Instance ID regex: ^[a-z][a-z0-9-]{1,10}[a-z0-9]$
   if [[ ! -z "$1" ]]; then
     MAS_INSTANCE_ID=$1
   fi
+  echo "${TEXT_DIM}Instance ID restrictions:"
+  echo " - Must be 3-12 characters long"
+  echo " - Must only use lowercase letters, numbers, and hypen (-) symbol"
+  echo " - Must start with a lowercase letter"
+  echo " - Must end with a lowercase letter or a number"
+  reset_colors
   prompt_for_input "MAS Instance ID" MAS_INSTANCE_ID
+  if [[ ! "${MAS_INSTANCE_ID}" =~ ^[a-z][a-z0-9-]{1,10}[a-z0-9]$ ]]; then
+    echo_warning "Instance ID (${MAS_INSTANCE_ID}) does not meet requirements"
+    exit 1
+  fi
+  echo
+
+  # Workspace ID regex: ^[a-z][a-z0-9]{2,11}$
+  echo "${TEXT_DIM}Workspace ID restrictions:"
+  echo " - Must be 3-12 characters long"
+  echo " - Must only use lowercase letters and numbers"
+  echo " - Must start with a lowercase letter"
+  reset_colors
   prompt_for_input "MAS Workspace ID" MAS_WORKSPACE_ID
+  if [[ ! "${MAS_WORKSPACE_ID}" =~ ^[a-z][a-z0-9]{2,11}$ ]]; then
+    echo_warning "Workspace ID (${MAS_WORKSPACE_ID}) does not meet requirements"
+    exit 1
+  fi
   prompt_for_input "MAS Workspace Display Name" MAS_WORKSPACE_NAME
-
-
 
   echo
   echo_h2 "Configure Operation Mode"


### PR DESCRIPTION
- Add clarity around supported versions of OCP to the catalogs
- Add instance ID and workspace ID restriction information to the CLI prompts
    - #244
![image](https://github.com/ibm-mas/cli/assets/4400618/146d0877-f454-4b30-823d-ad490180359a)

- Add workspace display name restrictions
![image](https://github.com/ibm-mas/cli/assets/4400618/3ff0bfc9-cfd8-464b-953e-c551a44642c3)

