### PR TITLE
[patch] remove double quotes kafka params

### DIFF
--- a/tekton/src/pipelines/taskdefs/dependencies/kafka.yml.j2
+++ b/tekton/src/pipelines/taskdefs/dependencies/kafka.yml.j2
@@ -9,15 +9,15 @@
 
     # Kafka - General variables
     - name: kafka_cluster_name
-      value: "$(params.kafka_cluster_name)"
+      value: $(params.kafka_cluster_name)
 
     # AMQ Streams (Kafka)
     - name: kafka_namespace
-      value: "$(params.kafka_namespace)"
+      value: $(params.kafka_namespace)
     - name: kafka_cluster_size
-      value: "$(params.kafka_cluster_size)"
+      value: $(params.kafka_cluster_size)
     - name: kafka_user_name
-      value: "$(params.kafka_user_name)"
+      value: $(params.kafka_user_name)
     - name: kafka_storage_class
       value: $(params.storage_class_rwo)
     - name: zookeeper_storage_class
@@ -27,35 +27,35 @@
 
     # AWS basic info
     - name: aws_access_key_id
-      value: "$(params.aws_access_key_id)"
+      value: $(params.aws_access_key_id)"
     - name: aws_secret_access_key
-      value: "$(params.aws_secret_access_key)"
+      value: $(params.aws_secret_access_key)"
     - name: aws_region
-      value: "$(params.aws_region)"
+      value: $(params.aws_region)"
 
     # AWS MSK (Kafka)
     - name: vpc_id
-      value: "$(params.vpc_id)"
+      value: $(params.vpc_id)
     - name: aws_kafka_user_name
-      value: "$(params.aws_kafka_user_name)"
+      value: $(params.aws_kafka_user_name)
     - name: aws_kafka_user_password
-      value: "$(params.aws_kafka_user_password)"
+      value: $(params.aws_kafka_user_password)
     - name: aws_msk_instance_type
-      value: "$(params.aws_msk_instance_type)"
+      value: $(params.aws_msk_instance_type)
     - name: aws_msk_instance_number
-      value: "$(params.aws_msk_instance_number)"
+      value: $(params.aws_msk_instance_number)
     - name: aws_msk_volume_size
-      value: "$(params.aws_msk_volume_size)"
+      value: $(params.aws_msk_volume_size)
     - name: aws_msk_cidr_az1
-      value: "$(params.aws_msk_cidr_az1)"
+      value: $(params.aws_msk_cidr_az1)
     - name: aws_msk_cidr_az2
-      value: "$(params.aws_msk_cidr_az2)"
+      value: $(params.aws_msk_cidr_az2)
     - name: aws_msk_cidr_az3
-      value: "$(params.aws_msk_cidr_az3)"
+      value: $(params.aws_msk_cidr_az3)
     - name: aws_msk_ingress_cidr
-      value: "$(params.aws_msk_ingress_cidr)"
+      value: $(params.aws_msk_ingress_cidr)
     - name: aws_msk_egress_cidr
-      value: "$(params.aws_msk_egress_cidr)"
+      value: $(params.aws_msk_egress_cidr)
 
     # IBM Cloud Event Streams (Kafka)
     - name: kafka_provider

--- a/tekton/src/tasks/dependencies/kafka.yml.j2
+++ b/tekton/src/tasks/dependencies/kafka.yml.j2
@@ -135,33 +135,33 @@ spec:
 
       # Optional - AWS MSK (Kafka)
       - name: AWS_ACCESS_KEY_ID
-        value: "$(params.aws_access_key_id)"
+        value: $(params.aws_access_key_id)
       - name: AWS_SECRET_ACCESS_KEY
-        value: "$(params.aws_secret_access_key)"
+        value: $(params.aws_secret_access_key)
       - name: AWS_REGION
-        value: "$(params.aws_region)"
+        value: $(params.aws_region)
       - name: VPC_ID
-        value: "$(params.vpc_id)"
+        value: $(params.vpc_id)
       - name: AWS_KAFKA_USER_NAME
-        value: "$(params.aws_kafka_user_name)"
+        value: $(params.aws_kafka_user_name)
       - name: AWS_KAFKA_USER_PASSWORD
-        value: "$(params.aws_kafka_user_password)"
+        value: $(params.aws_kafka_user_password)
       - name: AWS_MSK_INSTANCE_TYPE
-        value: "$(params.aws_msk_instance_type)"
+        value: $(params.aws_msk_instance_type)
       - name: AWS_MSK_INSTANCE_NUMBER
-        value: "$(params.aws_msk_instance_number)"
+        value: $(params.aws_msk_instance_number)
       - name: AWS_MSK_VOLUME_SIZE
-        value: "$(params.aws_msk_volume_size)"
+        value: $(params.aws_msk_volume_size)
       - name: AWS_MSK_CIDR_AZ1
-        value: "$(params.aws_msk_cidr_az1)"
+        value: $(params.aws_msk_cidr_az1)
       - name: AWS_MSK_CIDR_AZ2
-        value: "$(params.aws_msk_cidr_az2)"
+        value: $(params.aws_msk_cidr_az2)
       - name: AWS_MSK_CIDR_AZ3
-        value: "$(params.aws_msk_cidr_az3)"
+        value: $(params.aws_msk_cidr_az3)
       - name: AWS_MSK_INGRESS_CIDR
-        value: "$(params.aws_msk_ingress_cidr)"
+        value: $(params.aws_msk_ingress_cidr)
       - name: AWS_MSK_EGRESS_CIDR
-        value: "$(params.aws_msk_egress_cidr)"
+        value: $(params.aws_msk_egress_cidr)
 
       # Optional - IBM Cloud Event Streams (Kafka)
       - name: KAFKA_PROVIDER


### PR DESCRIPTION
Fixes the kafka pipeline where the value was used as string due to double quotes.