### PR TITLE
[patch] Calculate app name from pod name when label is missing

### DIFF
--- a/image/cli/mascli/must-gather/mg-collect-pods
+++ b/image/cli/mascli/must-gather/mg-collect-pods
@@ -40,8 +40,6 @@ for POD in ${PODS[@]}; do
   APP_DIR="${POD_DIR}/${APP}"
   mkdir -p "$APP_DIR" || { echo "    - Error creating directory: $APP_DIR"; exit 0; }
   
-  echo "  - testing"
-  
   # Get summary information for pod
   oc -n "${NAMESPACE}" get "${POD}" -o yaml > "${APP_DIR}/${POD_NAME}.yaml" || { echo "    - Error fetching pod information for $POD_NAME"; exit 0; }
   oc -n "${NAMESPACE}" describe "${POD}" > "${APP_DIR}/${POD_NAME}.txt" || { echo "    - Error describing pod $POD_NAME"; continue; }

--- a/image/cli/mascli/must-gather/mg-collect-pods
+++ b/image/cli/mascli/must-gather/mg-collect-pods
@@ -31,7 +31,9 @@ for POD in ${PODS[@]}; do
   fi
   APP_DIR="${POD_DIR}/${APP}"
   mkdir -p "$APP_DIR" || { echo "    - Error creating directory: $APP_DIR"; exit 0; }
-
+  
+  echo "  - testing"
+  
   # Get summary information for pod
   oc -n "${NAMESPACE}" get "${POD}" -o yaml > "${APP_DIR}/${POD_NAME}.yaml" || { echo "    - Error fetching pod information for $POD_NAME"; exit 0; }
   oc -n "${NAMESPACE}" describe "${POD}" > "${APP_DIR}/${POD_NAME}.txt" || { echo "    - Error describing pod $POD_NAME"; continue; }

--- a/image/cli/mascli/must-gather/mg-collect-pods
+++ b/image/cli/mascli/must-gather/mg-collect-pods
@@ -26,8 +26,16 @@ for POD in ${PODS[@]}; do
   # Extract POD_NAME and APP
   POD_NAME=$(echo "${POD}" | cut -d '/' -f 2)
   APP="$(oc -n "${NAMESPACE}" get "${POD}" -o jsonpath='{.metadata.labels.app}')"
+  
   if [[ "$APP" == "" ]]; then
-    APP="_other"
+    INSTANCE_ID=$(echo ${NAMESPACE%-*})
+    INSTANCE_ID=$(echo ${INSTANCE_ID#*-})
+    APP=$(echo ${POD_NAME%-*}) #removing 2nd ID
+    APP=$(echo ${APP%-*}) #removing 1st ID
+    
+    if [[ "$APP" == "$INSTANCE_ID" ]]; then
+      APP=$(echo ${POD_NAME%-*}) #removing 2nd ID only
+    fi
   fi
   APP_DIR="${POD_DIR}/${APP}"
   mkdir -p "$APP_DIR" || { echo "    - Error creating directory: $APP_DIR"; exit 0; }


### PR DESCRIPTION
On Must-Gather, if a pod does not have the label selector `app`, its information (*.txt and *.yaml) will go to a generic folder called `_others` and the logs will go to `_others > logs`. 
In this commit we're adding a way to handle that case, that way each pod will have its own folder with the related log(s). 
If a pod does not have `app` label selector, the `pod_name` will be used instead. For a better visualization, the final IDs are being removed and the folder created. Below some examples:
- Pod: ibm-mas-operator-6d8894445c-jwldp (Core project, does not have app label selector)
- Folder: ibm-mas-operator
- Pod: ibm-mas-manage-operator-79cc677d99-gqdzb (Manage project, most of pods don't use app label)
- Folder: ibm-mas-manage-operator

Core:
<img width="1208" alt="core" src="https://github.com/ibm-mas/cli/assets/32779810/6fc2a543-5342-437a-8819-7d6480b9751f">

Manage:
<img width="1287" alt="manage" src="https://github.com/ibm-mas/cli/assets/32779810/4acd6771-e6b8-4cd6-be9b-1af1c659594b">

Other products like Add, Assist, Iot and Monitor were checked too. 
