### PR TITLE
[patch] Fix doc formatting

### DIFF
--- a/docs/commands/install.md
+++ b/docs/commands/install.md
@@ -159,6 +159,7 @@ Provide the basic information about your MAS instance:
     - Must start with a lowercase letter
 
     Workspace display name restrictions:
+
     - Must be 3-300 characters long
     - Only the space (` `) whitespace character may be used
     - Must not start or end with a whitespace character


### PR DESCRIPTION
A missing newline prevents the list rendering as a list in mkdocs.