### PR TITLE
[patch] Add missing ivt_digest_core param

### DIFF
--- a/image/cli/masfvt/templates/mas-fvt-manage.yml.j2
+++ b/image/cli/masfvt/templates/mas-fvt-manage.yml.j2
@@ -36,6 +36,8 @@ spec:
       value: "{{ fvt_digest_manage }}"
     - name: fvt_digest_manage_pytest
       value: "{{ fvt_digest_manage_pytest }}"
+    - name: ivt_digest_core
+      value: "{{ fvt_digest_core }}"
     # Test data
     - name: fvt_manage_automation_version
       value: "{{ fvt_manage_automation_version }}"


### PR DESCRIPTION
The FVT launcher is missing the `ivt_digest_core` param from it's pipelinerun template.