### PR TITLE
[patch] Tidy up upgrade output

### DIFF
--- a/image/cli/mascli/functions/upgrade
+++ b/image/cli/mascli/functions/upgrade
@@ -96,7 +96,7 @@ function upgrade() {
   echo_h2 "Review Settings"
 
   echo "${TEXT_DIM}"
-  echo_h2 "Maximo Application Suite" "    "
+  echo_h4 "Maximo Application Suite" "    "
   echo_reset_dim "Instance ID ..................... ${COLOR_MAGENTA}${MAS_INSTANCE_ID}"
 
   echo


### PR DESCRIPTION
Small tweak to the output of `mas update`.

Before:
![image](https://github.com/ibm-mas/cli/assets/4400618/27a9070b-34e2-493b-bdcc-be3e2cac36ef)

After:
![image](https://github.com/ibm-mas/cli/assets/4400618/2f870f7c-43a1-46bf-a1aa-cce2113ff2d6)
