### PR TITLE
[patch] Fix wrong var used in prompt

### DIFF
--- a/image/cli/mascli/functions/pipeline_config
+++ b/image/cli/mascli/functions/pipeline_config
@@ -141,7 +141,7 @@ function pipeline_config() {
   echo
   prompt_for_input "Select Operational Mode" PROD_MODE_SELECTION "1"
 
-  case $MAS_CHANNEL_SELECTION in
+  case $PROD_MODE_SELECTION in
     1)
       USE_NON_PROD_MODE=false
       ;;


### PR DESCRIPTION
## Description

- The prompt for setting production vs non-production env failed because it used the wrong var in the case switch.
- Discussion [here](https://ibm-watson-iot.slack.com/archives/C040TETRV2T/p1697459591523059)

## Testing

- Tested the fix in my local cli container