### PR TITLE
[patch] SLS update is "dangling" in update pipeline

### DIFF
--- a/tekton/src/pipelines/update.yml.j2
+++ b/tekton/src/pipelines/update.yml.j2
@@ -242,6 +242,7 @@ spec:
         'devops_suite_name': 'post-deps-update-verify'
       }) | indent(4) }}
       runAfter:
+        - update-licenseservice
         - update-db2
         - update-mongodb
         - update-kafka


### PR DESCRIPTION
As below, the `licenseservice-update` stage in the pipeline doesn't feed into the post-deps-update-verify stage, thus we have an (admitedly tiny, perhaps even only theoretical) window where updates to SLS could be applied during/after the final veriify.

![image](https://github.com/ibm-mas/cli/assets/4400618/04bc50dd-8ca6-4540-8ef5-a6945fca4178)
