### PR TITLE
[patch] Fix env vars for launchfvt-monitor

### DIFF
--- a/tekton/src/tasks/fvt-launcher/launchfvt-monitor.yml.j2
+++ b/tekton/src/tasks/fvt-launcher/launchfvt-monitor.yml.j2
@@ -73,6 +73,12 @@ spec:
               name: mas-fvt-monitor
               key: MAS_APP_CHANNEL_MONITOR
               optional: false
+        - name: MAS_APP_CHANNEL_MANAGE
+          valueFrom:
+            secretKeyRef:
+              name: mas-fvt-monitor
+              key: MAS_APP_CHANNEL_MANAGE
+              optional: false
         - name: MAS_WORKSPACE_ID
           valueFrom:
             secretKeyRef:


### PR DESCRIPTION
The Monitor FVT launcher needs to know whether Manage application is being installed as well, because we run a different test suite depending on whether Monitor is installed alongside Manage or not.