### PR TITLE
[patch] Fix SLS 3.8.x registry mismatch

### DIFF
--- a/image/cli/mascli/functions/update
+++ b/image/cli/mascli/functions/update
@@ -112,6 +112,11 @@ function update() {
   echo_h4 "IBM Operator Catalog" "    "
   echo_reset_dim "Catalog Version ..................... ${COLOR_MAGENTA}${MAS_CATALOG_VERSION}"
 
+  # SLS changed the registry for api-licensing in 3.8.0
+  if [[ "$MAS_CATALOG_VERSION" == "v8-230926-amd64" ]]; then
+    SLS_ICR_CPOPEN=icr.io/cpopen
+  fi
+
   echo
   reset_colors
   if [[ "$NO_CONFIRM" != "true" ]]; then

--- a/image/cli/mascli/functions/update
+++ b/image/cli/mascli/functions/update
@@ -112,7 +112,9 @@ function update() {
   echo_h4 "IBM Operator Catalog" "    "
   echo_reset_dim "Catalog Version ..................... ${COLOR_MAGENTA}${MAS_CATALOG_VERSION}"
 
-  # SLS changed the registry for api-licensing in 3.8.0
+  # In SLS 3.8.0 registry was changed to icr.io/cpopen, however
+  # when updating from a previous version it would not automatically
+  # change the value from cp.icr.io/cp hence we need to patch it
   if [[ "$MAS_CATALOG_VERSION" == "v8-230926-amd64" ]]; then
     SLS_ICR_CPOPEN=icr.io/cpopen
   fi

--- a/image/cli/mascli/functions/update
+++ b/image/cli/mascli/functions/update
@@ -116,7 +116,9 @@ function update() {
   # when updating from a previous version it would not automatically
   # change the value from cp.icr.io/cp hence we need to patch it
   if [[ "$MAS_CATALOG_VERSION" == "v8-230926-amd64" ]]; then
-    SLS_ICR_CPOPEN=icr.io/cpopen
+    UPDATE_SLS_REGISTRY="true"
+  else
+    UPDATE_SLS_REGISTRY="false"
   fi
 
   echo

--- a/image/cli/mascli/templates/pipelinerun-update.yaml
+++ b/image/cli/mascli/templates/pipelinerun-update.yaml
@@ -19,5 +19,5 @@ spec:
       value: '$DB2_NAMESPACE'
     - name: mongodb_namespace
       value: '$MONGODB_NAMESPACE'
-    - name: sls_icr_cpopen
-      value: '$SLS_ICR_CPOPEN'
+    - name: update_sls_registry
+      value: '$UPDATE_SLS_REGISTRY'

--- a/image/cli/mascli/templates/pipelinerun-update.yaml
+++ b/image/cli/mascli/templates/pipelinerun-update.yaml
@@ -19,3 +19,5 @@ spec:
       value: '$DB2_NAMESPACE'
     - name: mongodb_namespace
       value: '$MONGODB_NAMESPACE'
+    - name: sls_icr_cpopen
+      value: '$SLS_ICR_CPOPEN'

--- a/tekton/generate-tekton-tasks.yml
+++ b/tekton/generate-tekton-tasks.yml
@@ -38,6 +38,7 @@
         - nvidia-gpu
         - ocp-verify
         - ocs
+        - sls-registry-update
         - sls
         - turbonomic
         - uds

--- a/tekton/src/pipelines/update.yml.j2
+++ b/tekton/src/pipelines/update.yml.j2
@@ -132,8 +132,8 @@ spec:
         - name: sls_icr_cpopen
           value: $(params.sls_icr_cpopen)
       when:
-        - input: ""
-          operator: notin
+        - input: "icr.io/cpopen"
+          operator: in
           values: ["$(params.sls_icr_cpopen)"]
 
     # 4. Verify health of the cluster before we consider the update complete

--- a/tekton/src/pipelines/update.yml.j2
+++ b/tekton/src/pipelines/update.yml.j2
@@ -125,7 +125,7 @@ spec:
     - name: update-licenseservice
       taskRef:
         kind: Task
-        name: mas-devops-ibm-catalogs
+        name: sls-registry-update
       runAfter:
         - update-catalog
       params:

--- a/tekton/src/pipelines/update.yml.j2
+++ b/tekton/src/pipelines/update.yml.j2
@@ -51,7 +51,7 @@ spec:
       type: string
       default: "upgrade"
       description: Set to 'upgrade' to update common_services
-    
+
     # db2 update
     - name: db2_action
       type: string
@@ -71,6 +71,12 @@ spec:
       type: string
       default: "mongoce"
       description: Namespace where mongodb instances will be updated
+
+    # SLS 3.8.0 registry change
+    - name: sls_icr_cpopen
+      default: ""
+      type: string
+      description: Required when updating SLS to 3.8.0 from a lower version
 
   tasks:
 {% if wait_for_install == true %}
@@ -114,7 +120,23 @@ spec:
         - name: artifactory_token
           value: $(params.artifactory_token)
 
-    # 3. Verify health of the cluster before we consider the update complete
+    # 3. Update SLS LicenseService CR registry if needed
+    # -------------------------------------------------------------------------
+    - name: update-licenseservice
+      taskRef:
+        kind: Task
+        name: mas-devops-ibm-catalogs
+      runAfter:
+        - update-catalog
+      params:
+        - name: sls_icr_cpopen
+          value: $(params.sls_icr_cpopen)
+      when:
+        - input: ""
+          operator: notin
+          values: ["$(params.sls_icr_cpopen)"]
+
+    # 4. Verify health of the cluster before we consider the update complete
     # -------------------------------------------------------------------------
     {{ lookup('template', 'taskdefs/cluster-setup/ocp-verify.yml.j2', template_vars={
         'name': 'post-update-verify-cluster',
@@ -165,7 +187,7 @@ spec:
         - post-update-verify-subscriptions
 
 
-    # 4. Update Dependencies
+    # 5. Update Dependencies
     # ---------------------------------------------------------------------------
     - name: update-ocs
       taskRef:
@@ -219,7 +241,7 @@ spec:
         - name: mongodb_namespace
           value: $(params.mongodb_namespace)
 
-    # 5. Verify health of the cluster after dependencies updates
+    # 6. Verify health of the cluster after dependencies updates
     # -------------------------------------------------------------------------
     {{ lookup('template', 'taskdefs/cluster-setup/ocp-verify.yml.j2', template_vars={
         'name': 'post-deps-update-verify-cluster',

--- a/tekton/src/pipelines/update.yml.j2
+++ b/tekton/src/pipelines/update.yml.j2
@@ -73,10 +73,10 @@ spec:
       description: Namespace where mongodb instances will be updated
 
     # SLS 3.8.0 registry change
-    - name: sls_icr_cpopen
+    - name: update_sls_registry
       default: ""
       type: string
-      description: Required when updating SLS to 3.8.0 from a lower version
+      description: Set to 'true' to change all LicenseService CRs' registry to cpopen
 
   tasks:
 {% if wait_for_install == true %}
@@ -128,13 +128,10 @@ spec:
         name: sls-registry-update
       runAfter:
         - update-catalog
-      params:
-        - name: sls_icr_cpopen
-          value: $(params.sls_icr_cpopen)
       when:
-        - input: "icr.io/cpopen"
+        - input: "true"
           operator: in
-          values: ["$(params.sls_icr_cpopen)"]
+          values: ["$(params.update_sls_registry)"]
 
     # 4. Verify health of the cluster before we consider the update complete
     # -------------------------------------------------------------------------

--- a/tekton/src/tasks/dependencies/sls-registry-update.yml.j2
+++ b/tekton/src/tasks/dependencies/sls-registry-update.yml.j2
@@ -4,10 +4,6 @@ kind: Task
 metadata:
   name: sls-registry-update
 spec:
-  params:
-    - name: sls_icr_cpopen
-      type: string
-
   steps:
     - name: update-licenseservice
       image: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest

--- a/tekton/src/tasks/dependencies/sls-registry-update.yml.j2
+++ b/tekton/src/tasks/dependencies/sls-registry-update.yml.j2
@@ -33,11 +33,3 @@ spec:
           SLS_INSTANCE_ID=$(echo "$LICENSE_SERVICE_INSTANCES" | awk -v "line=$l" 'NR==line {print $2}')
           oc patch --type=merge LicenseService/${SLS_INSTANCE_ID} -p '{"spec": {"settings": {"registry": "icr.io/cpopen"}}}' -n ${SLS_NAMESPACE}
         done
-
-      env:
-        - name: DEVOPS_BUILD_NUMBER
-          valueFrom:
-            secretKeyRef:
-              name: mas-devops
-              key: DEVOPS_BUILD_NUMBER
-              optional: false

--- a/tekton/src/tasks/dependencies/sls-registry-update.yml.j2
+++ b/tekton/src/tasks/dependencies/sls-registry-update.yml.j2
@@ -14,10 +14,10 @@ spec:
       script: |
         #!/usr/bin/env bash
 
-        echo "Updating registry for all LicenseService instances..."
+        echo "Updating registry to 'icr.io/cpopen' for all LicenseService CR instances..."
 
         echo ""
-        echo "Get all LicenseService Custom Resource instances..."
+        echo "Get all LicenseService CR instances..."
         echo "------------------------------------------------------------------"
 
         LICENSE_SERVICE_INSTANCES=`oc get LicenseService --all-namespaces`

--- a/tekton/src/tasks/dependencies/sls-registry-update.yml.j2
+++ b/tekton/src/tasks/dependencies/sls-registry-update.yml.j2
@@ -1,0 +1,43 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: sls-registry-update
+spec:
+  params:
+    - name: sls_icr_cpopen
+      type: string
+
+  steps:
+    - name: update-licenseservice
+      image: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
+      script: |
+        #!/usr/bin/env bash
+
+        echo "Updating registry for all LicenseService instances..."
+
+        echo ""
+        echo "Get all LicenseService Custom Resource instances..."
+        echo "------------------------------------------------------------------"
+
+        LICENSE_SERVICE_INSTANCES=`oc get LicenseService --all-namespaces`
+        INSTANCES_COUNT=$(wc -l <<< "${LICENSE_SERVICE_INSTANCES}" | sed 's/ //g')
+
+        echo ""
+        echo "Patching all LicenseService CR instances..."
+        echo "------------------------------------------------------------------"
+
+        for (( l=2; l<=${INSTANCES_COUNT}; l++ ))
+        do
+          SLS_NAMESPACE=$(echo "$LICENSE_SERVICE_INSTANCES" | awk -v "line=$l" 'NR==line {print $1}')
+          SLS_INSTANCE_ID=$(echo "$LICENSE_SERVICE_INSTANCES" | awk -v "line=$l" 'NR==line {print $2}')
+          oc patch --type=merge LicenseService/${SLS_INSTANCE_ID} -p '{"spec": {"settings": {"registry": "icr.io/cpopen"}}}' -n ${SLS_NAMESPACE}
+        done
+
+      env:
+        - name: DEVOPS_BUILD_NUMBER
+          valueFrom:
+            secretKeyRef:
+              name: mas-devops
+              key: DEVOPS_BUILD_NUMBER
+              optional: false


### PR DESCRIPTION
## Description

SLS `3.8.0` changed the registry for api-licensing from `cp.icr.io/cp` to `icr.io/cpopen`. For fresh installations this works fine as ansible-devops has been updated. However, we have noticed that during `mas update` when updating from a previous version of SLS to `3.8.0` the registry would stay as `cp.icr.io/cp` and cause the now pod to not pull the image.

- Added new task sls-registry-update to run when the latest catalog is chosen to update all LicenseService CRs' registries to `icr.io/cpopen`

<img width="961" alt="Screenshot 2023-09-28 at 12 25 26 am" src="https://github.com/ibm-mas/cli/assets/61942902/262ff8de-8a31-4ba2-9221-878bfc8aaacc">
