### PR TITLE
[patch] Fix Manage optional configuration

### DIFF
--- a/image/cli/mascli/functions/connect
+++ b/image/cli/mascli/functions/connect
@@ -1,7 +1,6 @@
 #!/bin/bash
 
 function connect() {
-  echo
   echo_h2 "Set Target OpenShift Cluster"
 
   PROMPT_FOR_LOGIN=false

--- a/image/cli/mascli/functions/pipeline_config
+++ b/image/cli/mascli/functions/pipeline_config
@@ -70,7 +70,7 @@ function pipeline_config() {
 
   echo
   echo_h2 "License Terms"
-  echo -e "${COLOR_YELLOW} For information about your license, see "$MAS_LICENSE_LINK " To continue with the installation, you must accept the license terms."
+  echo -e "${COLOR_YELLOW}For information about your license, see "$MAS_LICENSE_LINK " To continue with the installation, you must accept the license terms."
   prompt_for_confirm_default_yes "Do you accept the license terms?" LICENSE_RESPONSE
 
   if [[ "$LICENSE_RESPONSE" == "false" ]]; then
@@ -124,7 +124,7 @@ function pipeline_config() {
   echo_h2 "Configure Operation Mode"
   echo "${TEXT_DIM}Maximo Application Suite can be installed in a non-production mode for internal development and testing, this setting cannot be changed after installation:"
   echo " - All applications, add-ons, and solutions have 0 (zero) installation AppPoints in non-production installations."
-  echo " - These specifications are also visible in the metrics that are shared with IBM® and on the product UI."
+  echo " - These specifications are also visible in the metrics that are shared with IBM and in the product UI."
   echo
   reset_colors
   prompt_for_confirm "Use non-production mode?" USE_NON_PROD_MODE

--- a/image/cli/mascli/functions/pipeline_config_applications
+++ b/image/cli/mascli/functions/pipeline_config_applications
@@ -138,7 +138,11 @@ function config_pipeline_applications() {
   # Manage
   if prompt_for_confirm "Install Manage"; then
     channel_select_manage || exit 1
+
+    # Manage Settings - Populate database with demo data
     prompt_for_confirm "+ Create demo data" MAS_APP_SETTINGS_DEMODATA
+
+    # Manage Settings - Configure JMS
     if prompt_for_confirm "+ Configure JMS"; then
       MAS_APP_SETTINGS_DEFAULT_JMS=true
       MAS_APP_SETTINGS_PERSISTENT_VOLUMES_FLAG=true
@@ -148,6 +152,8 @@ function config_pipeline_applications() {
         MAS_APP_SETTINGS_SERVER_BUNDLES_SIZE='jms' # will deploy manage with 'mea','rpt','ui','cron' and 'jms' bundle pods
       fi
     fi
+
+    # Manage Settings - Configure Database
     if prompt_for_confirm "+ Customize database settings"; then
       MAS_APP_SETTINGS_DB2_SCHEMA='maximo'
       MAS_APP_SETTINGS_TABLESPACE='MAXDATA'
@@ -165,6 +171,8 @@ function config_pipeline_applications() {
         fi
       fi
     fi
+
+    # Manage Settings - Customization
     if prompt_for_confirm "+ Include customization archive"; then
       MAS_APP_SETTINGS_CUSTOMIZATION_ARCHIVE_NAME='manage-custom-archive'
       prompt_for_input "Customization archive name" MAS_APP_SETTINGS_CUSTOMIZATION_ARCHIVE_NAME
@@ -174,18 +182,19 @@ function config_pipeline_applications() {
         prompt_for_secret "Password" MAS_APP_SETTINGS_CUSTOMIZATION_ARCHIVE_PASSWORD
       fi
     fi
-    if prompt_for_confirm "+ Install and bind Watson Studio"; then
+
+    # Manage Bindings - Watson Studio Local
+    if prompt_for_confirm "+ Install and bind Watson Studio Local"; then
       MAS_APPWS_BINDINGS_HEALTH_WSL_FLAG=true
     fi
-    if prompt_for_confirm "+ Include industry solutions and add-ons"; then
+
+    # Manage Settings - Configure Components
+    if prompt_for_confirm "+ Customize Manage Components"; then
       echo
-      echo "${TEXT_DIM}Define which Manage Industry Solutions and Add-ons to be installed as part of the Manage base install."
-      echo "Include the Manage components and corresponding target version to be installed using comma-separated values."
-      echo
-      echo "Example: By default, Manage and Health will be installed, however to include Civil as additional component, type 'base=latest,health=latest,civil=latest'"
+      echo "${TEXT_DIM}Define which Manage Industry Solutions and Add-ons will be configured in the Manage install."
+      echo "Provide a comma-separated list of component=version values, e.g. 'base=latest,health=latest,civil=latest'"
       echo
       reset_colors
-      MAS_APPWS_COMPONENTS="base=latest,health=latest"
       prompt_for_input "Manage components to be installed" MAS_APPWS_COMPONENTS
       if [[ -z "$MAS_APPWS_COMPONENTS" ]]; then
         MAS_APPWS_COMPONENTS="base=latest,health=latest"

--- a/image/cli/mascli/functions/pipeline_config_applications
+++ b/image/cli/mascli/functions/pipeline_config_applications
@@ -120,139 +120,204 @@ function config_pipeline_applications() {
   MAS_APP_CHANNEL_OPTIMIZER='';
   MAS_APP_PLAN_OPTIMIZER=''
 
-  # IoT and Monitor haven't been tested on Single Node OpenShift
   if [[ "$SNO_MODE" != "true" ]]; then
     # IoT
-    if prompt_for_confirm "Install IoT"; then
+    if prompt_for_confirm "Install IoT?"; then
       channel_select_iot || exit 1
     fi
 
     if [[ "$MAS_APP_CHANNEL_IOT" != '' ]]; then
       # Monitor
-      if prompt_for_confirm "Install Monitor"; then
+      if prompt_for_confirm "Install Monitor?"; then
         channel_select_monitor || exit 1
       fi
     fi
   fi
 
   # Manage
-  if prompt_for_confirm "Install Manage"; then
+  if prompt_for_confirm "Install Manage?"; then
     channel_select_manage || exit 1
-
-    # Manage Settings - Populate database with demo data
-    prompt_for_confirm "+ Create demo data" MAS_APP_SETTINGS_DEMODATA
-
-    # Manage Settings - Configure JMS
-    if prompt_for_confirm "+ Configure JMS"; then
-      MAS_APP_SETTINGS_DEFAULT_JMS=true
-      MAS_APP_SETTINGS_PERSISTENT_VOLUMES_FLAG=true
-      if [[ "$SNO_MODE" == "true" ]]; then
-        MAS_APP_SETTINGS_SERVER_BUNDLES_SIZE='snojms' # will just deploy manage with 'all' + 'jms' bundle pods
-      else
-        MAS_APP_SETTINGS_SERVER_BUNDLES_SIZE='jms' # will deploy manage with 'mea','rpt','ui','cron' and 'jms' bundle pods
-      fi
-    fi
-
-    # Manage Settings - Configure Database
-    if prompt_for_confirm "+ Customize database settings"; then
-      MAS_APP_SETTINGS_DB2_SCHEMA='maximo'
-      MAS_APP_SETTINGS_TABLESPACE='MAXDATA'
-      MAS_APP_SETTINGS_INDEXSPACE='MAXINDEX'
-      prompt_for_input "Schema" MAS_APP_SETTINGS_DB2_SCHEMA
-      prompt_for_input "Tablespace" MAS_APP_SETTINGS_TABLESPACE
-      prompt_for_input "Indexspace" MAS_APP_SETTINGS_INDEXSPACE
-      if prompt_for_confirm "+ Customize database encryption settings"; then
-        prompt_for_input "MXE_SECURITY_CRYPTO_KEY" MAS_APP_SETTINGS_CRYPTO_KEY
-        prompt_for_input "MXE_SECURITY_CRYPTOX_KEY" MAS_APP_SETTINGS_CRYPTOX_KEY
-        prompt_for_input "MXE_SECURITY_OLD_CRYPTO_KEY" MAS_APP_SETTINGS_OLD_CRYPTO_KEY
-        prompt_for_input "MXE_SECURITY_OLD_CRYPTOX_KEY" MAS_APP_SETTINGS_OLD_CRYPTOX_KEY
-        if prompt_for_confirm "Override database encryption secrets with provided keys"; then
-          MAS_APP_SETTINGS_OVERRIDE_ENCRYPTION_SECRETS_FLAG=true
-        fi
-      fi
-    fi
-
-    # Manage Settings - Customization
-    if prompt_for_confirm "+ Include customization archive"; then
-      MAS_APP_SETTINGS_CUSTOMIZATION_ARCHIVE_NAME='manage-custom-archive'
-      prompt_for_input "Customization archive name" MAS_APP_SETTINGS_CUSTOMIZATION_ARCHIVE_NAME
-      prompt_for_input "Customization archive url" MAS_APP_SETTINGS_CUSTOMIZATION_ARCHIVE_URL
-      if prompt_for_confirm "+ Provide authentication to access customization archive url"; then
-        prompt_for_input "Username" MAS_APP_SETTINGS_CUSTOMIZATION_ARCHIVE_USERNAME
-        prompt_for_secret "Password" MAS_APP_SETTINGS_CUSTOMIZATION_ARCHIVE_PASSWORD
-      fi
-    fi
-
-    # Manage Bindings - Watson Studio Local
-    if prompt_for_confirm "+ Install and bind Watson Studio Local"; then
-      MAS_APPWS_BINDINGS_HEALTH_WSL_FLAG=true
-    fi
-
-    # Manage Settings - Configure Components
-    if prompt_for_confirm "+ Customize Manage Components"; then
-      echo
-      echo "${TEXT_DIM}Define which Manage Industry Solutions and Add-ons will be configured in the Manage install."
-      echo "Provide a comma-separated list of component=version values, e.g. 'base=latest,health=latest,civil=latest'"
-      echo
-      reset_colors
-      prompt_for_input "Manage components to be installed" MAS_APPWS_COMPONENTS
-      if [[ -z "$MAS_APPWS_COMPONENTS" ]]; then
-        MAS_APPWS_COMPONENTS="base=latest,health=latest"
-      fi
-    fi
   fi
 
-  # Optimizer, Predict, Visual Inspection, & Assist haven't been tested on Single Node OpenShift
   if [[ "$SNO_MODE" != "true" ]]; then
-    if prompt_for_confirm "Install Optimizer"; then
-      channel_select_optimizer || exit 1
-      # Optimizer install Plan + Validation
-      while : ; do
-        prompt_for_input '+ Plan [full/limited]' MAS_APP_PLAN_OPTIMIZER "full"
-        [[ "$MAS_APP_PLAN_OPTIMIZER" != "full" && "$MAS_APP_PLAN_OPTIMIZER" != "limited" ]] || break
-      done
-    fi
-
-    # Maximo Visual Inspection
-    if prompt_for_confirm "Install Visual Inspection"; then
-     channel_select_visualinspection || exit 1
-    fi
-
-    # Applications that require Manage
-    # TODO: these applications require Health component specifically,
-    # need to review this code when add-ons selection are in place
     if [[ "$MAS_APP_CHANNEL_MANAGE" != '' ]]; then
       # Predict
-      if prompt_for_confirm "Install Predict"; then
+      if prompt_for_confirm "Install Predict?"; then
         channel_select_predict || exit 1
-        if prompt_for_confirm "+ Install IBM SPSS Statistics"; then
-          CPD_INSTALL_SPSS=true
-        fi
-        if prompt_for_confirm "+ Install Watson OpenScale"; then
-          CPD_INSTALL_OPENSCALE=true
-        fi
       fi
     fi
 
     # Assist
-    if prompt_for_confirm "Install Assist"; then
+    if prompt_for_confirm "Install Assist?"; then
       channel_select_assist || exit 1
     fi
 
-    # Assist Dependencies
-    if [[ "$MAS_APP_CHANNEL_ASSIST" != '' ]]; then
-      while : ; do
-        prompt_for_input 'COS Provider [ibm/ocs]' COS_TYPE "ibm"
-        [[ "$COS_TYPE" != "ibm" && "$COS_TYPE" != "ocs" ]] || break
-      done
-      if [[ "$COS_TYPE" == "ibm" ]]; then
-        prompt_for_input "IBM Cloud API Key" IBMCLOUD_APIKEY $IBMCLOUD_APIKEY
-        prompt_for_input "IBM Cloud Resource Group" IBMCLOUD_RESOURCEGROUP $IBMCLOUD_RESOURCEGROUP "Default"
-      fi
+    if prompt_for_confirm "Install Optimizer?"; then
+      channel_select_optimizer || exit 1
     fi
 
-    if [[ "$MAS_APP_CHANNEL_PREDICT" != "" || "$MAS_APP_CHANNEL_ASSIST" != "" ]]; then
-      cp4d_channel_selection
+    # Maximo Visual Inspection
+    if prompt_for_confirm "Install Visual Inspection?"; then
+     channel_select_visualinspection || exit 1
     fi
   fi
+
+  if [[ "$MAS_APP_CHANNEL_ASSIST" != '' ]]; then assist_settings; fi
+  if [[ "$MAS_APP_CHANNEL_MANAGE" != '' ]]; then manage_settings; fi
+  if [[ "$MAS_APP_CHANNEL_OPTIMIZER" != '' ]]; then optimizer_settings; fi
+  if [[ "$MAS_APP_CHANNEL_PREDICT" != '' ]]; then predict_settings; fi
+
+  if [[ "$MAS_APP_CHANNEL_PREDICT" != "" || "$MAS_APP_CHANNEL_ASSIST" != "" ]]; then
+    cp4d_channel_selection
+  fi
+
+}
+
+
+# Assist Settings Function
+# -----------------------------------------------------------------------------
+function assist_settings() {
+  echo
+  echo_h3 "Configure Maximo Assist"
+  echo "${TEXT_DIM}Assist requires access to Cloud Object Storage (COS), this install supports automatic setup using either IBMCloud COS or in-cluster COS via OpenShift Container Storage/OpenShift Data Foundation (OCS/ODF)."
+  reset_colors
+  echo
+  while : ; do
+    prompt_for_input 'COS Provider [ibm/ocs]' COS_TYPE "ibm"
+    [[ "$COS_TYPE" != "ibm" && "$COS_TYPE" != "ocs" ]] || break
+  done
+  if [[ "$COS_TYPE" == "ibm" ]]; then
+    prompt_for_input "IBM Cloud API Key" IBMCLOUD_APIKEY $IBMCLOUD_APIKEY
+    prompt_for_input "IBM Cloud Resource Group" IBMCLOUD_RESOURCEGROUP $IBMCLOUD_RESOURCEGROUP "Default"
+  fi
+}
+
+
+# Manage Settings Function
+# -----------------------------------------------------------------------------
+function manage_settings() {
+  echo
+  echo_h3 "Configure Maximo Manage"
+  echo "${TEXT_DIM}Customize your Manage installation, refer to the product documentation for more information."
+  reset_colors
+
+  case $MAS_APP_CHANNEL_MANAGE in
+    8.9.x|8.10.x)
+      # Manage Bindings - Watson Studio Local (Manage v8.11 + only)
+      echo
+      echo_h4 "Manage Binding Configuration"
+      if prompt_for_confirm "Install and bind Watson Studio Local?"; then
+        MAS_APPWS_BINDINGS_HEALTH_WSL_FLAG=true
+      fi
+      ;;
+  esac
+
+  # Manage Component Selection
+  echo
+  echo_h4 "Manage Component Selection"
+  echo "${TEXT_DIM}Define which Manage Industry Solutions and Add-ons will be configured in the Manage install."
+  echo "Provide a comma-separated list of component=version values, e.g. 'base=latest,health=latest,civil=latest'"
+  reset_colors
+  echo
+  if prompt_for_confirm "Customize Manage components?"; then
+    prompt_for_input "Manage components to be installed" MAS_APPWS_COMPONENTS
+    if [[ -z "$MAS_APPWS_COMPONENTS" ]]; then
+      MAS_APPWS_COMPONENTS="base=latest,health=latest"
+    fi
+  fi
+
+  # Manage Settings - Database
+  echo
+  echo_h4 "Manage Settings - Database"
+  echo "${TEXT_DIM}Customise the schema, tablespace, indexspace, and encryption settings used by Manage"
+  reset_colors
+  echo
+  if prompt_for_confirm "Customize database settings?"; then
+    MAS_APP_SETTINGS_DB2_SCHEMA='maximo'
+    MAS_APP_SETTINGS_TABLESPACE='MAXDATA'
+    MAS_APP_SETTINGS_INDEXSPACE='MAXINDEX'
+    prompt_for_input "Schema" MAS_APP_SETTINGS_DB2_SCHEMA
+    prompt_for_input "Tablespace" MAS_APP_SETTINGS_TABLESPACE
+    prompt_for_input "Indexspace" MAS_APP_SETTINGS_INDEXSPACE
+    echo
+    if prompt_for_confirm "Customize database encryption settings?"; then
+      # TODO: Someone needs to explain what these actually do (with a link to documentation) and change the env vars to meaningful labels
+      prompt_for_input "MXE_SECURITY_CRYPTO_KEY" MAS_APP_SETTINGS_CRYPTO_KEY
+      prompt_for_input "MXE_SECURITY_CRYPTOX_KEY" MAS_APP_SETTINGS_CRYPTOX_KEY
+      prompt_for_input "MXE_SECURITY_OLD_CRYPTO_KEY" MAS_APP_SETTINGS_OLD_CRYPTO_KEY
+      prompt_for_input "MXE_SECURITY_OLD_CRYPTOX_KEY" MAS_APP_SETTINGS_OLD_CRYPTOX_KEY
+      if prompt_for_confirm "Override database encryption secrets with provided keys"; then
+        MAS_APP_SETTINGS_OVERRIDE_ENCRYPTION_SECRETS_FLAG=true
+      fi
+    fi
+  fi
+
+  # Manage Settings - Customization
+  echo
+  echo_h4 "Manage Settings - Customization"
+  # TODO: Improve the guidance here.  e.g. Should the url include the filename, or is archive name appended to the URL?
+  echo "${TEXT_DIM}Provide a customization archive to be used in the Manage build process"
+  reset_colors
+  echo
+  if prompt_for_confirm "Include customization archive?"; then
+    MAS_APP_SETTINGS_CUSTOMIZATION_ARCHIVE_NAME='manage-custom-archive'
+    prompt_for_input "Customization archive name" MAS_APP_SETTINGS_CUSTOMIZATION_ARCHIVE_NAME
+    prompt_for_input "Customization archive url" MAS_APP_SETTINGS_CUSTOMIZATION_ARCHIVE_URL
+    if prompt_for_confirm "Provide authentication to access customization archive URL?"; then
+      prompt_for_input "Username" MAS_APP_SETTINGS_CUSTOMIZATION_ARCHIVE_USERNAME
+      prompt_for_secret "Password" MAS_APP_SETTINGS_CUSTOMIZATION_ARCHIVE_PASSWORD
+    fi
+  fi
+
+  # Manage Settings - Other
+  echo
+  echo_h4 "Manage Settings - Other"
+  echo "${TEXT_DIM}Other miscellanous settings for the installation"
+  reset_colors
+  echo
+  prompt_for_confirm "Create demo data?" MAS_APP_SETTINGS_DEMODATA
+  if prompt_for_confirm "Configure JMS?"; then
+    MAS_APP_SETTINGS_DEFAULT_JMS=true
+    MAS_APP_SETTINGS_PERSISTENT_VOLUMES_FLAG=true
+    if [[ "$SNO_MODE" == "true" ]]; then
+      MAS_APP_SETTINGS_SERVER_BUNDLES_SIZE='snojms' # will just deploy manage with 'all' + 'jms' bundle pods
+    else
+      MAS_APP_SETTINGS_SERVER_BUNDLES_SIZE='jms' # will deploy manage with 'mea','rpt','ui','cron' and 'jms' bundle pods
+    fi
+  fi
+
+}
+
+
+# Predict Settings Function
+# -----------------------------------------------------------------------------
+function predict_settings() {
+  echo
+  echo_h3 "Configure Maximo Predict"
+  echo "${TEXT_DIM}Predict supports the use of optional services in IBM Cloud Pak for Data.  Unless requested these will not be installed with Cloud Pak for Data."
+  reset_colors
+  echo
+  if prompt_for_confirm "Install IBM SPSS Statistics"; then
+    CPD_INSTALL_SPSS=true
+  fi
+  if prompt_for_confirm "Install Watson OpenScale"; then
+    CPD_INSTALL_OPENSCALE=true
+  fi
+}
+
+
+# Optimizer Settings Function
+# -----------------------------------------------------------------------------
+function optimizer_settings() {
+  echo
+  echo_h3 "Configure Maximo Optimizer"
+  # TODO: Provide info + link to documentation about limited versus full
+  echo "${TEXT_DIM}Optimizer supports two install plans - limited and full."
+  reset_colors
+  echo
+
+  while : ; do
+    prompt_for_input 'Plan [full/limited]' MAS_APP_PLAN_OPTIMIZER "full"
+    [[ "$MAS_APP_PLAN_OPTIMIZER" != "full" && "$MAS_APP_PLAN_OPTIMIZER" != "limited" ]] || break
+  done
 }

--- a/image/cli/mascli/functions/pipeline_config_db2
+++ b/image/cli/mascli/functions/pipeline_config_db2
@@ -5,7 +5,6 @@
 function db2_for_iot() {
   if [ "$MAS_APP_CHANNEL_IOT" != "" ]; then
     # Set up system database - using db2u or external datasource
-    echo
     echo_h3 "Database configuration for Maximo IoT"
     echo "${TEXT_DIM}Maximo IoT requires a shared system-scope Db2 instance because others application in the suite require access to the same database source."
     echo " - Only IBM Db2 is supported for this database"
@@ -39,7 +38,6 @@ function db2_for_iot() {
 # -------------------------------------------------------------------------
 function db2_for_manage() {
   if [ "$MAS_APP_CHANNEL_MANAGE" != "" ]; then
-    echo ""
     echo_h3 "Database configuration for Maximo Manage"
     echo "${TEXT_DIM}Maximo Manage can be configured to share the system Db2 instance or use it's own dedicated database:"
     echo " - Use of a shared instance has a significant footprint reduction but is only recommended for development/test/demo installs"
@@ -49,7 +47,7 @@ function db2_for_manage() {
     reset_colors
 
     # Determine whether to use the system or a dedicated database
-    if [ "$MAS_APP_CHANNEL_IOT" == "" ] && prompt_for_confirm_default_yes "Re-use System Db2 instance for Manage application?"; then
+    if [ "$MAS_APP_CHANNEL_IOT" != "" ] && prompt_for_confirm_default_yes "Re-use System Db2 instance for Manage application?"; then
       # We are going to bind Manage to the system database, which has already been set up in the previous step
       MAS_APPWS_BINDINGS_JDBC_MANAGE=system
       DB2_ACTION_MANAGE=none

--- a/image/cli/mascli/functions/pipeline_config_dns
+++ b/image/cli/mascli/functions/pipeline_config_dns
@@ -2,7 +2,7 @@
 function config_pipeline_dns() {
   echo
   echo_h2 "Configure Domain & Certificate Management"
-  if prompt_for_confirm "Configure Custom Domain"; then
+  if prompt_for_confirm "Configure Custom Domain?"; then
     prompt_for_input "MAS Top Level Domain" MAS_DOMAIN
 
     echo
@@ -86,7 +86,7 @@ function config_pipeline_dns() {
         echo "in order for it to be able to resolve DNS entries for all the subdomains created for your Maximo Application Suite instance."
         echo ""
         echo "Therefore, the AWS Route 53 subdomain + the AWS Route 53 hosted zone name defined, when combined, needs to match with the chosen MAS Top Level domain, otherwise the DNS records won't be able to get resolved."
-        echo "" 
+        echo ""
         echo -e "${COLOR_YELLOW}Example:"
         echo "MAS Top Level Domain: masinst1.mycompany.com"
         echo "AWS Route 53 hosted zone name: mycompany.com"

--- a/image/cli/mascli/functions/utils
+++ b/image/cli/mascli/functions/utils
@@ -29,7 +29,8 @@ function echo_h2() {
 
   H2_COUNT=$(($H2_COUNT + 1))
   H3_COUNT=0
-  echo -e "${prefix}${TEXT_UNDERLINE}${H2_COUNT}. ${msg}${TEXT_RESET}"
+  echo
+  echo -e "${prefix}${TEXT_UNDERLINE}${H2_COUNT}) ${msg}${TEXT_RESET}"
 }
 
 function echo_h3() {
@@ -37,7 +38,8 @@ function echo_h3() {
   prefix=$2
 
   H3_COUNT=$(($H3_COUNT + 1))
-  echo -e "${prefix}${TEXT_UNDERLINE}${H2_COUNT}.${H3_COUNT}. ${msg}${TEXT_RESET}"
+  echo
+  echo -e "${prefix}${TEXT_UNDERLINE}${H2_COUNT}.${H3_COUNT}) ${msg}${TEXT_RESET}"
 }
 
 function echo_h4() {


### PR DESCRIPTION
TS014120442

> Problem: there is no option for "8. Application Selection" when installing MAS using ibmmas/cli:6.6.0
> so, cannot select applications to install.

The problem is a recent regression introduced by the new code to support additional settings for the Manage install, which this PR addresses while also tidying up a few formatting issues and resolving a logic failure in the Db2 configuration section when IoT is not installed and Manage is installed that prompts the user to re-use the system database used by IoT (when there hasn't been one set up because IoT is not being installed).

After fix:
![image](https://github.com/ibm-mas/cli/assets/4400618/ec82b0ab-323e-44aa-91f4-309f9cc8ef11)
