### PR TITLE
[patch] Simplify workspace name restrictions

### DIFF
--- a/docs/commands/install.md
+++ b/docs/commands/install.md
@@ -161,8 +161,6 @@ Provide the basic information about your MAS instance:
     Workspace display name restrictions:
 
     - Must be 3-300 characters long
-    - Only the space (` `) whitespace character may be used
-    - Must not start or end with a whitespace character
 
 ### Step 6: Configure Operation Mode
 The install will default to a production mode installation, but by choosing "y" at the prompt you will be able to install MAS in non-production mode.

--- a/image/cli/mascli/functions/pipeline_config
+++ b/image/cli/mascli/functions/pipeline_config
@@ -110,14 +110,12 @@ function pipeline_config() {
   fi
   echo
 
-  # Workspace display name regex: ^[^\ \t\n\r\f\v][^\t\n\r\f\v]{1,298}[^\ \t\n\r\f\v]$
+  # Workspace display name regex: ^.{3,300}$
   echo "${TEXT_DIM}Workspace display name restrictions:"
   echo " - Must be 3-300 characters long"
-  echo " - Only the space ( ) whitespace character may be used"
-  echo " - Must not start or end with a whitespace character"
   reset_colors
   prompt_for_input "MAS Workspace Display Name" MAS_WORKSPACE_NAME
-  if [[ ! "${MAS_WORKSPACE_NAME}" =~ ^[^\ \t\n\r\f\v][^\t\n\r\f\v]{1,298}[^\ \t\n\r\f\v]$ ]]; then
+  if [[ ! "${MAS_WORKSPACE_NAME}" =~ ^.{3,300}$ ]]; then
     echo_warning "Workspace name (${MAS_WORKSPACE_NAME}) does not meet requirements"
     exit 1
   fi


### PR DESCRIPTION
The regex functions differently on different platforms (e.g. rhel versus ubuntu).  Something simpler can achieve the same effective end result.