### PR TITLE
[patch] Double FVT timeout to 8 hours

### DIFF
--- a/image/cli/masfvt/templates/mas-fvt-assist.yml.j2
+++ b/image/cli/masfvt/templates/mas-fvt-assist.yml.j2
@@ -11,7 +11,7 @@ spec:
     name: mas-fvt-assist
 
   serviceAccountName: pipeline
-  timeout: "4h"
+  timeout: "8h"
 
   params:
     # Pull Policy

--- a/image/cli/masfvt/templates/mas-fvt-core.yml.j2
+++ b/image/cli/masfvt/templates/mas-fvt-core.yml.j2
@@ -11,7 +11,7 @@ spec:
     name: mas-fvt-core
 
   serviceAccountName: pipeline
-  timeout: "4h"
+  timeout: "8h"
 
   params:
     # Pull Policy

--- a/image/cli/masfvt/templates/mas-fvt-manage.yml.j2
+++ b/image/cli/masfvt/templates/mas-fvt-manage.yml.j2
@@ -11,7 +11,7 @@ spec:
     name: mas-fvt-manage
 
   serviceAccountName: pipeline
-  timeout: "4h"
+  timeout: "8h"
 
   params:
     # Pull Policy

--- a/tekton/src/tasks/fvt-launcher/launchfvt-assist.yml.j2
+++ b/tekton/src/tasks/fvt-launcher/launchfvt-assist.yml.j2
@@ -114,11 +114,11 @@ spec:
     - name: wait-for-pipelinerun
       image: quay.io/ibmmas/cli:latest
       imagePullPolicy: $(params.image_pull_policy)
-      # 50 retries at 5 minute intervals = just over 4 hours
+      # 50 retries at 10 minute intervals = just over 8 hours
       command:
         - /opt/app-root/src/wait-for-pipelinerun.sh
         - --delay
-        - "300"
+        - "600"
         - --max-retries
         - "50"
         - --ignore-failure

--- a/tekton/src/tasks/fvt-launcher/launchfvt-core.yml.j2
+++ b/tekton/src/tasks/fvt-launcher/launchfvt-core.yml.j2
@@ -121,11 +121,11 @@ spec:
     - name: wait-for-pipelinerun
       image: quay.io/ibmmas/cli:latest
       imagePullPolicy: $(params.image_pull_policy)
-      # 50 retries at 5 minute intervals = just over 4 hours
+      # 50 retries at 10 minute intervals = just over 8 hours
       command:
         - /opt/app-root/src/wait-for-pipelinerun.sh
         - --delay
-        - "300"
+        - "600"
         - --max-retries
         - "50"
         - --ignore-failure

--- a/tekton/src/tasks/fvt-launcher/launchfvt-manage.yml.j2
+++ b/tekton/src/tasks/fvt-launcher/launchfvt-manage.yml.j2
@@ -109,11 +109,11 @@ spec:
     - name: wait-for-pipelinerun
       image: quay.io/ibmmas/cli:latest
       imagePullPolicy: $(params.image_pull_policy)
-      # 50 retries at 5 minute intervals = just over 4 hours
+      # 50 retries at 10 minute intervals = just over 8 hours
       command:
         - /opt/app-root/src/wait-for-pipelinerun.sh
         - --delay
-        - "300"
+        - "600"
         - --max-retries
         - "50"
         - --ignore-failure


### PR DESCRIPTION
4 hours is't enough, and we really want the timeouts to be a last resort to catch rogue processes rather than something agressively tuned.

![image](https://github.com/ibm-mas/cli/assets/4400618/3b7f1fac-0e3b-4b33-b8b5-6ae551282ee6)
