### PR TITLE
[patch] Fix VERSION override from bad merge

### DIFF
--- a/image/cli/mascli/mas
+++ b/image/cli/mascli/mas
@@ -28,8 +28,8 @@ CONFIG_DIR="$HOME/.ibm-mas/config"
 LOG_DIR="$HOME/.ibm-mas/logs"
 LOGFILE=$LOG_DIR/mas.log
 
+# Note: "latest" is overwritten with the actual version at build time
 VERSION=latest
-VERSION=6.3.0-pre.turbo
 
 mkdir -p $LOG_DIR
 mkdir -p $CONFIG_DIR


### PR DESCRIPTION
This code was accidentally left in during merge, overriding the actual version of tekton pipelines etc used by the CLI image:

```
VERSION=6.3.0-pre.turbo
```