### PR TITLE
[patch] configtool-oidc function should login into OCP Cluster

### DIFF
--- a/image/cli/mascli/functions/configtool_oidc
+++ b/image/cli/mascli/functions/configtool_oidc
@@ -135,7 +135,7 @@ function configtool_oidc() {
 
   # login cluster
   echo Login $CLUSTER_SERVER...
-  #oc login --token=$CLUSTER_TOKEN --server=$CLUSTER_SERVER
+  oc login --token=$CLUSTER_TOKEN --server=$CLUSTER_SERVER
 
   # instance name and domain
   echo preparing for $MAS_HOME...


### PR DESCRIPTION
This PR is to uncomment previously commented line so that command can login cluster automatically.