### PR TITLE
[patch] Image mirroring doc updates

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -14,8 +14,7 @@ jobs:
 
       - name: Install and Build
         run: |
-          python -m pip install -q mkdocs mkdocs-redirects
-          mkdocs build --verbose --clean --strict
+          bash build/bin/build-docs.sh
 
       - name: Deploy
         uses: JamesIves/github-pages-deploy-action@4.1.7

--- a/build/bin/build-docs.sh
+++ b/build/bin/build-docs.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+# Update all the placeholders in the doc source
+# Make sure not to commit these changes if you run this script locally
+find docs -type f -name '*.md' -exec sed -i \
+  -e 's/@@CLI_LATEST_VERSION@@/7.4.3/g' \
+  -e 's/@@MAS_PREVIOUS_CHANNEL@@/8.10.x/g' \
+  -e 's/@@MAS_PREVIOUS_CATALOG@@/v8-230829-amd64/g' \
+  -e 's/@@MAS_LATEST_CHANNEL@@/8.11.x/g' \
+  -e 's/@@MAS_LATEST_CATALOG@@/v8-231004-amd64/g' \
+  {} \;
+
+python -m pip install -q mkdocs mkdocs-redirects
+mkdocs build --verbose --clean --strict

--- a/docs/commands/mirror-images.md
+++ b/docs/commands/mirror-images.md
@@ -117,15 +117,11 @@ The following example will mirror all images required for Maximo Application Sui
 
 ```bash
 docker run -ti --rm --pull always quay.io/ibmmas/cli mas mirror-images \
-  --mode direct \
-  --dir /tmp/registry \
-  --ibm-entitlement $IBM_ENTITLEMENT_KEY \
-  --redhat-username $REDHAT_CONNECT_USERNAME \
-  --redhat-password $REDHAT_CONNECT_PASSWORD \
-  -H mirror.mydomain.com -P 5000 \
-  -u $MIRROR_USERNAME -p $MIRROR_PASSWORD \
-  -c v8-230627-amd64 -C 8.10.x \
-  --mirror-core --mirror-iot --mirror-manage \
+  --mode direct --dir /tmp/registry \
+  --ibm-entitlement $IBM_ENTITLEMENT_KEY --redhat-username $REDHAT_USERNAME --redhat-password $REDHAT_PASSWORD \
+  -H mirror.mydomain.com -P 5000 -u $MIRROR_USERNAME -p $MIRROR_PASSWORD \
+  -c @@MAS_LATEST_CATALOG@@ -C @@MAS_LATEST_CHANNEL@@ \
+  --mirror-catalog --mirror-core --mirror-iot --mirror-manage \
   --mirror-cfs --mirror-uds --mirror-sls --mirror-tsm --mirror-mongo --mirror-db2 \
   --no-confirm
 ```
@@ -135,32 +131,25 @@ Two-Phase Image Mirroring
 -------------------------------------------------------------------------------
 Two-Phase image mirroring is required when you do not have a single system with both access to the public registries containing the source container images **and** your internal private registry.  In this case you will require a system with internet connectivity and another with access to your private network, along with a means to transfer data from one to the other (for example, a portable drive).
 
-!!! important
-    The examples here use a specific version of the container image (6.0.0).  You should always use the latest available container image, but because we are working in a disconnected environment we need to be specific about the version we are using.  Replace `6.0.0` with the appropriate version.
-
 ### Phase 1: Mirror to Filesystem
 First, download the latest version of the container image and start up a terminal session inside the container image, we are going to mount a local directory into the running container to persist the mirror filesystem.
 
 ```bash
-docker pull quay.io/ibmmas/cli:6.0.0
-docker run -ti --rm -v /registry:/mnt/registry quay.io/ibmmas/cli:6.0.0 mas mirror-images \
-  --mode to-filesystem \
-  --dir /mnt/registry \
-  --ibm-entitlement $IBM_ENTITLEMENT_KEY \
-  --redhat-username $REDHAT_CONNECT_USERNAME \
-  --redhat-password $REDHAT_CONNECT_PASSWORD \
-  -H mirror.mydomain.com -P 5000 \
-  -u $MIRROR_USERNAME -p $MIRROR_PASSWORD \
-  -c v8-230627-amd64 -C 8.10.x \
-  --mirror-core --mirror-iot --mirror-manage \
+docker pull quay.io/ibmmas/cli:@@CLI_LATEST_VERSION@@
+docker run -ti --rm -v /registry:/mnt/registry quay.io/ibmmas/cli:@@CLI_LATEST_VERSION@@ mas mirror-images \
+  --mode to-filesystem --dir /mnt/registry \
+  --ibm-entitlement $IBM_ENTITLEMENT_KEY --redhat-username $REDHAT_USERNAME --redhat-password $REDHAT_PASSWORD \
+  -H mirror.mydomain.com -P 5000 -u $MIRROR_USERNAME -p $MIRROR_PASSWORD \
+  -c @@MAS_LATEST_CATALOG@@ -C @@MAS_LATEST_CHANNEL@@ \
+  --mirror-catalog --mirror-core --mirror-iot --mirror-manage \
   --mirror-cfs --mirror-uds --mirror-sls --mirror-tsm --mirror-mongo --mirror-db2 \
   --no-confirm
 ```
 
-Once this process completes you will find the mirrored images in `/registry` on your local filesystem ready to transfer to the system inside your disconnected network on which we will perform phase 2 of this operator.  However, before we can do that we also need to mirror the CLI image to your mirror registry so that it's available on the disconnected host system.
+Once this process completes you will find the mirrored images in `/registry` on your local filesystem ready to transfer to the system inside your disconnected network on which we will perform phase 2 of this operation.  However, before we can do that we also need to mirror the CLI image to your mirror registry so that it's available on the disconnected host system.
 
 ```bash
-oc image mirror --dir /registry quay.io/ibmmas/cli:6.0.0 file://ibmmas/cli:6.0.0
+oc image mirror --dir /registry quay.io/ibmmas/cli:@@CLI_LATEST_VERSION@@ file://ibmmas/cli:@@CLI_LATEST_VERSION@@
 ```
 
 
@@ -168,24 +157,20 @@ oc image mirror --dir /registry quay.io/ibmmas/cli:6.0.0 file://ibmmas/cli:6.0.0
 Transfer the content of `/registry` to your system in the disconnected network.  Now we are going to put the CLI image in your registry:
 
 ```bash
-docker login <YOURPRIVATEREGISTRY> -u <MIRROR_USERNAME> -p <MIRROR_PASSWORD>
-oc image mirror --dir /registry file://ibmmas/cli:6.0.0 mirror.mydomain.com:5000/ibmmas/cli:6.0.0
+docker login mirror.mydomain.com:5000 -u $MIRROR_USERNAME -p $MIRROR_PASSWORD
+oc image mirror --dir /registry file://ibmmas/cli:@@CLI_LATEST_VERSION@@ mirror.mydomain.com:5000/ibmmas/cli:@@CLI_LATEST_VERSION@@
 ```
 
 Now we are ready to mirror the images to your registry using the CLI image in the same way we mirrored the images to the local disk in the first place:
 
 ```bash
-docker pull mirror.mydomain.com:5000/ibmmas/cli:6.0.0
-docker run -ti --rm -v /registry:/mnt/registry mirror.mydomain.com:5000/ibmmas/cli:6.0.0 mas mirror-images \
-  --mode from-filesystem \
-  --dir /mnt/registry \
-  --ibm-entitlement $IBM_ENTITLEMENT_KEY \
-  --redhat-username $REDHAT_CONNECT_USERNAME \
-  --redhat-password $REDHAT_CONNECT_PASSWORD \
-  -H mirror.mydomain.com -P 5000 \
-  -u $MIRROR_USERNAME -p $MIRROR_PASSWORD \
-  -c v8-230627-amd64 -C 8.10.x \
-  --mirror-core --mirror-iot --mirror-manage \
+docker pull mirror.mydomain.com:5000/ibmmas/cli:@@CLI_LATEST_VERSION@@
+docker run -ti --rm -v /registry:/mnt/registry mirror.mydomain.com:5000/ibmmas/cli:@@CLI_LATEST_VERSION@@ mas mirror-images \
+  --mode from-filesystem --dir /mnt/registry \
+  --ibm-entitlement $IBM_ENTITLEMENT_KEY --redhat-username $REDHAT_USERNAME --redhat-password $REDHAT_PASSWORD \
+  -H mirror.mydomain.com -P 5000 -u $MIRROR_USERNAME -p $MIRROR_PASSWORD \
+  -c @@MAS_LATEST_CATALOG@@ -C @@MAS_LATEST_CHANNEL@@ \
+  --mirror-catalog --mirror-core --mirror-iot --mirror-manage \
   --mirror-cfs --mirror-uds --mirror-sls --mirror-tsm --mirror-mongo --mirror-db2 \
   --no-confirm
 ```

--- a/docs/guides/choosing-the-right-catalog.md
+++ b/docs/guides/choosing-the-right-catalog.md
@@ -28,7 +28,7 @@ User-Controlled Updates
 
 The packages available in these catalogs are fixed. Multiple installations at different times will always result in exactly the same version of all operators being installed.
 
-When you are ready to apply updates you simply modify the CatalogSource installed in your cluster, changing it from e.g. `v8-220717-amd64` to `v8-220805-amd64`.  No further action is required, after a brief delay all installed operators will update automatically to the latest versions in the new catalog source.
+When you are ready to apply updates you simply modify the CatalogSource installed in your cluster, changing it from e.g. `@@MAS_PREVIOUS_CATALOG@@` to `@@MAS_LATEST_CATALOG@@`.  No further action is required, after a brief delay all installed operators will update automatically to the latest versions in the new catalog source.
 
 
 Multi-Cluster Version Equivalency

--- a/docs/guides/image-mirroring.md
+++ b/docs/guides/image-mirroring.md
@@ -1,0 +1,101 @@
+Image Mirroring
+===============================================================================
+
+
+Image Mirroring Overview
+-------------------------------------------------------------------------------
+We recommend the use of two-phase mirroring, it is slower than direct mirroring and requires more storage capacity, but can allow you to more easily recover from network glitches and creates a clean seperation of the tasks of getting the content from the source registry and putting it into the target registry which can make debugging failures easier.
+
+This guide assumes that you are looking to mirror content for the latest release (**@@MAS_LATEST_CHANNEL@@**) from the most recent catalog update (**@@MAS_LATEST_CATALOG@@**), and that you are installing all MAS applications.  If you are not installing certain applications or dependencies take care to remove the appropriate `--mirror-x` flags to avoid mirroring unnecessary images.
+
+
+Preparation
+-------------------------------------------------------------------------------
+Set the following environment variables that will be used in each stage:
+
+```bash
+export IBM_ENTITLEMENT_KEY=xxx
+export LOCAL_DIR=xxx
+export REGISTRY_HOST=xxx
+export REGISTRY_PORT=xxx
+export REGISTRY_USERNAME=xxx
+export REGISTRY_PASSWORD=xxx
+export REDHAT_USERNAME=xxx
+export REDHAT_PASSWORD=xxx
+```
+
+
+Stage 1 - Core
+-------------------------------------------------------------------------------
+Let's start simple and just get the MAS Core and IBM Maximo Operator Catalog mirrored to the registry, this shouldn't take long and provides an early measure of the download and upload performance to help estimate the time to complete the larger stages.
+
+```bash
+mas mirror-images -m to-filesystem -d $LOCAL_DIR/core \
+  -H $REGISTRY_HOST -P $REGISTRY_PORT -u $REGISTRY_USERNAME -p $REGISTRY_PASSWORD \
+  -c @@MAS_LATEST_CATALOG@@ -C @@MAS_LATEST_CHANNEL@@ \
+  --mirror-catalog --mirror-core \
+  --ibm-entitlement $IBM_ENTITLEMENT_KEY
+```
+
+Once the images are mirrored to local disk, we will mirror them from local disk to your registry, this should complete in very little time, depends on the speed of your internal network:
+
+```bash
+mas mirror-images -m from-filesystem -d $LOCAL_DIR/core \
+  -H $REGISTRY_HOST -P $REGISTRY_PORT -u $REGISTRY_USERNAME -p $REGISTRY_PASSWORD \
+  -c @@MAS_LATEST_CATALOG@@ -C @@MAS_LATEST_CHANNEL@@ \
+  --mirror-catalog --mirror-core
+```
+
+
+Stage 2 - Apps
+-------------------------------------------------------------------------------
+```bash
+mas mirror-images -m to-filesystem -d $LOCAL_DIR/apps \
+  -H $REGISTRY_HOST -P $REGISTRY_PORT -u $REGISTRY_USERNAME -p $REGISTRY_PASSWORD \
+  -c @@MAS_LATEST_CATALOG@@ -C @@MAS_LATEST_CHANNEL@@ \
+  --mirror-assist --mirror-hputilities --mirror-iot --mirror-manage --mirror-monitor --mirror-optimizer --mirror-predict --mirror-visualinspection \
+  --ibm-entitlement $IBM_ENTITLEMENT_KEY
+```
+
+```bash
+mas mirror-images -m from-filesystem -d $LOCAL_DIR/apps \
+  -H $REGISTRY_HOST -P $REGISTRY_PORT -u $REGISTRY_USERNAME -p $REGISTRY_PASSWORD \
+  -c @@MAS_LATEST_CATALOG@@ -C @@MAS_LATEST_CHANNEL@@ \
+  --mirror-assist --mirror-hputilities --mirror-iot --mirror-manage --mirror-monitor --mirror-optimizer --mirror-predict --mirror-visualinspection
+```
+
+
+Stage 3 - CP4D
+-------------------------------------------------------------------------------
+```bash
+mas mirror-images -m to-filesystem -d $LOCAL_DIR/cp4d \
+  -H $REGISTRY_HOST -P $REGISTRY_PORT- u $REGISTRY_USERNAME -p $REGISTRY_PASSWORD \
+  -c @@MAS_LATEST_CATALOG@@ -C @@MAS_LATEST_CHANNEL@@ \
+  --mirror-cp4d --mirror-wd --mirror-spark --mirror-wml --mirror-wsl \
+  --ibm-entitlement $IBM_ENTITLEMENT_KEY
+```
+
+```bash
+mas mirror-images -m from-filesystem -d $LOCAL_DIR/cp4d \
+  -H $REGISTRY_HOST -P $REGISTRY_PORT- u $REGISTRY_USERNAME -p $REGISTRY_PASSWORD \
+  -c @@MAS_LATEST_CATALOG@@ -C @@MAS_LATEST_CHANNEL@@ \
+  --mirror-cp4d --mirror-wd --mirror-spark --mirror-wml --mirror-wsl
+```
+
+
+Stage 4 - Other Dependencies
+-------------------------------------------------------------------------------
+```bash
+mas mirror-images -m to-filesystem -d $LOCAL_DIR/other \
+  -H $REGISTRY_HOST -P $REGISTRY_PORT -u $REGISTRY_USERNAME -p $REGISTRY_PASSWORD \
+  -c @@MAS_LATEST_CATALOG@@ -C @@MAS_LATEST_CHANNEL@@ \
+  --mirror-mongo --mirror-tsm --mirror-uds --mirror-sls --mirror-cfs --mirror-appconnect --mirror-db2 \
+  --ibm-entitlement $IBM_ENTITLEMENT_KEY --redhat-username $REDHAT_USERNAME --redhat-password $REDHAT_PASSWORD
+```
+
+```bash
+mas mirror-images -m from-filesystem -d $LOCAL_DIR/other \
+  -H $REGISTRY_HOST -P $REGISTRY_PORT -u $REGISTRY_USERNAME -p $REGISTRY_PASSWORD \
+  -c @@MAS_LATEST_CATALOG@@ -C @@MAS_LATEST_CHANNEL@@ \
+  --mirror-mongo --mirror-tsm --mirror-uds --mirror-sls --mirror-cfs --mirror-appconnect --mirror-db2
+```

--- a/docs/guides/install.md
+++ b/docs/guides/install.md
@@ -104,14 +104,13 @@ docker run -ti --pull always quay.io/ibmmas/cli mas mirror-images
 
 You will be prompted to set the target registry for the image mirroring and to [select the version of IBM Maximo Operator Catalog to mirror](choosing-the-right-catalog.md) and the subset of content that you wish to mirror.  You can choose to mirror everything from the catalog, or control exactly what is mirrored to your private registry to reduce the time and bandwidth used to mirror the images, as well reducing the storage requirements of the registry.
 
-This command can also be ran non-interactive, for full details refer to the [mirror-images](../commands/mirror-images.md) command documentation.
+This command can also be ran non-interactive, for full usgae information refer to the [mirror-images](../commands/mirror-images.md) command documentation, if you are looking for more detailed guidance on how to approach this activity refer to the [image mirroring guide](image-mirroring.md).
 
 ```bash
-mas mirror-images \
-  -m direct \
-  -d /mnt/local-mirror/ \
+mas mirror-images -m direct -d /mnt/local-mirror \
   -H myprivateregistry.com -P 5000 -u $REGISTRY_USERNAME -p $REGISTRY_PASSWORD \
-  -c v8-221025-amd64 --mirror-core --mirror-iot --mirror-optimizer --mirror-manage \
+  -c @@MAS_LATEST_CATALOG@@ -C @@MAS_LATEST_CHANNEL@@ \
+  --mirror-catalog --mirror-core --mirror-manage --mirror-mongo --mirror-tsm --mirror-uds --mirror-sls --mirror-cfs \
   --ibm-entitlement $IBM_ENTITLEMENT_KEY \
   --redhat-username $REDHAT_USERNAME --redhat-password $REDHAT_PASSWORD \
   --no-confirm

--- a/docs/guides/update.md
+++ b/docs/guides/update.md
@@ -32,13 +32,12 @@ You will be prompted to set the target registry for the image mirroring and to [
 This command can also be ran non-interactive, for full details refer to the [mirror-images](../commands/mirror-images.md) command documentation.
 
 ```bash
-mas mirror-images \
-  -m direct \
-  -d /mnt/local-mirror/ \
+mas mirror-images -m direct -d /mnt/local-mirror \
   -H myprivateregistry.com -P 5000 -u $REGISTRY_USERNAME -p $REGISTRY_PASSWORD \
-  -c v8-221129-amd64 -C 8.9.x --mirror-core --mirror-iot --mirror-optimizer --mirror-manage \
-  --ibm-entitlement $IBM_ENTITLEMENT_KEY \
-  --redhat-username $REDHAT_USERNAME --redhat-password $REDHAT_PASSWORD \
+  -c @@MAS_LATEST_CATALOG@@ -C @@MAS_LATEST_CHANNEL@@ \
+  --mirror-catalog --mirror-core --mirror-iot --mirror-manage \
+  --mirror-cfs --mirror-uds --mirror-sls --mirror-tsm --mirror-mongo --mirror-db2 \
+  --ibm-entitlement $IBM_ENTITLEMENT_KEY --redhat-username $REDHAT_USERNAME --redhat-password $REDHAT_PASSWORD \
   --no-confirm
 ```
 
@@ -61,5 +60,5 @@ docker run -ti --rm --pull always quay.io/ibmmas/cli mas update
 The command can also be ran non-interactive.
 
 ```bash
-mas update -c v8-221129-amd64 --no-confirm
+mas update -c @@MAS_LATEST_CATALOG@@ --no-confirm
 ```

--- a/docs/guides/upgrade.md
+++ b/docs/guides/upgrade.md
@@ -37,13 +37,12 @@ You will be prompted to set the target registry for the image mirroring and to [
 This command can also be ran non-interactive, for full details refer to the [mirror-images](../commands/mirror-images.md) command documentation.
 
 ```bash
-mas mirror-images \
-  -m direct \
-  -d /mnt/local-mirror/ \
+mas mirror-images -m direct -d /mnt/local-mirror \
   -H myprivateregistry.com -P 5000 -u $REGISTRY_USERNAME -p $REGISTRY_PASSWORD \
-  -c v8-230725-amd64 -C 8.10.x --mirror-core --mirror-cpfs --mirror-uds --mirror-sls --mirror-tsm \
-  --ibm-entitlement $IBM_ENTITLEMENT_KEY \
-  --redhat-username $REDHAT_USERNAME --redhat-password $REDHAT_PASSWORD \
+  -c @@MAS_LATEST_CATALOG@@ -C @@MAS_LATEST_CHANNEL@@ \
+  --mirror-catalog --mirror-core --mirror-iot --mirror-manage \
+  --mirror-cfs --mirror-uds --mirror-sls --mirror-tsm --mirror-mongo --mirror-db2 \
+  --ibm-entitlement $IBM_ENTITLEMENT_KEY --redhat-username $REDHAT_USERNAME --redhat-password $REDHAT_PASSWORD \
   --no-confirm
 ```
 

--- a/image/cli/mascli/functions/update
+++ b/image/cli/mascli/functions/update
@@ -15,8 +15,8 @@ Maximo Operator Catalog Selection (Required):
 Update Dependencies (Optional):
   --db2u-namespace ${COLOR_YELLOW}DB2_NAMESPACE${TEXT_RESET}        DB2 namespace where instances update will be performed
   --mongodb-namespace ${COLOR_YELLOW}MONGODB_NAMESPACE${TEXT_RESET} Namespace where MongoCE operator and instance will be updated
-  --kafka-namespace ${COLOR_YELLOW}KAFKA_NAMESPACE${TEXT_RESET} Namespace where Kafka operator and instance will be updated
-  --kafka-provider ${COLOR_YELLOW}KAFKA_PROVIDER${TEXT_RESET}  Set Kafka provider. Supported options are 'redhat' (Red Hat AMQ Streams), or 'strimzi'
+  --kafka-namespace ${COLOR_YELLOW}KAFKA_NAMESPACE${TEXT_RESET}     Namespace where Kafka operator and instance will be updated
+  --kafka-provider ${COLOR_YELLOW}KAFKA_PROVIDER${TEXT_RESET}       Set Kafka provider. Supported options are 'redhat' (Red Hat AMQ Streams), or 'strimzi'
 
 Other Commands:
       --no-confirm                      Launch the update without prompting for confirmation

--- a/image/cli/mascli/functions/upgrade
+++ b/image/cli/mascli/functions/upgrade
@@ -108,7 +108,7 @@ function upgrade() {
   echo_h2 "Launch Upgrade"
 
   # Create namespace, install MAS Tekton definitions, configure RBAC
-   pipeline_install_tasks|| exit 1
+  pipeline_install_tasks || exit 1
 
   # Replace ALL environment variables in templates
   eval "echo \"$(cat $CLI_DIR/templates/pipelinerun-upgrade.yaml)\"" > $CONFIG_DIR/pipelinerun-$MAS_INSTANCE_ID-upgrade.yaml

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -11,6 +11,7 @@ nav:
   - "Home": index.md
   - "Guides":
       - "Choosing the Right Catalog": guides/choosing-the-right-catalog.md
+      - "Image Mirroring": guides/image-mirroring.md
       - "Install": guides/install.md
       - "Update": guides/update.md
       - "Upgrade": guides/upgrade.md


### PR DESCRIPTION
Small docs updates to cover image mirroring for MAS, and a build system update to support parameterizing references to things like the latest CLI release, previous/latest MAS channel, and previous/latest catalog source.