### PR TITLE
[patch] fix kafka byo

### DIFF
--- a/tekton/src/pipelines/taskdefs/dependencies/kafka.yml.j2
+++ b/tekton/src/pipelines/taskdefs/dependencies/kafka.yml.j2
@@ -73,14 +73,14 @@
     - name: ibmcloud_apikey
       value: $(params.ibmcloud_apikey)
 
-  # Only install Kafka if the IoT application is being installed
+  # Only install Kafka if the IoT application is being installed or if "bring your own" kafka configuration is not defined
   when:
     - input: "$(params.mas_app_channel_iot)"
       operator: notin
       values: [""]
     - input: "$(params.kafka_action_system)"
-      operator: in
-      values: ["install"]
+      operator: notin
+      values: ["byo"]
     
   taskRef:
     kind: Task


### PR DESCRIPTION
Changes the kafka taskdef to only skip kafka task if iot is not being installed or byo is not defined