### PR TITLE
[patch] add required vars for mongo monitoring during update

### DIFF
--- a/tekton/src/pipelines/update.yml.j2
+++ b/tekton/src/pipelines/update.yml.j2
@@ -19,6 +19,10 @@ spec:
     # MAS Instance ID (the instance who's install to wait for)
     - name: mas_instance_id
       type: string
+    - name: fvt_image_registry
+      type: string
+    - name: fvt_image_digest
+      type: string
 {% endif %}
 
     # Tekton Pipeline image pull policy (for ibmmas/cli images)
@@ -287,6 +291,14 @@ spec:
         kind: Task
         name: mas-ivt-core
       params:
+        - name: fvt_image_registry
+          value: $(params.fvt_image_registry)
+        - name: fvt_image_digest
+          value: $(params.fvt_image_digest)
+        - name: mas_instance_id
+          value: $(params.mas_instance_id)
+        - name: mas_workspace_id
+          value:  "NOT_USED"
         - name: fvt_test_suite
-          value: mongohealth
+          value: "mongohealth"
 {% endif %}


### PR DESCRIPTION
## Missing parameters for MongoDB monitoring during update


https://jsw.ibm.com/browse/MASCORE-1028


The ivt pipeline that launches the MongoDB monitoring test requires additional params. Specifically:

        - name: fvt_image_registry
        - name: fvt_image_digest
        - name: mas_instance_id
        - name: mas_workspace_id
        - name: fvt_test_suite

The param `mas_workspace_id` is not used by the test so it is hardcoded to `NOT_USED`