### PR TITLE
[patch] - Must Gather - Change Pod folder structure

### DIFF
--- a/image/cli/mascli/must-gather/mg-collect-pods
+++ b/image/cli/mascli/must-gather/mg-collect-pods
@@ -28,11 +28,8 @@ for POD in ${PODS[@]}
 do
   # echo "    - $POD"
   POD_NAME=$(echo ${POD} | cut -d '/' -f 2)
-  APP="$(oc -n ${NAMESPACE} get $POD -o jsonpath='{.metadata.labels.app}')"
-  if [[ "$APP" == "" ]]; then
-    APP="_other"
-  fi
-  APP_DIR="${POD_DIR}/${APP}"
+  APP_DIR="${POD_DIR}/${POD_NAME}"
+
   mkdir -p $APP_DIR
 
   # Get summary information for pod
@@ -42,7 +39,7 @@ do
   # Get container logs
   if [[ "$POD_LOGS" == "true" ]]
   then
-    APP_LOG_DIR="${POD_DIR}/${APP}/logs"
+    APP_LOG_DIR="${APP_DIR}/logs"
     mkdir -p $APP_LOG_DIR
 
     CONTAINERS=$(oc -n ${NAMESPACE} get ${POD} -o json -o jsonpath='{range .status.containerStatuses[*]}[{.name}] {end}' | tr -d '[]')

--- a/image/cli/mascli/must-gather/mg-collect-pods
+++ b/image/cli/mascli/must-gather/mg-collect-pods
@@ -28,18 +28,15 @@ for POD in ${PODS[@]}
 do
   # echo "    - $POD"
   POD_NAME=$(echo ${POD} | cut -d '/' -f 2)
-  APP_DIR="${POD_DIR}/${POD_NAME}"
-
-  mkdir -p $APP_DIR
 
   # Get summary information for pod
-  oc -n ${NAMESPACE} get ${POD} -o yaml > ${APP_DIR}/${POD_NAME}.yaml
-  oc -n ${NAMESPACE} describe ${POD} > ${APP_DIR}/${POD_NAME}.txt
+  oc -n ${NAMESPACE} get ${POD} -o yaml > ${POD_DIR}/${POD_NAME}.yaml
+  oc -n ${NAMESPACE} describe ${POD} > ${POD_DIR}/${POD_NAME}.txt
 
   # Get container logs
   if [[ "$POD_LOGS" == "true" ]]
   then
-    APP_LOG_DIR="${APP_DIR}/logs"
+    APP_LOG_DIR="${POD_DIR}/logs"
     mkdir -p $APP_LOG_DIR
 
     CONTAINERS=$(oc -n ${NAMESPACE} get ${POD} -o json -o jsonpath='{range .status.containerStatuses[*]}[{.name}] {end}' | tr -d '[]')


### PR DESCRIPTION
As the last part of Enhanced Must-Gather for Manage work, we'd like to have a better organization for the pods logs. 

Today, all logs go under _others folder. This happens because the folder creation is based on a label selector called [app](https://github.com/ibm-mas/cli/blob/master/image/cli/mascli/must-gather/mg-collect-pods#L31). 

The behavior happens for other products as well. Even if the product has some folders created, eventually it will have _others folder created as well.

Researching on Manage, there's not a “common” label that we can use. We have different labels for different pods.

So, after talking to @durera about this, he suggested the following structure:

```
{something}/
- logs/{something}-{deploymentid}-{podid1}.log
- logs/{something}-{deploymentid}-{podid2}.log
- {something}-{deploymentid}-{podid1}.yaml
- {something}-{deploymentid}-{podid2}.yaml
- {something}-{deploymentid}-{podid1}.txt
- {something}-{deploymentid}-{podid2}.txt`
``` 

So we keep the number of directories here fixed regardless of the scale factor .. the same deployments will be present, and if you have a high scale factor there will just be more files in the directory, instead of having loads of top level directories.

The changes for this structure were made. Now all *.yaml and *.txt are under Pods folder. Logs are under Pods > Logs folders.

Testing it on Core, this is how it will look like:

![core](https://github.com/ibm-mas/cli/assets/32779810/24263010-1c22-421a-baf2-5fa5ba17f46f)

On Manage, this is the behavior:

![manage](https://github.com/ibm-mas/cli/assets/32779810/62e69739-1410-4337-a922-fa02798846b3)


This was checked on other products as well and, they presented the logs as expected. Below how Add will look like:

![add](https://github.com/ibm-mas/cli/assets/32779810/1b12db62-0afb-48f0-8548-1ebd3823335a)

