### PR TITLE
[patch] Moving manage sec-auth tests to phase 4

### DIFF
--- a/tekton/src/pipelines/taskdefs/fvt-manage/phase1.yml.j2
+++ b/tekton/src/pipelines/taskdefs/fvt-manage/phase1.yml.j2
@@ -2,8 +2,6 @@
 # PHASE 1
 # - fvt-manage-setup
 # - fvt-manage-monitoring
-# - fvt-manage-sec-audit-log
-# - fvt-manage-sec-inactive-auth
 # -------------------------------------------------------------
 
 # Manage FVT Setup
@@ -32,31 +30,5 @@
       value: core
     - name: fvt_test_suite
       value: monitoring
-  runAfter:
-    - fvt-manage-aviation-setup
-
-# Manage FVT Security Audit Logging
-- name: fvt-manage-sec-audit-log
-  {{ lookup('template', 'taskdefs/fvt-manage/ui/taskref.yml.j2') | indent(2) }}
-  {{ lookup('template', 'taskdefs/fvt-manage/ui/when.yml.j2') | indent(2) }}
-  params:
-    {{ lookup('template', 'taskdefs/fvt-manage/ui/params.yml.j2') | indent(4) }}
-    - name: fvt_test_suite_prefix
-      value: core
-    - name: fvt_test_suite
-      value: sec-audit-log
-  runAfter:
-    - fvt-manage-aviation-setup
-
-# Manage FVT Inactive User Authentication
-- name: fvt-manage-sec-inactive-auth
-  {{ lookup('template', 'taskdefs/fvt-manage/ui/taskref.yml.j2') | indent(2) }}
-  {{ lookup('template', 'taskdefs/fvt-manage/ui/when.yml.j2') | indent(2) }}
-  params:
-    {{ lookup('template', 'taskdefs/fvt-manage/ui/params.yml.j2') | indent(4) }}
-    - name: fvt_test_suite_prefix
-      value: core
-    - name: fvt_test_suite
-      value: sec-inactive-auth
   runAfter:
     - fvt-manage-aviation-setup

--- a/tekton/src/pipelines/taskdefs/fvt-manage/phase2.yml.j2
+++ b/tekton/src/pipelines/taskdefs/fvt-manage/phase2.yml.j2
@@ -23,8 +23,6 @@
   runAfter:
     - fvt-manage-setup
     - fvt-manage-monitoring
-    - fvt-manage-sec-audit-log
-    - fvt-manage-sec-inactive-auth
     
 # Manage FVT Classification
 - name: fvt-manage-classification
@@ -39,8 +37,6 @@
   runAfter:
     - fvt-manage-setup
     - fvt-manage-monitoring
-    - fvt-manage-sec-audit-log
-    - fvt-manage-sec-inactive-auth
 
 # Manage FVT Help Links
 - name: fvt-manage-helplinks
@@ -55,8 +51,6 @@
   runAfter:
     - fvt-manage-setup
     - fvt-manage-monitoring
-    - fvt-manage-sec-audit-log
-    - fvt-manage-sec-inactive-auth
 
 # Manage MIF setup
 - name: fvt-manage-mif-setup
@@ -71,8 +65,6 @@
   runAfter:
     - fvt-manage-setup
     - fvt-manage-monitoring
-    - fvt-manage-sec-audit-log
-    - fvt-manage-sec-inactive-auth
 
 # Manage FVT Metrics API
 - name: fvt-manage-metrics-api
@@ -87,8 +79,6 @@
   runAfter:
     - fvt-manage-setup
     - fvt-manage-monitoring
-    - fvt-manage-sec-audit-log
-    - fvt-manage-sec-inactive-auth
 
 # Manage FVT Work Order Basic Scenario
 - name: fvt-manage-wo-basic
@@ -103,8 +93,6 @@
   runAfter:
     - fvt-manage-setup
     - fvt-manage-monitoring
-    - fvt-manage-sec-audit-log
-    - fvt-manage-sec-inactive-auth
 
 # Manage FVT E-Signature Basic Scenario
 - name: fvt-manage-esig-basic
@@ -119,8 +107,6 @@
   runAfter:
     - fvt-manage-setup
     - fvt-manage-monitoring
-    - fvt-manage-sec-audit-log
-    - fvt-manage-sec-inactive-auth
 
 # Manage FVT E-Audit Basic
 - name: fvt-manage-eaudit-basic
@@ -135,5 +121,3 @@
   runAfter:
     - fvt-manage-setup
     - fvt-manage-monitoring
-    - fvt-manage-sec-audit-log
-    - fvt-manage-sec-inactive-auth

--- a/tekton/src/pipelines/taskdefs/fvt-manage/phase4.yml.j2
+++ b/tekton/src/pipelines/taskdefs/fvt-manage/phase4.yml.j2
@@ -1,11 +1,53 @@
 # -------------------------------------------------------------
 # PHASE 4
+# - fvt-manage-sec-audit-log
+# - fvt-manage-sec-inactive-auth
 # - fvt-manage-mif-kafka
 # - fvt-manage-wo-doclink
 # - fvt-manage-directprint
 # - fvt-manage-adhoc-report
 # - fvt-manage-jms-outbound
 # -------------------------------------------------------------
+
+# Manage FVT Security Audit Logging
+- name: fvt-manage-sec-audit-log
+  {{ lookup('template', 'taskdefs/fvt-manage/ui/taskref.yml.j2') | indent(2) }}
+  {{ lookup('template', 'taskdefs/fvt-manage/ui/when.yml.j2') | indent(2) }}
+  params:
+    {{ lookup('template', 'taskdefs/fvt-manage/ui/params.yml.j2') | indent(4) }}
+    - name: fvt_test_suite_prefix
+      value: core
+    - name: fvt_test_suite
+      value: sec-audit-log
+  runAfter:
+    - fvt-manage-escalation-action
+    - fvt-manage-autoscript-adddeletewo
+    - fvt-manage-jms-inbound
+    - fvt-manage-mif-kafka-setup
+    - fvt-manage-birt-report
+    - fvt-manage-user-crud
+    - fvt-manage-user-consumption
+    - fvt-manage-communication-temp
+
+# Manage FVT Inactive User Authentication
+- name: fvt-manage-sec-inactive-auth
+  {{ lookup('template', 'taskdefs/fvt-manage/ui/taskref.yml.j2') | indent(2) }}
+  {{ lookup('template', 'taskdefs/fvt-manage/ui/when.yml.j2') | indent(2) }}
+  params:
+    {{ lookup('template', 'taskdefs/fvt-manage/ui/params.yml.j2') | indent(4) }}
+    - name: fvt_test_suite_prefix
+      value: core
+    - name: fvt_test_suite
+      value: sec-inactive-auth
+  runAfter:
+    - fvt-manage-escalation-action
+    - fvt-manage-autoscript-adddeletewo
+    - fvt-manage-jms-inbound
+    - fvt-manage-mif-kafka-setup
+    - fvt-manage-birt-report
+    - fvt-manage-user-crud
+    - fvt-manage-user-consumption
+    - fvt-manage-communication-temp
 
 # Manage FVT Kafka Setup
 - name: fvt-manage-mif-kafka

--- a/tekton/src/pipelines/taskdefs/fvt-manage/phase5.yml.j2
+++ b/tekton/src/pipelines/taskdefs/fvt-manage/phase5.yml.j2
@@ -15,6 +15,8 @@
   params:
     {{ lookup('template', 'taskdefs/fvt-manage/ui/params.yml.j2') | indent(4) }}    
   runAfter:
+    - fvt-manage-sec-audit-log
+    - fvt-manage-sec-inactive-auth
     - fvt-manage-mif-kafka
     - fvt-manage-wo-doclink
     - fvt-manage-directprint


### PR DESCRIPTION
`fvt-manage-sec-audit-log` and `fvt-manage-sec-inactive-auth`depend on core-setup execution, so they cannot keep running in parallel with it during phase 1. This PR is to move them both to phase 4.