### PR TITLE
[minor] Add parameter to limit collection of some MAS instances

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -1,0 +1,6 @@
+adding a parameter --mas-instance-ids to the must-gather command to specify one or more instances to collect data from.
+when specified this only data from these instance will be collected along with data for Mongo and the cluster data.
+
+this is to avoid collecting instance details for different customers in case of multi tennant environment.
+
+when specified, only data from this/these instance(s) will be collected along with data for Mongo and the cluster data.

--- a/docs/commands/must-gather.md
+++ b/docs/commands/must-gather.md
@@ -12,6 +12,7 @@ Usage
 - `--no-pod-logs` Skip collection of pod logs, greatly speeds up must-gather collection time when pod logs are not required
 - `--artifactory-token ARTIFACTORY_TOKEN` Provide a token for Artifactory to automatically upload the file to `ARTIFACTORY_UPLOAD_DIRECTORY`
 - `--artifactory-upload-directory ARTIFACTORY_UPLOAD_DIRECTORY` Working URL to the root directory in Artifactory where the must-gather file should be uploaded
+- `--mas-instance-ids` Collects the data for the specifed MAS instances, if not specified will collect for all MAS instances on the cluster
 
 Content
 -------------------------------------------------------------------------------

--- a/image/cli/mascli/functions/must_gather
+++ b/image/cli/mascli/functions/must_gather
@@ -14,6 +14,7 @@ Collection Options (Optional):
   -k, --keep-files           Do not delete individual files after creating the must-gather compressed tar archive
   --summary-only             Perform a much faster must-gather that only gathers high level summary of resources in the cluster
   --no-pod-logs              Skip collection of pod logs, greatly speeds up must-gather collection time when pod logs are not required
+  --mas-instance-ids         Collects the data for the specifed MAS instances, if not specified will collect for all MAS instances on the cluster
 
 Artifactory Upload (Optional):
   --artifactory-token ${COLOR_YELLOW}ARTIFACTORY_TOKEN${TEXT_RESET}              Provide a token for Artifactory to automatically upload the file to ARTIFACTORY_UPLOAD_DIR
@@ -54,6 +55,9 @@ function mustgather() {
       ;;
     --no-logs|--no-pod-logs)
       POD_LOGS=false
+      ;;
+    --mas-instance-ids)
+      MAS_INSTANCE_IDS=$1; shift 
       ;;
     --artifactory-token)
       ARTIFACTORY_TOKEN=$1; shift
@@ -151,10 +155,13 @@ function mustgather() {
     $MG_SCRIPT_DIR/mg-collect-mongoce $MONGOCE_NAMESPACE $OUTPUT_DIR
   done
 
+  if [[ -z $MAS_INSTANCE_IDS ]]
+  then
+    # Find MAS instances
+    # -----------------------------------------------------------------------------
+    MAS_INSTANCE_IDS=$(oc get suite --all-namespaces --ignore-not-found -o jsonpath='{.items[*].metadata.name}')
+  fi
 
-  # Find MAS instances
-  # -----------------------------------------------------------------------------
-  MAS_INSTANCE_IDS=$(oc get suite --all-namespaces --ignore-not-found -o jsonpath='{.items[*].metadata.name}')
   echo ""
   for MAS_INSTANCE_ID in $MAS_INSTANCE_IDS
   do


### PR DESCRIPTION
adding a parameter --mas-instance-ids to the must-gather command to specify one or more instances to collect data from.

when specified this optional parameter, only data from these instances will be collected along with data for Mongo and the cluster data.