### PR TITLE
Add optimizer install+configure to gitops pipeline 

### DIFF
--- a/tekton/src/pipelines/gitops/provision-mas-apps.yml.j2
+++ b/tekton/src/pipelines/gitops/provision-mas-apps.yml.j2
@@ -622,3 +622,4 @@ spec:
     {{ lookup('template', pipeline_src_dir ~ '/taskdefs/gitops/apps/optimizer-workspace.yml.j2') | indent(4) }}
       runAfter:
         - app-install-optimizer
+

--- a/tekton/src/pipelines/gitops/provision-mas-apps.yml.j2
+++ b/tekton/src/pipelines/gitops/provision-mas-apps.yml.j2
@@ -248,6 +248,28 @@ spec:
     - name: mas_appws_spec_yaml_visualinspection
       type: string
 
+    - name: mas_app_channel_optimizer
+      type: string
+    - name: mas_app_catalog_source_optimizer
+      type: string
+      default: ibm-operator-catalog
+    - name: mas_app_api_version_optimizer
+      type: string
+      default: apps.mas.ibm.com/v1
+    - name: mas_app_kind_optimizer
+      type: string
+      default: OptimizerApp
+    - name: mas_appws_api_version_optimizer
+      type: string
+      default: apps.mas.ibm.com/v1
+    - name: mas_appws_kind_optimizer
+      type: string
+      default: OptimizerWorkspace
+    - name: mas_app_spec_yaml_optimizer
+      type: string
+    - name: mas_appws_spec_yaml_optimizer
+      type: string
+
   tasks:
 {% if wait_for_provision == true %}
     # 0. Wait for the fvt start pipeline to complete
@@ -588,3 +610,15 @@ spec:
     {{ lookup('template', pipeline_src_dir ~ '/taskdefs/gitops/apps/visualinspection-workspace.yml.j2') | indent(4) }}
       runAfter:
         - app-install-visualinspection
+
+    # 8. Install & Configure Optimizer
+    # -------------------------------------------------------------------------
+    # 8.1 Install Optimizer
+    {{ lookup('template', pipeline_src_dir ~ '/taskdefs/gitops/apps/optimizer-app.yml.j2') | indent(4) }}
+      runAfter:
+        - app-cfg-manage
+
+    # 8.2 Configure Optimizer workspace
+    {{ lookup('template', pipeline_src_dir ~ '/taskdefs/gitops/apps/optimizer-workspace.yml.j2') | indent(4) }}
+      runAfter:
+        - app-install-optimizer

--- a/tekton/src/pipelines/taskdefs/gitops/apps/optimizer-app.yml.j2
+++ b/tekton/src/pipelines/taskdefs/gitops/apps/optimizer-app.yml.j2
@@ -1,0 +1,45 @@
+- name: app-install-optimizer
+  params:
+    {{ lookup('template', pipeline_src_dir ~ '/taskdefs/common/cli-params.yml.j2') | indent(4) }}
+  
+    {{ lookup('template', pipeline_src_dir ~ '/taskdefs/gitops/common/gitops-params.yml.j2') | indent(4) }}
+
+    {{ lookup('template', pipeline_src_dir ~ '/taskdefs/gitops/common/secrets-params.yml.j2') | indent(4) }}
+
+    {{ lookup('template', pipeline_src_dir ~ '/taskdefs/gitops/common/git-params.yml.j2') | indent(4) }}
+
+    - name: devops_suite_name
+      value: app-optimizer-install
+    - name: mas_manual_cert_mgmt
+      value: $(params.mas_manual_cert_mgmt)
+    - name: mas_instance_id
+      value: $(params.mas_instance_id)
+    - name: mas_app_id
+      value: optimizer
+    - name: mas_app_channel
+      value: $(params.mas_app_channel_optimizer)
+    - name: custom_labels
+      value: $(params.custom_labels)
+    - name: mas_app_spec_yaml
+      value: $(params.mas_app_spec_yaml_optimizer)
+    - name: mas_app_catalog_source
+      value: $(params.mas_app_catalog_source_optimizer)
+    - name: mas_app_api_version
+      value: $(params.mas_app_api_version_optimizer)
+    - name: mas_app_kind
+      value: $(params.mas_app_kind_optimizer)
+    - name: default_file_storage_class
+      value: $(params.default_file_storage_class)
+  taskRef:
+    name: gitops-suite-app-install
+    kind: Task
+  # Only install optimizer if a channel has been chosen
+  when:
+    - input: "$(params.mas_app_channel_optimizer)"
+      operator: notin
+      values: [""]
+  workspaces:
+    - name: configs
+      workspace: configs
+    - name: shared-gitops-configs
+      workspace: shared-gitops-configs

--- a/tekton/src/pipelines/taskdefs/gitops/apps/optimizer-workspace.yml.j2
+++ b/tekton/src/pipelines/taskdefs/gitops/apps/optimizer-workspace.yml.j2
@@ -1,0 +1,41 @@
+- name: app-cfg-optimizer
+  params:
+    {{ lookup('template', pipeline_src_dir ~ '/taskdefs/common/cli-params.yml.j2') | indent(4) }}
+  
+    {{ lookup('template', pipeline_src_dir ~ '/taskdefs/gitops/common/gitops-params.yml.j2') | indent(4) }}
+
+    {{ lookup('template', pipeline_src_dir ~ '/taskdefs/gitops/common/secrets-params.yml.j2') | indent(4) }}
+
+    {{ lookup('template', pipeline_src_dir ~ '/taskdefs/gitops/common/git-params.yml.j2') | indent(4) }}
+
+    - name: devops_suite_name
+      value: app-optimizer-cfg
+    - name: mas_instance_id
+      value: $(params.mas_instance_id)
+    - name: mas_app_id
+      value: optimizer
+    - name: mas_workspace_id
+      value: $(params.mas_workspace_id)
+    - name: custom_labels
+      value: $(params.custom_labels)
+    - name: mas_appws_spec_yaml
+      value: $(params.mas_appws_spec_yaml_optimizer)
+    - name: mas_appws_api_version
+      value: $(params.mas_appws_api_version_optimizer)
+    - name: mas_appws_kind
+      value: $(params.mas_appws_kind_optimizer)
+    - name: mas_app_kind
+      value: $(params.mas_app_kind_optimizer)
+  taskRef:
+    name: gitops-suite-app-config
+    kind: Task
+  # Only configure a workspace for optimizer if a channel has been chosen
+  when:
+    - input: "$(params.mas_app_channel_optimizer)"
+      operator: notin
+      values: [""]
+  workspaces:
+    - name: configs
+      workspace: configs
+    - name: shared-gitops-configs
+      workspace: shared-gitops-configs

--- a/tekton/src/tasks/gitops/gitops-suite-app-install.yml.j2
+++ b/tekton/src/tasks/gitops/gitops-suite-app-install.yml.j2
@@ -15,7 +15,7 @@ spec:
       type: string
     - name: mas_app_kind
       type: string
-    - name: mas_app_spec_yml
+    - name: mas_app_spec_yaml
       type: string
       default: ""
     - name: default_block_storage_class
@@ -64,8 +64,8 @@ spec:
         value: $(params.mas_app_api_version)
       - name: MAS_APP_KIND
         value: $(params.mas_app_kind)
-      - name: MAS_APP_SPEC_YML
-        value: $(params.mas_app_spec_yml)
+      - name: MAS_APP_SPEC_YAML
+        value: $(params.mas_app_spec_yaml)
       - name: DEFAULT_BLOCK_STORAGE_CLASS
         value: $(params.default_block_storage_class)
       - name: DEFAULT_FILE_STORAGE_CLASS


### PR DESCRIPTION
[MASCORE-185](https://jsw.ibm.com/browse/MASCORE-185)

Counterpart to these changes: https://github.ibm.com/maximoappsuite/ansible-fvt/pull/351

Verified that the provision-mas-apps pipeline is setup correctly with the new tasks in masdeps2:

![image](https://github.com/ibm-mas/cli/assets/7372253/0c6850c9-f8d4-4ca6-a269-a2f74299d68a)

Also fixes an issue I spotted with the `gitops-suite-app-install`, the `mas_app_spec_yml` parameter didn't align with that passed in by the pipeline, and the corresponding `MAS_APP_SPEC_YAML` env var didn't align with that used in the gitops_suite_app_install script. 

Without this fix, specification of custom app specs (e.g. MAS_APP_SPEC_YAML_OPTIMIZER) in fvt-dev travis.yaml will not work. We haven't been using this capability (relying on the defaults instead) so I guess this has not actually caused any issues yet.