### PR TITLE
[patch] Add verification steps into upgrade pipeline

### DIFF
--- a/tekton/src/pipelines/upgrade.yml.j2
+++ b/tekton/src/pipelines/upgrade.yml.j2
@@ -24,7 +24,7 @@ spec:
 
   tasks:
 {% if wait_for_install == true %}
-    # Wait for the install pipeline to complete
+    # 0. Wait for the install pipeline to complete
     # -------------------------------------------------------------------------
     - name: wait-for-install
       params:
@@ -35,17 +35,27 @@ spec:
         name: mas-fvt-wait-for-install
 {% endif %}
 
-    # Phase 1
+
+    # 1. Verify health of the cluster before we change anything
     # -------------------------------------------------------------------------
-    # Suite Upgrade
-    - name: core-upgrade
-      taskRef:
-        kind: Task
-        name: mas-devops-suite-upgrade
+    {{ lookup('template', 'taskdefs/cluster-setup/ocp-verify-all.yml.j2', template_vars={
+        'name': 'pre-upgrade-check',
+        'devops_suite_name': 'pre-upgrade-check'
+      }) | indent(4) }}
 {% if wait_for_install == true %}
       runAfter:
         - wait-for-install
 {% endif %}
+
+
+    # 2. Suite Upgrade (Phase 1)
+    # -------------------------------------------------------------------------
+    - name: core-upgrade
+      taskRef:
+        kind: Task
+        name: mas-devops-suite-upgrade
+      runAfter:
+        - pre-upgrade-check
       params:
         - name: mas_instance_id
           value: $(params.mas_instance_id)
@@ -73,9 +83,8 @@ spec:
         - core-upgrade
 
 
-    # Phase 2 - Apps with no dependencies
+    # 3. IoT Upgrade (Phase 2)
     # -------------------------------------------------------------------------
-    # IoT Upgrade
     - name: iot-upgrade
       params:
         - name: mas_instance_id
@@ -94,7 +103,9 @@ spec:
       runAfter:
         - core-verify
 
-    # Manage Upgrade
+
+    # 4. Manage Upgrade (Phase 2)
+    # -------------------------------------------------------------------------
     - name: manage-upgrade
       params:
         - name: mas_instance_id
@@ -113,7 +124,9 @@ spec:
       runAfter:
         - core-verify
 
-    # Visual Inspection Upgrade
+
+    # 5. Visual Inspection Upgrade (Phase 2)
+    # -------------------------------------------------------------------------
     - name: visualinspection-upgrade
       params:
         - name: mas_instance_id
@@ -132,7 +145,9 @@ spec:
       runAfter:
         - core-verify
 
-    # Assist Upgrade
+
+    # 6. Assist Upgrade (Phase 2)
+    # -------------------------------------------------------------------------
     - name: assist-upgrade
       params:
         - name: mas_instance_id
@@ -151,7 +166,9 @@ spec:
       runAfter:
         - core-verify
 
-    # Optimizer Upgrade
+
+    # 7. Optimizer Upgrade (Phase 2)
+    # -------------------------------------------------------------------------
     - name: optimizer-upgrade
       params:
         - name: mas_instance_id
@@ -171,9 +188,8 @@ spec:
         - core-verify
 
 
-    # Phase 3 - Apps dependant on upgrades in Phase 2
+    # 8. Monitor Upgrade (Phase 3 - after IoT)
     # -------------------------------------------------------------------------
-    # Monitor Upgrade (after IoT)
     - name: monitor-upgrade
       params:
         - name: mas_instance_id
@@ -192,7 +208,9 @@ spec:
       runAfter:
         - iot-upgrade
 
-    # Predict Upgrade (after Manage)
+
+    # 9. Predict Upgrade (Phase 3 - after Manage)
+    # -------------------------------------------------------------------------
     - name: predict-upgrade
       params:
         - name: mas_instance_id
@@ -211,7 +229,9 @@ spec:
       runAfter:
         - manage-upgrade
 
-    # HP Utilities Upgrade (after Manage)
+
+    # 10. HP Utilities Upgrade (Phase 3 - after Manage)
+    # -------------------------------------------------------------------------
     - name: hputilities-upgrade
       params:
         - name: mas_instance_id
@@ -229,3 +249,20 @@ spec:
         name: mas-devops-suite-app-upgrade
       runAfter:
         - manage-upgrade
+
+
+    # 11. Verify health of the cluster after upgrade
+    # -------------------------------------------------------------------------
+    {{ lookup('template', 'taskdefs/cluster-setup/ocp-verify-all.yml.j2', template_vars={
+        'name': 'post-upgrade-verify',
+        'devops_suite_name': 'post-upgrade-verify'
+      }) | indent(4) }}
+      runAfter:
+        # Phase 2 apps that don't have a phase 3 app following it
+        - assist-upgrade
+        - optimizer-upgrade
+        - visualinspection-upgrade
+        # Phase 3 apps
+        - hputilities-upgrade
+        - predict-upgrade
+        - monitor-upgrade


### PR DESCRIPTION
Introduces the missing verification steps into the upgrade pipeline, these run before and after the upgrade is actioned to 1) prevent the upgrade starting if the cluster is unhealthy and 2) allow the pipeline to report that the upgrade was successful instead of just that it was accepted/started.

![image](https://github.com/ibm-mas/cli/assets/4400618/d8cec3e8-1da5-4adb-90a8-646b099539eb)
