### PR TITLE
[patch] Fix display of existing catalog version

### DIFF
--- a/image/cli/mascli/functions/update
+++ b/image/cli/mascli/functions/update
@@ -73,6 +73,8 @@ function show_current_catalog() {
   reset_colors
 
   if [[ "$catalogDisplayName" =~ .+(v8-[0-9]+-amd64) ]]; then
+    # catalogId = v8-yymmdd-amd64
+    # catalogVersion = yymmdd
     catalogId=$(sed -E "s/.+\\((v8-[0-9]+-amd64)\\)/\1/" <<< $catalogDisplayName)
     catalogVersion=$(sed -E "s/.+\\(v8-([0-9]+)-amd64\\)/\1/" <<< $catalogDisplayName)
     catalogIsDynamic=false
@@ -213,7 +215,7 @@ function update() {
 
   echo "${TEXT_DIM}"
   echo_h4 "IBM Operator Catalog" "    "
-  echo_reset_dim "Current Catalog Version .................... ${COLOR_MAGENTA}${catalogVersion:-unknown}${COLOR_RESET}"
+  echo_reset_dim "Current Catalog Version .................... ${COLOR_MAGENTA}${catalogId:-unknown}${COLOR_RESET}"
   echo_reset_dim "Updated Catalog Version .................... ${COLOR_MAGENTA}${MAS_CATALOG_VERSION}${COLOR_RESET}"
   echo "${TEXT_DIM}"
   echo_h4 "Updates" "    "


### PR DESCRIPTION
We currently show e.g. `231004` as the catalog version instead of `v8-231004-amd64` in the update confirmation section.

Before
![image](https://github.com/ibm-mas/cli/assets/4400618/b0fa53c9-df0c-402a-a78a-2bc7f4f6cdc3)

After
![image](https://github.com/ibm-mas/cli/assets/4400618/b3f20d2a-421f-460d-945b-7eae2d3b1a40)
