### PR TITLE
[patch] Fix default Manage component selection

### DIFF
--- a/image/cli/mascli/functions/pipeline_config_applications
+++ b/image/cli/mascli/functions/pipeline_config_applications
@@ -270,6 +270,8 @@ function manage_settings() {
         exit 1
       fi
     fi
+  else
+    MAS_APPWS_COMPONENTS="base=latest,health=latest"
   fi
 
   # Manage Settings - Database

--- a/image/cli/mascli/functions/pipeline_show_config
+++ b/image/cli/mascli/functions/pipeline_show_config
@@ -284,9 +284,7 @@ function pipeline_show_config() {
   [ "$MAS_APP_CHANNEL_VISUALINSPECTION" != "" ] && cmd+=" \\
   --visualinspection-channel $MAS_APP_CHANNEL_VISUALINSPECTION"
   [ "$MAS_APP_CHANNEL_OPTIMIZER" != "" ] && cmd+=" \\
-  --optimizer-channel $MAS_APP_CHANNEL_OPTIMIZER"
-  [ "$MAS_APP_CHANNEL_OPTIMIZER" != "" ] && [ "$MAS_APP_PLAN_OPTIMIZER" != "" ] && cmd+=" --optimizer-plan $MAS_APP_PLAN_OPTIMIZER"
-
+  --optimizer-channel $MAS_APP_CHANNEL_OPTIMIZER --optimizer-plan $MAS_APP_PLAN_OPTIMIZER"
 
   # Kafka
   [ "$KAFKA_PROVIDER" != "" ] && cmd+=" \\

--- a/image/cli/mascli/functions/pipeline_show_config
+++ b/image/cli/mascli/functions/pipeline_show_config
@@ -274,6 +274,9 @@ function pipeline_show_config() {
   --manage-channel $MAS_APP_CHANNEL_MANAGE"
   [ "$MAS_APPWS_BINDINGS_JDBC_MANAGE" != "" ] && cmd+=" \\
   --manage-jdbc $MAS_APPWS_BINDINGS_JDBC_MANAGE"
+  [ "$MAS_APPWS_COMPONENTS" != "" ] && cmd+=" --manage-components $MAS_APPWS_COMPONENTS"
+  [ "$MAS_APP_SETTINGS_DEMODATA" == "true" ] && cmd+=" --manage-demodata"
+
   [ "$MAS_APP_CHANNEL_PREDICT" != "" ] && cmd+=" \\
   --predict-channel $MAS_APP_CHANNEL_PREDICT"
   [ "$MAS_APP_CHANNEL_ASSIST" != "" ] && cmd+=" \\
@@ -282,7 +285,8 @@ function pipeline_show_config() {
   --visualinspection-channel $MAS_APP_CHANNEL_VISUALINSPECTION"
   [ "$MAS_APP_CHANNEL_OPTIMIZER" != "" ] && cmd+=" \\
   --optimizer-channel $MAS_APP_CHANNEL_OPTIMIZER"
-  [ "$MAS_APP_PLAN_OPTIMIZER" != "" ] && cmd+=" --optimizer-plan $MAS_APP_PLAN_OPTIMIZER"
+  [ "$MAS_APP_CHANNEL_OPTIMIZER" != "" ] && [ "$MAS_APP_PLAN_OPTIMIZER" != "" ] && cmd+=" --optimizer-plan $MAS_APP_PLAN_OPTIMIZER"
+
 
   # Kafka
   [ "$KAFKA_PROVIDER" != "" ] && cmd+=" \\
@@ -335,10 +339,8 @@ function pipeline_show_config() {
   # --cp4d-install-cognos
 
   # Manage Application - Advanced Configuration (Optional):
-  #       --manage-demodata                                                                                                   Enables demo data for Manage application
   #       --manage-jms                                                                                                        Enables JMS queues using local persistent volumes
   #       --manage-server-bundle-size ${COLOR_YELLOW}MAS_APP_SETTINGS_SERVER_BUNDLES_SIZE${TEXT_RESET}                        Set Manage server bundle size configuration i.e 'dev', 'small', 'jms' or 'snojms'
-  #       --manage-components ${COLOR_YELLOW}MAS_APPWS_COMPONENTS${TEXT_RESET}                                                Set Manage Components to be installed i.e 'base=latest,health=latest,civil=latest'
   #       --manage-customization-archive-name ${COLOR_YELLOW}MAS_APP_SETTINGS_CUSTOMIZATION_ARCHIVE_NAME${TEXT_RESET}         Set Manage Archive name
   #       --manage-customization-archive-url ${COLOR_YELLOW}MAS_APP_SETTINGS_CUSTOMIZATION_ARCHIVE_URL${TEXT_RESET}           Set Manage Archive url
   #       --manage-customization-archive-username ${COLOR_YELLOW}MAS_APP_SETTINGS_CUSTOMIZATION_ARCHIVE_USERNAME${TEXT_RESET} Set Manage Archive username, in case url requires basic authentication to pull the archive


### PR DESCRIPTION
At some point we lost the default Manage component selection being Base + Health, and it became just base.  This update puts the default back to base+health.

Health is a required manage component for other applications, so we enable it by default to streamline the install for customers who don't choose their components explicitly.