### PR TITLE
[patch] Pass fvt_test_suite to Monitor FVT pipeline

### DIFF
--- a/image/cli/masfvt/templates/mas-fvt-monitor.yml.j2
+++ b/image/cli/masfvt/templates/mas-fvt-monitor.yml.j2
@@ -38,6 +38,9 @@ spec:
       value: "{{ fvt_digest_ctf }}"
     - name: ivt_digest_core
       value: "{{ ivt_digest_core }}"
+    # Which FVT suite to run ('monitor_fvt' or 'monitor_fvt_with_manage')
+    - name: fvt_test_suite
+      value: "{{ fvt_test_suite }}"
 
   workspaces:
     # The generated configuration files

--- a/tekton/src/tasks/fvt/fvt-monitor.yml.j2
+++ b/tekton/src/tasks/fvt/fvt-monitor.yml.j2
@@ -40,8 +40,7 @@ spec:
       default: "true"
     - name: fvt_test_suite
       type: string
-      description: If the FVT container image contains multiple suites, use this to control the suite that will be executed
-      default: ""
+      description: Which Monitor FVT suite to run ('monitor_fvt' or 'monitor_fvt_with_manage')
     - name: ctf_is_local
       type: string
       description: Boolean value to check if tests are runninng locally or on fvt


### PR DESCRIPTION
We are currently failing to pass `fvt_test_suite` through the pipelinerun defintion in `/masfvt/templates` so when the Monitor FVT pipeline starts it does not know what FVT suite to run.

Also removes the default `""` value for  `fvt_test_suite`  from the pipeline definition, so that if this were to happen again it would be flagged as an invalid pipelinerun spec.