### PR TITLE
[patch] Update mas_devops dev version number

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@
 
 ansible-build:
 	ansible-galaxy collection build --output-path image/cli/install-ansible ../ansible-devops/ibm/mas_devops --force
-	mv image/cli/install-ansible/ibm-mas_devops-18.0.0.tar.gz image/cli/install-ansible/ibm-mas_devops.tar.gz
+	mv image/cli/install-ansible/ibm-mas_devops-100.0.0.tar.gz image/cli/install-ansible/ibm-mas_devops.tar.gz
 ansible-install:
 	ansible-galaxy collection install image/cli/install-ansible/ibm-mas_devops.tar.gz --force --no-deps
 ansible: ansible-build ansible-install


### PR DESCRIPTION
When we are building with the pre-release version of mas_devops we have previously ran that at major+1, but it required us to update this with every major release of mas_devops.  The version is now set to 100, so we won't have to update this for a while.