### PR TITLE
[patch] Improve CLI stdout readability

### DIFF
--- a/image/cli/app-root/ansible.cfg
+++ b/image/cli/app-root/ansible.cfg
@@ -3,16 +3,9 @@
 roles_path = /opt/ansible/roles
 library = /opt/ansible/library
 
-# Record timings per task, and enable junit result file generation
-# [DEPRECATION WARNING]: [defaults]callback_whitelist option, normalizing names
-# to new standard, use callbacks_enabled instead. This feature will be removed
-# from ansible-core in version 2.15. Deprecation warnings can be disabled by
-# setting deprecation_warnings=False in ansible.cfg.
-# callback_whitelist = profile_tasks,junit
-callbacks_enabled = profile_tasks,junit
+# Enable junit result file generation
+callbacks_enabled = junit
+stdout_callback = yaml
 
 # Verbosity: 0 (low) - 7 (high)
 verbosity = 1
-
-[callback_profile_tasks]
-task_output_limit = 100

--- a/image/cli/mascli/ansible.cfg
+++ b/image/cli/mascli/ansible.cfg
@@ -1,7 +1,0 @@
-[defaults]
-# Verbosity: 0 (low) - 7 (high)
-verbosity = 0
-# Use the YAML callback plugin.
-stdout_callback = unixy
-# Use the stdout_callback when running ad-hoc commands.
-bin_ansible_callbacks = True

--- a/image/cli/mascli/mas
+++ b/image/cli/mascli/mas
@@ -34,8 +34,6 @@ VERSION=latest
 mkdir -p $LOG_DIR
 mkdir -p $CONFIG_DIR
 
-# export ANSIBLE_CONFIG=$CLI_DIR/ansible.cfg
-
 # General purpose
 . $CLI_DIR/functions/catalog_utils
 . $CLI_DIR/functions/connect


### PR DESCRIPTION
Remove the timing data (it just pushes the useful error message up into the log, making it harder for inexperienced users to find) and convert the output format from json to yaml to make it more human readable.