### PR TITLE
[patch] merge podTemplates FVT tests into operatormaturity

### DIFF
--- a/tekton/src/pipelines/fvt-core.yml.j2
+++ b/tekton/src/pipelines/fvt-core.yml.j2
@@ -8,6 +8,8 @@ spec:
   workspaces:
     # The generated configuration files
     - name: shared-configs
+    # PodTemplates configurations
+    - name: shared-pod-templates
 
   params:
     # 1. Common Parameters

--- a/tekton/src/pipelines/taskdefs/fvt-core/phase4.yml.j2
+++ b/tekton/src/pipelines/taskdefs/fvt-core/phase4.yml.j2
@@ -9,6 +9,8 @@
   workspaces:
     - name: configs
       workspace: shared-configs
+    - name: pod-templates
+      workspace: shared-pod-templates
   params:
     - name: mas_instance_id
       value: $(params.mas_instance_id)

--- a/tekton/src/tasks/fvt/fvt-core-phase4.yml.j2
+++ b/tekton/src/tasks/fvt/fvt-core-phase4.yml.j2
@@ -110,9 +110,8 @@ spec:
     # 5. CoreIDP - SSO Config ... ???
     # 6. Licensing API .......... ???
     # 7. SMTP ................... Temporarily disables SMTP integration
-    # 8. Podtemplates ........... Affects resources (cpu, mem), number of replicas and affinity configuration
-    # 9. Trust CAs .............. ???
-    # 10. Operator Maturity ...... Other tests result in generation of resources in the cluster that we want to test
+    # 8. Trust CAs .............. ???
+    # 9. Operator Maturity ...... Other tests result in generation of resources in the cluster that we want to test
 
     # 1. adoptionusagemetering
     # -------------------------------------------------------------------------
@@ -226,23 +225,7 @@ spec:
         - name: TEST_SUITE
           value: smtp
 
-    # 8. podtemplates
-    # -------------------------------------------------------------------------
-    - name: fvt-podtemplates
-      image: '$(params.fvt_image_registry)/mas-devops/fvt-ibm-mas@$(params.fvt_image_digest)'
-      imagePullPolicy: $(params.image_pull_policy)
-      timeout: 2h0m0s # Ensure bad FVTs don't run forever
-      onError: continue # Ensure bad FVTs don't break the pipeline
-      resources: {}
-      workingDir: /opt/ibm/test/src
-      volumeMounts:
-        - mountPath: /dev/shm
-          name: dshm
-      env:
-        - name: TEST_SUITE
-          value: podtemplates
-
-    # 9. core-trustcas
+    # 8. core-trustcas
     # -------------------------------------------------------------------------
     - name: fvt-core-trustcas
       image: '$(params.fvt_image_registry)/mas-devops/fvt-ibm-mas@$(params.fvt_image_digest)'

--- a/tekton/src/tasks/fvt/fvt-core-phase4.yml.j2
+++ b/tekton/src/tasks/fvt/fvt-core-phase4.yml.j2
@@ -265,3 +265,5 @@ spec:
 
   workspaces:
     - name: configs
+    - name: pod-templates
+      optional: true


### PR DESCRIPTION
fix for this issue: 
https://github.ibm.com/maximoappsuite/tracker-fvt/issues/254

1. Merged the podtemplates test into operator maturity - to ensure similarity between podtemplates test for MAS and SLS 
2. Configs are copied - added shared-pod-templates to this, so that podtemplates configs for supported CRs is also copied. 

The change in this test is: podtemplates test is executed in OperatorMaturity - in Phase4 of fvt 