### PR TITLE
[patch] Force manage task to run in a priviledged context

### DIFF
--- a/tekton/src/tasks/fvt/fvt-manage.yml.j2
+++ b/tekton/src/tasks/fvt/fvt-manage.yml.j2
@@ -107,6 +107,9 @@ spec:
 
   stepTemplate:
     name: 'fvt-manage'
+    securityContext:
+      privileged: true
+      runAsUser: 0
     env:
       - name: PRODUCT_ID
         value: $(params.product_id)


### PR DESCRIPTION
This PR solves the permission denied issue faced during Manage FVT run in Fyre clusters, when new folders and files are created in mounted workspace volumes.

Tested using `tkn` as follows:

Before the fix:

```
Log: at org.testng.TestNG.run(TestNG.java:1067)
Log: at org.testng.TestNG.privateMain(TestNG.java:1414)
Log: at org.testng.TestNG.main(TestNG.java:1378)
Log: SEVERE: Resetting browser due to test failure
Log: SEVERE: TEST FAILED
Ending Task: Create new user 2_ADZ9EQ]]></failure>
</testcase>
<testcase name="Close down the browser" time="00:00:00" classname="Additional Steps">
</testcase>
</testsuite>
-------------------------------------------------------------------------
-------------------------------------------------------------------------
Save Data Files into shared workspace folder
-------------------------------------------------------------------------
>>>> Copying test output .data file(s) to shared workspace and test results dir
>>>> Creating shared manage .data directory at /workspace/configs/managedata
mkdir: cannot create directory '/workspace/configs/managedata': Permission denied
Copying test output .data to logs folder
Copying test output .data to /workspace/configs/managedata/
Traceback (most recent call last):
File "/usr/local/lib/python3.9/shutil.py", line 266, in copyfile
with open(dst, 'wb') as fdst:
IsADirectoryError: [Errno 21] Is a directory: '/workspace/configs/managedata/'
```

After the fix

```
-------------------------------------------------------------------------
Save Data Files into shared workspace folder
-------------------------------------------------------------------------
>>>> Copying test output .data file(s) to shared workspace and test results dir
Copying test output .data to logs folder
Copying test output .data to /workspace/configs/managedata/
>>>> Save data files updated by this test into shared /workspace/configs/managedata/datafiles folder
>>>> Saving a copy of /opt/ibm/wiotp/workspace/TestAutomation/maximo/testcases/bvt/SetupProperties.data
>>>> Verifying list of .data files now present in /workspace/configs/managedata/datafiles:
/workspace/configs/managedata/datafiles
/workspace/configs/managedata/datafiles/testcases
/workspace/configs/managedata/datafiles/testcases/bvt
/workspace/configs/managedata/datafiles/testcases/bvt/SetupProperties.data
```