### PR TITLE
[patch] Align IoT and SLS mustgather with function parameter change

### DIFF
--- a/image/cli/mascli/must-gather/mg-collect-mas-iot
+++ b/image/cli/mascli/must-gather/mg-collect-mas-iot
@@ -11,13 +11,16 @@ $DIR/mg-collect-mbgx-logs $NAMESPACE $OUTPUT_DIR
 # Collect Reconcile Logs
 # -----------------------------------------------------------------------------
 # Main IoT Component and workspace
-$DIR/mg-collect-reconcile-logs $NAMESPACE ibm-iot-operator $OUTPUT_DIR
-$DIR/mg-collect-reconcile-logs $NAMESPACE workspace-operator $OUTPUT_DIR
+$DIR/mg-collect-reconcile-logs $NAMESPACE control-plane ibm-iot-operator $OUTPUT_DIR
+$DIR/mg-collect-reconcile-logs $NAMESPACE control-plane workspace-operator $OUTPUT_DIR
+
+# Truststores
+$DIR/mg-collect-reconcile-logs $NAMESPACE operator ibm-truststore-mgr $OUTPUT_DIR
 
 # IoT Component Operator Reconcile logs
 for CONTROL_PLANE in actions-operator auth-operator datapower-operator devops-operator dm-operator dsc-operator edgeconfig-operator fpl-operator guardian-operator mbgx-operator mfgx-operator monitor-operator orgmgmt-operator provision-operator registry-operator state-operator webui-operator workspace-operator
 do
-  $DIR/mg-collect-reconcile-logs $NAMESPACE $CONTROL_PLANE $OUTPUT_DIR
+  $DIR/mg-collect-reconcile-logs $NAMESPACE control-plane $CONTROL_PLANE $OUTPUT_DIR
 done
 
 # Collect IoT Custom Resources

--- a/image/cli/mascli/must-gather/mg-collect-sls
+++ b/image/cli/mascli/must-gather/mg-collect-sls
@@ -8,7 +8,7 @@ OUTPUT_DIR=$2
 # Collect Reconcile Logs
 # -----------------------------------------------------------------------------
 # Primary Resources
-$DIR/mg-collect-reconcile-logs $NAMESPACE controller-manager $OUTPUT_DIR
+$DIR/mg-collect-reconcile-logs $NAMESPACE control-plane controller-manager $OUTPUT_DIR
 
 # Collect SLS Resources
 # -----------------------------------------------------------------------------

--- a/image/cli/mascli/must-gather/mg-collect-sls
+++ b/image/cli/mascli/must-gather/mg-collect-sls
@@ -10,6 +10,9 @@ OUTPUT_DIR=$2
 # Primary Resources
 $DIR/mg-collect-reconcile-logs $NAMESPACE control-plane controller-manager $OUTPUT_DIR
 
+# Truststores
+$DIR/mg-collect-reconcile-logs $NAMESPACE operator ibm-truststore-mgr $OUTPUT_DIR
+
 # Collect SLS Resources
 # -----------------------------------------------------------------------------
 for RESOURCE in LicenseService LicenseClient


### PR DESCRIPTION
There is a bug in the SLS and IoT mustgather - 

```
[must-gather] Error from server (BadRequest): Unable to find "/v1, Resource=pods" that match label selector "ibm-iot-operator=/workspace/mustgather/fvtnocpd-fvt-847/20230928-080426", field selector "": unable to parse requirement: values[0][ibm-iot-operator]: Invalid value: "/workspace/mustgather/fvtnocpd-fvt-847/20230928-080426": a valid label must be an empty string or consist of alphanumeric characters, '-', '_' or '.', and must start and end with an alphanumeric character (e.g. 'MyValue',  or 'my_value',  or '12345', regex used for validation is '(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?')
[must-gather] error executing jsonpath "{.items[0].[metadata.name](http://metadata.name/)}": Error executing template: array index out of bounds: index 0, length 0. Printing more information for debugging the template:
[must-gather] 	template was:
[must-gather] 		{.items[0].[metadata.name](http://metadata.name/)}
[must-gather] 	object given to jsonpath engine was:
[must-gather] 		map[string]interface {}{"apiVersion":"v1", "items":[]interface {}{}, "kind":"List", "metadata":map[string]interface {}{"resourceVersion":"", "selfLink":""}}
...
etc
...
```


Delivery of https://github.com/ibm-mas/cli/pull/462 crossed over with https://github.com/ibm-mas/cli/pull/453 which changed the function parameters of `mg-collect-reconcile-logs`, so we need to pass in the label name `control-plane` in most cases.