### PR TITLE
[patch] update MAS 8.11 channel selections for applications

### DIFF
--- a/image/cli/mascli/functions/pipeline_config_applications
+++ b/image/cli/mascli/functions/pipeline_config_applications
@@ -2,6 +2,9 @@
 
 function channel_select_iot() {
   case $MAS_CHANNEL in
+    8.11.x)
+      MAS_APP_CHANNEL_IOT=8.8.x
+      ;;
     8.10.x)
       MAS_APP_CHANNEL_IOT=8.7.x
       ;;
@@ -17,6 +20,9 @@ function channel_select_iot() {
 
 function channel_select_monitor() {
   case $MAS_CHANNEL in
+    8.11.x)
+      MAS_APP_CHANNEL_MONITOR=8.11.x
+      ;;
     8.10.x)
       MAS_APP_CHANNEL_MONITOR=8.10.x
       ;;
@@ -32,6 +38,9 @@ function channel_select_monitor() {
 
 function channel_select_manage() {
   case $MAS_CHANNEL in
+    8.11.x)
+      MAS_APP_CHANNEL_MANAGE=8.7.x
+      ;;
     8.10.x)
       MAS_APP_CHANNEL_MANAGE=8.6.x
       ;;
@@ -47,6 +56,9 @@ function channel_select_manage() {
 
 function channel_select_predict() {
   case $MAS_CHANNEL in
+    8.11.x)
+      MAS_APP_CHANNEL_PREDICT=8.9.x
+      ;;
     8.10.x)
       MAS_APP_CHANNEL_PREDICT=8.8.x
       ;;
@@ -63,6 +75,9 @@ function channel_select_predict() {
 
 function channel_select_optimizer() {
   case $MAS_CHANNEL in
+    8.11.x)
+      MAS_APP_CHANNEL_OPTIMIZER=8.5.x
+      ;;
     8.10.x)
       MAS_APP_CHANNEL_OPTIMIZER=8.4.x
       ;;
@@ -78,6 +93,9 @@ function channel_select_optimizer() {
 
 function channel_select_assist() {
   case $MAS_CHANNEL in
+    8.11.x)
+      MAS_APP_CHANNEL_ASSIST=8.8.x
+      ;;
     8.10.x)
       MAS_APP_CHANNEL_ASSIST=8.7.x
       ;;
@@ -93,6 +111,9 @@ function channel_select_assist() {
 
 function channel_select_visualinspection() {
   case $MAS_CHANNEL in
+    8.11.x)
+      MAS_APP_CHANNEL_VISUALINSPECTION=8.9.x
+      ;;
     8.10.x)
       MAS_APP_CHANNEL_VISUALINSPECTION=8.8.x
       ;;


### PR DESCRIPTION
## Create Default Application Channel Selection for MAS 8.11 

Provide the ability to select the correct channel for MAS 8.11 is missing for the applications. 

https://github.com/ibm-mas/cli/issues/531
