### PR TITLE
[patch] fix wrong kafka_version default

### DIFF
--- a/image/cli/mascli/functions/update
+++ b/image/cli/mascli/functions/update
@@ -183,10 +183,10 @@ function update_interactive() {
     if [ "$?" == "0" ]; then
       if [ "$KAFKA_OPERATOR" == "amq-streams" ]; then
         KAFKA_PROVIDER="redhat"
-        KAFKA_PROVIDER_NAME="AMQ Streams ................................"
+        KAFKA_PROVIDER_NAME="AMQ Streams) ........................"
       elif [ "$KAFKA_OPERATOR" == "strimzi-kafka-operator" ]; then
         KAFKA_PROVIDER="strimzi"
-        KAFKA_PROVIDER_NAME="Strimzi ...................................."
+        KAFKA_PROVIDER_NAME="Strimzi) ............................"
       fi
     fi
   fi
@@ -246,7 +246,7 @@ function update() {
 
   # Kafka (Strimzi/AMQ Streams)
   if [ "$KAFKA_NAMESPACE" != "" ]; then
-    echo_reset_dim "Kafka ($KAFKA_PROVIDER_NAME) ${COLOR_GREEN}Yes ($KAFKA_NAMESPACE)${COLOR_RESET}"
+    echo_reset_dim "Kafka ($KAFKA_PROVIDER_NAME ${COLOR_GREEN}Yes ($KAFKA_NAMESPACE)${COLOR_RESET}"
   else
     echo_reset_dim "Kafka ...................................... ${COLOR_RED}No${COLOR_RESET}"
   fi

--- a/tekton/src/tasks/dependencies/kafka.yml.j2
+++ b/tekton/src/tasks/dependencies/kafka.yml.j2
@@ -30,7 +30,7 @@ spec:
       default: "strimzi"
     - name: kafka_version
       type: string
-      default: "strimzi"
+      default: ""
     - name: kafka_cluster_name
       type: string
       default: "maskafka"


### PR DESCRIPTION
**- fix `kafka_version` invalid default value**

When running `mas update` we're having issues on kafka update task:

<img width="1373" alt="image" src="https://github.com/ibm-mas/cli/assets/31037381/3183035e-540a-4c5c-bab9-4c9fd69d4baa">

Issue is that we might have wrongly added `kafka_version` where it should be `kafka_provider` so it ended up having an invalid default value:
https://github.com/ibm-mas/cli/blob/master/tekton/src/tasks/dependencies/kafka.yml.j2#L33

This was the commit:
https://github.com/ibm-mas/cli/pull/569/files#diff-05055b21d5f83ada88536ba8a0c228bd16994afb78cc3c2ca010130cadd14840

with the fix:

<img width="774" alt="image" src="https://github.com/ibm-mas/cli/assets/31037381/14892d04-e82d-4b07-a7c8-a90a3d22fc5d">


**- fix kafka review settings alignment**

without the fix:

<img width="955" alt="image" src="https://github.com/ibm-mas/cli/assets/31037381/0d3cfd49-db86-45a1-b267-3f2e25baada5">

with the fix:

<img width="868" alt="image" src="https://github.com/ibm-mas/cli/assets/31037381/f5a7202a-3c6e-43d4-ac79-56681d34ea36">