### PR TITLE
[minor] Allow Mongodb update to use already configured storageclass

### DIFF
--- a/image/cli/mascli/functions/update
+++ b/image/cli/mascli/functions/update
@@ -191,6 +191,7 @@ function update_interactive() {
   fi
 
   MONGODB_CURRENT_VERSION=$(oc get mongodbcommunity.mongodbcommunity.mongodb.com -A -o jsonpath='{.items[0].status.version}' 2> /dev/null)
+  MONGODB_STORAGE_CLASS=`oc get mongodbcommunity.mongodbcommunity.mongodb.com -A -o jsonpath='{.items[0].spec.statefulSet.spec.volumeClaimTemplates[0].spec.storageClassName}' 2> /dev/null`
 
 
   # Detect Kafka in cluster and set namespace
@@ -231,6 +232,7 @@ function update() {
   export MAS_CATALOG_VERSION
   export DB2_NAMESPACE
   export MONGODB_NAMESPACE
+  export MONGODB_STORAGE_CLASS
   export MONGODB_V5_UPGRADE
   export KAFKA_NAMESPACE
   export KAFKA_PROVIDER
@@ -261,7 +263,7 @@ function update() {
     echo_reset_dim "IBM Db2 Universal Operator ................. ${COLOR_RED}No${TEXT_RESET}"
   fi
 
-  # IBM Db2
+  # MongoDB CE
   if [ "$MONGODB_NAMESPACE" != "" ]; then
     echo_reset_dim "MongoDb Community Edition .................. ${COLOR_GREEN}Yes ($MONGODB_NAMESPACE)${TEXT_RESET}"
   else

--- a/image/cli/mascli/templates/pipelinerun-update.yaml
+++ b/image/cli/mascli/templates/pipelinerun-update.yaml
@@ -19,6 +19,8 @@ spec:
       value: '$DB2_NAMESPACE'
     - name: mongodb_namespace
       value: '$MONGODB_NAMESPACE'
+    - name: mongodb_storage_class
+      value: '$MONGODB_STORAGE_CLASS'
     - name: mongodb_v5_upgrade
       value: '$MONGODB_V5_UPGRADE'
     - name: kafka_namespace

--- a/tekton/src/pipelines/update.yml.j2
+++ b/tekton/src/pipelines/update.yml.j2
@@ -75,6 +75,10 @@ spec:
       type: string
       description: Approves the MongoDb upgrade to version 5 if needed
       default: ""
+    - name: mongodb_storage_class
+      type: string
+      default: ""
+      description: Storage class for MongoDB data and logs
 
     # kafka update
     - name: kafka_action
@@ -218,6 +222,8 @@ spec:
           value: $(params.mongodb_namespace)
         - name: mongodb_v5_upgrade
           value: $(params.mongodb_v5_upgrade)
+        - name: mongodb_storage_class
+          value: $(params.mongodb_storage_class)
 
     - name: update-kafka
       taskRef:

--- a/tekton/src/pipelines/update.yml.j2
+++ b/tekton/src/pipelines/update.yml.j2
@@ -78,7 +78,7 @@ spec:
     - name: mongodb_storage_class
       type: string
       default: ""
-      description: Storage class for MongoDB data and logs
+      description: MongoDB Storage class for data and logs
 
     # kafka update
     - name: kafka_action


### PR DESCRIPTION
When "mas update" is run, mongodb community update needs to respect the existing storage class and not change it.