### PR TITLE
[patch] pass param ec2 instance linux region specific ami id

### DIFF
--- a/image/cli/mascli/functions/gitops_init_mongo
+++ b/image/cli/mascli/functions/gitops_init_mongo
@@ -196,6 +196,8 @@ function gitops_init_mongo() {
     echo_reset_dim "AWS Region  ........................... ${COLOR_MAGENTA}${AWS_REGION}"
     echo_reset_dim "AWS VPC ID  ........................... ${COLOR_MAGENTA}${VPC_ID}"
     echo_reset_dim "AWS DOCDB CLUSTER NAME  ............... ${COLOR_MAGENTA}${DOCDB_CLUSTER_NAME}"
+    echo_reset_dim "AWS DOCDB Instance count .............. ${COLOR_MAGENTA}${DOCDB_INSTANCE_NUMBER}"
+    
   fi
   if [ $MONGODB_PROVIDER == 'yaml' ]; then
     echo_reset_dim "YAML Configuration File ............... ${COLOR_MAGENTA}${MONGO_YAML_FILE}"
@@ -218,7 +220,7 @@ function gitops_init_mongo() {
     #export MAS_INSTANCE_ID=inst1
     export MONGODB_NAMESPACE=docdb
     export ROLE_NAME=mongodb
-    export DOCDB_INSTANCE_NUMBER=1
+    export DOCDB_INSTANCE_NUMBER=${DOCDB_INSTANCE_NUMBER:-"1"}
     export SLS_MONGO_RETRYWRITES=false
     export AWS_DEFAULT_OUTPUT="json"
     export MONGODB_ACTION=install
@@ -230,7 +232,7 @@ function gitops_init_mongo() {
     if [[ -n ${DOCDB_MASTER_PASSWORD} ]]; then
       export DOCDB_MASTER_PASSWORD=${DOCDB_MASTER_PASSWORD}
       echo "init_mongo : DOCDB_MASTER_PASSWORD=${DOCDB_MASTER_PASSWORD} is available in the secret, use the same while invoking the role again"
-    fi 
+    fi
 
     ansible-playbook ibm.mas_devops.run_role
     rc=$?

--- a/image/cli/mascli/functions/gitops_process_mongo_user
+++ b/image/cli/mascli/functions/gitops_process_mongo_user
@@ -42,6 +42,7 @@ AWS MongoDb Provider:
       --aws-access-key-id ${COLOR_YELLOW}AWS_ACCESS_KEY_ID${TEXT_RESET}                   Aws access key id
       --aws-secret-access-key ${COLOR_YELLOW}AWS_SECRET_ACCESS_KEY${TEXT_RESET}           Aws secret access key
       --secret-name-mongo-instance ${COLOR_YELLOW}SECRET_NAME_MONGO_INSTANCE${TEXT_RESET} AWS secret manager secret name where instance mongo username and password will be stored
+      --ec2-linux-ami-id ${COLOR_YELLOW}SECRET_NAME_MONGO_INSTANCE${TEXT_RESET}           AWS EC2 instance AMI ID
 
 
 Other Commands:
@@ -137,6 +138,9 @@ function gitops_process_mongo_user_noninteractive() {
       --secret-name-mongo-instance)
         export SECRET_NAME_MONGO_INSTANCE=$1 && shift
         ;;
+      --ec2-linux-ami-id)
+        export EC2_LINUX_AMI_ID=$1 && shift
+        ;;        
       # Other Commands
       -h|--help)
         gitops_process_mongo_user_help
@@ -158,6 +162,8 @@ function gitops_process_mongo_user_noninteractive() {
     [[ -z "$USER_ACTION" ]] && gitops_process_mongo_user_help "USER_ACTION is not set"
 
     [[ -z "$MAS_INSTANCE_ID" ]] && gitops_process_mongo_user_help "MAS_INSTANCE_ID is not set"
+
+    [[ -z "$EC2_LINUX_AMI_ID" ]] && gitops_process_mongo_user_help "EC2_LINUX_AMI_ID is not set"
 
     if [ -z $AWS_ACCESS_KEY_ID ] || [ -z $AWS_SECRET_ACCESS_KEY ] || [ -z $VPC_ID ] || [ -z $AWS_REGION ]; then
       echo 'Missing required params for AWS mongo provider, make sure to provide --aws-access-key, --aws-secret-key, --aws-region and --aws-vpc-id'
@@ -211,6 +217,7 @@ function gitops_process_mongo_user() {
     echo_reset_dim "AWS Region  ........................... ${COLOR_MAGENTA}${AWS_REGION}"
     echo_reset_dim "AWS VPC ID  ........................... ${COLOR_MAGENTA}${VPC_ID}"
     echo_reset_dim "AWS DOCDB CLUSTER NAME  ............... ${COLOR_MAGENTA}${DOCDB_CLUSTER_NAME}"
+    echo_reset_dim "AWS EC2 Linux AMI ID  ................. ${COLOR_MAGENTA}${EC2_LINUX_AMI_ID}"
   fi
 
   echo "${TEXT_DIM}"

--- a/tekton/src/pipelines/gitops/deprovision-mas-instance.yaml
+++ b/tekton/src/pipelines/gitops/deprovision-mas-instance.yaml
@@ -45,6 +45,8 @@ spec:
       type: string
     - name: aws_key_pair_name
       type: string
+    - name: ec2_linux_ami_id
+      type: string
     - name: argocd_url
       type: string
     - name: argocd_username
@@ -199,6 +201,8 @@ spec:
           value: $(params.docdb_user_action)
         - name: aws_key_pair_name
           value: $(params.aws_key_pair_name)
+        - name: ec2_linux_ami_id
+          value: $(params.ec2_linux_ami_id)
       workspaces:
         - name: configs
           workspace: configs

--- a/tekton/src/pipelines/gitops/provision-mas-instance.yaml
+++ b/tekton/src/pipelines/gitops/provision-mas-instance.yaml
@@ -52,6 +52,8 @@ spec:
       type: string
     - name: aws_key_pair_name
       type: string
+    - name: ec2_linux_ami_id
+      type: string
     - name: argocd_url
       type: string
     - name: argocd_username
@@ -85,6 +87,8 @@ spec:
           value: $(params.docdb_user_action)
         - name: aws_key_pair_name
           value: $(params.aws_key_pair_name)
+        - name: ec2_linux_ami_id
+          value: $(params.ec2_linux_ami_id)
       workspaces:
         - name: configs
           workspace: configs

--- a/tekton/src/tasks/gitops/gitops-process-mongo-user.yaml
+++ b/tekton/src/tasks/gitops/gitops-process-mongo-user.yaml
@@ -70,7 +70,11 @@ spec:
           vpc_name=$(aws ec2 describe-vpcs --output yaml | grep $CLUSTER_NAME | yq '.Value')
         fi
         export VPC_ID=$(aws ec2 describe-vpcs --filters '[{"Name": "tag:Name", "Values": ['$vpc_name']}]' --output yaml | yq -r '.Vpcs[].VpcId' )
-        
+
+        if [ -z "$EC2_LINUX_AMI_ID" ]; then
+          export EC2_LINUX_AMI_ID=$(aws ec2 describe-images --filters "Name=description,Values=Amazon Linux 2023 AMI 2023.1.20230809.0 x86_64 HVM kernel-6.1" --region ${SM_AWS_REGION}  --query 'sort_by(Images, &Name)[-1].ImageId')
+        fi
+
         mas gitops-process-mongo-user -a $ACCOUNT -c $CLUSTER_NAME -m $MAS_INSTANCE_ID \
         --secrets-path $SECRET_PATH \
         --mongo-provider $MONGO_PROVIDER \

--- a/tekton/src/tasks/gitops/gitops-process-mongo-user.yaml
+++ b/tekton/src/tasks/gitops/gitops-process-mongo-user.yaml
@@ -32,6 +32,8 @@ spec:
     - name: aws_key_pair_name
       type: string
       default: sre-key-pair
+    - name: ec2_linux_ami_id
+      type: string
   stepTemplate:
     name: gitops-process-mongo-user
     env:
@@ -57,6 +59,8 @@ spec:
         value: $(params.user_action)
       - name: AWS_KEY_PAIR_NAME
         value: $(params.aws_key_pair_name)
+      - name: EC2_LINUX_AMI_ID
+        value: $(params.ec2_linux_ami_id)
   steps:
     - args:
       - |-
@@ -79,7 +83,8 @@ spec:
         --aws-docdb-ingress-cidr $VPC_IPV4_CIDR \
         --aws-docdb-egress-cidr $VPC_IPV4_CIDR \
         --aws-ec2-cidr-az1 10.0.0.0/17 \
-        --aws-key-pair-name $AWS_KEY_PAIR_NAME
+        --aws-key-pair-name $AWS_KEY_PAIR_NAME \
+        --ec2-linux-ami-id $EC2_LINUX_AMI_ID
       command:
         - /bin/sh
         - -c


### PR DESCRIPTION
We need the ami id as the ami to use when creating the ec2 is determined by the region choosen.