### PR TITLE
[patch] Add MVI podTemplates

### DIFF
--- a/image/cli/mascli/functions/internal/install_pipelinerun_prepare
+++ b/image/cli/mascli/functions/internal/install_pipelinerun_prepare
@@ -70,6 +70,7 @@ function install_pipelinerun_prepare() {
       --from-file=${MAS_POD_TEMPLATES_DIR:+$MAS_POD_TEMPLATES_DIR/ibm-mas-slscfg.yml} \
       --from-file=${MAS_POD_TEMPLATES_DIR:+$MAS_POD_TEMPLATES_DIR/ibm-mas-smtpcfg.yml} \
       --from-file=${MAS_POD_TEMPLATES_DIR:+$MAS_POD_TEMPLATES_DIR/ibm-mas-suite.yml} \
+      --from-file=${MAS_POD_TEMPLATES_DIR:+$MAS_POD_TEMPLATES_DIR/ibm-mas-visualinspection.yml} \
       --from-file=${MAS_POD_TEMPLATES_DIR:+$MAS_POD_TEMPLATES_DIR/ibm-sls-licenseservice.yml} &>> $LOGFILE
   else
     # pipeline-pod-templates must exist (otherwise the suite-install step will hang), but can be empty

--- a/image/cli/mascli/templates/pod-templates/best-effort/ibm-mas-visualinspection.yml
+++ b/image/cli/mascli/templates/pod-templates/best-effort/ibm-mas-visualinspection.yml
@@ -1,0 +1,34 @@
+# supportedPodKeys
+# =============================================================================
+# This list defines the resources for pod containers/initContainers that get
+# assigned a QoS class of Guaranteed. More can be found here:
+# https://kubernetes.io/docs/tasks/configure-pod-container/quality-service-pod
+podTemplates:
+  - name: vision-service
+    containers:
+      - name: vision-service
+        resources: {}
+  - name: vision-ui
+    containers:
+      - name: vision-ui
+        resources: {}
+  - name: vision-video-microservice
+    containers:
+      - name: vision-video-microservice
+        resources: {}
+  - name: vision-dataset-summarization
+    containers:
+      - name: vision-dataset-summarization
+        resources: {}
+  - name: vision-edgeman
+    containers:
+      - name: vision-edgeman
+        resources: {}
+  - name: vision-dataset-feature
+    containers:
+      - name: vision-dataset-feature
+        resources: {}
+  - name: vision-model-conversion
+    containers:
+      - name: vision-model-conversion
+        resources: {}

--- a/image/cli/mascli/templates/pod-templates/guaranteed/ibm-mas-visualinspection.yml
+++ b/image/cli/mascli/templates/pod-templates/guaranteed/ibm-mas-visualinspection.yml
@@ -1,0 +1,76 @@
+# supportedPodKeys
+# =============================================================================
+# This list defines the resources for pod containers/initContainers that get
+# assigned a QoS class of Guaranteed. More can be found here:
+# https://kubernetes.io/docs/tasks/configure-pod-container/quality-service-pod
+podTemplates:
+  - name: vision-service
+    containers:
+      - name: vision-service
+        resources:
+          requests:
+            cpu: "20"
+            memory: "25Gi"
+          limits:
+            cpu: "20"
+            memory: "25Gi"
+  - name: vision-ui
+    containers:
+      - name: vision-ui
+        resources: 
+          requests:   
+            cpu: "1"
+            memory: "1024Mi"
+          limits:   
+            cpu: "1"
+            memory: "1024Mi"
+  - name: vision-video-microservice
+    containers:
+      - name: vision-video-microservice
+        resources:
+          requests:
+            cpu: "20"
+            memory: "12Gi"
+          limits:
+            cpu: "20"
+            memory: "12Gi"
+  - name: vision-dataset-summarization
+    containers:
+      - name: vision-dataset-summarization
+        resources:
+          requests:
+            cpu: "1"
+            memory: "1Gi"
+          limits:
+            cpu: "1"
+            memory: "1Gi"
+  - name: vision-edgeman
+    containers:
+      - name: vision-edgeman
+        resources:
+          requests:
+            cpu: "1"
+            memory: "1Gi"
+          limits:
+            cpu: "1"
+            memory: "1Gi"
+  - name: vision-dataset-feature
+    containers:
+      - name: vision-dataset-feature
+        resources:
+          requests:
+            cpu: "2"
+            memory: "10Gi"
+          limits:
+            cpu: "2"
+            memory: "10Gi"
+  - name: vision-model-conversion
+    containers:
+      - name: vision-model-conversion
+        resources:
+          requests:
+            cpu: "2"
+            memory: "6Gi"
+          limits:
+            cpu: "2"
+            memory: "6Gi"

--- a/image/cli/mascli/templates/pod-templates/guaranteed/ibm-mas-visualinspection.yml
+++ b/image/cli/mascli/templates/pod-templates/guaranteed/ibm-mas-visualinspection.yml
@@ -1,0 +1,77 @@
+# supportedPodKeys
+# =============================================================================
+# This list defines the resources for pod containers/initContainers that get
+# assigned a QoS class of Guaranteed. More can be found here:
+# https://kubernetes.io/docs/tasks/configure-pod-container/quality-service-pod
+podTemplates:
+  - name: vision-service
+    containers:
+      - name: vision-service
+        resources:
+          requests:
+            cpu: "20"
+            memory: "25Gi"
+          limits:
+            cpu: "20"
+            memory: "25Gi"
+  - name: vision-ui
+    containers:
+      - name: vision-ui
+        resources: 
+          requests:   
+            cpu: "1"
+            memory: "1024Mi"
+          limits:   
+            cpu: "1"
+            memory: "1024Mi"
+  - name: vision-video-microservice
+    containers:
+      - name: vision-video-microservice
+        resources:
+          requests:
+            cpu: "20"
+            memory: "12Gi"
+          limits:
+            cpu: "20"
+            memory: "12Gi"
+  - name: vision-dataset-summarization
+    containers:
+      - name: vision-dataset-summarization
+        resources:
+          requests:
+            cpu: "1"
+            memory: "1Gi"
+          limits:
+            cpu: "1"
+            memory: "1Gi"
+  - name: vision-edgeman
+    containers:
+      - name: vision-edgeman
+        resources:
+          requests:
+            cpu: "1"
+            memory: "1Gi"
+          limits:
+            cpu: "1"
+            memory: "1Gi"
+  - name: vision-dataset-feature
+    containers:
+      - name: vision-dataset-feature
+        resources:
+          requests:
+            cpu: "2"
+            memory: "10Gi"
+          limits:
+            cpu: "2"
+            memory: "10Gi"
+  - name: vision-model-conversion
+    containers:
+      - name: vision-model-conversion
+        resources:
+          requests:
+            cpu: "2"
+            memory: "6Gi"
+          limits:
+            cpu: "2"
+            memory: "6Gi"
+

--- a/image/cli/mascli/templates/pod-templates/saas-essentials/ibm-mas-visualinspection.yml
+++ b/image/cli/mascli/templates/pod-templates/saas-essentials/ibm-mas-visualinspection.yml
@@ -1,0 +1,46 @@
+# supportedPodKeys
+# =============================================================================
+# This list defines the resources for pod containers/initContainers that get
+# assigned a QoS class of Guaranteed. More can be found here:
+# https://kubernetes.io/docs/tasks/configure-pod-container/quality-service-pod
+podTemplates:
+  - name: vision-service
+    containers:
+      - name: vision-service
+        resources:
+          requests:
+            cpu: "1"
+            memory: 2Gi
+          limits:
+            cpu: "5"
+            memory: 10Gi
+  - name: vision-edgeman
+    containers:
+      - name: vision-edgeman
+        resources:
+          requests:
+            cpu: "0.25"
+            memory: 128Mi
+          limits:
+            cpu: "0.5"
+            memory: 256Mi
+  - name: vision-video-microservice
+    containers:
+      - name: vision-video-microservice
+        resources:
+          requests:
+            cpu: "0.1"
+            memory: 512Mi
+          limits:
+            cpu: "2"
+            memory: 2Gi
+  - name: vision-dataset-summarization
+    containers:
+      - name: vision-dataset-summarization
+        resources:
+          requests:
+            cpu: "0.1"
+            memory: 128Mi
+          limits:
+            cpu: "1"
+            memory: 1Gi


### PR DESCRIPTION
Visual Inspection added support for podTemplates in the last release, this update adds missing definitions for `guaranteed`, `best-effort`, and `saas-essentials` configurations to the samples available in the CLI.