### PR TITLE
[minor] Replace scaling test suite with new podtemplates suite

### DIFF
--- a/tekton/src/params/install.yml.j2
+++ b/tekton/src/params/install.yml.j2
@@ -362,10 +362,6 @@
   type: string
   default: ""
   description: Optional boolean parameter that when set to False, disables the normal trust of well known public certificate authorities
-- name: mas_customize_scaling
-  type: string
-  default: ""
-  description: Workload Scaling Custom ConfigMap Name
 - name: mas_manual_cert_mgmt
   type: string
   default: "False"

--- a/tekton/src/pipelines/taskdefs/core/suite-install.yml.j2
+++ b/tekton/src/pipelines/taskdefs/core/suite-install.yml.j2
@@ -29,8 +29,6 @@
       value: $(params.mas_icr_cpopen)
     - name: ibm_entitlement_key
       value: $(params.ibm_entitlement_key)
-    - name: mas_customize_scaling
-      value: $(params.mas_customize_scaling)
     - name: mas_manual_cert_mgmt
       value: $(params.mas_manual_cert_mgmt)
     - name: mas_trust_default_cas

--- a/tekton/src/tasks/fvt/fvt-core-phase4.yml.j2
+++ b/tekton/src/tasks/fvt/fvt-core-phase4.yml.j2
@@ -110,7 +110,7 @@ spec:
     # 5. CoreIDP - SSO Config ... ???
     # 6. Licensing API .......... ???
     # 7. SMTP ................... Temporarily disables SMTP integration
-    # 8. Scaling ................ ???
+    # 8. Podtemplates ........... Affects resources (cpu, mem), number of replicas and affinity configuration
     # 9. Trust CAs .............. ???
     # 10. Operator Maturity ...... Other tests result in generation of resources in the cluster that we want to test
 
@@ -226,9 +226,9 @@ spec:
         - name: TEST_SUITE
           value: smtp
 
-    # 8. core-scaling
+    # 8. podtemplates
     # -------------------------------------------------------------------------
-    - name: fvt-core-scaling
+    - name: fvt-podtemplates
       image: '$(params.fvt_image_registry)/mas-devops/fvt-ibm-mas@$(params.fvt_image_digest)'
       imagePullPolicy: $(params.image_pull_policy)
       timeout: 2h0m0s # Ensure bad FVTs don't run forever
@@ -240,7 +240,7 @@ spec:
           name: dshm
       env:
         - name: TEST_SUITE
-          value: core-scaling
+          value: podtemplates
 
     # 9. core-trustcas
     # -------------------------------------------------------------------------

--- a/tekton/src/tasks/suite-install.yml.j2
+++ b/tekton/src/tasks/suite-install.yml.j2
@@ -59,11 +59,6 @@ spec:
     - name: ibm_entitlement_key
       type: string
 
-    - name: mas_customize_scaling
-      type: string
-      default: ""
-      description: Optional Workload Scaling Custom ConfigMap Name
-
     - name: artifactory_username
       default: ''
       type: string
@@ -120,9 +115,6 @@ spec:
 
       - name: IBM_ENTITLEMENT_KEY
         value: $(params.ibm_entitlement_key)
-
-      - name: MAS_CUSTOMIZE_SCALING
-        value: $(params.mas_customize_scaling)
 
   steps:
     - name: suite-install


### PR DESCRIPTION
1. Removed var mas_customize_scaling
2. cleaned up reference to the old test suite which was used for scaling
3. Added reference to new test suite called podtemplates.
4. Podtemplates takes care of scaling, affinity and resource type