### PR TITLE
[patch] Enhanced must-gather for IoT and SLS

### DIFF
--- a/image/cli/mascli/functions/must_gather
+++ b/image/cli/mascli/functions/must_gather
@@ -170,11 +170,11 @@ function mustgather() {
         echo -e "- Performing must-gather in namespace ${MAS_APP_NAMESPACE}"
         # MAS-specific must-gather
         $MG_SCRIPT_DIR/mg-summary-mas-${MAS_APP_ID} $MAS_APP_NAMESPACE &> ${OUTPUT_DIR}/mas-${MAS_INSTANCE_ID}-${MAS_APP_ID}.txt
-        $MG_SCRIPT_DIR/mg-collect-mas-${MAS_APP_ID} $MAS_APP_NAMESPACE $OUTPUT_DIR
 
         # Generic Kubernetes must-gather
         if [[ "$SUMMARY_ONLY" == false ]]
         then
+          $MG_SCRIPT_DIR/mg-collect-mas-${MAS_APP_ID} $MAS_APP_NAMESPACE $OUTPUT_DIR
           $MG_SCRIPT_DIR/mg-collect-pods $MAS_APP_NAMESPACE $POD_LOGS $OUTPUT_DIR/resources
           for RESOURCE in configmaps secrets services routes pvc deployments statefulsets jobs operatorconditions clusterserviceversions installplans subscriptions serviceaccounts roles rolebindings
           do
@@ -183,6 +183,32 @@ function mustgather() {
         fi
       fi
     done
+  done
+
+  # Gather SLS data
+  # -----------------------------------------------------------------------------
+  SLS_NAMESPACES=$(oc get LicenseService --all-namespaces --ignore-not-found -o jsonpath='{.items[*].metadata.namespace}')
+  echo ""
+  for SLS_NAMESPACE in $SLS_NAMESPACES
+  do
+    # assume that there is only one LicenseService in the namespace
+    SLS_NAME=$(oc get LicenseService -n ${SLS_NAMESPACE} --ignore-not-found -o jsonpath='{.items[0].metadata.name}')
+    echo_h2 "Suite Licensing Service Must Gather from ${SLS_NAME} in ${SLS_NAMESPACE}"
+
+    # SLS-specific must-gather
+    $MG_SCRIPT_DIR/mg-summary-sls $SLS_NAMESPACE &> ${OUTPUT_DIR}/${SLS_NAMESPACE}.txt
+
+    # Generic Kubernetes must-gather
+    if [[ "$SUMMARY_ONLY" == false ]]
+    then
+      $MG_SCRIPT_DIR/mg-collect-sls $SLS_NAMESPACE $OUTPUT_DIR
+
+      $MG_SCRIPT_DIR/mg-collect-pods $SLS_NAMESPACE $POD_LOGS $OUTPUT_DIR/resources
+      for RESOURCE in configmaps secrets services routes deployments jobs operatorconditions clusterserviceversions installplans subscriptions serviceaccounts roles rolebindings
+      do
+        $MG_SCRIPT_DIR/mg-collect-resources -n $SLS_NAMESPACE -r $RESOURCE -d $OUTPUT_DIR/resources
+      done
+    fi
   done
 
   python3 $MG_SCRIPT_DIR/summarizer/mg-print-summary.py $OUTPUT_DIR | tee $OUTPUT_DIR/summary.txt

--- a/image/cli/mascli/functions/pipeline_config_applications
+++ b/image/cli/mascli/functions/pipeline_config_applications
@@ -175,6 +175,7 @@ function config_pipeline_applications() {
     fi
     if prompt_for_confirm "+ Install and bind Watson Studio"; then
       MAS_APPWS_BINDINGS_HEALTH_WSL_FLAG=true
+    fi
     if prompt_for_confirm "+ Include industry solutions and add-ons"; then
       echo
       echo "${TEXT_DIM}Define which Manage Industry Solutions and Add-ons to be installed as part of the Manage base install."

--- a/image/cli/mascli/must-gather/mg-collect-mas-iot
+++ b/image/cli/mascli/must-gather/mg-collect-mas-iot
@@ -1,3 +1,26 @@
 #!/bin/bash
+set -e
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
-exit 0
+NAMESPACE=$1
+OUTPUT_DIR=$2
+
+# Collect Reconcile Logs
+# -----------------------------------------------------------------------------
+# Main IoT Component and workspace
+$DIR/mg-collect-reconcile-logs $NAMESPACE ibm-iot-operator $OUTPUT_DIR
+$DIR/mg-collect-reconcile-logs $NAMESPACE workspace-operator $OUTPUT_DIR
+
+# IoT Component Operator Reconcile logs
+for CONTROL_PLANE in actions-operator auth-operator datapower-operator devops-operator dm-operator dsc-operator edgeconfig-operator fpl-operator guardian-operator mbgx-operator mfgx-operator monitor-operator orgmgmt-operator provision-operator registry-operator state-operator webui-operator workspace-operator
+do
+  $DIR/mg-collect-reconcile-logs -n $NAMESPACE -r $RESOURCE -d $OUTPUT_DIR/resources
+done
+
+
+# Collect IoT Custom Resources
+# -----------------------------------------------------------------------------
+for RESOURCE in IoT IoTWorkspace Truststore Actions Auth DataPower Devops Dm Dsc Edgeconfig Fpl Guardian Mbgx Mfgx Monitor Orgmgmt Provision Registry State WebUI 
+do
+  $DIR/mg-collect-resources -n $NAMESPACE -r $RESOURCE -d $OUTPUT_DIR/resources
+done

--- a/image/cli/mascli/must-gather/mg-collect-mas-iot
+++ b/image/cli/mascli/must-gather/mg-collect-mas-iot
@@ -1,9 +1,12 @@
 #!/bin/bash
-set -e
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 NAMESPACE=$1
 OUTPUT_DIR=$2
+
+# Collect MBGX Logs
+# -----------------------------------------------------------------------------
+$DIR/mg-collect-mbgx-logs $NAMESPACE $OUTPUT_DIR
 
 # Collect Reconcile Logs
 # -----------------------------------------------------------------------------
@@ -14,9 +17,8 @@ $DIR/mg-collect-reconcile-logs $NAMESPACE workspace-operator $OUTPUT_DIR
 # IoT Component Operator Reconcile logs
 for CONTROL_PLANE in actions-operator auth-operator datapower-operator devops-operator dm-operator dsc-operator edgeconfig-operator fpl-operator guardian-operator mbgx-operator mfgx-operator monitor-operator orgmgmt-operator provision-operator registry-operator state-operator webui-operator workspace-operator
 do
-  $DIR/mg-collect-reconcile-logs -n $NAMESPACE -r $RESOURCE -d $OUTPUT_DIR/resources
+  $DIR/mg-collect-reconcile-logs $NAMESPACE $CONTROL_PLANE $OUTPUT_DIR
 done
-
 
 # Collect IoT Custom Resources
 # -----------------------------------------------------------------------------

--- a/image/cli/mascli/must-gather/mg-collect-mbgx-logs
+++ b/image/cli/mascli/must-gather/mg-collect-mbgx-logs
@@ -1,0 +1,39 @@
+#!/bin/bash
+set -e
+
+NAMESPACE=$1
+OUTPUT_DIR=$2
+MBGX_PODS=$(oc -n $NAMESPACE get pods -l "app=mbgx-messagesight" -o jsonpath="{.items[*].metadata.name}")
+
+for MBGX_POD in $MBGX_PODS
+do
+  set +e
+  LOGFILES=$(oc -n $NAMESPACE exec $MBGX_POD -- find /var/messagesight/diag/logs/ -name *.log 2>/dev/null)
+  if [[ "$?" == "1" ]]; then
+    exit 0
+  fi
+  set -e
+
+  MBGX_LOG_DESTINATION_DIR=${OUTPUT_DIR}/mbgx-logs/$MBGX_POD
+  mkdir -p $MBGX_LOG_DESTINATION_DIR
+
+  echo "  - Collecting mbgx logs from '$MBGX_POD'"
+  set +e # the tar command may give warnings if files no longer exist, and they get cycled by the operator.
+  oc -n $NAMESPACE exec $MBGX_POD -- tar -czf - $LOGFILES > $MBGX_LOG_DESTINATION_DIR/mbgx-logs-$MBGX_POD.tgz 2> /dev/null
+  if [[ "$?" != "0" ]]; then
+    echo "    - Incomplete mbgx logs from $MBGX_POD"
+  fi
+  tar -xf $MBGX_LOG_DESTINATION_DIR/mbgx-logs-$MBGX_POD.tgz -C $MBGX_LOG_DESTINATION_DIR 2> /dev/null
+
+  if [[ "$?" == "0" ]]; then
+    mv $MBGX_LOG_DESTINATION_DIR/var/messagesight/diag/logs/* $MBGX_LOG_DESTINATION_DIR
+    rm $MBGX_LOG_DESTINATION_DIR/mbgx-logs-$MBGX_POD.tgz 
+    rm -r $MBGX_LOG_DESTINATION_DIR/var
+
+  else
+    echo "    - Unable to get mbgx logs from $MBGX_POD"
+  fi
+  set -e
+
+done  # MBGX_POD
+

--- a/image/cli/mascli/must-gather/mg-collect-mbgx-logs
+++ b/image/cli/mascli/must-gather/mg-collect-mbgx-logs
@@ -14,7 +14,7 @@ do
   fi
   set -e
 
-  MBGX_LOG_DESTINATION_DIR=${OUTPUT_DIR}/mbgx-logs/$MBGX_POD
+  MBGX_LOG_DESTINATION_DIR=${OUTPUT_DIR}/resources/${NAMESPACE}/mbgx-logs/$MBGX_POD
   mkdir -p $MBGX_LOG_DESTINATION_DIR
 
   echo "  - Collecting mbgx logs from '$MBGX_POD'"
@@ -26,6 +26,8 @@ do
   tar -xf $MBGX_LOG_DESTINATION_DIR/mbgx-logs-$MBGX_POD.tgz -C $MBGX_LOG_DESTINATION_DIR 2> /dev/null
 
   if [[ "$?" == "0" ]]; then
+    # Move the MBGX log files to the correct place in the must gather directory structure
+    #
     mv $MBGX_LOG_DESTINATION_DIR/var/messagesight/diag/logs/* $MBGX_LOG_DESTINATION_DIR
     rm $MBGX_LOG_DESTINATION_DIR/mbgx-logs-$MBGX_POD.tgz 
     rm -r $MBGX_LOG_DESTINATION_DIR/var

--- a/image/cli/mascli/must-gather/mg-collect-reconcile-logs
+++ b/image/cli/mascli/must-gather/mg-collect-reconcile-logs
@@ -17,13 +17,18 @@ TMP_DIR=${OUTPUT_DIR}/tmp-$CONTROL_PLANE
 mkdir -p $TMP_DIR
 
 echo "  - Collecting reconcile logs from control plane '$CONTROL_PLANE'"
+set +e # the tar command may give warnings if files no longer exist, and they get cycled by the operator.
 oc -n $NAMESPACE exec $POD -- tar -czf - $LOGFILES > $TMP_DIR/ansible-logs-$CONTROL_PLANE.tgz 2> /dev/null
+if [[ "$?" != "0" ]]; then
+  echo "    - Incomplete reconcile logs from $POD"
+fi
 tar -xf $TMP_DIR/ansible-logs-$CONTROL_PLANE.tgz -C $TMP_DIR 2> /dev/null
 if [[ "$?" == "0" ]]; then
   rm $TMP_DIR/ansible-logs-$CONTROL_PLANE.tgz
 else
-  echo_warning "    - Unable to get reconcile logs from $POD"
+  echo "    - Unable to get reconcile logs from $POD"
 fi
+set -e
 
 for API_DIR in $TMP_DIR/tmp/ansible-operator/runner/*
 do

--- a/image/cli/mascli/must-gather/mg-collect-reconcile-logs
+++ b/image/cli/mascli/must-gather/mg-collect-reconcile-logs
@@ -18,7 +18,7 @@ set -e
 TMP_DIR=${OUTPUT_DIR}/tmp-$LABEL_VALUE
 mkdir -p $TMP_DIR
 
-echo " - Collecting reconcile logs from '$LABEL_SELECTOR':'$LABEL_VALUE'"
+echo "  - Collecting reconcile logs from '$LABEL_SELECTOR':'$LABEL_VALUE'"
 oc -n $NAMESPACE exec $POD -- tar -czf - $LOGFILES > $TMP_DIR/ansible-logs-$LABEL_VALUE.tgz 2> /dev/null
 tar -xf $TMP_DIR/ansible-logs-$LABEL_VALUE.tgz -C $TMP_DIR 2> /dev/null
 
@@ -27,7 +27,6 @@ if [[ "$?" == "0" ]]; then
 else
   echo_warning "    - Unable to get reconcile logs from $POD"
 fi
-set -e
 
 for API_DIR in $TMP_DIR/tmp/ansible-operator/runner/*
 do

--- a/image/cli/mascli/must-gather/mg-collect-reconcile-logs
+++ b/image/cli/mascli/must-gather/mg-collect-reconcile-logs
@@ -18,18 +18,14 @@ set -e
 TMP_DIR=${OUTPUT_DIR}/tmp-$LABEL_VALUE
 mkdir -p $TMP_DIR
 
-echo "  - Collecting reconcile logs from control plane '$CONTROL_PLANE'"
-set +e # the tar command may give warnings if files no longer exist, and they get cycled by the operator.
-oc -n $NAMESPACE exec $POD -- tar -czf - $LOGFILES > $TMP_DIR/ansible-logs-$CONTROL_PLANE.tgz 2> /dev/null
-if [[ "$?" != "0" ]]; then
-  echo "    - Incomplete reconcile logs from $POD"
-fi
-tar -xf $TMP_DIR/ansible-logs-$CONTROL_PLANE.tgz -C $TMP_DIR 2> /dev/null
+echo " - Collecting reconcile logs from '$LABEL_SELECTOR':'$LABEL_VALUE'"
+oc -n $NAMESPACE exec $POD -- tar -czf - $LOGFILES > $TMP_DIR/ansible-logs-$LABEL_VALUE.tgz 2> /dev/null
+tar -xf $TMP_DIR/ansible-logs-$LABEL_VALUE.tgz -C $TMP_DIR 2> /dev/null
 
 if [[ "$?" == "0" ]]; then
   rm $TMP_DIR/ansible-logs-$LABEL_VALUE.tgz
 else
-  echo "    - Unable to get reconcile logs from $POD"
+  echo_warning "    - Unable to get reconcile logs from $POD"
 fi
 set -e
 

--- a/image/cli/mascli/must-gather/mg-collect-sls
+++ b/image/cli/mascli/must-gather/mg-collect-sls
@@ -1,0 +1,20 @@
+#!/bin/bash
+set -e
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+NAMESPACE=$1
+OUTPUT_DIR=$2
+
+# Collect Reconcile Logs
+# -----------------------------------------------------------------------------
+# Primary Resources
+$DIR/mg-collect-reconcile-logs $NAMESPACE controller-manager $OUTPUT_DIR
+
+# Collect SLS Resources
+# -----------------------------------------------------------------------------
+for RESOURCE in LicenseService LicenseClient
+do
+  $DIR/mg-collect-resources -n $NAMESPACE -r $RESOURCE -d $OUTPUT_DIR/resources
+done
+
+exit 0

--- a/image/cli/mascli/must-gather/mg-summary-sls
+++ b/image/cli/mascli/must-gather/mg-summary-sls
@@ -2,12 +2,14 @@
 
 echo "IBM Suite Licensing Service"
 echo "--------------------------------------------------------------------------------"
+echo ""
 echo "- License Service"
+echo ""
 oc get LicenseService -A
 echo ""
 
 echo "- License Client"
-echo "--------------------------------------------------------------------------------"
+echo ""
 oc get LicenseClient -A
 echo ""
 

--- a/image/cli/mascli/must-gather/mg-summary-sls
+++ b/image/cli/mascli/must-gather/mg-summary-sls
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+echo "IBM Suite Licensing Service"
+echo "--------------------------------------------------------------------------------"
+echo "- License Service"
+oc get LicenseService -A
+echo ""
+
+echo "- License Client"
+echo "--------------------------------------------------------------------------------"
+oc get LicenseClient -A
+echo ""
+
+exit 0


### PR DESCRIPTION
Add reconcile logs, operator CRs and mbgx trace logs in the mustgather for IoT
Add reconcile logs, CRs, standard kubernetes resource descriptions and summary for SLS

Implementing issues https://github.com/ibm-mas/cli/issues/279 and https://github.com/ibm-mas/cli/issues/286 (https://jsw.ibm.com/browse/IBMIOT-61 and https://jsw.ibm.com/browse/IBMSLS-2)

tested by running must-gathers against fvtstable environment