### PR TITLE
[patch] Various catalog documentation updates

### DIFF
--- a/docs/catalogs/index.md
+++ b/docs/catalogs/index.md
@@ -1,8 +1,17 @@
 Catalog Options
 -------------------------------------------------------------------------------
+As the MAS CLI is updated we maintain a rolling window of approximately four months worth of catalogs in the interactive mode choices for install, mirror-images, and update functions; after this period the catalogs will be removed from the options, generally speaking customers are recommended to use the latest catalog with the latest CLI for new installs, even if installing an older release of MAS.  Older catalogs can still be used once they are not shown in the interactive prompt, but this is not recommended.
+
+All catalogs are available **indefinitely**, but they have a useful lifespan limited by the support statements of the packages available in the catalog and the OCP release the catalog is certified on.
 
 !!! important
-    Whether you are using dynamic or static catalogs we **strongly discourage the use of manual update approvals on subscriptions**.  In our experience it leads to overly complicated updates requiring significant administrative effort when taking into account the range of operators running in a cluster across numerous namespaces.
+    No catalog prior to the June 16 update is currently supported because OCP 4.10 EOL was September 10th 2023 and the June update was the first certified for use with OCP v4.11 and v4.12.
+
+We **never** remove catalog images from the IBM Container Registry (ICR), even the first Maximo Operator Catalog ever published - [v8-220717-amd64](v8-220717-amd64.md) - is still available today, however it's usefulness is questionable due to the end of life of all compatible OCP releases.
+
+
+!!! important
+    Whether you are using dynamic or static catalogs we **strongly discourage the use of manual update approvals on subscriptions**, and when using the MAS CLI **use of manual update approvals is outright not supported**.  In our experience it leads to overly complicated updates requiring significant administrative effort when taking into account the range of operators running in a cluster across numerous namespaces.
 
     If you desire control over when updates are introduced to your cluster we highly recommend the use of static operator catalogs.
 
@@ -38,27 +47,28 @@ The static operator catalogs provide a fixed reference point, if you use a stati
 To receive security updates and bug fixes you must periodically update the version of the static catalog that you have installed in the cluster.  Once you do this all operators that you have installed from the catalog will automatically update to the newer version.  We aim to release a catalog update monthly.
 
 #### 2023
-| Catalog                               | OCP Support | End of Support                  |
-| ------------------------------------- | ----------- | ------------------------------- |
-| [v8-231031-amd64](v8-231031-amd64.md) | 4.10 - 4.12 | OCP 4.12 EOS January 17, 2025   |
-| [v8-231004-amd64](v8-231004-amd64.md) | 4.10 - 4.12 | OCP 4.12 EOS January 17, 2025   |
-| [v8-230926-amd64](v8-230926-amd64.md) | 4.10 - 4.12 | OCP 4.12 EOS January 17, 2025   |
-| [v8-230829-amd64](v8-230829-amd64.md) | 4.10 - 4.12 | OCP 4.12 EOS January 17, 2025   |
-| [v8-230725-amd64](v8-230725-amd64.md) | 4.10 - 4.12 | OCP 4.12 EOS January 17, 2025   |
-| [v8-230721-amd64](v8-230721-amd64.md) | 4.10 - 4.12 | OCP 4.12 EOS January 17, 2025   |
-| [v8-230616-amd64](v8-230616-amd64.md) | 4.10 - 4.12 | OCP 4.12 EOS January 17, 2025   |
-| [v8-230526-amd64](v8-230526-amd64.md) | 4.10        | OCP 4.10 EOS September 10, 2023 |
-| [v8-230518-amd64](v8-230518-amd64.md) | 4.10        | OCP 4.10 EOS September 10, 2023 |
-| [v8-230414-amd64](v8-230414-amd64.md) | 4.8 - 4.10  | OCP 4.10 EOS September 10, 2023 |
-| [v8-230314-amd64](v8-230314-amd64.md) | 4.8 - 4.10  | OCP 4.10 EOS September 10, 2023 |
-| [v8-230217-amd64](v8-230217-amd64.md) | 4.8 - 4.10  | OCP 4.10 EOS September 10, 2023 |
-| [v8-230111-amd64](v8-230111-amd64.md) | 4.8 - 4.10  | OCP 4.10 EOS September 10, 2023 |
+| Catalog                               | OCP Support | Recommended CLI | End of Support                  |
+| ------------------------------------- | ----------- | --------------- | ------------------------------- |
+| [v8-231031-amd64](v8-231031-amd64.md) | 4.10 - 4.12 | latest          | OCP 4.12 EOS January 17, 2025   |
+| [v8-231004-amd64](v8-231004-amd64.md) | 4.10 - 4.12 | latest          | OCP 4.12 EOS January 17, 2025   |
+| [v8-230926-amd64](v8-230926-amd64.md) | 4.10 - 4.12 | latest          | OCP 4.12 EOS January 17, 2025   |
+| [v8-230829-amd64](v8-230829-amd64.md) | 4.10 - 4.12 | latest          | OCP 4.12 EOS January 17, 2025   |
+| [v8-230725-amd64](v8-230725-amd64.md) | 4.10 - 4.12 | latest          | OCP 4.12 EOS January 17, 2025   |
+| [v8-230721-amd64](v8-230721-amd64.md) | 4.10 - 4.12 | latest          | OCP 4.12 EOS January 17, 2025   |
+| [v8-230627-amd64](v8-230627-amd64.md) | 4.10 - 4.12 | 5.5.0           | OCP 4.12 EOS January 17, 2025   |
+| [v8-230616-amd64](v8-230616-amd64.md) | 4.10 - 4.12 | 5.5.0           | OCP 4.12 EOS January 17, 2025   |
+| [v8-230526-amd64](v8-230526-amd64.md) | 4.10        | 5.5.0           | OCP 4.10 EOS September 10, 2023 |
+| [v8-230518-amd64](v8-230518-amd64.md) | 4.10        | 5.5.0           | OCP 4.10 EOS September 10, 2023 |
+| [v8-230414-amd64](v8-230414-amd64.md) | 4.8 - 4.10  | 5.5.0           | OCP 4.10 EOS September 10, 2023 |
+| [v8-230314-amd64](v8-230314-amd64.md) | 4.8 - 4.10  | 4.3.1           | OCP 4.10 EOS September 10, 2023 |
+| [v8-230217-amd64](v8-230217-amd64.md) | 4.8 - 4.10  | 4.3.1           | OCP 4.10 EOS September 10, 2023 |
+| [v8-230111-amd64](v8-230111-amd64.md) | 4.8 - 4.10  | 4.3.1           | OCP 4.10 EOS September 10, 2023 |
 
 #### 2022
-| Catalog                               | OCP Support | End of Support                  |
-| ------------------------------------- | ----------- | ------------------------------- |
-| [v8-221228-amd64](v8-221228-amd64.md) | 4.6 - 4.10  | OCP 4.10 EOS September 10, 2023 |
-| [v8-221129-amd64](v8-221129-amd64.md) | 4.6 - 4.10  | OCP 4.10 EOS September 10, 2023 |
-| [v8-221025-amd64](v8-221025-amd64.md) | 4.6 - 4.10  | OCP 4.10 EOS September 10, 2023 |
-| [v8-220927-amd64](v8-220927-amd64.md) | 4.6 - 4.10  | OCP 4.10 EOS September 10, 2023 |
-| [v8-220805-amd64](v8-220805-amd64.md) | 4.6 - 4.10  | OCP 4.10 EOS September 10, 2023 |
+| Catalog                               | OCP Support | Recommended CLI | End of Support                  |
+| ------------------------------------- | ----------- | --------------- |------------------------------- |
+| [v8-221228-amd64](v8-221228-amd64.md) | 4.6 - 4.10  | 3.9.0           | OCP 4.10 EOS September 10, 2023 |
+| [v8-221129-amd64](v8-221129-amd64.md) | 4.6 - 4.10  | 3.9.0           | OCP 4.10 EOS September 10, 2023 |
+| [v8-221025-amd64](v8-221025-amd64.md) | 4.6 - 4.10  | 3.9.0           | OCP 4.10 EOS September 10, 2023 |
+| [v8-220927-amd64](v8-220927-amd64.md) | 4.6 - 4.10  | 3.5.0           | OCP 4.10 EOS September 10, 2023 |
+| [v8-220805-amd64](v8-220805-amd64.md) | 4.6 - 4.10  | 3.5.0           | OCP 4.10 EOS September 10, 2023 |

--- a/docs/catalogs/index.md
+++ b/docs/catalogs/index.md
@@ -1,13 +1,10 @@
 Catalog Options
 -------------------------------------------------------------------------------
-As the MAS CLI is updated we maintain a rolling window of approximately four months worth of catalogs in the interactive mode choices for install, mirror-images, and update functions; after this period the catalogs will be removed from the options, generally speaking customers are recommended to use the latest catalog with the latest CLI for new installs, even if installing an older release of MAS.  Older catalogs can still be used once they are not shown in the interactive prompt, but this is not recommended.
+As the MAS CLI is updated we maintain a rolling window of approximately four months worth of catalogs in the interactive mode choices for install, mirror-images, and update functions; after this period the catalogs will be removed from the options, generally speaking customers are recommended to use the latest catalog with the latest CLI for new installs, even if installing an older release of MAS.
 
-All catalogs are available **indefinitely**, but they have a useful lifespan limited by the support statements of the packages available in the catalog and the OCP release the catalog is certified on.
+Older catalogs can still be used once they are not shown in the interactive prompt, but this is not recommended, refer to the table below for the recommended version of the CLI to use with each catalog update.
 
-!!! important
-    No catalog prior to the June 16 update is currently supported because OCP 4.10 EOL was September 10th 2023 and the June update was the first certified for use with OCP v4.11 and v4.12.
-
-We **never** remove catalog images from the IBM Container Registry (ICR), even the first Maximo Operator Catalog ever published - [v8-220717-amd64](v8-220717-amd64.md) - is still available today, however it's usefulness is questionable due to the end of life of all compatible OCP releases.
+All catalogs are available **indefinitely**, but they have a useful lifespan limited by the support statements of the packages available in the catalog and the OCP release the catalog is certified on.  We **never** remove catalog images from the IBM Container Registry (ICR), even the first Maximo Operator Catalog ever published - [v8-220717-amd64](v8-220717-amd64.md) - is still available today, however it's usefulness is questionable due to the end of life of all compatible OCP releases.
 
 
 !!! important

--- a/docs/catalogs/v8-220717-amd64.md
+++ b/docs/catalogs/v8-220717-amd64.md
@@ -10,6 +10,9 @@ Details
   <tr><td>Digest</td><td>sha256:02db98338386f874dead37fb9a0b956fe59b851db09440e5523b634f7341e4bf</tr></tr>
 </table>
 
+!!! warning
+    This catalog is only certified for use on OpenShift Container Platform versions 4.8, 4.9, & 4.10, which are have all reached end of support as of **September 10th, 2023**.  For more information about the OCP lifecycle refer to the [Red Hat OpenShift Container Platform Life Cycle Policy](https://access.redhat.com/support/policy/updates/openshift/)
+
 
 Manual Installation
 -------------------------------------------------------------------------------

--- a/docs/catalogs/v8-220805-amd64.md
+++ b/docs/catalogs/v8-220805-amd64.md
@@ -10,6 +10,9 @@ Details
   <tr><td>Digest</td><td>sha256:012839d2dd801863b5a1f35de3d1e1e39d8e4a3e707f894beee091608c09aca4</tr></tr>
 </table>
 
+!!! warning
+    This catalog is only certified for use on OpenShift Container Platform versions 4.8, 4.9, & 4.10, which are have all reached end of support as of **September 10th, 2023**.  For more information about the OCP lifecycle refer to the [Red Hat OpenShift Container Platform Life Cycle Policy](https://access.redhat.com/support/policy/updates/openshift/)
+
 
 Manual Installation
 -------------------------------------------------------------------------------

--- a/docs/catalogs/v8-220927-amd64.md
+++ b/docs/catalogs/v8-220927-amd64.md
@@ -12,6 +12,10 @@ Details
 
 Other IBM content curated from `icr.io/cpopen/ibm-operator-catalog@sha256:9c7552673a8d90bfe1da16dd8c28288b00cf6ffd6bad6edb26042c2991f266e0`
 
+!!! warning
+    This catalog is only certified for use on OpenShift Container Platform versions 4.8, 4.9, & 4.10, which are have all reached end of support as of **September 10th, 2023**.  For more information about the OCP lifecycle refer to the [Red Hat OpenShift Container Platform Life Cycle Policy](https://access.redhat.com/support/policy/updates/openshift/)
+
+
 Manual Installation
 -------------------------------------------------------------------------------
 `oc apply -f https://raw.githubusercontent.com/ibm-mas/cli/master/catalogs/v8-220927-amd64.yaml`

--- a/docs/catalogs/v8-221025-amd64.md
+++ b/docs/catalogs/v8-221025-amd64.md
@@ -12,6 +12,10 @@ Details
 
 Other IBM content curated from `icr.io/cpopen/ibm-operator-catalog@sha256:9c7552673a8d90bfe1da16dd8c28288b00cf6ffd6bad6edb26042c2991f266e0`
 
+!!! warning
+    This catalog is only certified for use on OpenShift Container Platform versions 4.8, 4.9, & 4.10, which are have all reached end of support as of **September 10th, 2023**.  For more information about the OCP lifecycle refer to the [Red Hat OpenShift Container Platform Life Cycle Policy](https://access.redhat.com/support/policy/updates/openshift/)
+
+
 Manual Installation
 -------------------------------------------------------------------------------
 `oc apply -f https://raw.githubusercontent.com/ibm-mas/cli/master/catalogs/v8-221025-amd64.yaml`

--- a/docs/catalogs/v8-221129-amd64.md
+++ b/docs/catalogs/v8-221129-amd64.md
@@ -16,7 +16,10 @@ Other IBM content curated from `icr.io/cpopen/ibm-operator-catalog@sha256:9c7552
     There is a known issue with image digests for Optimizer 8.2.2 and disconnected installation.  If you are running a disconnected install and want to use Optimizer v8.2 it is recommended that you skip this catalog update and wait for the December update.  This issue does not affect Optimizer 8.3.0.
 
 !!! warning
-    Manage v8.5.0 introduces a regression with air gap support, as such this catalog is unsuitable for customers using Maximo Manage in an air gap environment.
+    Manage v8.5.0 introduces a regression with disconnected install support, as such this catalog is unsuitable for customers using Maximo Manage in a disconnected environment.
+
+!!! warning
+    This catalog is only certified for use on OpenShift Container Platform versions 4.8, 4.9, & 4.10, which are have all reached end of support as of **September 10th, 2023**.  For more information about the OCP lifecycle refer to the [Red Hat OpenShift Container Platform Life Cycle Policy](https://access.redhat.com/support/policy/updates/openshift/)
 
 
 Manual Installation

--- a/docs/catalogs/v8-221228-amd64.md
+++ b/docs/catalogs/v8-221228-amd64.md
@@ -15,6 +15,9 @@ Other IBM content curated from `icr.io/cpopen/ibm-operator-catalog@sha256:9c7552
 !!! warning
     Manage v8.5.0 introduces a regression with air gap support, as such this catalog is unsuitable for customers using Maximo Manage in an air gap environment.
 
+!!! warning
+    This catalog is only certified for use on OpenShift Container Platform versions 4.8, 4.9, & 4.10, which are have all reached end of support as of **September 10th, 2023**.  For more information about the OCP lifecycle refer to the [Red Hat OpenShift Container Platform Life Cycle Policy](https://access.redhat.com/support/policy/updates/openshift/)
+
 
 Manual Installation
 -------------------------------------------------------------------------------

--- a/docs/catalogs/v8-230111-amd64.md
+++ b/docs/catalogs/v8-230111-amd64.md
@@ -12,6 +12,10 @@ Details
 
 Other IBM content curated from `icr.io/cpopen/ibm-operator-catalog@sha256:9c7552673a8d90bfe1da16dd8c28288b00cf6ffd6bad6edb26042c2991f266e0`
 
+!!! warning
+    This catalog is only certified for use on OpenShift Container Platform versions 4.8, 4.9, & 4.10, which are have all reached end of support as of **September 10th, 2023**.  For more information about the OCP lifecycle refer to the [Red Hat OpenShift Container Platform Life Cycle Policy](https://access.redhat.com/support/policy/updates/openshift/)
+
+
 Manual Installation
 -------------------------------------------------------------------------------
 `oc apply -f https://raw.githubusercontent.com/ibm-mas/cli/master/catalogs/v8-230111-amd64.yaml`

--- a/docs/catalogs/v8-230217-amd64.md
+++ b/docs/catalogs/v8-230217-amd64.md
@@ -12,6 +12,10 @@ Details
 
 Other IBM content curated from `icr.io/cpopen/ibm-operator-catalog@sha256:8521ac8527cf723041066e88997a264094d5f8eae20e9ffe30353444768cb3c0`
 
+!!! warning
+    This catalog is only certified for use on OpenShift Container Platform versions 4.8, 4.9, & 4.10, which are have all reached end of support as of **September 10th, 2023**.  For more information about the OCP lifecycle refer to the [Red Hat OpenShift Container Platform Life Cycle Policy](https://access.redhat.com/support/policy/updates/openshift/)
+
+
 Manual Installation
 -------------------------------------------------------------------------------
 `oc apply -f https://raw.githubusercontent.com/ibm-mas/cli/master/catalogs/v8-230217-amd64.yaml`

--- a/docs/catalogs/v8-230314-amd64.md
+++ b/docs/catalogs/v8-230314-amd64.md
@@ -12,6 +12,10 @@ Details
 
 Other IBM content curated from `icr.io/cpopen/ibm-operator-catalog@sha256:8521ac8527cf723041066e88997a264094d5f8eae20e9ffe30353444768cb3c0`
 
+!!! warning
+    This catalog is only certified for use on OpenShift Container Platform versions 4.8, 4.9, & 4.10, which are have all reached end of support as of **September 10th, 2023**.  For more information about the OCP lifecycle refer to the [Red Hat OpenShift Container Platform Life Cycle Policy](https://access.redhat.com/support/policy/updates/openshift/)
+
+
 Manual Installation
 -------------------------------------------------------------------------------
 `oc apply -f https://raw.githubusercontent.com/ibm-mas/cli/master/catalogs/v8-230314-amd64.yaml`

--- a/docs/catalogs/v8-230414-amd64.md
+++ b/docs/catalogs/v8-230414-amd64.md
@@ -14,6 +14,9 @@ Manual Installation
 -------------------------------------------------------------------------------
 `oc apply -f https://raw.githubusercontent.com/ibm-mas/cli/master/catalogs/v8-230414-amd64.yaml`
 
+!!! warning
+    This catalog is only certified for use on OpenShift Container Platform versions 4.8, 4.9, & 4.10, which are have all reached end of support as of **September 10th, 2023**.  For more information about the OCP lifecycle refer to the [Red Hat OpenShift Container Platform Life Cycle Policy](https://access.redhat.com/support/policy/updates/openshift/)
+
 
 Source
 -------------------------------------------------------------------------------

--- a/docs/catalogs/v8-230518-amd64.md
+++ b/docs/catalogs/v8-230518-amd64.md
@@ -13,6 +13,10 @@ Details
 !!! warning
     There is a known issue with image digests for Maximo Monitor v8.10.1.  If you have installed Monitor using the 8.10.x channel it is recommended that you skip this catalog update and move directly to the [May 26 Catalog Update](v8-230526-amd64.md) which provides a fix for this issue in Monitor v8.10.2.  This issue does not affect Monitor v8.9.5.
 
+!!! warning
+    This catalog is only certified for use on OpenShift Container Platform versions 4.8, 4.9, & 4.10, which are have all reached end of support as of **September 10th, 2023**.  For more information about the OCP lifecycle refer to the [Red Hat OpenShift Container Platform Life Cycle Policy](https://access.redhat.com/support/policy/updates/openshift/)
+
+
 Manual Installation
 -------------------------------------------------------------------------------
 `oc apply -f https://raw.githubusercontent.com/ibm-mas/cli/master/catalogs/v8-230518-amd64.yaml`

--- a/docs/catalogs/v8-230526-amd64.md
+++ b/docs/catalogs/v8-230526-amd64.md
@@ -10,6 +10,10 @@ Details
   <tr><td>Digest</td><td>sha256:bdae03cfd469399d29a962448dcf790dcf81d309c4bc233637c3acecf228aa1f</tr></tr>
 </table>
 
+!!! warning
+    This catalog is only certified for use on OpenShift Container Platform versions 4.8, 4.9, & 4.10, which are have all reached end of support as of **September 10th, 2023**.  For more information about the OCP lifecycle refer to the [Red Hat OpenShift Container Platform Life Cycle Policy](https://access.redhat.com/support/policy/updates/openshift/)
+
+
 Manual Installation
 -------------------------------------------------------------------------------
 `oc apply -f https://raw.githubusercontent.com/ibm-mas/cli/master/catalogs/v8-230526-amd64.yaml`

--- a/docs/catalogs/v8-230616-amd64.md
+++ b/docs/catalogs/v8-230616-amd64.md
@@ -10,6 +10,7 @@ Details
   <tr><td>Digest</td><td>sha256:cb0a38132a1e16964d9aa9b7eb5d247543df5feea218bb1100757290a07bc042</tr></tr>
 </table>
 
+
 Manual Installation
 -------------------------------------------------------------------------------
 `oc apply -f https://raw.githubusercontent.com/ibm-mas/cli/master/catalogs/v8-230616-amd64.yaml`
@@ -71,7 +72,6 @@ For more information about the OCP lifecycle refer to the [Red Hat OpenShift Con
 </table>
 
  1. Note that **IBM App Connect** and **IBM Cloud Pak for Data** do not support odd-numbered OpenShift releases, so if you intend to use Predict, HP Utilities, or Assist you are limited to use of the even numbered OCP releases.
-
 
 
 ### Certified Operators

--- a/docs/catalogs/v8-230627-amd64.md
+++ b/docs/catalogs/v8-230627-amd64.md
@@ -10,6 +10,7 @@ Details
   <tr><td>Digest</td><td>sha256:42891d978163c24737f799ed870ad340f5b3e6cd9b14644eaf1c5810ed5ef7cf</tr></tr>
 </table>
 
+
 Manual Installation
 -------------------------------------------------------------------------------
 `oc apply -f https://raw.githubusercontent.com/ibm-mas/cli/master/catalogs/v8-230627-amd64.yaml`

--- a/docs/catalogs/v8-230926-amd64.md
+++ b/docs/catalogs/v8-230926-amd64.md
@@ -10,6 +10,10 @@ Details
   <tr><td>Digest</td><td>sha256:b3ad0d8d20eee9c7e48ba93b956a4f452e48ba0a648e76c39100c352f2cb6537</tr></tr>
 </table>
 
+!!! warning
+    We strongly discourage use of this catalog.  An emergency fix was issues for the `ibm-mas` package in the [v8-231004-amd64](v8-231004-amd64.md) catalog due to a serious bug in the `8.11.0` version included in this catalog.
+
+
 Manual Installation
 -------------------------------------------------------------------------------
 `oc apply -f https://raw.githubusercontent.com/ibm-mas/cli/master/catalogs/v8-230926-amd64.yaml`
@@ -32,6 +36,7 @@ spec:
   priority: 90
 ```
 
+
 Red Hat OpenShift Container Platform Support
 -------------------------------------------------------------------------------
 IBM Maximo Application Suite will run anywhere that you can run a supported OpenShift release on AMD64 architecture, including:
@@ -45,49 +50,39 @@ For more information about the OCP lifecycle refer to the [Red Hat OpenShift Con
 
 <table class="compatabilityMatrix">
   <tr>
-    <th>OCP</th><td rowspan="6" class="spacer"></td>
+    <th>OCP</th><td rowspan="3" class="spacer"></td>
     <th>General Availability</th>
     <th>End of Support</th>
     <th>Supported MAS Releases</th>
   </tr>
   <tr>
-    <td class="firstColumn">4.10</td>
-    <td>March 10, 2022</td>
-    <td>September 10, 2023</td>
-    <td>8.9 - 8.10</td>
-  </tr>
-  <tr>
     <td class="firstColumn">4.11<sup>1</sup></td>
     <td>August 10, 2022</td>
     <td>February 10, 2024</td>
-    <td>8.9 - 8.10</td>
+    <td>8.9 - 8.11</td>
   </tr>
   <tr>
     <td class="firstColumn">4.12</td>
     <td>January 17, 2023</td>
     <td>January 17, 2025</td>
-    <td>8.9 - 8.10</td>
+    <td>8.9 - 8.11</td>
   </tr>
 </table>
 
- 1. Note that **IBM App Connect** and **IBM Cloud Pak for Data** do not support odd-numbered OpenShift releases, so if you intend to use Predict, HP Utilities, or Assist you are limited to use of the even numbered OCP releases.
-
-
 
 ### Certified Operators
-- `registry.redhat.io/redhat/certified-operator-index:v4.10`
 - `registry.redhat.io/redhat/certified-operator-index:v4.11`
 - `registry.redhat.io/redhat/certified-operator-index:v4.12`
 
 The following packages from this catalog are used in the Maximo Application Suite install:
 
+- **strimzi-kafka-operator** required by `ibm.mas_devops.kafka` role (if using Strimzi as Kakfa provider)
 - **crunchy-postgres-operator** required by `ibm.mas_devops.uds` role
 - **gpu-operator-certified** required by `ibm.mas_devops.nvidia_gpu` role
 - **kubeturbo-certified** required by `ibm.mas_devops.kubeturbo` role
 
 
 ### Community Operators
-- `registry.redhat.io/redhat/community-operator-index:v4.10`
 - `registry.redhat.io/redhat/community-operator-index:v4.11`
 - `registry.redhat.io/redhat/community-operator-index:v4.12`
 
@@ -98,19 +93,17 @@ The following packages from this catalog are used in the Maximo Application Suit
 
 
 ### Red Hat Operators
-- `registry.redhat.io/redhat/redhat-operator-index:v4.10`
 - `registry.redhat.io/redhat/redhat-operator-index:v4.11`
 - `registry.redhat.io/redhat/redhat-operator-index:v4.12`
 
 The following packages from this catalog are used in the Maximo Application Suite install:
 
-- **amq-streams** (required by `ibm.mas_devops.kafka` role)
+- **amq-streams** required by `ibm.mas_devops.kafka` role (if using AMQ Streams as Kakfa provider)
 - **openshift-pipelines-operator-rh** required by the MAS CLI
 - **nfd** required by `ibm.mas_devops.nvidia_gpu` role
 - **aws-efs-csi-driver-operator**  required by `ibm.mas_devops.ocp_efs` role
 - **local-storage-operator**  required by `ibm.mas_devops.ocs` role
-- **ocs-operator**  required by `ibm.mas_devops.ocs` role (OCP 4.10)
-- **odf-operator**  required by `ibm.mas_devops.ocs` role (OCP 4.11+)
+- **odf-operator**  required by `ibm.mas_devops.ocs` role
 
 
 IBM Cloud Pak for Data Compatibility
@@ -120,7 +113,6 @@ Maximo application compatibility with Cloud Pak for Data (CP4D) is complicated b
 Cloud Pak for Data covers the following application's dependencies:
 
 - **Assist**: Watson Discovery, Watson Text to Speak, Watson Speach to Text, Watson Assistant
-- **Health & Predict Utilities**: Watson Studio
 - **Predict**: Watson Studio, Watson Machine Learning, Watson Analytics Service, Watson Openscale
 
 <table class="compatabilityMatrix">
@@ -136,47 +128,12 @@ Cloud Pak for Data covers the following application's dependencies:
     <th>General Availability</th>
     <th>End of Support</th>
   </tr>
-  <tr> <td class="firstColumn" rowspan="1">4.10</td><td>4.6.3</td>            <td>February, 2023</td>    <td>TBD</td> <td>8.9 - 8.10</td> </tr>
-</table>
-
-
-IBM App Connect Compatibility
--------------------------------------------------------------------------------
-Health and Predict Utilities compatibility with IBM App Connect is complicated by limited OpenShift Container Platform support and need to manage an explicit license inside each operand.  For more information review the material in [IBM App Connect Enterprise certified container versions](https://www.ibm.com/support/pages/ibm-app-connect-enterprise-certified-container-versions) (also available [here](https://www.ibm.com/support/pages/node/6239294)) and [Licensing reference for IBM App Connect Operator](https://www.ibm.com/docs/en/app-connect/containers_cd?topic=resources-licensing-reference-app-connect-operator).
-
-<table class="compatabilityMatrix">
-  <tr>
-    <th class="firstColumn" rowspan="2">HP Utilities</th>
-    <td rowspan="9" class="spacer"></td>
-    <th rowspan="2">OCP</th>
-    <td rowspan="9" class="spacer"></td>
-    <th colspan="3">App Connect</th>
-  </tr>
-  <tr>
-    <th>Operator</th>
-    <th>Operand</th>
-    <th>License</th>
-  </tr>
-  <tr>
-    <td class="firstColumn">8.4 - 8.5</td>
-    <td>4.10</td>
-    <td>5.0 - 5.2</td>
-    <td>12.0.4</td>
-    <td>L-APEH-C9NCK6</td>
-  </tr>
-  <tr>
-    <td class="firstColumn">8.6</td>
-    <td>4.10,4.12 </td>
-    <td>7.1</td>
-    <td>12.0.7</td>
-    <td>L-APEH-CJUCNR</td>
-  </tr>
+  <tr> <td class="firstColumn" rowspan="1">4.11 - 4.12</td><td>4.6.6</td>            <td>February, 2023</td>    <td>TBD</td> <td>8.9 - 8.11</td> </tr>
 </table>
 
 
 Package Manifest
 -------------------------------------------------------------------------------
-
 
 ### IBM Maximo Application Suite
 | Package                  | Default Channel   | Channel   | Latest Version   |

--- a/docs/catalogs/v8-231004-amd64.md
+++ b/docs/catalogs/v8-231004-amd64.md
@@ -32,6 +32,7 @@ spec:
   priority: 90
 ```
 
+
 Red Hat OpenShift Container Platform Support
 -------------------------------------------------------------------------------
 IBM Maximo Application Suite will run anywhere that you can run a supported OpenShift release on AMD64 architecture, including:
@@ -45,49 +46,39 @@ For more information about the OCP lifecycle refer to the [Red Hat OpenShift Con
 
 <table class="compatabilityMatrix">
   <tr>
-    <th>OCP</th><td rowspan="6" class="spacer"></td>
+    <th>OCP</th><td rowspan="3" class="spacer"></td>
     <th>General Availability</th>
     <th>End of Support</th>
     <th>Supported MAS Releases</th>
   </tr>
   <tr>
-    <td class="firstColumn">4.10</td>
-    <td>March 10, 2022</td>
-    <td>September 10, 2023</td>
-    <td>8.9 - 8.10</td>
-  </tr>
-  <tr>
     <td class="firstColumn">4.11<sup>1</sup></td>
     <td>August 10, 2022</td>
     <td>February 10, 2024</td>
-    <td>8.9 - 8.10</td>
+    <td>8.9 - 8.11</td>
   </tr>
   <tr>
     <td class="firstColumn">4.12</td>
     <td>January 17, 2023</td>
     <td>January 17, 2025</td>
-    <td>8.9 - 8.10</td>
+    <td>8.9 - 8.11</td>
   </tr>
 </table>
 
- 1. Note that **IBM App Connect** and **IBM Cloud Pak for Data** do not support odd-numbered OpenShift releases, so if you intend to use Predict, HP Utilities, or Assist you are limited to use of the even numbered OCP releases.
-
-
 
 ### Certified Operators
-- `registry.redhat.io/redhat/certified-operator-index:v4.10`
 - `registry.redhat.io/redhat/certified-operator-index:v4.11`
 - `registry.redhat.io/redhat/certified-operator-index:v4.12`
 
 The following packages from this catalog are used in the Maximo Application Suite install:
 
+- **strimzi-kafka-operator** required by `ibm.mas_devops.kafka` role (if using Strimzi as Kakfa provider)
 - **crunchy-postgres-operator** required by `ibm.mas_devops.uds` role
 - **gpu-operator-certified** required by `ibm.mas_devops.nvidia_gpu` role
 - **kubeturbo-certified** required by `ibm.mas_devops.kubeturbo` role
 
 
 ### Community Operators
-- `registry.redhat.io/redhat/community-operator-index:v4.10`
 - `registry.redhat.io/redhat/community-operator-index:v4.11`
 - `registry.redhat.io/redhat/community-operator-index:v4.12`
 
@@ -98,19 +89,17 @@ The following packages from this catalog are used in the Maximo Application Suit
 
 
 ### Red Hat Operators
-- `registry.redhat.io/redhat/redhat-operator-index:v4.10`
 - `registry.redhat.io/redhat/redhat-operator-index:v4.11`
 - `registry.redhat.io/redhat/redhat-operator-index:v4.12`
 
 The following packages from this catalog are used in the Maximo Application Suite install:
 
-- **amq-streams** (required by `ibm.mas_devops.kafka` role)
+- **amq-streams** required by `ibm.mas_devops.kafka` role (if using AMQ Streams as Kakfa provider)
 - **openshift-pipelines-operator-rh** required by the MAS CLI
 - **nfd** required by `ibm.mas_devops.nvidia_gpu` role
 - **aws-efs-csi-driver-operator**  required by `ibm.mas_devops.ocp_efs` role
 - **local-storage-operator**  required by `ibm.mas_devops.ocs` role
-- **ocs-operator**  required by `ibm.mas_devops.ocs` role (OCP 4.10)
-- **odf-operator**  required by `ibm.mas_devops.ocs` role (OCP 4.11+)
+- **odf-operator**  required by `ibm.mas_devops.ocs` role
 
 
 IBM Cloud Pak for Data Compatibility
@@ -120,7 +109,6 @@ Maximo application compatibility with Cloud Pak for Data (CP4D) is complicated b
 Cloud Pak for Data covers the following application's dependencies:
 
 - **Assist**: Watson Discovery, Watson Text to Speak, Watson Speach to Text, Watson Assistant
-- **Health & Predict Utilities**: Watson Studio
 - **Predict**: Watson Studio, Watson Machine Learning, Watson Analytics Service, Watson Openscale
 
 <table class="compatabilityMatrix">
@@ -136,47 +124,12 @@ Cloud Pak for Data covers the following application's dependencies:
     <th>General Availability</th>
     <th>End of Support</th>
   </tr>
-  <tr> <td class="firstColumn" rowspan="1">4.10</td><td>4.6.3</td>            <td>February, 2023</td>    <td>TBD</td> <td>8.9 - 8.10</td> </tr>
-</table>
-
-
-IBM App Connect Compatibility
--------------------------------------------------------------------------------
-Health and Predict Utilities compatibility with IBM App Connect is complicated by limited OpenShift Container Platform support and need to manage an explicit license inside each operand.  For more information review the material in [IBM App Connect Enterprise certified container versions](https://www.ibm.com/support/pages/ibm-app-connect-enterprise-certified-container-versions) (also available [here](https://www.ibm.com/support/pages/node/6239294)) and [Licensing reference for IBM App Connect Operator](https://www.ibm.com/docs/en/app-connect/containers_cd?topic=resources-licensing-reference-app-connect-operator).
-
-<table class="compatabilityMatrix">
-  <tr>
-    <th class="firstColumn" rowspan="2">HP Utilities</th>
-    <td rowspan="9" class="spacer"></td>
-    <th rowspan="2">OCP</th>
-    <td rowspan="9" class="spacer"></td>
-    <th colspan="3">App Connect</th>
-  </tr>
-  <tr>
-    <th>Operator</th>
-    <th>Operand</th>
-    <th>License</th>
-  </tr>
-  <tr>
-    <td class="firstColumn">8.4 - 8.5</td>
-    <td>4.10</td>
-    <td>5.0 - 5.2</td>
-    <td>12.0.4</td>
-    <td>L-APEH-C9NCK6</td>
-  </tr>
-  <tr>
-    <td class="firstColumn">8.6</td>
-    <td>4.10,4.12 </td>
-    <td>7.1</td>
-    <td>12.0.7</td>
-    <td>L-APEH-CJUCNR</td>
-  </tr>
+  <tr> <td class="firstColumn" rowspan="1">4.11 - 4.12</td><td>4.6.6</td>            <td>February, 2023</td>    <td>TBD</td> <td>8.9 - 8.11</td> </tr>
 </table>
 
 
 Package Manifest
 -------------------------------------------------------------------------------
-
 
 ### IBM Maximo Application Suite
 | Package                  | Default Channel   | Channel   | Latest Version   |

--- a/docs/catalogs/v8-231031-amd64.md
+++ b/docs/catalogs/v8-231031-amd64.md
@@ -45,49 +45,39 @@ For more information about the OCP lifecycle refer to the [Red Hat OpenShift Con
 
 <table class="compatabilityMatrix">
   <tr>
-    <th>OCP</th><td rowspan="6" class="spacer"></td>
+    <th>OCP</th><td rowspan="3" class="spacer"></td>
     <th>General Availability</th>
     <th>End of Support</th>
     <th>Supported MAS Releases</th>
   </tr>
   <tr>
-    <td class="firstColumn">4.10</td>
-    <td>March 10, 2022</td>
-    <td>September 10, 2023</td>
-    <td>8.9 - 8.10</td>
-  </tr>
-  <tr>
     <td class="firstColumn">4.11<sup>1</sup></td>
     <td>August 10, 2022</td>
     <td>February 10, 2024</td>
-    <td>8.9 - 8.10</td>
+    <td>8.9 - 8.11</td>
   </tr>
   <tr>
     <td class="firstColumn">4.12</td>
     <td>January 17, 2023</td>
     <td>January 17, 2025</td>
-    <td>8.9 - 8.10</td>
+    <td>8.9 - 8.11</td>
   </tr>
 </table>
 
- 1. Note that **IBM App Connect** and **IBM Cloud Pak for Data** do not support odd-numbered OpenShift releases, so if you intend to use Predict, HP Utilities, or Assist you are limited to use of the even numbered OCP releases.
-
-
 
 ### Certified Operators
-- `registry.redhat.io/redhat/certified-operator-index:v4.10`
 - `registry.redhat.io/redhat/certified-operator-index:v4.11`
 - `registry.redhat.io/redhat/certified-operator-index:v4.12`
 
 The following packages from this catalog are used in the Maximo Application Suite install:
 
+- **strimzi-kafka-operator** required by `ibm.mas_devops.kafka` role (if using Strimzi as Kakfa provider)
 - **crunchy-postgres-operator** required by `ibm.mas_devops.uds` role
 - **gpu-operator-certified** required by `ibm.mas_devops.nvidia_gpu` role
 - **kubeturbo-certified** required by `ibm.mas_devops.kubeturbo` role
 
 
 ### Community Operators
-- `registry.redhat.io/redhat/community-operator-index:v4.10`
 - `registry.redhat.io/redhat/community-operator-index:v4.11`
 - `registry.redhat.io/redhat/community-operator-index:v4.12`
 
@@ -98,19 +88,17 @@ The following packages from this catalog are used in the Maximo Application Suit
 
 
 ### Red Hat Operators
-- `registry.redhat.io/redhat/redhat-operator-index:v4.10`
 - `registry.redhat.io/redhat/redhat-operator-index:v4.11`
 - `registry.redhat.io/redhat/redhat-operator-index:v4.12`
 
 The following packages from this catalog are used in the Maximo Application Suite install:
 
-- **amq-streams** (required by `ibm.mas_devops.kafka` role)
+- **amq-streams** required by `ibm.mas_devops.kafka` role (if using AMQ Streams as Kakfa provider)
 - **openshift-pipelines-operator-rh** required by the MAS CLI
 - **nfd** required by `ibm.mas_devops.nvidia_gpu` role
 - **aws-efs-csi-driver-operator**  required by `ibm.mas_devops.ocp_efs` role
 - **local-storage-operator**  required by `ibm.mas_devops.ocs` role
-- **ocs-operator**  required by `ibm.mas_devops.ocs` role (OCP 4.10)
-- **odf-operator**  required by `ibm.mas_devops.ocs` role (OCP 4.11+)
+- **odf-operator**  required by `ibm.mas_devops.ocs` role
 
 
 IBM Cloud Pak for Data Compatibility
@@ -120,7 +108,6 @@ Maximo application compatibility with Cloud Pak for Data (CP4D) is complicated b
 Cloud Pak for Data covers the following application's dependencies:
 
 - **Assist**: Watson Discovery, Watson Text to Speak, Watson Speach to Text, Watson Assistant
-- **Health & Predict Utilities**: Watson Studio
 - **Predict**: Watson Studio, Watson Machine Learning, Watson Analytics Service, Watson Openscale
 
 <table class="compatabilityMatrix">
@@ -136,47 +123,12 @@ Cloud Pak for Data covers the following application's dependencies:
     <th>General Availability</th>
     <th>End of Support</th>
   </tr>
-  <tr> <td class="firstColumn" rowspan="1">4.10</td><td>4.6.3</td>            <td>February, 2023</td>    <td>TBD</td> <td>8.9 - 8.10</td> </tr>
-</table>
-
-
-IBM App Connect Compatibility
--------------------------------------------------------------------------------
-Health and Predict Utilities compatibility with IBM App Connect is complicated by limited OpenShift Container Platform support and need to manage an explicit license inside each operand.  For more information review the material in [IBM App Connect Enterprise certified container versions](https://www.ibm.com/support/pages/ibm-app-connect-enterprise-certified-container-versions) (also available [here](https://www.ibm.com/support/pages/node/6239294)) and [Licensing reference for IBM App Connect Operator](https://www.ibm.com/docs/en/app-connect/containers_cd?topic=resources-licensing-reference-app-connect-operator).
-
-<table class="compatabilityMatrix">
-  <tr>
-    <th class="firstColumn" rowspan="2">HP Utilities</th>
-    <td rowspan="9" class="spacer"></td>
-    <th rowspan="2">OCP</th>
-    <td rowspan="9" class="spacer"></td>
-    <th colspan="3">App Connect</th>
-  </tr>
-  <tr>
-    <th>Operator</th>
-    <th>Operand</th>
-    <th>License</th>
-  </tr>
-  <tr>
-    <td class="firstColumn">8.4 - 8.5</td>
-    <td>4.10</td>
-    <td>5.0 - 5.2</td>
-    <td>12.0.4</td>
-    <td>L-APEH-C9NCK6</td>
-  </tr>
-  <tr>
-    <td class="firstColumn">8.6</td>
-    <td>4.10,4.12 </td>
-    <td>7.1</td>
-    <td>12.0.7</td>
-    <td>L-APEH-CJUCNR</td>
-  </tr>
+  <tr> <td class="firstColumn" rowspan="1">4.11 - 4.12</td><td>4.6.6</td>            <td>February, 2023</td>    <td>TBD</td> <td>8.9 - 8.11</td> </tr>
 </table>
 
 
 Package Manifest
 -------------------------------------------------------------------------------
-
 
 ### IBM Maximo Application Suite
 | Package                  | Default Channel   | Channel   | Latest Version   |

--- a/image/cli/mascli/functions/internal/install_pipelinerun_prepare
+++ b/image/cli/mascli/functions/internal/install_pipelinerun_prepare
@@ -116,7 +116,7 @@ function install_pipelinerun_prepare() {
     echo "- It could also mean that your cluster's ImageContentSourcePolicy is misconfigured and does not contain an entry for quay.io/ibmmas"
     echo "- Check the deployment status of mas-cli in your pipeline namespace. This will provide you with more information about the issue."
 
-    echo -e "\n\n[WARNING] $CLI_IMAGE is unavailable from the target OCP cluster" >> $LOGFILE
+    echo -e "\n\n[WARNING] Failed to validate $CLI_IMAGE in the target OCP cluster" >> $LOGFILE
     echo_hr1 >> $LOGFILE
     oc -n $PIPELINES_NS get pods --selector="app=mas-cli" -o yaml >> $LOGFILE
     exit 1

--- a/image/cli/mascli/functions/internal/install_pipelinerun_prepare
+++ b/image/cli/mascli/functions/internal/install_pipelinerun_prepare
@@ -110,10 +110,11 @@ function install_pipelinerun_prepare() {
     echo -en "\033[u" # Restore cursor position
 
     # We can't get the image, so there's no point running the pipeline
-    echo_warning "$CLI_IMAGE is unavailable from the target OCP cluster"
+    echo_warning "Failed to validate $CLI_IMAGE in the target OCP cluster"
     echo "This image must be accessible from your OpenShift cluster to run the installation:"
     echo "- If you are running an offline (air gap) installation this likely means you have not mirrored this image to your private registry"
     echo "- It could also mean that your cluster's ImageContentSourcePolicy is misconfigured and does not contain an entry for quay.io/ibmmas"
+    echo "- Check the deployment status of mas-cli in your pipeline namespace. This will provide you with more information about the issue."
 
     echo -e "\n\n[WARNING] $CLI_IMAGE is unavailable from the target OCP cluster" >> $LOGFILE
     echo_hr1 >> $LOGFILE


### PR DESCRIPTION
During a recent case study with a client, we noticed an inconsistency with the error message. Instead of an issue related to pulling the CLI image, the error was due to a different cause. 

In this particular client situation, a complication occurred during volume mounting in the deployment process. The storage account did not possess the necessary permissions to finalize the pod volume mount. This resulted in a miscommunication where the CLI inaccurately reported an image pulling error.

With the current change we are asking the admin to closely examine any deployment error messages within the cluster. Note: These errors can differ based on the environment.