### PR TITLE
[minor] Add ROSA deprovision pipeline

### DIFF
--- a/image/cli/mascli/functions/gitops_deprovision_cluster
+++ b/image/cli/mascli/functions/gitops_deprovision_cluster
@@ -1,0 +1,232 @@
+#!/usr/bin/env bash
+
+function gitops_deprovision_cluster_help() {
+  [[ -n "$1" ]] && echo_warning "$1"
+  reset_colors
+  cat << EOM
+Usage:
+  mas gitops-deprovision-cluster [options]
+Where ${COLOR_YELLOW}specified${TEXT_RESET} each option may also be defined by setting the appropriate environment variable.
+When no options are specified on the command line, interactive-mode will be enabled by default.
+
+GitOps Configuration:
+  -d, --dir ${COLOR_YELLOW}GITOPS_WORKING_DIR${TEXT_RESET}            Directory for GitOps repository
+  -a, --account-id ${COLOR_YELLOW}ACCOUNT_ID${TEXT_RESET}             Account ID
+  -c, --cluster-id ${COLOR_YELLOW}CLUSTER_ID${TEXT_RESET}             Cluster ID
+
+Secrets Manager:
+      --secrets-path ${COLOR_YELLOW}SECRETS_PATH${TEXT_RESET}                     Secrets Manager path
+      --secrets-key-seperator ${COLOR_YELLOW}SECRETS_KEY_SEPERATOR${TEXT_RESET}   Secrets Manager key seperator string
+
+Automatic GitHub Push:
+  -P, --github-push ${COLOR_YELLOW}GITHUB_PUSH${TEXT_RESET}           Enable automatic push to GitHub
+  -H, --github-host ${COLOR_YELLOW}GITHUB_HOST${TEXT_RESET}           GitHub Hostname for your GitOps repository
+  -O, --github-org  ${COLOR_YELLOW}GITHUB_ORG${TEXT_RESET}            Github org for your GitOps repository
+  -R, --github-repo ${COLOR_YELLOW}GITHUB_REPO${TEXT_RESET}           Github repo for your GitOps repository
+  -B, --git-branch ${COLOR_YELLOW}GIT_BRANCH${TEXT_RESET}             Git branch to commit to of your GitOps repository
+  -M, --git-commit-msg ${COLOR_YELLOW}GIT_COMMIT_MSG${TEXT_RESET}     Git commit message to use when committing to of your GitOps repository
+  -S , --github-ssh  ${COLOR_YELLOW}GIT_SSH${TEXT_RESET}              Git ssh key path
+Other Commands:
+  -h, --help                              Show this help message
+EOM
+  [[ -n "$1" ]] && exit 1 || exit 0
+}
+
+function gitops_deprovision_cluster_noninteractive() {
+  # TODO: Remember to change the defaults to suite public before release!
+  GITOPS_WORKING_DIR=$PWD/working-dir
+  SECRETS_KEY_SEPERATOR="/"
+
+  GITHUB_PUSH="false"
+  GIT_COMMIT_MSG="gitops-deprovision-cluster commit"
+
+  while [[ $# -gt 0 ]]
+  do
+    key="$1"
+    shift
+    case $key in
+      # GitOps Configuration
+      -d|--dir)
+        export GITOPS_WORKING_DIR=$1 && shift
+        ;;
+      -a|--account-id)
+        export ACCOUNT_ID=$1 && shift
+        ;;
+      -c|--cluster-id)
+        export CLUSTER_ID=$1 && shift
+        ;;
+
+      # Secrets Manager
+      --secrets-path)
+        export SECRETS_PATH=$1 && shift
+        ;;
+      --secrets-key-seperator)
+        export SECRETS_KEY_SEPERATOR=$1 && shift
+        ;;
+
+      # Automatic GitHub Push
+      -P|--github-push)
+        export GITHUB_PUSH=true
+        ;;
+      -H|--github-host)
+        export GITHUB_HOST=$1 && shift
+        ;;
+      -O|--github-org)
+        export GITHUB_ORG=$1 && shift
+        ;;
+      -R|--github-repo)
+        export GITHUB_REPO=$1 && shift
+        ;;
+      -B|--git-branch)
+        export GIT_BRANCH=$1 && shift
+        ;;
+      -M|--git-commit-msg)
+        export GIT_COMMIT_MSG=$1 && shift
+        ;;
+      
+      -S|--github-ssh)
+        export GIT_SSH=$1 && shift
+        ;;
+
+
+      # Other Commands
+      -h|--help)
+        gitops_deprovision_cluster_help
+        ;;
+      *)
+        # unknown option
+        echo -e "${COLOR_RED}Usage Error: Unsupported option \"${key}\"${COLOR_RESET}\n"
+        gitops_deprovision_cluster_help
+        exit 1
+        ;;
+    esac
+  done
+
+  [[ -z "$ACCOUNT_ID" ]] && gitops_deprovision_cluster_help "ACCOUNT_ID is not set"
+  [[ -z "$CLUSTER_ID" ]] && gitops_deprovision_cluster_help "CLUSTER_ID is not set"
+
+  if [[ "$GITHUB_PUSH" == "true" ]]; then
+    [[ -z "$GITHUB_HOST" ]] && gitops_deprovision_cluster_help "GITHUB_HOST is not set"
+    [[ -z "$GITHUB_ORG" ]] && gitops_deprovision_cluster_help "GITHUB_ORG is not set"
+    [[ -z "$GITHUB_REPO" ]] && gitops_deprovision_cluster_help "GITHUB_REPO is not set"
+    [[ -z "$GIT_BRANCH" ]] && gitops_deprovision_cluster_help "GIT_BRANCH is not set"
+  fi
+
+}
+
+function gitops_deprovision_cluster() {
+  # Take the first parameter off (it will be create-gitops)
+  shift
+  if [[ $# -gt 0 ]]; then
+    gitops_deprovision_cluster_noninteractive "$@"
+  else
+    echo "Not supported yet"
+    exit 1
+    gitops_deprovision_cluster_interactive
+  fi
+
+  mkdir -p ${GITOPS_WORKING_DIR}
+  GITOPS_CLUSTER_DIR=${GITOPS_WORKING_DIR}/${GITHUB_REPO}/${CLUSTER_ID}
+  GITOPS_APPS_DIR=${GITOPS_CLUSTER_DIR}/apps
+
+  echo
+  reset_colors
+  echo_h2 "Review Settings"
+
+  echo "${TEXT_DIM}"
+  echo_h2 "Target" "    "
+  echo_reset_dim "Account ID ............................ ${COLOR_MAGENTA}${ACCOUNT_ID}"
+  echo_reset_dim "Cluster ID ............................ ${COLOR_MAGENTA}${CLUSTER_ID}"
+  echo_reset_dim "Application Directory ................. ${COLOR_MAGENTA}${GITOPS_APPS_DIR}"
+  reset_colors
+
+  echo "${TEXT_DIM}"
+  if [[ "$GITHUB_PUSH" == "true" ]]; then
+    echo_h2 "GitOps Target" "    "
+    echo_reset_dim "Automatic Push ........................ ${COLOR_GREEN}Enabled"
+    echo_reset_dim "Working Directory ..................... ${COLOR_MAGENTA}${GITOPS_WORKING_DIR}"
+    echo_reset_dim "Host .................................. ${COLOR_MAGENTA}${GITHUB_HOST}"
+    echo_reset_dim "Organization .......................... ${COLOR_MAGENTA}${GITHUB_ORG}"
+    echo_reset_dim "Repository ............................ ${COLOR_MAGENTA}${GITHUB_REPO}"
+    echo_reset_dim "Branch ................................ ${COLOR_MAGENTA}${GIT_BRANCH}"
+  else
+    echo_h2 "GitOps Target" "    "
+    echo_reset_dim "Automatic Push ........................ ${COLOR_RED}Disabled"
+    echo_reset_dim "Working Directory ..................... ${COLOR_MAGENTA}${GITOPS_WORKING_DIR}"
+  fi
+  reset_colors
+
+  echo "${TEXT_DIM}"
+  echo_h2 "Secrets Manager" "    "
+  echo_reset_dim "Secrets Path .......................... ${COLOR_MAGENTA}${SECRETS_PATH}"
+  reset_colors
+
+
+  # Set up secrets
+  # ---------------------------------------------------------------------------
+  echo
+  echo_h2 "Deleting Cluster secrets"
+  AVP_TYPE=aws  # Support for IBM will be added later
+  sm_login
+
+  export SECRET_NAME_IBM_ENTITLEMENT=${ACCOUNT_ID}${SECRETS_KEY_SEPERATOR}${CLUSTER_ID}${SECRETS_KEY_SEPERATOR}ibm_entitlement
+
+  sm_delete_secret $SECRET_NAME_IBM_ENTITLEMENT 
+  if [ -z $GIT_SSH ]; then
+    export GIT_SSH="false"
+  fi
+
+  # Clone github target repo
+  # ---------------------------------------------------------------------------
+  if [ "$GITHUB_PUSH" == "true" ]; then
+    echo
+    echo_h2 "Cloning GitHub repo $GITHUB_ORG $GITHUB_REPO"
+    clone_target_git_repo $GITHUB_HOST $GITHUB_ORG $GITHUB_REPO $GIT_BRANCH $GITOPS_WORKING_DIR $GIT_SSH
+  fi
+  mkdir -p ${GITOPS_APPS_DIR}
+
+
+  # Deleting ArgoApps
+  # ---------------------------------------------------------------------------
+  echo
+  echo_h2 "Deleting Argo Applications"
+  echo "- IBM Operator Catalog"
+  rm ${GITOPS_APPS_DIR}/ibm-operator-catalog.yaml
+  echo "- IBM Common Services"
+  rm ${GITOPS_APPS_DIR}/ibm-common-services.yaml
+
+
+  # Commit and push to github target repo
+  # ---------------------------------------------------------------------------
+  if [ "$GITHUB_PUSH" == "true" ]; then
+    echo
+    echo_h2 "Commit and push changes to GitHub repo $GITHUB_ORG $GITHUB_REPO"
+    save_to_target_git_repo $GITHUB_HOST $GITHUB_ORG $GITHUB_REPO $GIT_BRANCH $GITOPS_APPS_DIR "${GIT_COMMIT_MSG}"
+
+    argocd_login
+    argocd_sync_watcher ${CLUSTER_ID}-watcher
+    argocd_prune_sync_watcher ${CLUSTER_ID}-watcher
+    check_argo_app_deleted ibm-common-services ${CLUSTER_ID}-cluster-scope
+    check_argo_app_deleted ibm-operator-catalog ${CLUSTER_ID}-cluster-scope
+  fi
+
+  # Deleting Argo AppProject
+  # ---------------------------------------------------------------------------
+  echo
+  echo_h2 "Deleting Argo AppProject"
+  echo "- Cluster Scoped AppProject"
+  rm ${GITOPS_APPS_DIR}/appproject-cluster-scope.yaml
+
+  # Commit and push to github target repo
+  # ---------------------------------------------------------------------------
+  if [ "$GITHUB_PUSH" == "true" ]; then
+    echo
+    echo_h2 "Commit and push changes to GitHub repo $GITHUB_ORG $GITHUB_REPO"
+    save_to_target_git_repo $GITHUB_HOST $GITHUB_ORG $GITHUB_REPO $GIT_BRANCH $GITOPS_APPS_DIR "${GIT_COMMIT_MSG}"
+    remove_git_repo_clone $GITOPS_WORKING_DIR/$GITHUB_REPO
+
+    argocd_login
+    argocd_sync_watcher ${CLUSTER_ID}-watcher
+    argocd_prune_sync_watcher ${CLUSTER_ID}-watcher
+  fi
+}

--- a/image/cli/mascli/functions/gitops_deprovision_cluster
+++ b/image/cli/mascli/functions/gitops_deprovision_cluster
@@ -224,9 +224,5 @@ function gitops_deprovision_cluster() {
     echo_h2 "Commit and push changes to GitHub repo $GITHUB_ORG $GITHUB_REPO"
     save_to_target_git_repo $GITHUB_HOST $GITHUB_ORG $GITHUB_REPO $GIT_BRANCH $GITOPS_APPS_DIR "${GIT_COMMIT_MSG}"
     remove_git_repo_clone $GITOPS_WORKING_DIR/$GITHUB_REPO
-
-    argocd_login
-    argocd_sync_watcher ${CLUSTER_ID}-watcher
-    argocd_prune_sync_watcher ${CLUSTER_ID}-watcher
   fi
 }

--- a/image/cli/mascli/functions/gitops_deprovision_mongo
+++ b/image/cli/mascli/functions/gitops_deprovision_mongo
@@ -1,0 +1,233 @@
+#!/usr/bin/env bash
+
+function gitops_deprovision_mongo_help() {
+  [[ -n "$1" ]] && echo_warning "$1"
+
+  reset_colors
+  cat << EOM
+Usage:
+  mas gitops-deprovision-mongo [options]
+Where ${COLOR_YELLOW}specified${TEXT_RESET} each option may also be defined by setting the appropriate environment variable.
+When no options are specified on the command line, interactive-mode will be enabled by default.
+
+GitOps Configuration:
+  -a, --account-id ${COLOR_YELLOW}ACCOUNT_ID${TEXT_RESET}   Account name that the cluster belongs to
+  -c, --cluster-id ${COLOR_YELLOW}CLUSTER_ID${TEXT_RESET}   Cluster ID
+
+Secrets Manager:
+      --secrets-path ${COLOR_YELLOW}SECRETS_PATH${TEXT_RESET}                    Secrets Manager path
+      --secrets-key-seperator ${COLOR_YELLOW}SECRETS_KEY_SEPERATOR${TEXT_RESET}  Secrets Manager key seperator string
+
+MongoDb Provider Selection:
+      --mongo-provider ${COLOR_YELLOW}MONGODB_PROVIDER${TEXT_RESET}  The mongodb provider to install. Only "aws" is supported
+
+AWS MongoDb Provider:
+      --aws-access-key ${COLOR_YELLOW}AWS_ACCESS_KEY_ID${TEXT_RESET}                                       Access Key
+      --aws-secret-key ${COLOR_YELLOW}AWS_SECRET_ACCESS_KEY_ID${TEXT_RESET}                                Secret Key
+      --aws-region ${COLOR_YELLOW}AWS_REGION${TEXT_RESET}                                                  Region
+      --aws-vpc-id ${COLOR_YELLOW}VPC_ID${TEXT_RESET}                                                      VPC ID
+      --aws-docdb-cluster-name ${COLOR_YELLOW}DOCDB_CLUSTER_NAME${TEXT_RESET}                              Cluster Name
+      --aws-docdb-ingress-cidr ${COLOR_YELLOW}DOCDB_INGRESS_CIDR${TEXT_RESET}                              Ingress CIDR
+      --aws-docdb-egress-cidr ${COLOR_YELLOW}DOCDB_EGRESS_CIDR${TEXT_RESET}                                Egress CIDR
+      --aws-docdb-cidr-az1 ${COLOR_YELLOW}DOCDB_CIDR_AZ1${TEXT_RESET}                                      Availability Zone 1 CIDR
+      --aws-docdb-cidr-az2 ${COLOR_YELLOW}DOCDB_CIDR_AZ2${TEXT_RESET}                                      Availability Zone 2 CIDR
+      --aws-docdb-cidr-az3 ${COLOR_YELLOW}DOCDB_CIDR_AZ3${TEXT_RESET}                                      Availability Zone 3 CIDR
+      --aws-docdb-instance_identifier_prefix ${COLOR_YELLOW}DOCDB_INSTANCE_IDENTIFIER_PREFIX${TEXT_RESET}  Prefix
+
+
+Other Commands:
+  -h, --help                                      Show this help message
+EOM
+  [[ -n "$1" ]] && exit 1 || exit 0
+}
+
+
+function gitops_deprovision_mongo_noninteractive() {
+  SECRETS_KEY_SEPERATOR="/"
+
+  while [[ $# -gt 0 ]]
+  do
+    key="$1"
+    shift
+    case $key in
+      # GitOps Configuration
+      -a|--account-id)
+        export ACCOUNT_ID=$1 && shift
+        ;;
+      -c|--cluster-id)
+        export CLUSTER_ID=$1 && shift
+        ;;
+
+      # Secrets Manager
+      --secrets-path)
+        export SECRETS_PATH=$1 && shift
+        ;;
+      --secrets-key-seperator)
+        export SECRETS_KEY_SEPERATOR=$1 && shift
+        ;;
+
+      # MongoDb Provider Selection
+      --mongo-provider)
+        export MONGODB_PROVIDER=$1 && shift
+        ;;
+
+      # AWS MongoDb provider
+      --aws-access-key)
+        export AWS_ACCESS_KEY_ID=$1 && shift
+        ;;
+      --aws-secret-key)
+        export AWS_SECRET_ACCESS_KEY=$1 && shift
+        ;;
+      --aws-region)
+        export AWS_REGION=$1 && shift
+        ;;
+      --aws-vpc-id)
+        export VPC_ID=$1 && shift
+        ;;
+      --aws-docdb-cluster-name)
+        export DOCDB_CLUSTER_NAME=$1 && shift
+        ;;
+      --aws-docdb-ingress-cidr)
+        export DOCDB_INGRESS_CIDR=$1 && shift
+        ;;
+      --aws-docdb-egress-cidr)
+        export DOCDB_EGRESS_CIDR=$1 && shift
+        ;;
+      --aws-docdb-cidr-az1)
+        export DOCDB_CIDR_AZ1=$1 && shift
+        ;;
+      --aws-docdb-cidr-az2)
+        export DOCDB_CIDR_AZ2=$1 && shift
+        ;;
+      --aws-docdb-cidr-az3)
+        export DOCDB_CIDR_AZ3=$1 && shift
+        ;;
+      --aws-docdb-instance_identifier_prefix)
+        export DOCDB_INSTANCE_IDENTIFIER_PREFIX=$1 && shift
+        ;;
+
+      # YAML MongoDb provider
+      --yaml-file)
+        export MONGO_YAML_FILE=$1 && shift
+        ;;
+      --mongo-username)
+        export MONGO_USERNAME=$1 && shift
+        ;;
+      --mongo-password)
+        export MONGO_PASSWORD=$1 && shift
+        ;;
+
+      # Other Commands
+      -h|--help)
+        gitops_deprovision_mongo_help
+        ;;
+      *)
+        # unknown option
+        echo -e "${COLOR_RED}Usage Error: Unsupported option \"${key}\"${COLOR_RESET}\n"
+        gitops_deprovision_mongo_help
+        exit 1
+        ;;
+      esac
+  done
+
+  [[ -z "$CLUSTER_ID" ]] && gitops_deprovision_mongo_help "CLUSTER_ID is not set"
+  [[ -z "$MONGODB_PROVIDER" ]] && gitops_deprovision_mongo_help "MONGODB_PROVIDER is not set"
+  [[ -z "$ACCOUNT_ID" ]] && gitops_deprovision_mongo_help "ACCOUNT_ID is not set"
+
+  if [ $MONGODB_PROVIDER == 'aws' ]; then
+    if [ -z $AWS_ACCESS_KEY_ID ] || [ -z $AWS_SECRET_ACCESS_KEY ] || [ -z $VPC_ID ] || [ -z $AWS_REGION ]; then
+      echo 'Missing required params for AWS mongo provider, make sure to provide --aws-access-key, --aws-secret-key, --aws-region and --aws-vpc-id'
+      exit 1
+    fi
+    if [ -z $DOCDB_INGRESS_CIDR ] || [ -z $DOCDB_EGRESS_CIDR ] || [ -z $DOCDB_CIDR_AZ1 ] || [ -z $DOCDB_CIDR_AZ2 ] || [ -z $DOCDB_CIDR_AZ3 ]; then
+      echo 'Missing required params for AWS mongo provider, make sure to provide --aws-docdb-ingress-cidr, --aws-docdb-egress-cidr, --aws-docdb-cidr-az1, --aws-docdb-cidr-az2 and --aws-docdb-cidr-az3'
+      exit 1
+    fi
+    if [ -z $DOCDB_CLUSTER_NAME ] || [ -z $DOCDB_INSTANCE_IDENTIFIER_PREFIX ]; then
+      echo 'Missing required params for AWS mongo provider, make sure to provide --aws-docdb-instance_identifier_prefix, --aws-docdb-cluster-name'
+      exit 1
+    fi
+  fi
+
+  if [ $MONGODB_PROVIDER == 'yaml' ]; then
+    if [ -z $MONGO_YAML_FILE ] || [ -z $MONGO_USERNAME ] || [ -z $MONGO_PASSWORD ]; then
+      echo 'Missing required params for AWS mongo provider, make sure to provide --yaml-file, --mongo-username, --mongo-password'
+      exit 1
+    fi
+  fi
+}
+
+function gitops_deprovision_mongo() {
+  # Take the first parameter off (it will be create-gitops)
+  shift
+  if [[ $# -gt 0 ]]; then
+    gitops_deprovision_mongo_noninteractive "$@"
+  else
+    echo "Not supported yet"
+    exit 1
+    gitops_deprovision_mongo_interactive
+  fi
+
+  echo
+  reset_colors
+  echo_h2 "Review Settings"
+
+  echo "${TEXT_DIM}"
+  echo_h2 "Target" "    "
+  echo_reset_dim "Account ID ............................ ${COLOR_MAGENTA}${ACCOUNT_ID}"
+  echo_reset_dim "Cluster ID ............................ ${COLOR_MAGENTA}${CLUSTER_ID}"
+  reset_colors
+
+  echo "${TEXT_DIM}"
+  echo_h2 "Secrets Manager" "    "
+  echo_reset_dim "Secrets Path .......................... ${COLOR_MAGENTA}${SECRETS_PATH}"
+  reset_colors
+
+  echo "${TEXT_DIM}"
+  echo_h2 "Mongo" "    "
+  echo_reset_dim "Mongo Provider  ....................... ${COLOR_MAGENTA}${MONGODB_PROVIDER}"
+  if [ $MONGODB_PROVIDER == 'aws' ]; then
+    echo_reset_dim "AWS Access Key ID  .................... ${COLOR_MAGENTA}${AWS_ACCESS_KEY_ID}"
+    echo_reset_dim "AWS Secret Access Key  ................ ${COLOR_MAGENTA}${AWS_SECRET_ACCESS_KEY:0:8}<snip>"
+    echo_reset_dim "AWS Region  ........................... ${COLOR_MAGENTA}${AWS_REGION}"
+    echo_reset_dim "AWS VPC ID  ........................... ${COLOR_MAGENTA}${VPC_ID}"
+    echo_reset_dim "AWS DOCDB CLUSTER NAME  ............... ${COLOR_MAGENTA}${DOCDB_CLUSTER_NAME}"
+  fi
+  if [ $MONGODB_PROVIDER == 'yaml' ]; then
+    echo_reset_dim "YAML Configuration File ............... ${COLOR_MAGENTA}${MONGO_YAML_FILE}"
+  fi
+
+  export SECRET_NAME_MONGO=${ACCOUNT_ID}${SECRETS_KEY_SEPERATOR}${CLUSTER_ID}${SECRETS_KEY_SEPERATOR}mongo
+
+  AVP_TYPE=aws  # Support for IBM will be added later
+  sm_login
+
+  if [ $MONGODB_PROVIDER == 'aws' ]; then
+    # Set the MAS_CONFIG_DIR and MAS_INSTANCE_ID to generate the config details.
+    # The MAS_INSTANCE_ID doesn't have to be the correct instance id
+    # The MONGODB_NAMESPACE defines the name of the config file created
+    CURRENT_DIR=$PWD
+    TEMP_DIR=$CURRENT_DIR/tmp-mongo-deprovision
+    rm -rf $TEMP_DIR
+    mkdir -p $TEMP_DIR
+    export MAS_CONFIG_DIR=$TEMP_DIR
+    export MONGODB_NAMESPACE=docdb
+    export ROLE_NAME=mongodb
+    export DOCDB_INSTANCE_NUMBER=1
+    export MONGODB_ACTION=uninstall
+
+    ansible-playbook ibm.mas_devops.run_role
+    rc=$?
+    [ $rc -ne 0 ] && exit $rc
+
+    echo -e "Deleting secret  $SECRET_NAME_MONGO"
+    sm_delete_secret $SECRET_NAME_MONGO
+    rm -rf $TEMP_DIR
+
+  elif [ $MONGODB_PROVIDER == 'yaml' ]; then
+    echo -e "Deleting secret  $SECRET_NAME_MONGO"
+    sm_delete_secret $SECRET_NAME_MONGO 
+  fi
+
+  exit 0
+}

--- a/image/cli/mascli/functions/gitops_deprovision_rosa
+++ b/image/cli/mascli/functions/gitops_deprovision_rosa
@@ -10,6 +10,8 @@ When no options are specified on the command line, interactive-mode will be enab
 
 Options:
   -c, --cluster-id ${COLOR_YELLOW}CLUSTER_ID${TEXT_RESET}      Cluster ID
+      --delete-vpc ${COLOR_YELLOW}DELETE_VPC${TEXT_RESET}      Whether to delete the VPC or not
+      --aws-vpc-id ${COLOR_YELLOW}VPC_ID${TEXT_RESET}          VPC ID
 
 Other Commands:
   -h, --help     Show this help message
@@ -26,6 +28,12 @@ function gitops_deprovision_rosa_noninteractive() {
       -c|--cluster-id)
         export CLUSTER_ID=$1 && shift
         ;;
+      --delete-vpc)
+        export DELETE_VPC=true
+        ;;
+      --aws-vpc-id)
+        export VPC_ID=$1 && shift
+        ;;
       # Show help
       -h|--help)
         gitops_deprovision_rosa_help
@@ -39,6 +47,10 @@ function gitops_deprovision_rosa_noninteractive() {
     esac
   done
   [[ -z "$CLUSTER_ID" ]] && gitops_deprovision_rosa_help "CLUSTER_ID is not set"
+  
+  if [[ "$DELETE_VPC" == "true" ]]; then
+    [[ -z "$VPC_ID" ]] && gitops_deprovision_rosa_help "VPC_ID is not set"
+  fi
 }
 
 function gitops_deprovision_rosa(){
@@ -59,8 +71,10 @@ function gitops_deprovision_rosa(){
   echo "${TEXT_DIM}"
   echo_h2 "Cluster Details" "    "
   echo_reset_dim "Cluster Id ..................... ${COLOR_MAGENTA}${CLUSTER_ID}"
-  echo_reset_dim "ROSA Token .......... ${COLOR_MAGENTA}${ROSA_TOKEN:0:8}<snip>"
-  echo_reset_dim "ROSA Action .......... ${COLOR_MAGENTA}${ROSA_ACTION}<snip>"
+  echo_reset_dim "ROSA Token ..................... ${COLOR_MAGENTA}${ROSA_TOKEN:0:8}<snip>"
+  echo_reset_dim "ROSA Action .................... ${COLOR_MAGENTA}${ROSA_ACTION}"
+  echo_reset_dim "Delete VPC  .................... ${COLOR_MAGENTA}${DELETE_VPC}"
+  echo_reset_dim "VPC ID  ........................ ${COLOR_MAGENTA}${VPC_ID}"
   reset_colors
 
   echo
@@ -84,4 +98,8 @@ function gitops_deprovision_rosa(){
   export ROSA_ACTION=deprovision
   ansible-playbook ibm.mas_devops.run_role
 
+  if [ "$DELETE_VPC" == "true" ]; then
+    echo_h2 "Removing VPC ${VPC_ID}"
+    aws delete-vpc --vpc-id ${VPC_ID}
+  fi
 }

--- a/image/cli/mascli/functions/gitops_deprovision_rosa
+++ b/image/cli/mascli/functions/gitops_deprovision_rosa
@@ -1,0 +1,87 @@
+
+function gitops_deprovision_rosa_help() {
+  [[ -n "$1" ]] && echo_warning "$1"
+  reset_colors
+  cat << EOM
+Usage:
+mas gitops-deprovision-rosa [options]
+Where ${COLOR_YELLOW}specified${TEXT_RESET} each option may also be defined by setting the appropriate environment variable.
+When no options are specified on the command line, interactive-mode will be enabled by default.
+
+Options:
+  -c, --cluster-id ${COLOR_YELLOW}CLUSTER_ID${TEXT_RESET}      Cluster ID
+
+Other Commands:
+  -h, --help     Show this help message
+EOM
+  [[ -n "$1" ]] && exit 1 || exit 0
+}
+
+function gitops_deprovision_rosa_noninteractive() {
+  while [[ $# -gt 0 ]]
+  do
+    key="$1"
+    shift
+    case $key in
+      -c|--cluster-id)
+        export CLUSTER_ID=$1 && shift
+        ;;
+      # Show help
+      -h|--help)
+        gitops_deprovision_rosa_help
+        ;;
+      # Unknown option
+      *)
+        echo -e "\n${COLOR_RED}Usage Error: Unsupported flag \"${key}\" ${COLOR_OFF}\n\n"
+        gitops_deprovision_rosa_help
+        exit 1
+        ;;
+    esac
+  done
+  [[ -z "$CLUSTER_ID" ]] && gitops_deprovision_rosa_help "CLUSTER_ID is not set"
+}
+
+function gitops_deprovision_rosa(){
+  shift
+  if [[ $# -gt 0 ]]; then
+    gitops_deprovision_rosa_noninteractive "$@"
+  else
+    echo "Not supported yet"
+    exit 1
+    gitops_deprovision_rosa_interactive
+  fi
+
+  echo
+  reset_colors
+  echo_h2 "Review Settings"
+  echo $CLUSTER_ID ">>>"
+  echo ""
+  echo "${TEXT_DIM}"
+  echo_h2 "Cluster Details" "    "
+  echo_reset_dim "Cluster Id ..................... ${COLOR_MAGENTA}${CLUSTER_ID}"
+  echo_reset_dim "ROSA Token .......... ${COLOR_MAGENTA}${ROSA_TOKEN:0:8}<snip>"
+  echo_reset_dim "ROSA Action .......... ${COLOR_MAGENTA}${ROSA_ACTION}<snip>"
+  reset_colors
+
+  echo
+  echo_h2 "Provision Rosa Cluster"
+
+  if [[ -z $ROSA_TOKEN  ]]; then
+    echo_reset_dim "${COLOR_RED} ROSA_TOKEN is required. Export this environment variable before use this function"
+    exit 1
+  fi
+
+  if [[ -z $ROSA_CONFIG_DIR  ]]; then
+    CURRENT_DIR=$PWD
+    TEMP_DIR=$CURRENT_DIR/tmp-rosa-deprovision
+    rm -rf $TEMP_DIR
+    mkdir -p $TEMP_DIR
+    export ROSA_CONFIG_DIR=$TEMP_DIR
+  fi
+  export CLUSTER_NAME=${CLUSTER_ID}
+  export ROLE_NAME=ocp_provision
+  export CLUSTER_TYPE=rosa
+  export ROSA_ACTION=deprovision
+  ansible-playbook ibm.mas_devops.run_role
+
+}

--- a/image/cli/mascli/functions/gitops_deprovision_rosa
+++ b/image/cli/mascli/functions/gitops_deprovision_rosa
@@ -10,8 +10,6 @@ When no options are specified on the command line, interactive-mode will be enab
 
 Options:
   -c, --cluster-id ${COLOR_YELLOW}CLUSTER_ID${TEXT_RESET}      Cluster ID
-      --delete-vpc ${COLOR_YELLOW}DELETE_VPC${TEXT_RESET}      Whether to delete the VPC or not
-      --aws-vpc-id ${COLOR_YELLOW}VPC_ID${TEXT_RESET}          VPC ID
 
 Other Commands:
   -h, --help     Show this help message
@@ -28,12 +26,6 @@ function gitops_deprovision_rosa_noninteractive() {
       -c|--cluster-id)
         export CLUSTER_ID=$1 && shift
         ;;
-      --delete-vpc)
-        export DELETE_VPC=true
-        ;;
-      --aws-vpc-id)
-        export VPC_ID=$1 && shift
-        ;;
       # Show help
       -h|--help)
         gitops_deprovision_rosa_help
@@ -48,9 +40,6 @@ function gitops_deprovision_rosa_noninteractive() {
   done
   [[ -z "$CLUSTER_ID" ]] && gitops_deprovision_rosa_help "CLUSTER_ID is not set"
   
-  if [[ "$DELETE_VPC" == "true" ]]; then
-    [[ -z "$VPC_ID" ]] && gitops_deprovision_rosa_help "VPC_ID is not set"
-  fi
 }
 
 function gitops_deprovision_rosa(){
@@ -73,8 +62,6 @@ function gitops_deprovision_rosa(){
   echo_reset_dim "Cluster Id ..................... ${COLOR_MAGENTA}${CLUSTER_ID}"
   echo_reset_dim "ROSA Token ..................... ${COLOR_MAGENTA}${ROSA_TOKEN:0:8}<snip>"
   echo_reset_dim "ROSA Action .................... ${COLOR_MAGENTA}${ROSA_ACTION}"
-  echo_reset_dim "Delete VPC  .................... ${COLOR_MAGENTA}${DELETE_VPC}"
-  echo_reset_dim "VPC ID  ........................ ${COLOR_MAGENTA}${VPC_ID}"
   reset_colors
 
   echo
@@ -97,9 +84,4 @@ function gitops_deprovision_rosa(){
   export CLUSTER_TYPE=rosa
   export ROSA_ACTION=deprovision
   ansible-playbook ibm.mas_devops.run_role
-
-  if [ "$DELETE_VPC" == "true" ]; then
-    echo_h2 "Removing VPC ${VPC_ID}"
-    aws delete-vpc --vpc-id ${VPC_ID}
-  fi
 }

--- a/image/cli/mascli/mas
+++ b/image/cli/mascli/mas
@@ -86,6 +86,9 @@ mkdir -p $CONFIG_DIR
 . $DIR/functions/gitops_process_mongo_user
 . $DIR/functions/gitops_init_aws_infrastructure
 . $DIR/functions/gitops_init_rosa
+. $DIR/functions/gitops_deprovision_rosa
+. $DIR/functions/gitops_deprovision_cluster
+. $DIR/functions/gitops_deprovision_mongo
 
 load_config
 case $1 in
@@ -290,6 +293,30 @@ case $1 in
     gitops_deprovision_suite "$@"
     ;;
 
+  gitops-deprovision-rosa)
+    echo "${TEXT_UNDERLINE}IBM Maximo Application Suite GitOps Manager (v${VERSION})${TEXT_RESET}"
+    echo "Powered by ${COLOR_CYAN}${TEXT_UNDERLINE}https://github.com/ibm-mas/gitops/${TEXT_RESET}"
+    echo
+    reset_colors
+    gitops_deprovision_rosa "$@"
+    ;;
+
+  gitops-deprovision-cluster)
+    echo "${TEXT_UNDERLINE}IBM Maximo Application Suite GitOps Manager (v${VERSION})${TEXT_RESET}"
+    echo "Powered by ${COLOR_CYAN}${TEXT_UNDERLINE}https://github.com/ibm-mas/gitops/${TEXT_RESET}"
+    echo
+    reset_colors
+    gitops_deprovision_cluster "$@"
+    ;;
+
+  gitops-deprovision-mongo)
+    echo "${TEXT_UNDERLINE}IBM Maximo Application Suite GitOps Manager (v${VERSION})${TEXT_RESET}"
+    echo "Powered by ${COLOR_CYAN}${TEXT_UNDERLINE}https://github.com/ibm-mas/gitops/${TEXT_RESET}"
+    echo
+    reset_colors
+    gitops_deprovision_mongo "$@"
+    ;;
+  
   gitops-init-efs)
     echo "${TEXT_UNDERLINE}IBM Maximo Application Suite GitOps Manager (v${VERSION})${TEXT_RESET}"
     echo "Powered by ${COLOR_CYAN}${TEXT_UNDERLINE}https://github.com/ibm-mas/gitops/${TEXT_RESET}"

--- a/tekton/src/pipelines/gitops/deprovision-cluster.yaml
+++ b/tekton/src/pipelines/gitops/deprovision-cluster.yaml
@@ -1,0 +1,136 @@
+
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: deprovision-cluster
+spec:
+  description: Deprovision ROSA, docDb and GitOps Cluster
+  workspaces:
+    - name: configs
+  params:
+    - name: cluster_name
+      type: string    
+    - name: ocp_version
+      type: string
+    - name: avp_type
+      type: string
+    - name: avp_aws_secret_region
+      type: string
+    - name: avp_aws_secret_key
+      type: string
+    - name: avp_aws_access_key
+      type: string
+    - name: github_url
+      type: string
+    - name: github_pat
+      type: string
+    - name: rosa_token
+      type: string
+    - name: account
+      type: string
+    - name: secrets_path
+      type: string
+    - name: git_branch
+      type: string
+    - name: github_org
+      type: string
+    - name: github_repo
+      type: string
+    - name: github_host
+      type: string
+    - name: vpc_ipv4_cidr
+      type: string
+    - name: mongo_provider
+      type: string
+      default: aws
+    - name: argocd_url
+      type: string
+    - name: argocd_username
+      type: string
+    - name: argocd_password
+      type: string
+  tasks:
+    - name: gitops-deprovision-mongo
+      params:
+        - name: cluster_name
+          value: $(params.cluster_name)
+        - name: account
+          value: $(params.account)
+        - name: secrets_path
+          value: $(params.secrets_path)
+        - name: avp_aws_secret_region
+          value: $(params.avp_aws_secret_region)
+        - name: avp_aws_secret_key
+          value: $(params.avp_aws_secret_key)
+        - name: avp_aws_access_key
+          value: $(params.avp_aws_access_key)
+        - name: vpc_ipv4_cidr
+          value: $(params.vpc_ipv4_cidr)
+        - name: mongo_provider
+          value: $(params.mongo_provider)
+      taskRef:
+        kind: Task
+        name: gitops-deprovision-mongo
+      workspaces:
+        - name: configs
+          workspace: configs
+    - name: gitops-deprovision-cluster
+      runAfter:
+        - gitops-deprovision-mongo
+      params:
+        - name: cluster_name
+          value: $(params.cluster_name)
+        - name: account
+          value: $(params.account)
+        - name: secrets_path
+          value: $(params.secrets_path)
+        - name: git_branch
+          value: $(params.git_branch)
+        - name: github_org
+          value: $(params.github_org)
+        - name: github_repo
+          value: $(params.github_repo)
+        - name: github_host
+          value: $(params.github_host)
+        - name: avp_aws_secret_region
+          value: $(params.avp_aws_secret_region)
+        - name: avp_aws_secret_key
+          value: $(params.avp_aws_secret_key)
+        - name: avp_aws_access_key
+          value: $(params.avp_aws_access_key)
+        - name: github_pat
+          value: $(params.github_pat)
+        - name: argocd_url
+          value: $(params.argocd_url)
+        - name: argocd_username
+          value: $(params.argocd_username)
+        - name: argocd_password
+          value: $(params.argocd_password)
+      taskRef:
+        kind: Task
+        name: gitops-deprovision-cluster
+      workspaces:
+        - name: configs
+          workspace: configs
+    - name: gitops-deprovision-rosa
+      runAfter:
+        - gitops-deprovision-cluster
+      params:
+        - name: cluster_name
+          value: $(params.cluster_name)
+        - name: aws_region
+          value: $(params.avp_aws_secret_region)
+        - name: aws_secret_access_key
+          value: $(params.avp_aws_secret_key)
+        - name: aws_access_key_id
+          value: $(params.avp_aws_access_key)
+        - name: rosa_token
+          value: $(params.rosa_token)
+        - name: ocp_version
+          value: $(params.ocp_version)
+      taskRef:
+        kind: Task
+        name: gitops-deprovision-rosa
+      workspaces:
+        - name: configs
+          workspace: configs

--- a/tekton/src/pipelines/gitops/deprovision-mas-instance.yaml
+++ b/tekton/src/pipelines/gitops/deprovision-mas-instance.yaml
@@ -26,8 +26,6 @@ spec:
       type: string
     - name: mas_instance_id
       type: string
-    - name: vpc_id
-      type: string
     - name: vpc_ipv4_cidr
       type: string
     - name: mongo_provider
@@ -193,8 +191,6 @@ spec:
           value: $(params.avp_aws_access_key)
         - name: mas_instance_id
           value: $(params.mas_instance_id)
-        - name: vpc_id
-          value: $(params.vpc_id)
         - name: vpc_ipv4_cidr
           value: $(params.vpc_ipv4_cidr)
         - name: mongo_provider

--- a/tekton/src/pipelines/gitops/provision-mas-instance.yaml
+++ b/tekton/src/pipelines/gitops/provision-mas-instance.yaml
@@ -27,8 +27,6 @@ spec:
       type: string
     - name: mas_instance_id
       type: string
-    - name: vpc_id
-      type: string
     - name: vpc_ipv4_cidr
       type: string
     - name: mongo_provider
@@ -79,8 +77,6 @@ spec:
           value: $(params.avp_aws_access_key)
         - name: mas_instance_id
           value: $(params.mas_instance_id)
-        - name: vpc_id
-          value: $(params.vpc_id)
         - name: vpc_ipv4_cidr
           value: $(params.vpc_ipv4_cidr)
         - name: mongo_provider

--- a/tekton/src/tasks/gitops/gitops-deprovision-cluster.yaml
+++ b/tekton/src/tasks/gitops/gitops-deprovision-cluster.yaml
@@ -1,0 +1,90 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: gitops-deprovision-cluster
+spec:
+  params:
+    - name: cluster_name
+      type: string
+    - name: account
+      type: string
+    - name: secrets_path
+      type: string
+    - name: git_branch
+      type: string
+    - name: github_org
+      type: string
+    - name: github_repo
+      type: string
+    - name: github_host
+      type: string
+    - name: github_pat
+      type: string
+    - name: avp_aws_access_key
+      type: string
+    - name: avp_aws_secret_key
+      type: string
+    - name: avp_aws_secret_region
+      type: string
+    - name: argocd_url
+      type: string
+    - name: argocd_username
+      type: string
+    - name: argocd_password
+      type: string
+  stepTemplate:
+    name: gitops-deprovision-cluster
+    env:
+      - name: CLUSTER_NAME
+        value: $(params.cluster_name)
+      - name: ACCOUNT
+        value: $(params.account)
+      - name: SECRET_PATH
+        value: $(params.secrets_path)
+      - name: GIT_BRANCH
+        value: $(params.git_branch)
+      - name: GITHUB_ORG
+        value: $(params.github_org)
+      - name: GITHUB_HOST
+        value: $(params.github_host)
+      - name: GITHUB_REPO
+        value: $(params.github_repo)
+      - name: SM_AWS_ACCESS_KEY_ID
+        value: $(params.avp_aws_access_key)
+      - name: SM_AWS_SECRET_ACCESS_KEY
+        value: $(params.avp_aws_secret_key)
+      - name: SM_AWS_REGION
+        value: $(params.avp_aws_secret_region)
+      - name: GITHUB_PAT
+        value: $(params.github_pat)
+      - name: ARGOCD_URL
+        value: $(params.argocd_url)
+      - name: ARGOCD_USERNAME
+        value: $(params.argocd_username)
+      - name: ARGOCD_PASSWORD
+        value: $(params.argocd_password)  
+  steps:
+    - args:
+      - |-
+        git config --global user.name "yourUsername"
+        git config --global user.email "you@example.com"
+        git config --global user.password $GITHUB_PAT
+
+        mkdir -p /workspace/configs/$GITHUB_REPO
+        mas gitops-deprovision-cluster -a $ACCOUNT -c $CLUSTER_NAME \
+        --dir /workspace/configs/$GITHUB_REPO \
+        --github-push \
+        --github-host $GITHUB_HOST \
+        --github-org  $GITHUB_ORG \
+        --github-repo $GITHUB_REPO \
+        --git-branch $GIT_BRANCH \
+        --secrets-path $SECRET_PATH
+      command:
+        - /bin/sh
+        - -c
+      name: gitops-deprovision-cluster
+      imagePullPolicy: Always
+      image: quay.io/ibmmas/cli:6.4.0-pre.ajw-rosa-deprov
+  workspaces:
+    - name: configs

--- a/tekton/src/tasks/gitops/gitops-deprovision-mongo.yaml
+++ b/tekton/src/tasks/gitops/gitops-deprovision-mongo.yaml
@@ -2,7 +2,7 @@
 apiVersion: tekton.dev/v1beta1
 kind: Task
 metadata:
-  name: gitops-process-mongo-user
+  name: gitops-deprovision-mongo
 spec:
   params:
     - name: cluster_name
@@ -17,23 +17,13 @@ spec:
       type: string
     - name: avp_aws_access_key
       type: string
-    - name: mas_instance_id
-      type: string
-    - name: vpc_id
-      type: string
     - name: vpc_ipv4_cidr
       type: string
     - name: mongo_provider
       type: string
       default: aws
-    - name: user_action
-      type: string
-      default: add
-    - name: aws_key_pair_name
-      type: string
-      default: sre-key-pair
   stepTemplate:
-    name: gitops-process-mongo-user
+    name: gitops-deprovision-mongo
     env:
       - name: CLUSTER_NAME
         value: $(params.cluster_name)
@@ -47,19 +37,17 @@ spec:
         value: $(params.avp_aws_secret_key)
       - name: SM_AWS_ACCESS_KEY_ID
         value: $(params.avp_aws_access_key)
-      - name: MAS_INSTANCE_ID
-        value: $(params.mas_instance_id)
       - name: VPC_IPV4_CIDR
         value: $(params.vpc_ipv4_cidr)
       - name: MONGO_PROVIDER
         value: $(params.mongo_provider)
-      - name: USER_ACTION
-        value: $(params.user_action)
-      - name: AWS_KEY_PAIR_NAME
-        value: $(params.aws_key_pair_name)
   steps:
     - args:
       - |-
+        aws configure set aws_access_key_id $(params.avp_aws_access_key)
+        aws configure set aws_secret_access_key $(params.avp_aws_secret_key)
+        aws configure set default.region $(params.avp_aws_secret_region)
+
         vpc_name=$(aws ec2 describe-vpcs --output yaml | grep $CLUSTER_NAME | yq '.[].Value')
         if [ -z "$vpc_name" ]; then
           # Needed if there is only one cluster in account
@@ -67,24 +55,34 @@ spec:
         fi
         export VPC_ID=$(aws ec2 describe-vpcs --filters '[{"Name": "tag:Name", "Values": ['$vpc_name']}]' --output yaml | yq -r '.Vpcs[].VpcId' )
         
-        mas gitops-process-mongo-user -a $ACCOUNT -c $CLUSTER_NAME -m $MAS_INSTANCE_ID \
+        export MAS_INSTANCE_ID=gitops
+        
+        aws ec2 associate-vpc-cidr-block \
+        --vpc-id $VPC_ID \
+        --cidr-block 10.1.0.0/23
+
+        mas gitops-deprovision-mongo -a $ACCOUNT -c $CLUSTER_NAME \
         --secrets-path $SECRET_PATH \
         --mongo-provider $MONGO_PROVIDER \
-        --user-action $USER_ACTION \
         --aws-region $SM_AWS_REGION \
         --aws-secret-key $SM_AWS_SECRET_ACCESS_KEY \
         --aws-access-key $SM_AWS_ACCESS_KEY_ID \
         --aws-vpc-id $VPC_ID \
         --aws-docdb-cluster-name docdb-$CLUSTER_NAME \
-        --aws-docdb-ingress-cidr $VPC_IPV4_CIDR \
+        --aws-docdb-ingress-cidr $VPC_IPV4_CIDR  \
         --aws-docdb-egress-cidr $VPC_IPV4_CIDR \
-        --aws-ec2-cidr-az1 10.0.0.0/17 \
-        --aws-key-pair-name $AWS_KEY_PAIR_NAME
+        --aws-docdb-cidr-az1 10.1.0.0/27 \
+        --aws-docdb-cidr-az2 10.1.0.32/27 \
+        --aws-docdb-cidr-az3 10.1.0.64/27 \
+        --aws-docdb-instance_identifier_prefix docdb-$CLUSTER_NAME
       command:
         - /bin/sh
         - -c
-      name: gitops-process-mongo-user
+      name: gitops-deprovision-mongo
       imagePullPolicy: Always
-      image: quay.io/ibmmas/cli:6.4.0-pre.gitops
+      image: quay.io/ibmmas/cli:6.4.0-pre.ajw-rosa-deprov
   workspaces:
     - name: configs
+
+
+

--- a/tekton/src/tasks/gitops/gitops-deprovision-rosa.yaml
+++ b/tekton/src/tasks/gitops/gitops-deprovision-rosa.yaml
@@ -1,0 +1,43 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: gitops-deprovision-rosa
+spec:
+
+  params:
+    - name: cluster_name
+      type: string
+    - name: rosa_token
+      type: string
+    - name: ocp_version
+      type: string
+    - name: aws_access_key_id
+      type: string
+    - name: aws_secret_access_key
+      type: string
+    - name: aws_region
+      type: string
+  stepTemplate:
+    name: gitops-deprovision-rosa
+  steps:
+    - args:
+      - |-
+        export ROSA_TOKEN=$(params.rosa_token)
+        export OCP_VERSION=$(params.ocp_version)
+  
+        aws configure set aws_access_key_id $(params.aws_access_key_id)
+        aws configure set aws_secret_access_key $(params.aws_secret_access_key)
+        aws configure set default.region $(params.aws_region)
+
+        export ROSA_CONFIG_DIR=/workspace/configs/tmp-rosa-deprovision
+        mkdir -p $ROSA_CONFIG_DIR
+        mas gitops-deprovision-rosa -c $(params.cluster_name)
+      command:
+        - /bin/sh
+        - -c
+      name: gitops-deprovision-rosa
+      imagePullPolicy: Always
+      image: quay.io/ibmmas/cli:6.4.0-pre.ajw-rosa-deprov
+  workspaces:
+    - name: configs


### PR DESCRIPTION
Adds the following new functions:
- gitiops-deprovison-mongo
- gitops-deprovision-cluster
- gitops-deprovsion-rosa

Also then includes that tekton tasks for these and a new pipeline called `deprovsion-cluster` that will call these tasks.

The pipeline will delete the docdb instance, remove the details from secrets-manager. It will then remove the cluster resources like ibm-common-services and then finally deletes the rosa cluster and infrastructure around it.

As a sidechange this also updates the mas-provision tasks so that we don't need to provide the vpc_id but instead computes it based on the name of the cluster.

This is all part of the work for internal issue https://github.ibm.com/wiotp/tracker/issues/13189

It has been tested and confirmed to work, there was an issue with the mongodb role not waiting long enough after sending the delete request but this has been updated here https://github.com/ibm-mas/ansible-devops/commit/7ae5668f0d54f861b6e3d586afc2be713c3fde62