### PR TITLE
[patch] - Create folders based on Pod Name for Must-Gather

### DIFF
--- a/image/cli/mascli/must-gather/mg-collect-pods
+++ b/image/cli/mascli/must-gather/mg-collect-pods
@@ -28,11 +28,8 @@ for POD in ${PODS[@]}
 do
   # echo "    - $POD"
   POD_NAME=$(echo ${POD} | cut -d '/' -f 2)
-  APP="$(oc -n ${NAMESPACE} get $POD -o jsonpath='{.metadata.labels.app}')"
-  if [[ "$APP" == "" ]]; then
-    APP="_other"
-  fi
-  APP_DIR="${POD_DIR}/${APP}"
+  APP_DIR="${POD_DIR}/${POD_NAME}"
+
   mkdir -p $APP_DIR
 
   # Get summary information for pod
@@ -42,7 +39,7 @@ do
   # Get container logs
   if [[ "$POD_LOGS" == "true" ]]
   then
-    APP_LOG_DIR="${POD_DIR}/${APP}/logs"
+    APP_LOG_DIR="${APP_DIR}/logs"
     mkdir -p $APP_LOG_DIR
 
     CONTAINERS=$(oc -n ${NAMESPACE} get ${POD} -o json -o jsonpath='{range .status.containerStatuses[*]}[{.name}] {end}' | tr -d '[]')


### PR DESCRIPTION
Today we have the Pods Logs for Manage all located under _others folder (_resources > manage project > pods > _others_). This is happening because Manage pods do not have a label selector called ["app"](https://github.com/ibm-mas/cli/blob/master/image/cli/mascli/must-gather/mg-collect-pods#L31C1-L31C1). 
After some investigation, it was observed that this selector is found in some pods for other products (like Core, IoT, Optimizer, and others). It attends a portion of the pods for those products. The pods that do not have this label are also located under _others folder. 
This solution would use the Pod Name instead of "app" label selector. With that, if the pod has a name it should have it's own folder.

Below there's a comparison showing how the Logs would be shown for Core and Manage. On the top we have the current way called "Current code" and below it's shown how it would look like "New Code". 

Core: 
![folders-core](https://github.com/ibm-mas/cli/assets/32779810/3bd2f1fd-96cc-4041-963b-b2bc1b440b0f)

Manage:
![folders-manage](https://github.com/ibm-mas/cli/assets/32779810/29b07c0d-f09c-4314-90bf-df7053969680)

This solution would also affect other products. As mentioned a portion of the pods for those products have the [app](https://github.com/ibm-mas/cli/blob/master/image/cli/mascli/must-gather/mg-collect-pods#L31C1-L31C1) label selector. The other portion doesn't. So, in most of products we still can see _others folder in the top of the list. Below we have a comparison showing how they are (top screenshot) and how they would look like (below screenshot).

Add:
![folders-add](https://github.com/ibm-mas/cli/assets/32779810/418ceb0c-3919-4499-9260-21a0649488ef)

IoT:
![folders-iot](https://github.com/ibm-mas/cli/assets/32779810/30fe1078-2f6f-4cca-b784-65fe9557be90)

Optimizer:
![folders-optimizer](https://github.com/ibm-mas/cli/assets/32779810/16e646e3-71c2-46e7-aac8-cf982cac5bf0)

VisualInspection:
![folders-visualinspection](https://github.com/ibm-mas/cli/assets/32779810/a56370af-358f-48ee-8a36-e9978fe40051)
