### PR TITLE
[patch] Enhancements on Must-Gather for Manage

### DIFF
--- a/image/cli/mascli/must-gather/mg-summary-mas-manage
+++ b/image/cli/mascli/must-gather/mg-summary-mas-manage
@@ -35,4 +35,16 @@ echo "--------------------------------------------------------------------------
 oc get managestatuschecker -n $1
 echo ""
 
+echo ""
+echo "IBM Maximo Application Suite - Maximo Healthext application"
+echo "--------------------------------------------------------------------------------"
+oc get healthextapp -n $1
+echo ""
+
+echo ""
+echo "IBM Maximo Application Suite - Maximo Healthext Workspace"
+echo "--------------------------------------------------------------------------------"
+oc get healthextworkspace -n $1
+echo ""
+
 exit 0

--- a/image/cli/mascli/must-gather/mg-summary-mas-manage
+++ b/image/cli/mascli/must-gather/mg-summary-mas-manage
@@ -36,18 +36,6 @@ oc get managestatuschecker -n $1
 echo ""
 
 echo ""
-echo "IBM Maximo Application Suite - Maximo Healthext Application"
-echo "--------------------------------------------------------------------------------"
-oc get healthextapp -n $1
-echo ""
-
-echo ""
-echo "IBM Maximo Application Suite - Maximo Healthext Workspace"
-echo "--------------------------------------------------------------------------------"
-oc get healthextworkspace -n $1
-echo ""
-
-echo ""
 echo "IBM Maximo Application Suite - Image Stitching"
 echo "--------------------------------------------------------------------------------"
 oc get imagestitching -n $1
@@ -57,6 +45,30 @@ echo ""
 echo "IBM Maximo Application Suite - Open Telemetry Deployment"
 echo "--------------------------------------------------------------------------------"
 oc get opentelemetrydeployment -n $1
+echo ""
+
+echo ""
+echo "IBM Maximo Application Suite - Maximo Health Application"
+echo "--------------------------------------------------------------------------------"
+oc get healthapp -n $1
+echo ""
+
+echo ""
+echo "IBM Maximo Application Suite - Maximo Healthext Application"
+echo "--------------------------------------------------------------------------------"
+oc get healthextapp -n $1
+echo ""
+
+echo ""
+echo "IBM Maximo Application Suite - Maximo Health Workspace"
+echo "--------------------------------------------------------------------------------"
+oc get healthworkspace -n $1
+echo ""
+
+echo ""
+echo "IBM Maximo Application Suite - Maximo Healthext Workspace"
+echo "--------------------------------------------------------------------------------"
+oc get healthextworkspace -n $1
 echo ""
 
 exit 0

--- a/image/cli/mascli/must-gather/mg-summary-mas-manage
+++ b/image/cli/mascli/must-gather/mg-summary-mas-manage
@@ -29,4 +29,10 @@ echo "--------------------------------------------------------------------------
 oc get manageserverbundle -n $1
 echo ""
 
+echo ""
+echo "IBM Maximo Application Suite - Manage Status Checker"
+echo "--------------------------------------------------------------------------------"
+oc get managestatuschecker -n $1
+echo ""
+
 exit 0

--- a/image/cli/mascli/must-gather/mg-summary-mas-manage
+++ b/image/cli/mascli/must-gather/mg-summary-mas-manage
@@ -36,15 +36,9 @@ oc get managestatuschecker -n $1
 echo ""
 
 echo ""
-echo "IBM Maximo Application Suite - Maximo Health Application"
+echo "IBM Maximo Application Suite - Maximo Healthext Application"
 echo "--------------------------------------------------------------------------------"
-oc get healthapp -n $1
-echo ""
-
-echo ""
-echo "IBM Maximo Application Suite - Maximo Health Workspace"
-echo "--------------------------------------------------------------------------------"
-oc get healthworkspace -n $1
+oc get healthextapp -n $1
 echo ""
 
 echo ""

--- a/image/cli/mascli/must-gather/mg-summary-mas-manage
+++ b/image/cli/mascli/must-gather/mg-summary-mas-manage
@@ -36,15 +36,33 @@ oc get managestatuschecker -n $1
 echo ""
 
 echo ""
-echo "IBM Maximo Application Suite - Maximo Healthext application"
+echo "IBM Maximo Application Suite - Maximo Health Application"
 echo "--------------------------------------------------------------------------------"
-oc get healthextapp -n $1
+oc get healthapp -n $1
+echo ""
+
+echo ""
+echo "IBM Maximo Application Suite - Maximo Health Workspace"
+echo "--------------------------------------------------------------------------------"
+oc get healthworkspace -n $1
 echo ""
 
 echo ""
 echo "IBM Maximo Application Suite - Maximo Healthext Workspace"
 echo "--------------------------------------------------------------------------------"
 oc get healthextworkspace -n $1
+echo ""
+
+echo ""
+echo "IBM Maximo Application Suite - Image Stitching"
+echo "--------------------------------------------------------------------------------"
+oc get imagestitching -n $1
+echo ""
+
+echo ""
+echo "IBM Maximo Application Suite - Open Telemetry Deployment"
+echo "--------------------------------------------------------------------------------"
+oc get opentelemetrydeployment -n $1
 echo ""
 
 exit 0


### PR DESCRIPTION
Continuing the work on Must-Gather for Manage, on this PR we're updating the CRs presented on Manage Summary. The following CRs were added:

- managestatuschecker
- imagestitching
- opentelemetrydeployment
- healthapp
- healthextapp
- healthworkspace
- heatlhextworkspace

Attached there's the execution performed today against IVT811X-01 environment. Summary is now presented as expected:
[must-gather-20230828-132315.tgz](https://github.com/ibm-mas/cli/files/12455348/must-gather-20230828-132315.tgz)

@wangqymro fyi
