### PR TITLE
[patch] Fix tasks to fail in gitops + fix password reset each time task is run

### DIFF
--- a/image/cli/mascli/functions/gitops_bootstrap
+++ b/image/cli/mascli/functions/gitops_bootstrap
@@ -73,7 +73,7 @@ function gitops_bootstrap_noninteractive() {
       # Unknown option
       *)
         echo -e "\n${COLOR_RED}Usage Error: Unsupported flag \"${key}\" ${COLOR_OFF}\n\n"
-        gitops_bootstrap_help
+        gitops_bootstrap_help "Usage Error: Unsupported option \"${key}\" "
         exit 1
         ;;
     esac

--- a/image/cli/mascli/functions/gitops_db2u_jdbc_config_rotate_password
+++ b/image/cli/mascli/functions/gitops_db2u_jdbc_config_rotate_password
@@ -136,7 +136,7 @@ function gitops_db2u_jdbc_config_rotate_password_noninteractive() {
       *)
         # unknown option
         echo -e "${COLOR_RED}Usage Error: Unsupported option \"${key}\"${COLOR_RESET}\n"
-        gitops_db2u_jdbc_config_rotate_password_help
+        gitops_db2u_jdbc_config_rotate_password_help "Usage Error: Unsupported option \"${key}\" "
         exit 1
         ;;
       esac

--- a/image/cli/mascli/functions/gitops_deprovision_cluster
+++ b/image/cli/mascli/functions/gitops_deprovision_cluster
@@ -96,7 +96,7 @@ function gitops_deprovision_cluster_noninteractive() {
       *)
         # unknown option
         echo -e "${COLOR_RED}Usage Error: Unsupported option \"${key}\"${COLOR_RESET}\n"
-        gitops_deprovision_cluster_help
+        gitops_deprovision_cluster_help "Usage Error: Unsupported option \"${key}\" "
         exit 1
         ;;
     esac

--- a/image/cli/mascli/functions/gitops_deprovision_mongo
+++ b/image/cli/mascli/functions/gitops_deprovision_mongo
@@ -124,7 +124,7 @@ function gitops_deprovision_mongo_noninteractive() {
       *)
         # unknown option
         echo -e "${COLOR_RED}Usage Error: Unsupported option \"${key}\"${COLOR_RESET}\n"
-        gitops_deprovision_mongo_help
+        gitops_deprovision_mongo_help "Usage Error: Unsupported option \"${key}\" "
         exit 1
         ;;
       esac

--- a/image/cli/mascli/functions/gitops_deprovision_rosa
+++ b/image/cli/mascli/functions/gitops_deprovision_rosa
@@ -33,7 +33,7 @@ function gitops_deprovision_rosa_noninteractive() {
       # Unknown option
       *)
         echo -e "\n${COLOR_RED}Usage Error: Unsupported flag \"${key}\" ${COLOR_OFF}\n\n"
-        gitops_deprovision_rosa_help
+        gitops_deprovision_rosa_help "Usage Error: Unsupported option \"${key}\" "
         exit 1
         ;;
     esac

--- a/image/cli/mascli/functions/gitops_deprovision_suite
+++ b/image/cli/mascli/functions/gitops_deprovision_suite
@@ -140,7 +140,7 @@ function gitops_deprovision_suite_noninteractive() {
       *)
         # unknown option
         echo -e "${COLOR_RED}Usage Error: Unsupported option \"${key}\"${COLOR_RESET}\n"
-        gitops_deprovision_suite_help
+        gitops_deprovision_suite_help  "Usage Error: Unsupported option \"${key}\" "
         exit 1
         ;;
       esac

--- a/image/cli/mascli/functions/gitops_deprovision_suite_config
+++ b/image/cli/mascli/functions/gitops_deprovision_suite_config
@@ -101,7 +101,7 @@ function gitops_deprovision_suite_config_noninteractive() {
       *)
         # unknown option
         echo -e "${COLOR_RED}Usage Error: Unsupported option \"${key}\"${COLOR_RESET}\n"
-        gitops_deprovision_suite_config_help
+        gitops_deprovision_suite_config_help  "Usage Error: Unsupported option \"${key}\" "
         exit 1
         ;;
       esac

--- a/image/cli/mascli/functions/gitops_deprovision_suite_workspace
+++ b/image/cli/mascli/functions/gitops_deprovision_suite_workspace
@@ -94,7 +94,7 @@ function gitops_deprovision_suite_workspace_noninteractive() {
       *)
         # unknown option
         echo -e "${COLOR_RED}Usage Error: Unsupported option \"${key}\"${COLOR_RESET}\n"
-        gitops_deprovision_suite_workspace_help
+        gitops_deprovision_suite_workspace_help  "Usage Error: Unsupported option \"${key}\" "
         exit 1
         ;;
       esac

--- a/image/cli/mascli/functions/gitops_init_cluster
+++ b/image/cli/mascli/functions/gitops_init_cluster
@@ -123,7 +123,7 @@ function gitops_init_cluster_noninteractive() {
       *)
         # unknown option
         echo -e "${COLOR_RED}Usage Error: Unsupported option \"${key}\"${COLOR_RESET}\n"
-        gitops_init_cluster_help
+        gitops_init_cluster_help  "Usage Error: Unsupported option \"${key}\" "
         exit 1
         ;;
     esac

--- a/image/cli/mascli/functions/gitops_init_db2u
+++ b/image/cli/mascli/functions/gitops_init_db2u
@@ -230,7 +230,7 @@ function gitops_init_db2u_noninteractive() {
       *)
         # unknown option
         echo -e "${COLOR_RED}Usage Error: Unsupported option \"${key}\"${COLOR_RESET}\n"
-        gitops_init_db2u_help
+        gitops_init_db2u_help  "Usage Error: Unsupported option \"${key}\" "
         exit 1
         ;;
       esac

--- a/image/cli/mascli/functions/gitops_init_db2u_jdbc_config
+++ b/image/cli/mascli/functions/gitops_init_db2u_jdbc_config
@@ -133,7 +133,7 @@ function gitops_init_db2u_jdbc_config_noninteractive() {
       *)
         # unknown option
         echo -e "${COLOR_RED}Usage Error: Unsupported option \"${key}\"${COLOR_RESET}\n"
-        gitops_init_db2u_jdbc_config_help
+        gitops_init_db2u_jdbc_config_help  "Usage Error: Unsupported option \"${key}\" "
         exit 1
         ;;
       esac

--- a/image/cli/mascli/functions/gitops_init_efs
+++ b/image/cli/mascli/functions/gitops_init_efs
@@ -62,7 +62,7 @@ function gitops_init_efs_noninteractive() {
       *)
         # unknown option
         echo -e "${COLOR_RED}Usage Error: Unsupported option \"${key}\"${COLOR_RESET}\n"
-        gitops_init_efs_help
+        gitops_init_efs_help  "Usage Error: Unsupported option \"${key}\" "
         exit 1
         ;;
       esac

--- a/image/cli/mascli/functions/gitops_init_kafka
+++ b/image/cli/mascli/functions/gitops_init_kafka
@@ -155,7 +155,7 @@ function gitops_init_kafka_noninteractive() {
       *)
         # unknown option
         echo -e "${COLOR_RED}Usage Error: Unsupported option \"${key}\"${COLOR_RESET}\n"
-        gitops_init_kafka_help
+        gitops_init_kafka_help  "Usage Error: Unsupported option \"${key}\" "
         exit 1
         ;;
       esac

--- a/image/cli/mascli/functions/gitops_init_kafka_config
+++ b/image/cli/mascli/functions/gitops_init_kafka_config
@@ -102,7 +102,7 @@ function gitops_init_kafka_config_noninteractive() {
       *)
         # unknown option
         echo -e "${COLOR_RED}Usage Error: Unsupported option \"${key}\"${COLOR_RESET}\n"
-        gitops_init_kafka_config_help
+        gitops_init_kafka_config_help  "Usage Error: Unsupported option \"${key}\" "
         exit 1
         ;;
       esac

--- a/image/cli/mascli/functions/gitops_init_license
+++ b/image/cli/mascli/functions/gitops_init_license
@@ -63,7 +63,7 @@ function gitops_init_license_noninteractive() {
       *)
         # unknown option
         echo -e "${COLOR_RED}Usage Error: Unsupported option \"${key}\"${COLOR_RESET}\n"
-        gitops_init_license_help
+        gitops_init_license_help  "Usage Error: Unsupported option \"${key}\" "
         exit 1
         ;;
       esac

--- a/image/cli/mascli/functions/gitops_init_mongo
+++ b/image/cli/mascli/functions/gitops_init_mongo
@@ -128,7 +128,7 @@ function gitops_init_mongo_noninteractive() {
       *)
         # unknown option
         echo -e "${COLOR_RED}Usage Error: Unsupported option \"${key}\"${COLOR_RESET}\n"
-        gitops_init_mongo_help
+        gitops_init_mongo_help  "Usage Error: Unsupported option \"${key}\" "
         exit 1
         ;;
       esac

--- a/image/cli/mascli/functions/gitops_init_rosa
+++ b/image/cli/mascli/functions/gitops_init_rosa
@@ -38,7 +38,7 @@ function gitops_init_rosa_noninteractive() {
       # Unknown option
       *)
         echo -e "\n${COLOR_RED}Usage Error: Unsupported flag \"${key}\" ${COLOR_OFF}\n\n"
-        gitops_init_rosa_help
+        gitops_init_rosa_help "Usage Error: Unsupported flag \"${key}\" "
         exit 1
         ;;
     esac

--- a/image/cli/mascli/functions/gitops_init_suite
+++ b/image/cli/mascli/functions/gitops_init_suite
@@ -140,7 +140,7 @@ function gitops_init_suite_noninteractive() {
       *)
         # unknown option
         echo -e "${COLOR_RED}Usage Error: Unsupported option \"${key}\"${COLOR_RESET}\n"
-        gitops_init_suite_help
+        gitops_init_suite_help "Usage Error: Unsupported option \"${key}\" "
         exit 1
         ;;
       esac

--- a/image/cli/mascli/functions/gitops_init_suite_config
+++ b/image/cli/mascli/functions/gitops_init_suite_config
@@ -109,7 +109,7 @@ function gitops_init_suite_config_noninteractive() {
       *)
         # unknown option
         echo -e "${COLOR_RED}Usage Error: Unsupported option \"${key}\"${COLOR_RESET}\n"
-        gitops_init_suite_config_help
+        gitops_init_suite_config_help "Usage Error: Unsupported option \"${key}\" "
         exit 1
         ;;
       esac

--- a/image/cli/mascli/functions/gitops_init_suite_workspace
+++ b/image/cli/mascli/functions/gitops_init_suite_workspace
@@ -94,7 +94,7 @@ function gitops_init_suite_workspace_noninteractive() {
       *)
         # unknown option
         echo -e "${COLOR_RED}Usage Error: Unsupported option \"${key}\"${COLOR_RESET}\n"
-        gitops_init_suite_workspace_help
+        gitops_init_suite_workspace_help "Usage Error: Unsupported option \"${key}\" "
         exit 1
         ;;
       esac

--- a/image/cli/mascli/functions/gitops_process_mongo_user
+++ b/image/cli/mascli/functions/gitops_process_mongo_user
@@ -149,7 +149,7 @@ function gitops_process_mongo_user_noninteractive() {
       *)
         # unknown option
         echo -e "${COLOR_RED}Usage Error: Unsupported option \"${key}\"${COLOR_RESET}\n"
-        gitops_process_mongo_user_help "Usage Error: Unsupported option ${key}"
+        gitops_process_mongo_user_help "Usage Error: Unsupported option \"${key}\" "
         exit 1
         ;;
       esac

--- a/image/cli/mascli/functions/gitops_process_mongo_user
+++ b/image/cli/mascli/functions/gitops_process_mongo_user
@@ -48,6 +48,7 @@ AWS MongoDb Provider:
 Other Commands:
   -h, --help                                      Show this help message
 EOM
+
   [[ -n "$1" ]] && exit 1 || exit 0
 }
 
@@ -140,7 +141,7 @@ function gitops_process_mongo_user_noninteractive() {
         ;;
       --ec2-linux-ami-id)
         export EC2_LINUX_AMI_ID=$1 && shift
-        ;;        
+        ;;
       # Other Commands
       -h|--help)
         gitops_process_mongo_user_help
@@ -148,7 +149,7 @@ function gitops_process_mongo_user_noninteractive() {
       *)
         # unknown option
         echo -e "${COLOR_RED}Usage Error: Unsupported option \"${key}\"${COLOR_RESET}\n"
-        gitops_process_mongo_user_help
+        gitops_process_mongo_user_help "Usage Error: Unsupported option ${key}"
         exit 1
         ;;
       esac
@@ -248,20 +249,31 @@ function gitops_process_mongo_user() {
     export DOCDB_MASTER_USERNAME=$(jq -r .username $MONGO_SECRET_FILE)
     export DOCDB_MASTER_PASSWORD=$(jq -r .password $MONGO_SECRET_FILE)    
     echo -e "${USER_ACTION}_mongo_user : DOCDB_HOST=${DOCDB_HOST} \t DOCDB_PORT=${DOCDB_PORT} \t DOCDB_MASTER_USERNAME=${DOCDB_MASTER_USERNAME} \t DOCDB_MASTER_PASSWORD=${DOCDB_MASTER_PASSWORD}"
-    
+
     export DOCDB_INSTANCE_USERNAME=masinst_${MAS_INSTANCE_ID}
     export SECRET_NAME_MONGO_INSTANCE=${ACCOUNT_ID}${SECRETS_KEY_SEPERATOR}${CLUSTER_ID}${SECRETS_KEY_SEPERATOR}${MAS_INSTANCE_ID}${SECRETS_KEY_SEPERATOR}mongo
+    # Set docdb instance password if present in secret manager
+    if [[ "${USER_ACTION}" == "add" ]]; then
+      MONGO_INSTANCE_USER_FILE=${TEMP_DIR}/lookup-mongo-user.json
+      sm_get_secret_file ${SECRET_NAME_MONGO_INSTANCE} $MONGO_INSTANCE_USER_FILE
+      TEMP_DOCDB_INSTANCE_USERNAME=$(jq -r .username $MONGO_INSTANCE_USER_FILE)
+      TEMP_DOCDB_INSTANCE_PASSWORD=$(jq -r .password $MONGO_INSTANCE_USER_FILE)
+      if [[ -n ${TEMP_DOCDB_INSTANCE_PASSWORD} ]]; then
+        export DOCDB_INSTANCE_PASSWORD=${TEMP_DOCDB_INSTANCE_PASSWORD}
+        echo  -e "${USER_ACTION}_mongo_user : DOCDB INSTANCE USERNAME / PASSWORD : ${TEMP_DOCDB_INSTANCE_USERNAME} / ${TEMP_DOCDB_INSTANCE_PASSWORD} from secret, same used while invoking role again"
+      fi
+    fi
     export ROLE_NAME=aws_ec2_documentdb
     ansible-playbook ibm.mas_devops.run_role
     rc=$?
     [ $rc -ne 0 ] && exit $rc
 
     if [[ "${USER_ACTION}" == "add" ]]; then
-      export MONGO_INSTANCE_USER_FILE=$TEMP_DIR/created-mongo-user.json
+      export MONGO_INSTANCE_USER_FILE=${TEMP_DIR}/created-mongo-user.json
       sm_get_secret_file ${SECRET_NAME_MONGO_INSTANCE} $MONGO_INSTANCE_USER_FILE
       DOCDB_INSTANCE_USERNAME=$(jq -r .username $MONGO_INSTANCE_USER_FILE)
       DOCDB_INSTANCE_PASSWORD=$(jq -r .password $MONGO_INSTANCE_USER_FILE)
-      echo -e "${USER_ACTION}_mongo_user : DOCDB_INSTANCE_USERNAME=${DOCDB_INSTANCE_USERNAME} \t DOCDB_INSTANCE_PASSWORD=${DOCDB_INSTANCE_PASSWORD}"    
+      echo -e "${USER_ACTION}_mongo_user : DOCDB INSTANCE USERNAME / PASSWORD : ${DOCDB_INSTANCE_USERNAME}  / ${DOCDB_INSTANCE_PASSWORD}"
       
       if [[ "${DOCDB_INSTANCE_USERNAME}" != masinst_"${MAS_INSTANCE_ID}" ]]; then
         echo "${USER_ACTION}_mongo_user : DOCDB_INSTANCE_USERNAME is not matching the right value"
@@ -270,5 +282,5 @@ function gitops_process_mongo_user() {
     fi
 
   fi
-  exit 0  
+  exit 0
 }


### PR DESCRIPTION
- [ ] Logic to ensure pipeline tasks fail when gitops function fails https://jsw.ibm.com/browse/MASCORE-101
- [ ] Setting docdb instance password if present in AWS secret manager while calling gitops-process-mongo-user https://jsw.ibm.com/browse/MASCORE-117