### PR TITLE
[patch] Fix sls in non-interactive mode

### DIFF
--- a/image/cli/mascli/functions/install
+++ b/image/cli/mascli/functions/install
@@ -12,11 +12,13 @@ Catalog Selection (Required):
 
 Entitlement & Licensing (Required):
       --ibm-entitlement-key ${COLOR_YELLOW}IBM_ENTITLEMENT_KEY${TEXT_RESET}            IBM entitlement key
-      --license-id ${COLOR_YELLOW}SLS_LICENSE_ID${TEXT_RESET}                          MAS license ID
       --license-file ${COLOR_YELLOW}SLS_LICENSE_FILE_LOCAL${TEXT_RESET}                Path to MAS license file
       --uds-email ${COLOR_YELLOW}UDS_CONTACT_EMAIL${TEXT_RESET}                        Contact e-mail address
       --uds-firstname ${COLOR_YELLOW}UDS_CONTACT_FIRSTNAME${TEXT_RESET}                Contact first name
       --uds-lastname ${COLOR_YELLOW}UDS_CONTACT_LASTNAME${TEXT_RESET}                  Contact last name
+
+Entitlement & Licensing (Only required up to v8-230414-amd64):
+      --license-id ${COLOR_YELLOW}SLS_LICENSE_ID${TEXT_RESET}                          MAS license ID. Required for SLS 3.6.0 and below
 
 Storage Class Selection (Required):
       --storage-rwo ${COLOR_YELLOW}STORAGE_CLASS_RWO${TEXT_RESET}                      Read Write Once (RWO) storage class (e.g. ibmc-block-gold)
@@ -548,12 +550,19 @@ function install_noninteractive() {
     exit 1
   fi
 
+  # Work out which SLS var to use for bootstrap
+  sls_prompt_selection
+  if [[ "$SLS_PROMPT_LICENSE_ID" == "true" ]]; then
+    export SLS_LICENSE_FILE="/workspace/entitlement/$(basename $SLS_LICENSE_FILE_LOCAL)"
+  else
+    export SLS_ENTITLEMENT_FILE="/workspace/entitlement/$(basename $SLS_LICENSE_FILE_LOCAL)"
+  fi
+
 }
 
 function install_interactive() {
   pipeline_config
 }
-
 
 function ocp_version_check() {
   # Check for OCP 4.9 and 4.10
@@ -579,16 +588,6 @@ function ocp_version_check() {
     reset_colors
     echo
     prompt_for_confirm "Continue anyway?" || exit 0
-  fi
-}
-
-# Non-interactive mode
-function set_sls_license_file() {
-  sls_prompt_selection
-  if [[ "$SLS_PROMPT_LICENSE_ID" == "true" ]]; then
-    export SLS_LICENSE_FILE="/workspace/entitlement/$(basename $SLS_LICENSE_FILE_LOCAL)"
-  else
-    export SLS_ENTITLEMENT_FILE="/workspace/entitlement/$(basename $SLS_LICENSE_FILE_LOCAL)"
   fi
 }
 
@@ -624,7 +623,6 @@ function install() {
     detect_airgap
     detect_sno
     install_noninteractive "$@"
-    set_sls_license_file
     pipeline_install_operator
     config_pipeline_additional_configs
   fi

--- a/image/cli/mascli/functions/install
+++ b/image/cli/mascli/functions/install
@@ -399,12 +399,6 @@ function install_noninteractive() {
           echo_warning "Error: File does not exist: $SLS_LICENSE_FILE_LOCAL"
           exit 1
         fi
-        sls_prompt_selection
-        if [[ "$SLS_PROMPT_LICENSE_ID" == "true" ]]; then
-          export SLS_LICENSE_FILE="/workspace/entitlement/$(basename $SLS_LICENSE_FILE_LOCAL)"
-        else
-          export SLS_ENTITLEMENT_FILE="/workspace/entitlement/$(basename $SLS_LICENSE_FILE_LOCAL)"
-        fi
         ;;
 
       # UDS
@@ -588,6 +582,15 @@ function ocp_version_check() {
   fi
 }
 
+# Non-interactive mode
+function set_sls_license_file() {
+  sls_prompt_selection
+  if [[ "$SLS_PROMPT_LICENSE_ID" == "true" ]]; then
+    export SLS_LICENSE_FILE="/workspace/entitlement/$(basename $SLS_LICENSE_FILE_LOCAL)"
+  else
+    export SLS_ENTITLEMENT_FILE="/workspace/entitlement/$(basename $SLS_LICENSE_FILE_LOCAL)"
+  fi
+}
 
 function install() {
   # Take the first parameter off (it will be "install")
@@ -621,6 +624,7 @@ function install() {
     detect_airgap
     detect_sno
     install_noninteractive
+    set_sls_license_file
     pipeline_install_operator
     config_pipeline_additional_configs
   fi


### PR DESCRIPTION
## Description

- Discussion [here](https://ibm-watson-iot.slack.com/archives/C04T6HQCHCP/p1697297065618519)
- Moved the sls_prompt_selection to after the param inputs so that regardless of where we set the catalog param it will evaluate the sls vars correctly


### Scenario 1 - `--mas-catalog-version` before `--license-file`

Running:
```bash
mas install --mas-catalog-version v8-231004-amd64 --accept-license \
  --license-file /mnt/home/entitlement/entitlement.lic \
  --uds-email 'rawa.resul@ibm.com' --uds-firstname 'Rawa' --uds-lastname 'Resul' \
  --storage-rwo 'ocs-storagecluster-ceph-rbd' --storage-rwx 'ocs-storagecluster-cephfs' --storage-pipeline 'ocs-storagecluster-cephfs' --storage-accessmode 'ReadWriteMany' \
  --mas-instance-id 'rawa' --mas-workspace-id 'masdev' --mas-workspace-name 'masdev' \
  --mas-channel '8.11.x'
```

### Scenario 2 - `--mas-catalog-version` after `--license-file`

Running
```bash
mas install --mas-catalog-version v8-231004-amd64 --accept-license \
  --license-file /mnt/home/entitlement/entitlement.lic \
  --uds-email 'rawa.resul@ibm.com' --uds-firstname 'Rawa' --uds-lastname 'Resul' \
  --storage-rwo 'ocs-storagecluster-ceph-rbd' --storage-rwx 'ocs-storagecluster-cephfs' --storage-pipeline 'ocs-storagecluster-cephfs' --storage-accessmode 'ReadWriteMany' \
  --mas-instance-id 'rawa' --mas-workspace-id 'masdev' --mas-workspace-name 'masdev' \
  --mas-channel '8.11.x'
```
In both scenarios the right env vars for SLS were set
<img width="758" alt="Screenshot 2023-10-17 at 1 37 55 pm" src="https://github.com/ibm-mas/cli/assets/61942902/309a3b89-38cf-426b-a7b9-a7fc64b8bdbb">
