### PR TITLE
[patch] add test to monitor for disruption during mongo upgrade

### DIFF
--- a/tekton/src/pipelines/update.yml.j2
+++ b/tekton/src/pipelines/update.yml.j2
@@ -272,3 +272,15 @@ spec:
         kind: Task
         name: mas-fvt-finalize
 {% endif %}
+
+{% if wait_for_install == true %}
+    # 7. Test for outages during mongo update
+    # -------------------------------------------------------------------------
+    - name: fvt-mongo-update
+      taskRef:
+        kind: Task
+        name: mas-ivt-core
+      params:
+        - name: fvt_test_suite
+          value: mongohealth
+{% endif %}


### PR DESCRIPTION
## Monitor MongoDB for Disruption During Upgrade Test

Adding a Task to the `mas-update-after-install` pipeline that will invoke a test to monitor for disruption to MongoDB. The test will begin by detecting the current version of MongoDB and will exit successfully after the MongoDB version has been updated and the MongoDB instance is running.

The test will tolerate up to five connection issues consecutively or up to 20 total exceptions before failing.
