### PR TITLE
[patch] Non-interactive mode isn't parsing any params

### DIFF
--- a/image/cli/mascli/functions/install
+++ b/image/cli/mascli/functions/install
@@ -620,7 +620,7 @@ function install() {
     # Non-interactive mode assumes you are already connected
     detect_airgap
     detect_sno
-    install_noninteractive
+    install_noninteractive "$@"
     pipeline_install_operator
     config_pipeline_additional_configs
   fi


### PR DESCRIPTION
We are not passing the command flags to the `install_noninteractive` function, so it has nothing to process.