### PR TITLE
[patch] Prevent invalid update scenarios

### DIFF
--- a/image/cli/mascli/functions/catalog_utils
+++ b/image/cli/mascli/functions/catalog_utils
@@ -3,6 +3,12 @@
 # This file contains all the code that needs to change whenever a new catalog is released
 # Make sure to update every function in this file when adding support for a new catalog
 
+# This is used when determining whether a user can convert from the dynamic catalog to
+# a static catalog.  We only support converting from v8-amd64 to the latest static catalog
+# because any other change would be a downgrade and would result in the HEAD bundle in
+# our packages regressing, which would confuse OLM.
+MOST_RECENT_CATALOG=v8-231004-amd64
+
 # Choose a catalog only
 # -----------------------------------------------------------------------------
 # Currently only used in the mas update function.  The user does not need to select
@@ -80,7 +86,7 @@ function choose_mas_version() {
       MAS_CHANNEL=8.9.x
       MAS_CATALOG_VERSION=v8-230829-amd64
       ;;
-    
+
     # July 2023
     5)
       MAS_CHANNEL=8.10.x

--- a/image/cli/mascli/functions/update
+++ b/image/cli/mascli/functions/update
@@ -25,9 +25,74 @@ EOM
   [[ -n "$1" ]] && exit 1 || exit 0
 }
 
+# Validate Selected Catalog
+# -----------------------------------------------------------------------------
+# Validates that the selected catalog version is one that is suitable to use
+# based on the currently installed catalog source
+#
+# - You can't update to an older catalog source
+# - The dynamic catalog can only be updated to the most recent static catalog
+#
+# Note: We don't currently support conversion from static to dynamic
+#
+function validate_update() {
+  if [[ "$catalogVersion" != "" ]] && [[ "$catalogId" > "$MAS_CATALOG_VERSION" ]]; then
+    echo
+    if [[ "$catalogIsDynamic" == "true" ]];
+      then echo_warning "Selected catalog is older than the currently installed catalog.  Dynamic catalog can only be updated to the latest static catalog ($MOST_RECENT_CATALOG)"
+      else echo_warning "Selected catalog is older than the currently installed catalog.  Unable to update catalog from $catalogId to $MAS_CATALOG_VERSION"
+    fi
+    echo
+    exit 1
+  fi
+}
 
+
+# Inspect Installed Catalog
+# -----------------------------------------------------------------------------
+# Lookup details of the installed catalog source to determine:
+#
+# - Whether a dynamic or static catalog source is in use
+# - The version of the catalog source in use
+#
+# This information is shown the user, along with a message indicating that
+# this command would switch a dynamic catalog install to a static catalog install
+# if they proceed.
+#
+# If we cannot determine the version of the catalog we show an error message
+# but allow the install to proceed as this is not a fatal issue.
+#
+function show_current_catalog() {
+  catalogDisplayName=$(oc -n openshift-marketplace get catalogsource ibm-operator-catalog -o yaml | yq -r ".spec.displayName")
+  catalogImage=$(oc -n openshift-marketplace get catalogsource ibm-operator-catalog -o yaml | yq -r ".spec.image")
+
+  echo_h2 "Review Installed Catalog"
+  echo "${catalogDisplayName}"
+  echo -e "   ${COLOR_CYAN}${TEXT_UNDERLINE}${catalogImage}"
+  reset_colors
+
+  if [[ "$catalogDisplayName" =~ .+(v8-[0-9]+-amd64) ]]; then
+    catalogId=$(sed -E "s/.+\\((v8-[0-9]+-amd64)\\)/\1/" <<< $catalogDisplayName)
+    catalogVersion=$(sed -E "s/.+\\(v8-([0-9]+)-amd64\\)/\1/" <<< $catalogDisplayName)
+    catalogIsDynamic=false
+  elif [[ "$catalogDisplayName" =~ .+(v8-amd64) ]]; then
+    catalogId=$MOST_RECENT_CATALOG
+    catalogVersion=$(sed -E "s/.+\\(v8-([0-9]+)-amd64\\)/\1/" <<< $MOST_RECENT_CATALOG)
+    catalogIsDynamic=true
+
+    echo
+    echo "Automatic catalog updates are currently enabled on this cluster, completing this update will switch to a manually managed catalog source"
+    echo "For more information refer to: ${COLOR_CYAN}${TEXT_UNDERLINE}https://ibm-mas.github.io/cli/guides/choosing-the-right-catalog/"
+    reset_colors
+  else
+    echo_warning "Unable to determine identity & version of currently installed ibm-operator-catalog"
+  fi
+}
+
+
+# Perform non-interative update
+# -----------------------------------------------------------------------------
 function update_noninteractive() {
-
   detect_airgap
   while [[ $# -gt 0 ]]
   do
@@ -66,15 +131,26 @@ function update_noninteractive() {
 
   # Check all args have been set
   [[ -z "$MAS_CATALOG_VERSION" ]] && update_help "MAS_CATALOG_VERSION is not set"
+
+  show_current_catalog
+  validate_update
 }
 
+
+# Perform interative update
+# -----------------------------------------------------------------------------
 function update_interactive() {
   connect
   detect_airgap
 
+  show_current_catalog
+
   echo
   echo_h2 "Select IBM Maximo Operator Catalog Version"
   choose_catalog_version
+  echo
+
+  validate_update
   echo
 
   echo_h2 "Dependencies Update"
@@ -125,6 +201,8 @@ function update_interactive() {
 }
 
 
+# Main function
+# -----------------------------------------------------------------------------
 function update() {
   # Take the first parameter off (it will be "update")
   shift

--- a/image/cli/mascli/mas
+++ b/image/cli/mascli/mas
@@ -3,12 +3,9 @@
 # Usage: mas install
 
 function trap_exit {
-  RC=$?
-  if [[ $RC != "0" ]]; then
-    echo_warning "\nFatal Error[$RC]  See $LOGFILE for details"
-  fi
   save_config
 }
+
 function trap_int {
   # Reset any modifications made to the terminal
   tset


### PR DESCRIPTION
This update prevents a user from updating to an older catalog source than what is already installed, doing this would cause many problems in OLM on the cluster.

Non-interactive catalog downgrade
![image](https://github.com/ibm-mas/cli/assets/4400618/07ce156d-e8f0-4b82-9725-b43d7ff65789)

Non-interactive switch from dynamic to older static catalog
![image](https://github.com/ibm-mas/cli/assets/4400618/15ad6127-a04d-44f8-8756-f08225e6853d)

Interactive catalog downgrade
![image](https://github.com/ibm-mas/cli/assets/4400618/a6765021-4a55-4c8f-b11c-f944307ed1c4)
