### PR TITLE
Add mas-apps deprovision

### DIFF
--- a/image/cli/mascli/functions/gitops_deprovision_app_config
+++ b/image/cli/mascli/functions/gitops_deprovision_app_config
@@ -1,0 +1,248 @@
+#!/usr/bin/env bash
+
+function gitops_deprovision_app_config_help() {
+  [[ -n "$1" ]] && echo_warning "$1"
+  reset_colors
+  cat << EOM
+Usage:
+  mas gitops_deprovision_app_config [options]
+Where ${COLOR_YELLOW}specified${TEXT_RESET} each option may also be defined by setting the appropriate environment variable.
+When no options are specified on the command line, interactive-mode will be enabled by default.
+
+Options:
+
+GitOps Configuration:
+  -d, --dir ${COLOR_YELLOW}GITOPS_WORKING_DIR${TEXT_RESET}           Working directory for GitOps repository
+  -g, --gitops-version ${COLOR_YELLOW}GITOPS_VERSION${TEXT_RESET}    Version of ibm-mas/gitops to use
+  -a, --account-id ${COLOR_YELLOW}ACCOUNT_ID${TEXT_RESET}            Account name that the cluster belongs to
+  -c, --cluster-id ${COLOR_YELLOW}CLUSTER_ID${TEXT_RESET}            Cluster ID
+  -f, --force-removal ${COLOR_YELLOW}FORCE_REMOVAL${TEXT_RESET}      Force remove the ArgoCD Application, when deletion exceeds timeout  
+
+Maximo Application Suite:
+  -m, --mas-instance-id ${COLOR_YELLOW}MAS_INSTANCE_ID${TEXT_RESET}                                       IBM Suite Maximo Application Suite Instance ID
+  -W, --mas-workspace-id ${COLOR_YELLOW}MAS_WORKSPACE_ID${TEXT_RESET}                                     IBM Suite Maximo Application Suite workspace ID
+  --mas-app-id ${COLOR_YELLOW}MAS_APP_ID${TEXT_RESET}                                                     IBM Suite Maximo Application Suite Application ID
+
+Secrets Manager:
+      --secrets-path ${COLOR_YELLOW}SECRETS_PATH${TEXT_RESET}                    Secrets Manager path
+      --secrets-key-seperator ${COLOR_YELLOW}SECRETS_KEY_SEPERATOR${TEXT_RESET}  Secrets Manager key seperator string
+
+Automatic GitHub Push:
+  -P, --github-push ${COLOR_YELLOW}GITHUB_PUSH${TEXT_RESET}        Enable automatic push to GitHub
+  -H, --github-host ${COLOR_YELLOW}GITHUB_HOST${TEXT_RESET}        GitHub Hostname for your GitOps repository
+  -O, --github-org  ${COLOR_YELLOW}GITHUB_ORG${TEXT_RESET}         Github org for your GitOps repository
+  -R, --github-repo ${COLOR_YELLOW}GITHUB_REPO${TEXT_RESET}        Github repo for your GitOps repository
+  -B, --git-branch ${COLOR_YELLOW}GIT_BRANCH${TEXT_RESET}          Git branch to commit to of your GitOps repository
+  -M, --git-commit-msg ${COLOR_YELLOW}GIT_COMMIT_MSG${TEXT_RESET}  Git commit message to use when committing to of your GitOps repository
+  -S , --github-ssh  ${COLOR_YELLOW}GIT_SSH${TEXT_RESET}           Git ssh key path
+
+Other Commands:
+  -h, --help                                      Show this help message
+EOM
+  [[ -n "$1" ]] && exit 1 || exit 0
+}
+
+function gitops_deprovision_app_config_noninteractive() {
+  GITOPS_WORKING_DIR=$PWD/working-dir
+  SECRETS_KEY_SEPERATOR="/"
+  GIT_COMMIT_MSG="gitops-deprovision-app-config commit"
+  export GITOPS_VERSION=${GITOPS_VERSION:-poc}
+
+  while [[ $# -gt 0 ]]
+  do
+    key="$1"
+    shift
+    case $key in
+      -d|--dir)
+        export GITOPS_WORKING_DIR=$1 && shift
+        ;;
+      -g|--gitops-version)
+        export GITOPS_VERSION=$1 && shift
+        ;;
+      -a|--account-id)
+        export ACCOUNT_ID=$1 && shift
+        ;;
+      -c|--cluster-id)
+        export CLUSTER_ID=$1 && shift
+        ;;
+      -f|--force-removal)
+        export FORCE_REMOVAL=$1 && shift
+        ;;
+
+      # MAS
+      -m|--mas-instance-id)
+        export MAS_INSTANCE_ID=$1 && shift
+        ;;
+      -W|--mas-workspace-id)
+        export MAS_WORKSPACE_ID=$1 && shift
+        ;;
+      --mas-app-id)
+        export MAS_APP_ID=$1 && shift
+        ;;
+
+      # Secrets Manager
+      --secrets-path)
+        export SECRETS_PATH=$1 && shift
+        ;;
+      --secrets-key-seperator)
+        export SECRETS_KEY_SEPERATOR=$1 && shift
+        ;;
+
+      # Automatic GitHub Push
+      -P|--github-push)
+        export GITHUB_PUSH=true
+        ;;
+      -H|--github-host)
+        export GITHUB_HOST=$1 && shift
+        ;;
+      -O|--github-org)
+        export GITHUB_ORG=$1 && shift
+        ;;
+      -R|--github-repo)
+        export GITHUB_REPO=$1 && shift
+        ;;
+      -B|--git-branch)
+        export GIT_BRANCH=$1 && shift
+        ;;
+      -M|--git-commit-msg)
+        export GIT_COMMIT_MSG=$1 && shift
+        ;;
+       -S|--github-ssh)
+        export GIT_SSH=$1 && shift
+        ;;
+
+      -h|--help)
+        gitops_deprovision_app_config_help
+        ;;
+      *)
+        # unknown option
+        echo -e "${COLOR_RED}Usage Error: Unsupported option \"${key}\"${COLOR_RESET}\n"
+        gitops_deprovision_app_config_help  "Usage Error: Unsupported option \"${key}\" "
+        exit 1
+        ;;
+      esac
+  done
+
+  [[ -z "$MAS_INSTANCE_ID" ]] && gitops_deprovision_app_config_help "MAS_INSTANCE_ID is not set"
+  [[ -z "$MAS_WORKSPACE_ID" ]] && gitops_deprovision_app_config_help "MAS_WORKSPACE_ID is not set"
+  [[ -z "$MAS_APP_ID" ]] && gitops_deprovision_app_config_help "MAS_APP_ID is not set"
+
+  [[ -z "$GITOPS_WORKING_DIR" ]] && gitops_deprovision_app_config_help "GITOPS_WORKING_DIR is not set"
+  [[ -z "$GITOPS_VERSION" ]] && gitops_deprovision_app_config_help "GITOPS_VERSION is not set"
+  [[ -z "$CLUSTER_ID" ]] && gitops_deprovision_app_config_help "CLUSTER_ID is not set"
+  [[ -z "$ACCOUNT_ID" ]] && gitops_deprovision_app_config_help "ACCOUNT_ID is not set"
+  if [[ "$GITHUB_PUSH" == "true" ]]; then
+    [[ -z "$GITHUB_HOST" ]] && gitops_deprovision_app_config_help "GITHUB_HOST is not set"
+    [[ -z "$GITHUB_ORG" ]] && gitops_deprovision_app_config_help "GITHUB_ORG is not set"
+    [[ -z "$GITHUB_REPO" ]] && gitops_deprovision_app_config_help "GITHUB_REPO is not set"
+    [[ -z "$GIT_BRANCH" ]] && gitops_deprovision_app_config_help "GIT_BRANCH is not set"
+  fi
+}
+
+function gitops_deprovision_app_config() {
+  # Take the first parameter off (it will be create-gitops)
+  shift
+  if [[ $# -gt 0 ]]; then
+    gitops_deprovision_app_config_noninteractive "$@"
+  else
+    echo "Not supported yet"
+    exit 1
+    gitops_deprovision_app_config_interactive
+  fi
+
+  mkdir -p ${GITOPS_WORKING_DIR}
+  GITOPS_CLUSTER_DIR=${GITOPS_WORKING_DIR}/${GITHUB_REPO}/${CLUSTER_ID}
+  GITOPS_APPS_DIR=${GITOPS_CLUSTER_DIR}/apps
+
+  echo
+  reset_colors
+  echo_h2 "Review Settings"
+
+  echo "${TEXT_DIM}"
+  echo_h2 "Target" "    "
+  echo_reset_dim "Account ID............................. ${COLOR_MAGENTA}${ACCOUNT_ID}"
+  echo_reset_dim "Cluster ID ............................ ${COLOR_MAGENTA}${CLUSTER_ID}"
+  echo_reset_dim "Application Directory ................. ${COLOR_MAGENTA}${GITOPS_APPS_DIR}"
+  echo_reset_dim "Force Remove Application Flag ......... ${COLOR_MAGENTA}${FORCE_REMOVAL}"
+  reset_colors
+
+  echo "${TEXT_DIM}"
+  echo_h2 "Secrets Manager" "    "
+  echo_reset_dim "Secrets Path .......................... ${COLOR_MAGENTA}${SECRETS_PATH}"
+  reset_colors
+
+  echo "${TEXT_DIM}"
+  echo_h2 "GitOps Source" "    "
+  echo_reset_dim "GitOps URL ............................ ${COLOR_MAGENTA}https://github.com/ibm-mas/gitops"
+  echo_reset_dim "GitOps Version ........................ ${COLOR_MAGENTA}${GITOPS_VERSION}"
+  reset_colors
+
+  echo "${TEXT_DIM}"
+  if [[ "$GITHUB_PUSH" == "true" ]]; then
+    echo_h2 "GitOps Target" "    "
+    echo_reset_dim "Automatic Push ........................ ${COLOR_GREEN}Enabled"
+    echo_reset_dim "Working Directory ..................... ${COLOR_MAGENTA}${GITOPS_WORKING_DIR}"
+    echo_reset_dim "Host .................................. ${COLOR_MAGENTA}${GITHUB_HOST}"
+    echo_reset_dim "Organization .......................... ${COLOR_MAGENTA}${GITHUB_ORG}"
+    echo_reset_dim "Repository ............................ ${COLOR_MAGENTA}${GITHUB_REPO}"
+    echo_reset_dim "Branch ................................ ${COLOR_MAGENTA}${GIT_BRANCH}"
+  else
+    echo_h2 "GitOps Target" "    "
+    echo_reset_dim "Automatic Push ........................ ${COLOR_RED}Disabled"
+    echo_reset_dim "Working Directory ..................... ${COLOR_MAGENTA}${GITOPS_WORKING_DIR}"
+  fi
+  reset_colors
+
+  echo "${TEXT_DIM}"
+  echo_h2 "IBM Maximo Application Suite" "    "
+  echo_reset_dim "Instance ID ............................. ${COLOR_MAGENTA}${MAS_INSTANCE_ID}"
+  echo_reset_dim "Application ID .......................... ${COLOR_MAGENTA}${MAS_APP_ID}"
+  echo_reset_dim "Workspace ID ............................ ${COLOR_MAGENTA}${MAS_WORKSPACE_ID}"
+  reset_colors
+
+  # Get the cluster-level secrets used
+  # ---------------------------------------------------------------------------
+  CURRENT_DIR=$PWD
+  TEMP_DIR=$CURRENT_DIR/tmp-app-config-deprovision
+  rm -rf $TEMP_DIR
+  mkdir -p $TEMP_DIR
+
+  if [ -z $GIT_SSH ]; then
+    export GIT_SSH="false"
+  fi
+
+  # Clone github target repo
+  # ---------------------------------------------------------------------------
+  if [ "$GITHUB_PUSH" == "true" ]; then
+    echo
+    echo_h2 "Cloning GitHub repo $GITHUB_ORG $GITHUB_REPO"
+    clone_target_git_repo $GITHUB_HOST $GITHUB_ORG $GITHUB_REPO $GIT_BRANCH $GITOPS_WORKING_DIR $GIT_SSH
+  fi
+  mkdir -p ${GITOPS_APPS_DIR}
+
+  # Delete ArgoApps
+  # ---------------------------------------------------------------------------
+  # Per MAS instance
+  rm ${GITOPS_APPS_DIR}/${MAS_INSTANCE_ID}.${MAS_WORKSPACE_ID}.ibm-mas-${MAS_APP_ID}-app-config.yaml
+
+  if [ "$MAS_APP_ID" == "manage" ]; then
+    rm ${GITOPS_APPS_DIR}/${MAS_INSTANCE_ID}-${MAS_APP_ID}-${MAS_WORKSPACE_ID}-manage-additional-server-config-no-activation.xml
+    rm ${GITOPS_APPS_DIR}/${MAS_INSTANCE_ID}-${MAS_APP_ID}-${MAS_WORKSPACE_ID}-manage-additional-server-config.xml
+    rm ${GITOPS_APPS_DIR}/${MAS_INSTANCE_ID}-${MAS_APP_ID}-${MAS_WORKSPACE_ID}-manage-jms-additional-server-config.xml
+  fi
+
+  # Commit and push to github target repo
+  # ---------------------------------------------------------------------------
+  if [ "$GITHUB_PUSH" == "true" ]; then
+    echo
+    echo_h2 "Commit and push changes to GitHub repo $GITHUB_ORG $GITHUB_REPO"
+    save_to_target_git_repo $GITHUB_HOST $GITHUB_ORG $GITHUB_REPO $GIT_BRANCH $GITOPS_APPS_DIR "${GIT_COMMIT_MSG}"
+    remove_git_repo_clone $GITOPS_WORKING_DIR/$GITHUB_REPO
+
+    argocd_login
+
+    argocd_prune_sync ${CLUSTER_ID}-watcher
+    check_argo_app_deleted mas-${MAS_INSTANCE_ID}-${MAS_APP_ID}-app-config-${MAS_WORKSPACE_ID} ${MAS_INSTANCE_ID} ${FORCE_REMOVAL}
+
+ fi
+}

--- a/image/cli/mascli/functions/gitops_deprovision_app_install
+++ b/image/cli/mascli/functions/gitops_deprovision_app_install
@@ -1,0 +1,235 @@
+#!/usr/bin/env bash
+
+function gitops_deprovision_app_install_help() {
+  [[ -n "$1" ]] && echo_warning "$1"
+  reset_colors
+  cat << EOM
+Usage:
+  mas gitops_deprovision_app_install [options]
+Where ${COLOR_YELLOW}specified${TEXT_RESET} each option may also be defined by setting the appropriate environment variable.
+When no options are specified on the command line, interactive-mode will be enabled by default.
+
+Options:
+
+GitOps Configuration:
+  -d, --dir ${COLOR_YELLOW}GITOPS_WORKING_DIR${TEXT_RESET}           Working directory for GitOps repository
+  -g, --gitops-version ${COLOR_YELLOW}GITOPS_VERSION${TEXT_RESET}    Version of ibm-mas/gitops to use
+  -a, --account-id ${COLOR_YELLOW}ACCOUNT_ID${TEXT_RESET}            Account name that the cluster belongs to
+  -c, --cluster-id ${COLOR_YELLOW}CLUSTER_ID${TEXT_RESET}            Cluster ID
+  -f, --force-removal ${COLOR_YELLOW}FORCE_REMOVAL${TEXT_RESET}      Force remove the ArgoCD Application, when deletion exceeds timeout  
+
+Maximo Application Suite:
+  -m, --mas-instance-id ${COLOR_YELLOW}MAS_INSTANCE_ID${TEXT_RESET}                                       IBM Suite Maximo Application Suite Instance ID
+  --mas-app-id ${COLOR_YELLOW}MAS_APP_ID${TEXT_RESET}                                                     IBM Suite Maximo Application Suite Application ID
+
+Secrets Manager:
+      --secrets-path ${COLOR_YELLOW}SECRETS_PATH${TEXT_RESET}                    Secrets Manager path
+      --secrets-key-seperator ${COLOR_YELLOW}SECRETS_KEY_SEPERATOR${TEXT_RESET}  Secrets Manager key seperator string
+
+Automatic GitHub Push:
+  -P, --github-push ${COLOR_YELLOW}GITHUB_PUSH${TEXT_RESET}        Enable automatic push to GitHub
+  -H, --github-host ${COLOR_YELLOW}GITHUB_HOST${TEXT_RESET}        GitHub Hostname for your GitOps repository
+  -O, --github-org  ${COLOR_YELLOW}GITHUB_ORG${TEXT_RESET}         Github org for your GitOps repository
+  -R, --github-repo ${COLOR_YELLOW}GITHUB_REPO${TEXT_RESET}        Github repo for your GitOps repository
+  -B, --git-branch ${COLOR_YELLOW}GIT_BRANCH${TEXT_RESET}          Git branch to commit to of your GitOps repository
+  -M, --git-commit-msg ${COLOR_YELLOW}GIT_COMMIT_MSG${TEXT_RESET}  Git commit message to use when committing to of your GitOps repository
+  -S , --github-ssh  ${COLOR_YELLOW}GIT_SSH${TEXT_RESET}           Git ssh key path
+
+Other Commands:
+  -h, --help                                      Show this help message
+EOM
+  [[ -n "$1" ]] && exit 1 || exit 0
+}
+
+function gitops_deprovision_app_install_noninteractive() {
+  GITOPS_WORKING_DIR=$PWD/working-dir
+  SECRETS_KEY_SEPERATOR="/"
+  GIT_COMMIT_MSG="gitops-deprovision-app-install commit"
+  export GITOPS_VERSION=${GITOPS_VERSION:-poc}
+
+  while [[ $# -gt 0 ]]
+  do
+    key="$1"
+    shift
+    case $key in
+      -d|--dir)
+        export GITOPS_WORKING_DIR=$1 && shift
+        ;;
+      -g|--gitops-version)
+        export GITOPS_VERSION=$1 && shift
+        ;;
+      -a|--account-id)
+        export ACCOUNT_ID=$1 && shift
+        ;;
+      -c|--cluster-id)
+        export CLUSTER_ID=$1 && shift
+        ;;
+      -f|--force-removal)
+        export FORCE_REMOVAL=$1 && shift
+        ;;
+
+      # MAS
+      -m|--mas-instance-id)
+        export MAS_INSTANCE_ID=$1 && shift
+        ;;
+      --mas-app-id)
+        export MAS_APP_ID=$1 && shift
+        ;;
+
+      # Secrets Manager
+      --secrets-path)
+        export SECRETS_PATH=$1 && shift
+        ;;
+      --secrets-key-seperator)
+        export SECRETS_KEY_SEPERATOR=$1 && shift
+        ;;
+
+      # Automatic GitHub Push
+      -P|--github-push)
+        export GITHUB_PUSH=true
+        ;;
+      -H|--github-host)
+        export GITHUB_HOST=$1 && shift
+        ;;
+      -O|--github-org)
+        export GITHUB_ORG=$1 && shift
+        ;;
+      -R|--github-repo)
+        export GITHUB_REPO=$1 && shift
+        ;;
+      -B|--git-branch)
+        export GIT_BRANCH=$1 && shift
+        ;;
+      -M|--git-commit-msg)
+        export GIT_COMMIT_MSG=$1 && shift
+        ;;
+       -S|--github-ssh)
+        export GIT_SSH=$1 && shift
+        ;;
+
+      -h|--help)
+        gitops_deprovision_app_install_help
+        ;;
+      *)
+        # unknown option
+        echo -e "${COLOR_RED}Usage Error: Unsupported option \"${key}\"${COLOR_RESET}\n"
+        gitops_deprovision_app_install_help  "Usage Error: Unsupported option \"${key}\" "
+        exit 1
+        ;;
+      esac
+  done
+
+  [[ -z "$MAS_INSTANCE_ID" ]] && gitops_deprovision_app_install_help "MAS_INSTANCE_ID is not set"
+  [[ -z "$MAS_APP_ID" ]] && gitops_deprovision_app_install_help "MAS_APP_ID is not set"
+
+  [[ -z "$GITOPS_WORKING_DIR" ]] && gitops_deprovision_app_install_help "GITOPS_WORKING_DIR is not set"
+  [[ -z "$GITOPS_VERSION" ]] && gitops_deprovision_app_install_help "GITOPS_VERSION is not set"
+  [[ -z "$CLUSTER_ID" ]] && gitops_deprovision_app_install_help "CLUSTER_ID is not set"
+  [[ -z "$ACCOUNT_ID" ]] && gitops_deprovision_app_install_help "ACCOUNT_ID is not set"
+  if [[ "$GITHUB_PUSH" == "true" ]]; then
+    [[ -z "$GITHUB_HOST" ]] && gitops_deprovision_app_install_help "GITHUB_HOST is not set"
+    [[ -z "$GITHUB_ORG" ]] && gitops_deprovision_app_install_help "GITHUB_ORG is not set"
+    [[ -z "$GITHUB_REPO" ]] && gitops_deprovision_app_install_help "GITHUB_REPO is not set"
+    [[ -z "$GIT_BRANCH" ]] && gitops_deprovision_app_install_help "GIT_BRANCH is not set"
+  fi
+}
+
+function gitops_deprovision_app_install() {
+  # Take the first parameter off (it will be create-gitops)
+  shift
+  if [[ $# -gt 0 ]]; then
+    gitops_deprovision_app_install_noninteractive "$@"
+  else
+    echo "Not supported yet"
+    exit 1
+    gitops_deprovision_app_install_interactive
+  fi
+
+  mkdir -p ${GITOPS_WORKING_DIR}
+  GITOPS_CLUSTER_DIR=${GITOPS_WORKING_DIR}/${GITHUB_REPO}/${CLUSTER_ID}
+  GITOPS_APPS_DIR=${GITOPS_CLUSTER_DIR}/apps
+
+  echo
+  reset_colors
+  echo_h2 "Review Settings"
+
+  echo "${TEXT_DIM}"
+  echo_h2 "Target" "    "
+  echo_reset_dim "Account ID............................. ${COLOR_MAGENTA}${ACCOUNT_ID}"
+  echo_reset_dim "Cluster ID ............................ ${COLOR_MAGENTA}${CLUSTER_ID}"
+  echo_reset_dim "Application Directory ................. ${COLOR_MAGENTA}${GITOPS_APPS_DIR}"
+  echo_reset_dim "Force Remove Application Flag ......... ${COLOR_MAGENTA}${FORCE_REMOVAL}"
+  reset_colors
+
+  echo "${TEXT_DIM}"
+  echo_h2 "Secrets Manager" "    "
+  echo_reset_dim "Secrets Path .......................... ${COLOR_MAGENTA}${SECRETS_PATH}"
+  reset_colors
+
+  echo "${TEXT_DIM}"
+  echo_h2 "GitOps Source" "    "
+  echo_reset_dim "GitOps URL ............................ ${COLOR_MAGENTA}https://github.com/ibm-mas/gitops"
+  echo_reset_dim "GitOps Version ........................ ${COLOR_MAGENTA}${GITOPS_VERSION}"
+  reset_colors
+
+  echo "${TEXT_DIM}"
+  if [[ "$GITHUB_PUSH" == "true" ]]; then
+    echo_h2 "GitOps Target" "    "
+    echo_reset_dim "Automatic Push ........................ ${COLOR_GREEN}Enabled"
+    echo_reset_dim "Working Directory ..................... ${COLOR_MAGENTA}${GITOPS_WORKING_DIR}"
+    echo_reset_dim "Host .................................. ${COLOR_MAGENTA}${GITHUB_HOST}"
+    echo_reset_dim "Organization .......................... ${COLOR_MAGENTA}${GITHUB_ORG}"
+    echo_reset_dim "Repository ............................ ${COLOR_MAGENTA}${GITHUB_REPO}"
+    echo_reset_dim "Branch ................................ ${COLOR_MAGENTA}${GIT_BRANCH}"
+  else
+    echo_h2 "GitOps Target" "    "
+    echo_reset_dim "Automatic Push ........................ ${COLOR_RED}Disabled"
+    echo_reset_dim "Working Directory ..................... ${COLOR_MAGENTA}${GITOPS_WORKING_DIR}"
+  fi
+  reset_colors
+
+  echo "${TEXT_DIM}"
+  echo_h2 "IBM Maximo Application Suite" "    "
+  echo_reset_dim "Instance ID ............................. ${COLOR_MAGENTA}${MAS_INSTANCE_ID}"
+  echo_reset_dim "Application ID .......................... ${COLOR_MAGENTA}${MAS_APP_ID}"
+  reset_colors
+
+  # Get the cluster-level secrets used
+  # ---------------------------------------------------------------------------
+  CURRENT_DIR=$PWD
+  TEMP_DIR=$CURRENT_DIR/tmp-app-install-deprovision
+  rm -rf $TEMP_DIR
+  mkdir -p $TEMP_DIR
+
+  if [ -z $GIT_SSH ]; then
+    export GIT_SSH="false"
+  fi
+
+  # Clone github target repo
+  # ---------------------------------------------------------------------------
+  if [ "$GITHUB_PUSH" == "true" ]; then
+    echo
+    echo_h2 "Cloning GitHub repo $GITHUB_ORG $GITHUB_REPO"
+    clone_target_git_repo $GITHUB_HOST $GITHUB_ORG $GITHUB_REPO $GIT_BRANCH $GITOPS_WORKING_DIR $GIT_SSH
+  fi
+  mkdir -p ${GITOPS_APPS_DIR}
+
+  # Delete ArgoApps
+  # ---------------------------------------------------------------------------
+  # Per MAS instance
+  rm ${GITOPS_APPS_DIR}/${MAS_INSTANCE_ID}.ibm-mas-${MAS_APP_ID}-app-install.yaml
+
+  # Commit and push to github target repo
+  # ---------------------------------------------------------------------------
+  if [ "$GITHUB_PUSH" == "true" ]; then
+    echo
+    echo_h2 "Commit and push changes to GitHub repo $GITHUB_ORG $GITHUB_REPO"
+    save_to_target_git_repo $GITHUB_HOST $GITHUB_ORG $GITHUB_REPO $GIT_BRANCH $GITOPS_APPS_DIR "${GIT_COMMIT_MSG}"
+    remove_git_repo_clone $GITOPS_WORKING_DIR/$GITHUB_REPO
+
+    argocd_login
+
+    argocd_prune_sync ${CLUSTER_ID}-watcher
+    check_argo_app_deleted mas-${MAS_INSTANCE_ID}-${MAS_APP_ID}-app-install ${MAS_INSTANCE_ID} ${FORCE_REMOVAL}
+  fi
+}

--- a/image/cli/mascli/functions/gitops_suite_app_config
+++ b/image/cli/mascli/functions/gitops_suite_app_config
@@ -298,7 +298,7 @@ function wait_till_cr_ready(){
   # wait till CR Ready status turns to true
   while true
   do
-    export APP_CR_STATUS=`oc get  ${crd} ${cr} -n ${ns} -o=jsonpath="{.status.conditions[?(@.type=='Ready')].status}"`    
+    export APP_CR_STATUS=`oc get  ${crd} ${cr} -n ${ns} -o=jsonpath="{.status.conditions[?(@.type=='Ready')].status}"`
     echo_reset_dim "APP_CR_STATUS .... ${COLOR_MAGENTA}${APP_CR_STATUS}"
     if [[ "$APP_CR_STATUS" == "True" ]]; then
       break
@@ -535,7 +535,7 @@ function gitops_suite_app_config() {
   if [ "$MAS_APP_ID" == "manage" ]; then
     # these settings will be applied to ui, cron and report - these server bundles don't need the activation specification in the JMS config xml
     echo "- Generate SERVER_BUNDLES_ADD_SERVER_CONFIG_NO_ACTIVATION_CONTENT "
-    sed "s#SERVER_BUNDLE_JMS_INTERNAL_ENDPOINT#$SERVER_BUNDLE_JMS_INTERNAL_ENDPOINT#g" $CLI_DIR/templates/gitops/files/manage/manage-additional-server-config-no-activation.xml.j2 > ${GITOPS_APPS_DIR}/${MAS_INSTANCE_ID}-${MAS_APP_ID}-${MAS_WORKSPACE_ID}-manage-additional-server-config-no-activation.xml  
+    sed "s#SERVER_BUNDLE_JMS_INTERNAL_ENDPOINT#$SERVER_BUNDLE_JMS_INTERNAL_ENDPOINT#g" $CLI_DIR/templates/gitops/files/manage/manage-additional-server-config-no-activation.xml.j2 > ${GITOPS_APPS_DIR}/${MAS_INSTANCE_ID}-${MAS_APP_ID}-${MAS_WORKSPACE_ID}-manage-additional-server-config-no-activation.xml
       SERVER_BUNDLES_ADD_SERVER_CONFIG_NO_ACTIVATION_CONTENT=${GITOPS_APPS_DIR}/${MAS_INSTANCE_ID}-${MAS_APP_ID}-${MAS_WORKSPACE_ID}-manage-additional-server-config-no-activation.xml
     SERVER_BUNDLES_ADD_SERVER_CONFIG_NO_ACTIVATION_CONTENT=$(cat $SERVER_BUNDLES_ADD_SERVER_CONFIG_NO_ACTIVATION_CONTENT)
     export SERVER_BUNDLES_ADD_SERVER_CONFIG_NO_ACTIVATION_CONTENT=$(echo -n $SERVER_BUNDLES_ADD_SERVER_CONFIG_NO_ACTIVATION_CONTENT | base64  -w 0)

--- a/image/cli/mascli/mas
+++ b/image/cli/mascli/mas
@@ -79,8 +79,8 @@ mkdir -p $CONFIG_DIR
 . $CLI_DIR/functions/gitops_suite_objectstorage_config
 . $CLI_DIR/functions/gitops_suite_smtp_config
 . $CLI_DIR/functions/gitops_suite_workspace
-. $CLI_DIR/functions/gitops-deprovision-app-config
-. $CLI_DIR/functions/gitops-deprovision-app-install
+. $CLI_DIR/functions/gitops_deprovision_app_config
+. $CLI_DIR/functions/gitops_deprovision_app_install
 . $CLI_DIR/functions/gitops_deprovision_cos
 . $CLI_DIR/functions/gitops_deprovision_suite
 . $CLI_DIR/functions/gitops_deprovision_suite_config

--- a/image/cli/mascli/mas
+++ b/image/cli/mascli/mas
@@ -79,6 +79,8 @@ mkdir -p $CONFIG_DIR
 . $CLI_DIR/functions/gitops_suite_objectstorage_config
 . $CLI_DIR/functions/gitops_suite_smtp_config
 . $CLI_DIR/functions/gitops_suite_workspace
+. $CLI_DIR/functions/gitops-deprovision-app-config
+. $CLI_DIR/functions/gitops-deprovision-app-install
 . $CLI_DIR/functions/gitops_deprovision_cos
 . $CLI_DIR/functions/gitops_deprovision_suite
 . $CLI_DIR/functions/gitops_deprovision_suite_config
@@ -367,6 +369,22 @@ case $1 in
     echo
     reset_colors
     gitops_suite_workspace "$@"
+    ;;
+
+  gitops-deprovision-app-config)
+    echo "${TEXT_UNDERLINE}IBM Maximo Application Suite GitOps Manager (v${VERSION})${TEXT_RESET}"
+    echo "Powered by ${COLOR_CYAN}${TEXT_UNDERLINE}https://github.com/ibm-mas/gitops/${TEXT_RESET}"
+    echo
+    reset_colors
+    gitops_deprovision_app_config "$@"
+    ;;
+
+  gitops-deprovision-app-install)
+    echo "${TEXT_UNDERLINE}IBM Maximo Application Suite GitOps Manager (v${VERSION})${TEXT_RESET}"
+    echo "Powered by ${COLOR_CYAN}${TEXT_UNDERLINE}https://github.com/ibm-mas/gitops/${TEXT_RESET}"
+    echo
+    reset_colors
+    gitops_deprovision_app_install "$@"
     ;;
 
   gitops-deprovision-suite-workspace)

--- a/tekton/generate-tekton-pipelines.yml
+++ b/tekton/generate-tekton-pipelines.yml
@@ -77,6 +77,7 @@
         dest: "{{ pipeline_target_dir }}/{{ item }}.yaml"
       with_items:
         - deprovision-cluster
+        - deprovision-mas-apps
         - deprovision-mas-instance
         - provision-bootstrap-cluster
         - provision-mas-instance
@@ -97,6 +98,7 @@
       with_items:
         - provision-bootstrap-cluster
         - deprovision-cluster
+        - deprovision-mas-instance
 
     # 5. Generate Gitops Pipelines with waits
     # -------------------------------------------------------------------------

--- a/tekton/generate-tekton-tasks.yml
+++ b/tekton/generate-tekton-tasks.yml
@@ -143,6 +143,8 @@
         - gitops-db2u-config
         - gitops-db2u-database
         - gitops-delete-kafka-config
+        - gitops-deprovision-app-config
+        - gitops-deprovision-app-install
         - gitops-deprovision-cluster
         - gitops-deprovision-cos
         - gitops-deprovision-mongo

--- a/tekton/src/pipelines/gitops/deprovision-cluster.yml.j2
+++ b/tekton/src/pipelines/gitops/deprovision-cluster.yml.j2
@@ -8,7 +8,7 @@ metadata:
   name: gitops-deprovision-cluster
 {% endif %}
 spec:
-  description: Deprovision ROSA, docDb and GitOps Cluster
+  description: Deprovision ROSA, docDb, kafka and GitOps Cluster
   workspaces:
     - name: configs
   params:
@@ -22,7 +22,7 @@ spec:
       description: Set to 'True' or 'False' (case-sensitive) to configure whether this pipeline continue if the pipeline we are waiting for has failed.
 {% endif %}
     - name: cluster_name
-      type: string    
+      type: string
     - name: ocp_version
       type: string
     - name: avp_type

--- a/tekton/src/pipelines/gitops/deprovision-mas-apps.yml.j2
+++ b/tekton/src/pipelines/gitops/deprovision-mas-apps.yml.j2
@@ -34,50 +34,53 @@ spec:
       type: string
       default: ""
 
-    # If no <app>_workspace_id is set then we deprovision any config/workspace found for that app
-    # If no <app> channel is set then we deprovsion the app itself
-    # If there is a <app>_workspace_id but no <app> channel then nothing is deprovisioned for that app
-    # If there is no <app>_workspace_id but a <app> channel then just the config/workspace is deprovisioned
+    - name: mas_workspace_id
+      type: string
+      default: ""
+
+    # If no <app> channel is set then we deprovsion the app itself only when "deactivate" is set for the workspace_action
+    # If there is a <app>_workspace_action that is not "deactivate" but no <app> channel then nothing is deprovisioned for that app
+    # If there is no <app>_workspace_action of "deactivate" but a <app> channel then just the config/workspace is deprovisioned
     - name: mas_app_channel_iot
       type: string
       default: ""
-    - name: iot_workspace_id
+    - name: iot_workspace_action
       type: string
       default: ""
     - name: mas_app_channel_monitor
       type: string
       default: ""
-    - name: monitor_workspace_id
+    - name: monitor_workspace_action
       type: string
       default: ""
     - name: mas_app_channel_manage
       type: string
       default: ""
-    - name: manage_workspace_id
+    - name: manage_workspace_action
       type: string
       default: ""
     - name: mas_app_channel_assist
       type: string
       default: ""
-    - name: assist_workspace_id
+    - name: assist_workspace_action
       type: string
       default: ""
     - name: mas_app_channel_predict
       type: string
       default: ""
-    - name: predict_workspace_id
+    - name: predict_workspace_action
       type: string
       default: ""
     - name: mas_app_channel_visualinspection
       type: string
       default: ""
-    - name: visualinspection_workspace_id
+    - name: visualinspection_workspace_action
       type: string
       default: ""
     - name: mas_app_channel_optimizer
       type: string
       default: ""
-    - name: optimizer_workspace_id
+    - name: optimizer_workspace_action
       type: string
       default: ""
 
@@ -95,7 +98,7 @@ spec:
         - name: mas_instance_id
           value: $(params.mas_instance_id)
         - name: mas_workspace_id
-          value: $(params.monitor_workspace_id)
+          value: $(params.mas_workspace_id)
         - name: force_removal
           value: $(params.force_removal)
         - name: mas_app_id
@@ -108,9 +111,9 @@ spec:
         - name: configs
           workspace: configs
       when:
-        - input: "$(params.monitor_workspace_id)"
+        - input: "$(params.monitor_workspace_action)"
           operator: in
-          values: [""]
+          values: ["deactivate"]
 
     # 1.2 Monitor App
     - name: gitops-deprovision-mas-app-install-monitor
@@ -135,9 +138,9 @@ spec:
         - name: configs
           workspace: configs
       when:
-        - input: "$(params.monitor_workspace_id)"
+        - input: "$(params.monitor_workspace_action)"
           operator: in
-          values: [""]
+          values: ["deactivate"]
         - input: "$(params.mas_app_channel_monitor)"
           operator: in
           values: [""]
@@ -154,7 +157,7 @@ spec:
         - name: mas_instance_id
           value: $(params.mas_instance_id)
         - name: mas_workspace_id
-          value: $(params.predict_workspace_id)
+          value: $(params.mas_workspace_id)
         - name: force_removal
           value: $(params.force_removal)
         - name: mas_app_id
@@ -167,9 +170,9 @@ spec:
         - name: configs
           workspace: configs
       when:
-        - input: "$(params.predict_workspace_id)"
+        - input: "$(params.predict_workspace_action)"
           operator: in
-          values: [""]
+          values: ["deactivate"]
 
     # 2.2 Predict App
     - name: gitops-deprovision-mas-app-install-predict
@@ -194,9 +197,9 @@ spec:
         - name: configs
           workspace: configs
       when:
-        - input: "$(params.predict_workspace_id)"
+        - input: "$(params.predict_workspace_action)"
           operator: in
-          values: [""]
+          values: ["deactivate"]
         - input: "$(params.mas_app_channel_predict)"
           operator: in
           values: [""]
@@ -213,7 +216,7 @@ spec:
         - name: mas_instance_id
           value: $(params.mas_instance_id)
         - name: mas_workspace_id
-          value: $(params.visualinspection_workspace_id)
+          value: $(params.mas_workspace_id)
         - name: force_removal
           value: $(params.force_removal)
         - name: mas_app_id
@@ -226,9 +229,9 @@ spec:
         - name: configs
           workspace: configs
       when:
-        - input: "$(params.visualinspection_workspace_id)"
+        - input: "$(params.visualinspection_workspace_action)"
           operator: in
-          values: [""]
+          values: ["deactivate"]
 
     # 3.2 Visualinspection App
     - name: gitops-deprovision-mas-app-install-visualinspection
@@ -253,9 +256,9 @@ spec:
         - name: configs
           workspace: configs
       when:
-        - input: "$(params.visualinspection_workspace_id)"
+        - input: "$(params.visualinspection_workspace_action)"
           operator: in
-          values: [""]
+          values: ["deactivate"]
         - input: "$(params.mas_app_channel_visualinspection)"
           operator: in
           values: [""]
@@ -272,7 +275,7 @@ spec:
         - name: mas_instance_id
           value: $(params.mas_instance_id)
         - name: mas_workspace_id
-          value: $(params.optimizer_workspace_id)
+          value: $(params.mas_workspace_id)
         - name: force_removal
           value: $(params.force_removal)
         - name: mas_app_id
@@ -285,9 +288,9 @@ spec:
         - name: configs
           workspace: configs
       when:
-        - input: "$(params.optimizer_workspace_id)"
+        - input: "$(params.optimizer_workspace_action)"
           operator: in
-          values: [""]
+          values: ["deactivate"]
 
     # 4.2 Optimizer App
     - name: gitops-deprovision-mas-app-install-optimizer
@@ -312,9 +315,9 @@ spec:
         - name: configs
           workspace: configs
       when:
-        - input: "$(params.optimizer_workspace_id)"
+        - input: "$(params.optimizer_workspace_action)"
           operator: in
-          values: [""]
+          values: ["deactivate"]
         - input: "$(params.mas_app_channel_optimizer)"
           operator: in
           values: [""]
@@ -331,7 +334,7 @@ spec:
         - name: mas_instance_id
           value: $(params.mas_instance_id)
         - name: mas_workspace_id
-          value: $(params.assist_workspace_id)
+          value: $(params.mas_workspace_id)
         - name: force_removal
           value: $(params.force_removal)
         - name: mas_app_id
@@ -344,9 +347,9 @@ spec:
         - name: configs
           workspace: configs
       when:
-        - input: "$(params.assist_workspace_id)"
+        - input: "$(params.assist_workspace_action)"
           operator: in
-          values: [""]
+          values: ["deactivate"]
 
     # 5.2 Assist App
     - name: gitops-deprovision-mas-app-install-assist
@@ -371,9 +374,9 @@ spec:
         - name: configs
           workspace: configs
       when:
-        - input: "$(params.assist_workspace_id)"
+        - input: "$(params.assist_workspace_action)"
           operator: in
-          values: [""]
+          values: ["deactivate"]
         - input: "$(params.mas_app_channel_assist)"
           operator: in
           values: [""]
@@ -394,7 +397,7 @@ spec:
         - name: mas_instance_id
           value: $(params.mas_instance_id)
         - name: mas_workspace_id
-          value: $(params.manage_workspace_id)
+          value: $(params.mas_workspace_id)
         - name: force_removal
           value: $(params.force_removal)
         - name: mas_app_id
@@ -407,9 +410,9 @@ spec:
         - name: configs
           workspace: configs
       when:
-        - input: "$(params.manage_workspace_id)"
+        - input: "$(params.manage_workspace_action)"
           operator: in
-          values: [""]
+          values: ["deactivate"]
 
     # 6.2 Manage App
     - name: gitops-deprovision-mas-app-install-manage
@@ -434,9 +437,9 @@ spec:
         - name: configs
           workspace: configs
       when:
-        - input: "$(params.manage_workspace_id)"
+        - input: "$(params.manage_workspace_action)"
           operator: in
-          values: [""]
+          values: ["deactivate"]
         - input: "$(params.mas_app_channel_manage)"
           operator: in
           values: [""]
@@ -455,7 +458,7 @@ spec:
         - name: mas_instance_id
           value: $(params.mas_instance_id)
         - name: mas_workspace_id
-          value: $(params.iot_workspace_id)
+          value: $(params.mas_workspace_id)
         - name: force_removal
           value: $(params.force_removal)
         - name: mas_app_id
@@ -468,9 +471,9 @@ spec:
         - name: configs
           workspace: configs
       when:
-        - input: "$(params.iot_workspace_id)"
+        - input: "$(params.iot_workspace_action)"
           operator: in
-          values: [""]
+          values: ["deactivate"]
 
     # 7.2 IoT App
     - name: gitops-deprovision-mas-app-install-iot
@@ -495,9 +498,9 @@ spec:
         - name: configs
           workspace: configs
       when:
-        - input: "$(params.iot_workspace_id)"
+        - input: "$(params.iot_workspace_action)"
           operator: in
-          values: [""]
+          values: ["deactivate"]
         - input: "$(params.mas_app_channel_iot)"
           operator: in
           values: [""]

--- a/tekton/src/pipelines/gitops/deprovision-mas-apps.yml.j2
+++ b/tekton/src/pipelines/gitops/deprovision-mas-apps.yml.j2
@@ -1,0 +1,503 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: gitops-deprovision-mas-apps
+spec:
+  workspaces:
+    - name: configs
+  description: Deprovision MAS GitOps Apps and App Configs/Workspaces
+  params:
+    - name: cluster_name
+      type: string
+    - name: account
+      type: string
+    - name: secrets_path
+      type: string
+    - name: avp_aws_secret_region
+      type: string
+    - name: avp_aws_secret_key
+      type: string
+    - name: avp_aws_access_key
+      type: string
+
+    # 1. Gitops git Parameters
+    # -------------------------------------------------------------------------
+    {{ lookup('template', params_src_dir ~ '/gitops-git.yml.j2') | indent(4) }}
+
+    - name: github_url
+      type: string
+    - name: mas_instance_id
+      type: string
+
+    - name: force_removal
+      type: string
+      default: ""
+
+    # If no <app>_workspace_id is set then we deprovision any config/workspace found for that app
+    # If no <app> channel is set then we deprovsion the app itself
+    # If there is a <app>_workspace_id but no <app> channel then nothing is deprovisioned for that app
+    # If there is no <app>_workspace_id but a <app> channel then just the config/workspace is deprovisioned
+    - name: mas_app_channel_iot
+      type: string
+      default: ""
+    - name: iot_workspace_id
+      type: string
+      default: ""
+    - name: mas_app_channel_monitor
+      type: string
+      default: ""
+    - name: monitor_workspace_id
+      type: string
+      default: ""
+    - name: mas_app_channel_manage
+      type: string
+      default: ""
+    - name: manage_workspace_id
+      type: string
+      default: ""
+    - name: mas_app_channel_assist
+      type: string
+      default: ""
+    - name: assist_workspace_id
+      type: string
+      default: ""
+    - name: mas_app_channel_predict
+      type: string
+      default: ""
+    - name: predict_workspace_id
+      type: string
+      default: ""
+    - name: mas_app_channel_visualinspection
+      type: string
+      default: ""
+    - name: visualinspection_workspace_id
+      type: string
+      default: ""
+    - name: mas_app_channel_optimizer
+      type: string
+      default: ""
+    - name: optimizer_workspace_id
+      type: string
+      default: ""
+
+  tasks:
+
+    # 1. Monitor
+    # -------------------------------------------------------------------------
+    # 1.1 Monitor Config/Workspace
+    - name: gitops-deprovision-mas-app-config-monitor
+      params:
+        {{ lookup('template', pipeline_src_dir ~ '/taskdefs/gitops/common/gitops-params.yml.j2') | indent(8) }}
+        {{ lookup('template', pipeline_src_dir ~ '/taskdefs/gitops/common/secrets-params.yml.j2') | indent(8) }}
+        {{ lookup('template', pipeline_src_dir ~ '/taskdefs/gitops/common/git-params.yml.j2') | indent(8) }}
+
+        - name: mas_instance_id
+          value: $(params.mas_instance_id)
+        - name: mas_workspace_id
+          value: $(params.monitor_workspace_id)
+        - name: force_removal
+          value: $(params.force_removal)
+        - name: mas_app_id
+          value: monitor
+
+      taskRef:
+        kind: Task
+        name: gitops-deprovision-app-config
+      workspaces:
+        - name: configs
+          workspace: configs
+      when:
+        - input: "$(params.monitor_workspace_id)"
+          operator: in
+          values: [""]
+
+    # 1.2 Monitor App
+    - name: gitops-deprovision-mas-app-install-monitor
+      runAfter:
+        - gitops-deprovision-mas-app-config-monitor
+      params:
+        {{ lookup('template', pipeline_src_dir ~ '/taskdefs/gitops/common/gitops-params.yml.j2') | indent(8) }}
+        {{ lookup('template', pipeline_src_dir ~ '/taskdefs/gitops/common/secrets-params.yml.j2') | indent(8) }}
+        {{ lookup('template', pipeline_src_dir ~ '/taskdefs/gitops/common/git-params.yml.j2') | indent(8) }}
+
+        - name: mas_instance_id
+          value: $(params.mas_instance_id)
+        - name: force_removal
+          value: $(params.force_removal)
+        - name: mas_app_id
+          value: monitor
+
+      taskRef:
+        kind: Task
+        name: gitops-deprovision-app-install
+      workspaces:
+        - name: configs
+          workspace: configs
+      when:
+        - input: "$(params.monitor_workspace_id)"
+          operator: in
+          values: [""]
+        - input: "$(params.mas_app_channel_monitor)"
+          operator: in
+          values: [""]
+
+    # 2. Predict
+    # -------------------------------------------------------------------------
+    # 2.1 Predict Config/Workspace
+    - name: gitops-deprovision-mas-app-config-predict
+      params:
+        {{ lookup('template', pipeline_src_dir ~ '/taskdefs/gitops/common/gitops-params.yml.j2') | indent(8) }}
+        {{ lookup('template', pipeline_src_dir ~ '/taskdefs/gitops/common/secrets-params.yml.j2') | indent(8) }}
+        {{ lookup('template', pipeline_src_dir ~ '/taskdefs/gitops/common/git-params.yml.j2') | indent(8) }}
+
+        - name: mas_instance_id
+          value: $(params.mas_instance_id)
+        - name: mas_workspace_id
+          value: $(params.predict_workspace_id)
+        - name: force_removal
+          value: $(params.force_removal)
+        - name: mas_app_id
+          value: predict
+
+      taskRef:
+        kind: Task
+        name: gitops-deprovision-app-config
+      workspaces:
+        - name: configs
+          workspace: configs
+      when:
+        - input: "$(params.predict_workspace_id)"
+          operator: in
+          values: [""]
+
+    # 2.2 Predict App
+    - name: gitops-deprovision-mas-app-install-predict
+      runAfter:
+        - gitops-deprovision-mas-app-config-predict
+      params:
+        {{ lookup('template', pipeline_src_dir ~ '/taskdefs/gitops/common/gitops-params.yml.j2') | indent(8) }}
+        {{ lookup('template', pipeline_src_dir ~ '/taskdefs/gitops/common/secrets-params.yml.j2') | indent(8) }}
+        {{ lookup('template', pipeline_src_dir ~ '/taskdefs/gitops/common/git-params.yml.j2') | indent(8) }}
+
+        - name: mas_instance_id
+          value: $(params.mas_instance_id)
+        - name: force_removal
+          value: $(params.force_removal)
+        - name: mas_app_id
+          value: predict
+
+      taskRef:
+        kind: Task
+        name: gitops-deprovision-app-install
+      workspaces:
+        - name: configs
+          workspace: configs
+      when:
+        - input: "$(params.predict_workspace_id)"
+          operator: in
+          values: [""]
+        - input: "$(params.mas_app_channel_predict)"
+          operator: in
+          values: [""]
+
+    # 3. Visualinspection
+    # -------------------------------------------------------------------------
+    # 3.1 Visualinspection Config/Workspace
+    - name: gitops-deprovision-mas-app-config-visualinspection
+      params:
+        {{ lookup('template', pipeline_src_dir ~ '/taskdefs/gitops/common/gitops-params.yml.j2') | indent(8) }}
+        {{ lookup('template', pipeline_src_dir ~ '/taskdefs/gitops/common/secrets-params.yml.j2') | indent(8) }}
+        {{ lookup('template', pipeline_src_dir ~ '/taskdefs/gitops/common/git-params.yml.j2') | indent(8) }}
+
+        - name: mas_instance_id
+          value: $(params.mas_instance_id)
+        - name: mas_workspace_id
+          value: $(params.visualinspection_workspace_id)
+        - name: force_removal
+          value: $(params.force_removal)
+        - name: mas_app_id
+          value: visualinspection
+
+      taskRef:
+        kind: Task
+        name: gitops-deprovision-app-config
+      workspaces:
+        - name: configs
+          workspace: configs
+      when:
+        - input: "$(params.visualinspection_workspace_id)"
+          operator: in
+          values: [""]
+
+    # 3.2 Visualinspection App
+    - name: gitops-deprovision-mas-app-install-visualinspection
+      runAfter:
+        - gitops-deprovision-mas-app-config-visualinspection
+      params:
+        {{ lookup('template', pipeline_src_dir ~ '/taskdefs/gitops/common/gitops-params.yml.j2') | indent(8) }}
+        {{ lookup('template', pipeline_src_dir ~ '/taskdefs/gitops/common/secrets-params.yml.j2') | indent(8) }}
+        {{ lookup('template', pipeline_src_dir ~ '/taskdefs/gitops/common/git-params.yml.j2') | indent(8) }}
+
+        - name: mas_instance_id
+          value: $(params.mas_instance_id)
+        - name: force_removal
+          value: $(params.force_removal)
+        - name: mas_app_id
+          value: visualinspection
+
+      taskRef:
+        kind: Task
+        name: gitops-deprovision-app-install
+      workspaces:
+        - name: configs
+          workspace: configs
+      when:
+        - input: "$(params.visualinspection_workspace_id)"
+          operator: in
+          values: [""]
+        - input: "$(params.mas_app_channel_visualinspection)"
+          operator: in
+          values: [""]
+
+    # 4. Optimizer
+    # -------------------------------------------------------------------------
+    # 4.1 Optimizer Config/Workspace
+    - name: gitops-deprovision-mas-app-config-optimizer
+      params:
+        {{ lookup('template', pipeline_src_dir ~ '/taskdefs/gitops/common/gitops-params.yml.j2') | indent(8) }}
+        {{ lookup('template', pipeline_src_dir ~ '/taskdefs/gitops/common/secrets-params.yml.j2') | indent(8) }}
+        {{ lookup('template', pipeline_src_dir ~ '/taskdefs/gitops/common/git-params.yml.j2') | indent(8) }}
+
+        - name: mas_instance_id
+          value: $(params.mas_instance_id)
+        - name: mas_workspace_id
+          value: $(params.optimizer_workspace_id)
+        - name: force_removal
+          value: $(params.force_removal)
+        - name: mas_app_id
+          value: optimizer
+
+      taskRef:
+        kind: Task
+        name: gitops-deprovision-app-config
+      workspaces:
+        - name: configs
+          workspace: configs
+      when:
+        - input: "$(params.optimizer_workspace_id)"
+          operator: in
+          values: [""]
+
+    # 4.2 Optimizer App
+    - name: gitops-deprovision-mas-app-install-optimizer
+      runAfter:
+        - gitops-deprovision-mas-app-config-optimizer
+      params:
+        {{ lookup('template', pipeline_src_dir ~ '/taskdefs/gitops/common/gitops-params.yml.j2') | indent(8) }}
+        {{ lookup('template', pipeline_src_dir ~ '/taskdefs/gitops/common/secrets-params.yml.j2') | indent(8) }}
+        {{ lookup('template', pipeline_src_dir ~ '/taskdefs/gitops/common/git-params.yml.j2') | indent(8) }}
+
+        - name: mas_instance_id
+          value: $(params.mas_instance_id)
+        - name: force_removal
+          value: $(params.force_removal)
+        - name: mas_app_id
+          value: optimizer
+
+      taskRef:
+        kind: Task
+        name: gitops-deprovision-app-install
+      workspaces:
+        - name: configs
+          workspace: configs
+      when:
+        - input: "$(params.optimizer_workspace_id)"
+          operator: in
+          values: [""]
+        - input: "$(params.mas_app_channel_optimizer)"
+          operator: in
+          values: [""]
+
+    # 5. Assist
+    # -------------------------------------------------------------------------
+    # 5.1 Assist Config/Workspace
+    - name: gitops-deprovision-mas-app-config-assist
+      params:
+        {{ lookup('template', pipeline_src_dir ~ '/taskdefs/gitops/common/gitops-params.yml.j2') | indent(8) }}
+        {{ lookup('template', pipeline_src_dir ~ '/taskdefs/gitops/common/secrets-params.yml.j2') | indent(8) }}
+        {{ lookup('template', pipeline_src_dir ~ '/taskdefs/gitops/common/git-params.yml.j2') | indent(8) }}
+
+        - name: mas_instance_id
+          value: $(params.mas_instance_id)
+        - name: mas_workspace_id
+          value: $(params.assist_workspace_id)
+        - name: force_removal
+          value: $(params.force_removal)
+        - name: mas_app_id
+          value: assist
+
+      taskRef:
+        kind: Task
+        name: gitops-deprovision-app-config
+      workspaces:
+        - name: configs
+          workspace: configs
+      when:
+        - input: "$(params.assist_workspace_id)"
+          operator: in
+          values: [""]
+
+    # 5.2 Assist App
+    - name: gitops-deprovision-mas-app-install-assist
+      runAfter:
+        - gitops-deprovision-mas-app-config-assist
+      params:
+        {{ lookup('template', pipeline_src_dir ~ '/taskdefs/gitops/common/gitops-params.yml.j2') | indent(8) }}
+        {{ lookup('template', pipeline_src_dir ~ '/taskdefs/gitops/common/secrets-params.yml.j2') | indent(8) }}
+        {{ lookup('template', pipeline_src_dir ~ '/taskdefs/gitops/common/git-params.yml.j2') | indent(8) }}
+
+        - name: mas_instance_id
+          value: $(params.mas_instance_id)
+        - name: force_removal
+          value: $(params.force_removal)
+        - name: mas_app_id
+          value: assist
+
+      taskRef:
+        kind: Task
+        name: gitops-deprovision-app-install
+      workspaces:
+        - name: configs
+          workspace: configs
+      when:
+        - input: "$(params.assist_workspace_id)"
+          operator: in
+          values: [""]
+        - input: "$(params.mas_app_channel_assist)"
+          operator: in
+          values: [""]
+
+    # 6. Manage
+    # -------------------------------------------------------------------------
+    # 6.1 Manage Config/Workspace
+    - name: gitops-deprovision-mas-app-config-manage
+      runAfter:
+        - gitops-deprovision-mas-app-install-predict
+        - gitops-deprovision-mas-app-install-monitor
+        - gitops-deprovision-mas-app-install-optimizer
+      params:
+        {{ lookup('template', pipeline_src_dir ~ '/taskdefs/gitops/common/gitops-params.yml.j2') | indent(8) }}
+        {{ lookup('template', pipeline_src_dir ~ '/taskdefs/gitops/common/secrets-params.yml.j2') | indent(8) }}
+        {{ lookup('template', pipeline_src_dir ~ '/taskdefs/gitops/common/git-params.yml.j2') | indent(8) }}
+
+        - name: mas_instance_id
+          value: $(params.mas_instance_id)
+        - name: mas_workspace_id
+          value: $(params.manage_workspace_id)
+        - name: force_removal
+          value: $(params.force_removal)
+        - name: mas_app_id
+          value: manage
+
+      taskRef:
+        kind: Task
+        name: gitops-deprovision-app-config
+      workspaces:
+        - name: configs
+          workspace: configs
+      when:
+        - input: "$(params.manage_workspace_id)"
+          operator: in
+          values: [""]
+
+    # 6.2 Manage App
+    - name: gitops-deprovision-mas-app-install-manage
+      runAfter:
+        - gitops-deprovision-mas-app-config-manage
+      params:
+        {{ lookup('template', pipeline_src_dir ~ '/taskdefs/gitops/common/gitops-params.yml.j2') | indent(8) }}
+        {{ lookup('template', pipeline_src_dir ~ '/taskdefs/gitops/common/secrets-params.yml.j2') | indent(8) }}
+        {{ lookup('template', pipeline_src_dir ~ '/taskdefs/gitops/common/git-params.yml.j2') | indent(8) }}
+
+        - name: mas_instance_id
+          value: $(params.mas_instance_id)
+        - name: force_removal
+          value: $(params.force_removal)
+        - name: mas_app_id
+          value: manage
+
+      taskRef:
+        kind: Task
+        name: gitops-deprovision-app-install
+      workspaces:
+        - name: configs
+          workspace: configs
+      when:
+        - input: "$(params.manage_workspace_id)"
+          operator: in
+          values: [""]
+        - input: "$(params.mas_app_channel_manage)"
+          operator: in
+          values: [""]
+
+    # 7. IoT
+    # -------------------------------------------------------------------------
+    # 7.1 IoT Config/Workspace
+    - name: gitops-deprovision-mas-app-config-iot
+      runAfter:
+        - gitops-deprovision-mas-app-install-monitor
+      params:
+        {{ lookup('template', pipeline_src_dir ~ '/taskdefs/gitops/common/gitops-params.yml.j2') | indent(8) }}
+        {{ lookup('template', pipeline_src_dir ~ '/taskdefs/gitops/common/secrets-params.yml.j2') | indent(8) }}
+        {{ lookup('template', pipeline_src_dir ~ '/taskdefs/gitops/common/git-params.yml.j2') | indent(8) }}
+
+        - name: mas_instance_id
+          value: $(params.mas_instance_id)
+        - name: mas_workspace_id
+          value: $(params.iot_workspace_id)
+        - name: force_removal
+          value: $(params.force_removal)
+        - name: mas_app_id
+          value: iot
+
+      taskRef:
+        kind: Task
+        name: gitops-deprovision-app-config
+      workspaces:
+        - name: configs
+          workspace: configs
+      when:
+        - input: "$(params.iot_workspace_id)"
+          operator: in
+          values: [""]
+
+    # 7.2 IoT App
+    - name: gitops-deprovision-mas-app-install-iot
+      runAfter:
+        - gitops-deprovision-mas-app-config-iot
+      params:
+        {{ lookup('template', pipeline_src_dir ~ '/taskdefs/gitops/common/gitops-params.yml.j2') | indent(8) }}
+        {{ lookup('template', pipeline_src_dir ~ '/taskdefs/gitops/common/secrets-params.yml.j2') | indent(8) }}
+        {{ lookup('template', pipeline_src_dir ~ '/taskdefs/gitops/common/git-params.yml.j2') | indent(8) }}
+
+        - name: mas_instance_id
+          value: $(params.mas_instance_id)
+        - name: force_removal
+          value: $(params.force_removal)
+        - name: mas_app_id
+          value: iot
+
+      taskRef:
+        kind: Task
+        name: gitops-deprovision-app-install
+      workspaces:
+        - name: configs
+          workspace: configs
+      when:
+        - input: "$(params.iot_workspace_id)"
+          operator: in
+          values: [""]
+        - input: "$(params.mas_app_channel_iot)"
+          operator: in
+          values: [""]

--- a/tekton/src/pipelines/gitops/deprovision-mas-instance.yml.j2
+++ b/tekton/src/pipelines/gitops/deprovision-mas-instance.yml.j2
@@ -2,12 +2,25 @@
 apiVersion: tekton.dev/v1beta1
 kind: Pipeline
 metadata:
+{% if wait_for_deprovision == true %}
+  name: gitops-deprovision-mas-instance-after-deprovision
+{% else %}
   name: gitops-deprovision-mas-instance
+{% endif %}
 spec:
   workspaces:
     - name: configs
   description: Deprovision MAS GitOps Instance
   params:
+{% if wait_for_deprovision == true %}
+      # Name of the PipelineRun to wait for
+    - name: pipelinerun_name
+      type: string
+    - name: ignore_failure
+      type: string
+      default: "False"
+      description: Set to 'True' or 'False' (case-sensitive) to configure whether this pipeline continue if the pipeline we are waiting for has failed.
+{% endif %}
     - name: cluster_name
       type: string
     - name: account
@@ -79,210 +92,148 @@ spec:
       type: string
       default: ""
   tasks:
-    - name: gitops-deprovision-suite-smtp-config
-      runAfter:
-        - gitops-deprovision-suite-workspace
+{% if wait_for_deprovision == true %}
+    # 0. Wait for the deprovsion mas apps pipeline to complete
+    # -------------------------------------------------------------------------
+    - name: wait-for-deprovision
       params:
-        - name: cluster_name
-          value: $(params.cluster_name)
-        - name: account
-          value: $(params.account)
-        - name: secrets_path
-          value: $(params.secrets_path)
-        - name: mas_instance_id
-          value: $(params.mas_instance_id)
-        - name: git_branch
-          value: $(params.git_branch)
-        - name: github_org
-          value: $(params.github_org)
-        - name: github_repo
-          value: $(params.github_repo)
-        - name: github_host
-          value: $(params.github_host)
-        - name: git_commit_msg
-          value: $(params.git_commit_msg)
-        - name: github_pat
-          value: $(params.github_pat)
-        - name: avp_aws_secret_region
-          value: $(params.avp_aws_secret_region)
-        - name: avp_aws_secret_key
-          value: $(params.avp_aws_secret_key)
-        - name: avp_aws_access_key
-          value: $(params.avp_aws_access_key)
-        - name: force_removal
-          value: $(params.force_removal)
+        - name: pipelinerun_name
+          value: $(params.pipelinerun_name)
+        - name: ignore_failure
+          value: $(params.ignore_failure)
       taskRef:
         kind: Task
-        name: gitops-deprovision-suite-smtp-config
-      workspaces:
-        - name: configs
-          workspace: configs
-    - name: gitops-deprovision-suite-idp-config
-      runAfter:
-        - gitops-deprovision-suite-workspace
-      params:
-        - name: cluster_name
-          value: $(params.cluster_name)
-        - name: account
-          value: $(params.account)
-        - name: secrets_path
-          value: $(params.secrets_path)
-        - name: mas_instance_id
-          value: $(params.mas_instance_id)
-        - name: git_branch
-          value: $(params.git_branch)
-        - name: github_org
-          value: $(params.github_org)
-        - name: github_repo
-          value: $(params.github_repo)
-        - name: github_host
-          value: $(params.github_host)
-        - name: git_commit_msg
-          value: $(params.git_commit_msg)
-        - name: github_pat
-          value: $(params.github_pat)
-        - name: avp_aws_secret_region
-          value: $(params.avp_aws_secret_region)
-        - name: avp_aws_secret_key
-          value: $(params.avp_aws_secret_key)
-        - name: avp_aws_access_key
-          value: $(params.avp_aws_access_key)
-        - name: force_removal
-          value: $(params.force_removal)
-      taskRef:
-        kind: Task
-        name: gitops-deprovision-suite-idp-config
-      workspaces:
-        - name: configs
-          workspace: configs
+        name: mas-fvt-wait-for-pipelinerun
+{% endif %}
+
+    # 1. Deprovision workspace
+    # -------------------------------------------------------------------------
     - name: gitops-deprovision-suite-workspace
+{% if wait_for_deprovision == true %}
+      runAfter:
+        - wait-for-deprovision
+{% endif %}
       params:
-        - name: cluster_name
-          value: $(params.cluster_name)
-        - name: account
-          value: $(params.account)
-        - name: secrets_path
-          value: $(params.secrets_path)
+        {{ lookup('template', pipeline_src_dir ~ '/taskdefs/gitops/common/gitops-params.yml.j2') | indent(8) }}
+        {{ lookup('template', pipeline_src_dir ~ '/taskdefs/gitops/common/secrets-params.yml.j2') | indent(8) }}
+        {{ lookup('template', pipeline_src_dir ~ '/taskdefs/gitops/common/git-params.yml.j2') | indent(8) }}
+
         - name: mas_instance_id
           value: $(params.mas_instance_id)
         - name: workspace_id
           value: $(params.workspace_id)
         - name: workspace_name
           value: $(params.workspace_name)
-        - name: git_branch
-          value: $(params.git_branch)
-        - name: github_org
-          value: $(params.github_org)
-        - name: github_repo
-          value: $(params.github_repo)
-        - name: github_host
-          value: $(params.github_host)
-        - name: git_commit_msg
-          value: $(params.git_commit_msg)
-        - name: github_pat
-          value: $(params.github_pat)
         - name: force_removal
           value: $(params.force_removal)
+
       taskRef:
         kind: Task
         name: gitops-deprovision-suite-workspace
       workspaces:
         - name: configs
           workspace: configs
+
+    # 2. Deprovision SMTP config
+    # -------------------------------------------------------------------------
+    - name: gitops-deprovision-suite-smtp-config
+      runAfter:
+        - gitops-deprovision-suite-workspace
+      params:
+        {{ lookup('template', pipeline_src_dir ~ '/taskdefs/gitops/common/gitops-params.yml.j2') | indent(8) }}
+        {{ lookup('template', pipeline_src_dir ~ '/taskdefs/gitops/common/secrets-params.yml.j2') | indent(8) }}
+        {{ lookup('template', pipeline_src_dir ~ '/taskdefs/gitops/common/git-params.yml.j2') | indent(8) }}
+
+        - name: mas_instance_id
+          value: $(params.mas_instance_id)
+        - name: force_removal
+          value: $(params.force_removal)
+
+      taskRef:
+        kind: Task
+        name: gitops-deprovision-suite-smtp-config
+      workspaces:
+        - name: configs
+          workspace: configs
+
+    # 3. Deprovision IDP config
+    # -------------------------------------------------------------------------
+    - name: gitops-deprovision-suite-idp-config
+      runAfter:
+        - gitops-deprovision-suite-workspace
+      params:
+        {{ lookup('template', pipeline_src_dir ~ '/taskdefs/gitops/common/gitops-params.yml.j2') | indent(8) }}
+        {{ lookup('template', pipeline_src_dir ~ '/taskdefs/gitops/common/secrets-params.yml.j2') | indent(8) }}
+        {{ lookup('template', pipeline_src_dir ~ '/taskdefs/gitops/common/git-params.yml.j2') | indent(8) }}
+
+        - name: mas_instance_id
+          value: $(params.mas_instance_id)
+        - name: force_removal
+          value: $(params.force_removal)
+
+      taskRef:
+        kind: Task
+        name: gitops-deprovision-suite-idp-config
+      workspaces:
+        - name: configs
+          workspace: configs
+
+    # 4. Deprovision Suite config
+    # -------------------------------------------------------------------------
     - name: gitops-deprovision-suite-config
       runAfter:
         - gitops-delete-kafka-config
       params:
-        - name: cluster_name
-          value: $(params.cluster_name)
-        - name: account
-          value: $(params.account)
-        - name: secrets_path
-          value: $(params.secrets_path)
+        {{ lookup('template', pipeline_src_dir ~ '/taskdefs/gitops/common/gitops-params.yml.j2') | indent(8) }}
+        {{ lookup('template', pipeline_src_dir ~ '/taskdefs/gitops/common/secrets-params.yml.j2') | indent(8) }}
+        {{ lookup('template', pipeline_src_dir ~ '/taskdefs/gitops/common/git-params.yml.j2') | indent(8) }}
+
         - name: mas_instance_id
           value: $(params.mas_instance_id)
-        - name: git_branch
-          value: $(params.git_branch)
-        - name: github_org
-          value: $(params.github_org)
-        - name: github_repo
-          value: $(params.github_repo)
-        - name: github_host
-          value: $(params.github_host)
-        - name: git_commit_msg
-          value: $(params.git_commit_msg)
-        - name: github_pat
-          value: $(params.github_pat)
-        - name: avp_aws_secret_region
-          value: $(params.avp_aws_secret_region)
-        - name: avp_aws_secret_key
-          value: $(params.avp_aws_secret_key)
-        - name: avp_aws_access_key
-          value: $(params.avp_aws_access_key)
         - name: force_removal
           value: $(params.force_removal)
+
       workspaces:
         - name: configs
           workspace: configs
       taskRef:
         name: gitops-deprovision-suite-config
         kind: Task
+
+    # 5. Deprovision Suite config
+    # -------------------------------------------------------------------------
     - name: gitops-deprovision-suite
       runAfter:
         - gitops-deprovision-suite-config
       params:
-        - name: cluster_name
-          value: $(params.cluster_name)
-        - name: account
-          value: $(params.account)
-        - name: secrets_path
-          value: $(params.secrets_path)
+        {{ lookup('template', pipeline_src_dir ~ '/taskdefs/gitops/common/gitops-params.yml.j2') | indent(8) }}
+        {{ lookup('template', pipeline_src_dir ~ '/taskdefs/gitops/common/secrets-params.yml.j2') | indent(8) }}
+        {{ lookup('template', pipeline_src_dir ~ '/taskdefs/gitops/common/git-params.yml.j2') | indent(8) }}
+
         - name: mas_instance_id
           value: $(params.mas_instance_id)
         - name: mongo_provider
           value: $(params.mongo_provider)
-        - name: git_branch
-          value: $(params.git_branch)
-        - name: github_org
-          value: $(params.github_org)
-        - name: github_repo
-          value: $(params.github_repo)
-        - name: github_host
-          value: $(params.github_host)
-        - name: git_commit_msg
-          value: $(params.git_commit_msg)
-        - name: github_pat
-          value: $(params.github_pat)
-        - name: avp_aws_secret_region
-          value: $(params.avp_aws_secret_region)
-        - name: avp_aws_secret_key
-          value: $(params.avp_aws_secret_key)
-        - name: avp_aws_access_key
-          value: $(params.avp_aws_access_key)
         - name: force_removal
           value: $(params.force_removal)
+
       taskRef:
         kind: Task
         name: gitops-deprovision-suite
       workspaces:
         - name: configs
           workspace: configs
+
+    # 6. Remove Mongo User
+    # -------------------------------------------------------------------------
     - name: gitops-process-mongo-user
       runAfter:
         - gitops-deprovision-suite
       params:
-        - name: cluster_name
-          value: $(params.cluster_name)
-        - name: account
-          value: $(params.account)
-        - name: secrets_path
-          value: $(params.secrets_path)
-        - name: avp_aws_secret_region
-          value: $(params.avp_aws_secret_region)
-        - name: avp_aws_secret_key
-          value: $(params.avp_aws_secret_key)
-        - name: avp_aws_access_key
-          value: $(params.avp_aws_access_key)
+        {{ lookup('template', pipeline_src_dir ~ '/taskdefs/gitops/common/gitops-params.yml.j2') | indent(8) }}
+        {{ lookup('template', pipeline_src_dir ~ '/taskdefs/gitops/common/secrets-params.yml.j2') | indent(8) }}
+        {{ lookup('template', pipeline_src_dir ~ '/taskdefs/gitops/common/git-params.yml.j2') | indent(8) }}
+
         - name: mas_instance_id
           value: $(params.mas_instance_id)
         - name: vpc_ipv4_cidr
@@ -301,38 +252,22 @@ spec:
       taskRef:
         kind: Task
         name: gitops-process-mongo-user
+
+    # 7. Deprovision db2u operator
+    # -------------------------------------------------------------------------
     - name: gitops-deprovision-db2u
       runAfter:
         - gitops-deprovision-suite
       params:
-        - name: cluster_name
-          value: $(params.cluster_name)
-        - name: account
-          value: $(params.account)
-        - name: secrets_path
-          value: $(params.secrets_path)
-        - name: avp_aws_secret_region
-          value: $(params.avp_aws_secret_region)
-        - name: avp_aws_secret_key
-          value: $(params.avp_aws_secret_key)
-        - name: avp_aws_access_key
-          value: $(params.avp_aws_access_key)
+        {{ lookup('template', pipeline_src_dir ~ '/taskdefs/gitops/common/gitops-params.yml.j2') | indent(8) }}
+        {{ lookup('template', pipeline_src_dir ~ '/taskdefs/gitops/common/secrets-params.yml.j2') | indent(8) }}
+        {{ lookup('template', pipeline_src_dir ~ '/taskdefs/gitops/common/git-params.yml.j2') | indent(8) }}
+
         - name: mas_instance_id
           value: $(params.mas_instance_id)
-        - name: git_branch
-          value: $(params.git_branch)
-        - name: github_org
-          value: $(params.github_org)
-        - name: github_repo
-          value: $(params.github_repo)
-        - name: github_host
-          value: $(params.github_host)
-        - name: git_commit_msg
-          value: $(params.git_commit_msg)
-        - name: github_pat
-          value: $(params.github_pat)
         - name: db2_action
           value: $(params.db2_action)
+
       workspaces:
         - name: configs
           workspace: configs
@@ -343,6 +278,9 @@ spec:
         - input: "$(params.db2_action)"
           operator: in
           values: ["remove"]
+
+    # 8. Deprovision EFS
+    # -------------------------------------------------------------------------
     - name: gitops-deprovision-efs
       runAfter:
         - gitops-deprovision-suite
@@ -365,44 +303,35 @@ spec:
       taskRef:
         kind: Task
         name: gitops-deprovision-efs
+
+    # 9. Deprovision Kafka config
+    # -------------------------------------------------------------------------
     - name: gitops-delete-kafka-config
       runAfter:
         - gitops-deprovision-suite-smtp-config
         - gitops-deprovision-suite-idp-config
       params:
-        - name: cluster_name
-          value: $(params.cluster_name)
-        - name: account
-          value: $(params.account)
-        - name: secrets_path
-          value: $(params.secrets_path)
+        {{ lookup('template', pipeline_src_dir ~ '/taskdefs/gitops/common/gitops-params.yml.j2') | indent(8) }}
+        {{ lookup('template', pipeline_src_dir ~ '/taskdefs/gitops/common/secrets-params.yml.j2') | indent(8) }}
+        {{ lookup('template', pipeline_src_dir ~ '/taskdefs/gitops/common/git-params.yml.j2') | indent(8) }}
+
         - name: mas_instance_id
           value: $(params.mas_instance_id)
-        - name: git_branch
-          value: $(params.git_branch)
-        - name: github_org
-          value: $(params.github_org)
-        - name: github_repo
-          value: $(params.github_repo)
-        - name: github_host
-          value: $(params.github_host)
-        - name: git_commit_msg
-          value: $(params.git_commit_msg)
-        - name: github_pat
-          value: $(params.github_pat)
-        - name: avp_aws_secret_region
-          value: $(params.avp_aws_secret_region)
-        - name: avp_aws_secret_key
-          value: $(params.avp_aws_secret_key)
-        - name: avp_aws_access_key
-          value: $(params.avp_aws_access_key)
+
       workspaces:
         - name: configs
           workspace: configs
       taskRef:
         kind: Task
         name: gitops-delete-kafka-config
+
+    # 10. Deprovision Objectstorage config
+    # -------------------------------------------------------------------------
     - name: gitops-deprovision-suite-objectstorage-config
+{% if wait_for_deprovision == true %}
+      runAfter:
+        - wait-for-deprovision
+{% endif %}
       params:
         {{ lookup('template', pipeline_src_dir ~ '/taskdefs/gitops/common/gitops-params.yml.j2') | indent(8) }}
         {{ lookup('template', pipeline_src_dir ~ '/taskdefs/gitops/common/secrets-params.yml.j2') | indent(8) }}
@@ -418,6 +347,9 @@ spec:
       workspaces:
         - name: configs
           workspace: configs
+
+    # 11. Deprovision COS
+    # -------------------------------------------------------------------------
     - name: gitops-deprovision-cos
       runAfter:
         - gitops-deprovision-suite-objectstorage-config

--- a/tekton/src/pipelines/gitops/provision-mas-apps.yml.j2
+++ b/tekton/src/pipelines/gitops/provision-mas-apps.yml.j2
@@ -221,6 +221,9 @@ spec:
       type: string
     - name: mas_appws_spec_yaml_iot
       type: string
+    - name: iot_workspace_id
+      type: string
+      default: ""
 
     - name: mas_app_channel_manage
       type: string
@@ -243,6 +246,9 @@ spec:
       type: string
     - name: mas_appws_spec_yaml_manage
       type: string
+    - name: manage_workspace_id
+      type: string
+      default: ""
 
     - name: mas_app_channel_monitor
       type: string
@@ -265,6 +271,9 @@ spec:
       type: string
     - name: mas_appws_spec_yaml_monitor
       type: string
+    - name: monitor_workspace_id
+      type: string
+      default: ""
 
     - name: mas_app_channel_visualinspection
       type: string
@@ -287,6 +296,9 @@ spec:
       type: string
     - name: mas_appws_spec_yaml_visualinspection
       type: string
+    - name: visualinspection_workspace_id
+      type: string
+      default: ""
 
     - name: mas_app_channel_assist
       type: string
@@ -309,6 +321,9 @@ spec:
       type: string
     - name: mas_appws_spec_yaml_assist
       type: string
+    - name: assist_workspace_id
+      type: string
+      default: ""
 
     - name: mas_app_channel_optimizer
       type: string
@@ -331,6 +346,9 @@ spec:
       type: string
     - name: mas_appws_spec_yaml_optimizer
       type: string
+    - name: optimizer_workspace_id
+      type: string
+      default: ""
 
   tasks:
 {% if wait_for_provision == true %}

--- a/tekton/src/pipelines/gitops/provision-mas-apps.yml.j2
+++ b/tekton/src/pipelines/gitops/provision-mas-apps.yml.j2
@@ -221,7 +221,7 @@ spec:
       type: string
     - name: mas_appws_spec_yaml_iot
       type: string
-    - name: iot_workspace_id
+    - name: iot_workspace_action
       type: string
       default: ""
 
@@ -246,7 +246,7 @@ spec:
       type: string
     - name: mas_appws_spec_yaml_manage
       type: string
-    - name: manage_workspace_id
+    - name: manage_workspace_action
       type: string
       default: ""
 
@@ -271,7 +271,7 @@ spec:
       type: string
     - name: mas_appws_spec_yaml_monitor
       type: string
-    - name: monitor_workspace_id
+    - name: monitor_workspace_action
       type: string
       default: ""
 
@@ -296,7 +296,7 @@ spec:
       type: string
     - name: mas_appws_spec_yaml_visualinspection
       type: string
-    - name: visualinspection_workspace_id
+    - name: visualinspection_workspace_action
       type: string
       default: ""
 
@@ -321,7 +321,7 @@ spec:
       type: string
     - name: mas_appws_spec_yaml_assist
       type: string
-    - name: assist_workspace_id
+    - name: assist_workspace_action
       type: string
       default: ""
 
@@ -346,7 +346,7 @@ spec:
       type: string
     - name: mas_appws_spec_yaml_optimizer
       type: string
-    - name: optimizer_workspace_id
+    - name: optimizer_workspace_action
       type: string
       default: ""
 

--- a/tekton/src/pipelines/taskdefs/gitops/apps/assist-workspace.yml.j2
+++ b/tekton/src/pipelines/taskdefs/gitops/apps/assist-workspace.yml.j2
@@ -15,7 +15,7 @@
     - name: mas_app_id
       value: assist
     - name: mas_workspace_id
-      value: $(params.mas_workspace_id)
+      value: $(params.assist_workspace_id)
     - name: custom_labels
       value: $(params.custom_labels)
     - name: mas_appws_spec_yaml
@@ -32,6 +32,9 @@
   # Only configure a workspace for assist if a channel has been chosen
   when:
     - input: "$(params.mas_app_channel_assist)"
+      operator: notin
+      values: [""]
+    - input: "$(params.assist_workspace_id)"
       operator: notin
       values: [""]
   workspaces:

--- a/tekton/src/pipelines/taskdefs/gitops/apps/assist-workspace.yml.j2
+++ b/tekton/src/pipelines/taskdefs/gitops/apps/assist-workspace.yml.j2
@@ -15,7 +15,7 @@
     - name: mas_app_id
       value: assist
     - name: mas_workspace_id
-      value: $(params.assist_workspace_id)
+      value: $(params.mas_workspace_id)
     - name: custom_labels
       value: $(params.custom_labels)
     - name: mas_appws_spec_yaml
@@ -34,9 +34,9 @@
     - input: "$(params.mas_app_channel_assist)"
       operator: notin
       values: [""]
-    - input: "$(params.assist_workspace_id)"
-      operator: notin
-      values: [""]
+    - input: "$(params.assist_workspace_action)"
+      operator: in
+      values: ["activate"]
   workspaces:
     - name: configs
       workspace: configs

--- a/tekton/src/pipelines/taskdefs/gitops/apps/iot-workspace.yml.j2
+++ b/tekton/src/pipelines/taskdefs/gitops/apps/iot-workspace.yml.j2
@@ -15,7 +15,7 @@
     - name: mas_app_id
       value: iot
     - name: mas_workspace_id
-      value: $(params.mas_workspace_id)
+      value: $(params.iot_workspace_id)
     - name: custom_labels
       value: $(params.custom_labels)
     - name: mas_appws_spec_yaml
@@ -32,6 +32,9 @@
   # Only configure a workspace for IoT if a channel has been chosen
   when:
     - input: "$(params.mas_app_channel_iot)"
+      operator: notin
+      values: [""]
+    - input: "$(params.iot_workspace_id)"
       operator: notin
       values: [""]
   workspaces:

--- a/tekton/src/pipelines/taskdefs/gitops/apps/iot-workspace.yml.j2
+++ b/tekton/src/pipelines/taskdefs/gitops/apps/iot-workspace.yml.j2
@@ -15,7 +15,7 @@
     - name: mas_app_id
       value: iot
     - name: mas_workspace_id
-      value: $(params.iot_workspace_id)
+      value: $(params.mas_workspace_id)
     - name: custom_labels
       value: $(params.custom_labels)
     - name: mas_appws_spec_yaml
@@ -34,9 +34,9 @@
     - input: "$(params.mas_app_channel_iot)"
       operator: notin
       values: [""]
-    - input: "$(params.iot_workspace_id)"
-      operator: notin
-      values: [""]
+    - input: "$(params.iot_workspace_action)"
+      operator: in
+      values: ["activate"]
   workspaces:
     - name: configs
       workspace: configs

--- a/tekton/src/pipelines/taskdefs/gitops/apps/manage-workspace.yml.j2
+++ b/tekton/src/pipelines/taskdefs/gitops/apps/manage-workspace.yml.j2
@@ -17,7 +17,7 @@
     - name: mas_app_id
       value: manage
     - name: mas_workspace_id
-      value: $(params.manage_workspace_id)
+      value: $(params.mas_workspace_id)
     - name: custom_labels
       value: $(params.custom_labels)
     - name: mas_appws_spec_yaml
@@ -40,9 +40,9 @@
     - input: "$(params.mas_app_channel_manage)"
       operator: notin
       values: [""]
-    - input: "$(params.manage_workspace_id)"
-      operator: notin
-      values: [""]
+    - input: "$(params.manage_workspace_action)"
+      operator: in
+      values: ["activate"]
   workspaces:
     - name: configs
       workspace: configs

--- a/tekton/src/pipelines/taskdefs/gitops/apps/manage-workspace.yml.j2
+++ b/tekton/src/pipelines/taskdefs/gitops/apps/manage-workspace.yml.j2
@@ -17,7 +17,7 @@
     - name: mas_app_id
       value: manage
     - name: mas_workspace_id
-      value: $(params.mas_workspace_id)
+      value: $(params.manage_workspace_id)
     - name: custom_labels
       value: $(params.custom_labels)
     - name: mas_appws_spec_yaml
@@ -38,6 +38,9 @@
   # Only configure a workspace for Manage if a channel has been chosen
   when:
     - input: "$(params.mas_app_channel_manage)"
+      operator: notin
+      values: [""]
+    - input: "$(params.manage_workspace_id)"
       operator: notin
       values: [""]
   workspaces:

--- a/tekton/src/pipelines/taskdefs/gitops/apps/monitor-workspace.yml.j2
+++ b/tekton/src/pipelines/taskdefs/gitops/apps/monitor-workspace.yml.j2
@@ -15,7 +15,7 @@
     - name: mas_app_id
       value: monitor
     - name: mas_workspace_id
-      value: $(params.monitor_workspace_id)
+      value: $(params.mas_workspace_id)
     - name: custom_labels
       value: $(params.custom_labels)
     - name: mas_appws_spec_yaml
@@ -34,9 +34,9 @@
     - input: "$(params.mas_app_channel_monitor)"
       operator: notin
       values: [""]
-    - input: "$(params.monitor_workspace_id)"
-      operator: notin
-      values: [""]
+    - input: "$(params.monitor_workspace_action)"
+      operator: in
+      values: ["activate"]
   workspaces:
     - name: configs
       workspace: configs

--- a/tekton/src/pipelines/taskdefs/gitops/apps/monitor-workspace.yml.j2
+++ b/tekton/src/pipelines/taskdefs/gitops/apps/monitor-workspace.yml.j2
@@ -15,7 +15,7 @@
     - name: mas_app_id
       value: monitor
     - name: mas_workspace_id
-      value: $(params.mas_workspace_id)
+      value: $(params.monitor_workspace_id)
     - name: custom_labels
       value: $(params.custom_labels)
     - name: mas_appws_spec_yaml
@@ -32,6 +32,9 @@
   # Only configure a workspace for Monitor if a channel has been chosen
   when:
     - input: "$(params.mas_app_channel_monitor)"
+      operator: notin
+      values: [""]
+    - input: "$(params.monitor_workspace_id)"
       operator: notin
       values: [""]
   workspaces:

--- a/tekton/src/pipelines/taskdefs/gitops/apps/optimizer-workspace.yml.j2
+++ b/tekton/src/pipelines/taskdefs/gitops/apps/optimizer-workspace.yml.j2
@@ -15,7 +15,7 @@
     - name: mas_app_id
       value: optimizer
     - name: mas_workspace_id
-      value: $(params.optimizer_workspace_id)
+      value: $(params.mas_workspace_id)
     - name: custom_labels
       value: $(params.custom_labels)
     - name: mas_appws_spec_yaml
@@ -34,9 +34,9 @@
     - input: "$(params.mas_app_channel_optimizer)"
       operator: notin
       values: [""]
-    - input: "$(params.optimizer_workspace_id)"
-      operator: notin
-      values: [""]
+    - input: "$(params.optimizer_workspace_action)"
+      operator: in
+      values: ["activate"]
   workspaces:
     - name: configs
       workspace: configs

--- a/tekton/src/pipelines/taskdefs/gitops/apps/optimizer-workspace.yml.j2
+++ b/tekton/src/pipelines/taskdefs/gitops/apps/optimizer-workspace.yml.j2
@@ -15,7 +15,7 @@
     - name: mas_app_id
       value: optimizer
     - name: mas_workspace_id
-      value: $(params.mas_workspace_id)
+      value: $(params.optimizer_workspace_id)
     - name: custom_labels
       value: $(params.custom_labels)
     - name: mas_appws_spec_yaml
@@ -32,6 +32,9 @@
   # Only configure a workspace for optimizer if a channel has been chosen
   when:
     - input: "$(params.mas_app_channel_optimizer)"
+      operator: notin
+      values: [""]
+    - input: "$(params.optimizer_workspace_id)"
       operator: notin
       values: [""]
   workspaces:

--- a/tekton/src/pipelines/taskdefs/gitops/apps/visualinspection-workspace.yml.j2
+++ b/tekton/src/pipelines/taskdefs/gitops/apps/visualinspection-workspace.yml.j2
@@ -15,7 +15,7 @@
     - name: mas_app_id
       value: visualinspection
     - name: mas_workspace_id
-      value: $(params.mas_workspace_id)
+      value: $(params.visualinspection_workspace_id)
     - name: custom_labels
       value: $(params.custom_labels)
     - name: mas_appws_spec_yaml
@@ -32,6 +32,9 @@
   # Only configure a workspace for visualinspection if a channel has been chosen
   when:
     - input: "$(params.mas_app_channel_visualinspection)"
+      operator: notin
+      values: [""]
+    - input: "$(params.visualinspection_workspace_id)"
       operator: notin
       values: [""]
   workspaces:

--- a/tekton/src/pipelines/taskdefs/gitops/apps/visualinspection-workspace.yml.j2
+++ b/tekton/src/pipelines/taskdefs/gitops/apps/visualinspection-workspace.yml.j2
@@ -15,7 +15,7 @@
     - name: mas_app_id
       value: visualinspection
     - name: mas_workspace_id
-      value: $(params.visualinspection_workspace_id)
+      value: $(params.mas_workspace_id)
     - name: custom_labels
       value: $(params.custom_labels)
     - name: mas_appws_spec_yaml
@@ -34,9 +34,9 @@
     - input: "$(params.mas_app_channel_visualinspection)"
       operator: notin
       values: [""]
-    - input: "$(params.visualinspection_workspace_id)"
-      operator: notin
-      values: [""]
+    - input: "$(params.visualinspection_workspace_action)"
+      operator: in
+      values: ["activate"]
   workspaces:
     - name: configs
       workspace: configs

--- a/tekton/src/tasks/gitops/gitops-deprovision-app-config.yml.j2
+++ b/tekton/src/tasks/gitops/gitops-deprovision-app-config.yml.j2
@@ -95,6 +95,6 @@ spec:
         - -c
       name: gitops-deprovision-app-config
       imagePullPolicy: Always
-      image: quay.io/ibmmas/cli:7.10.0-pre.gitops
+      image: quay.io/ibmmas/cli:7.10.0-pre.mascore-63
   workspaces:
     - name: configs

--- a/tekton/src/tasks/gitops/gitops-deprovision-app-config.yml.j2
+++ b/tekton/src/tasks/gitops/gitops-deprovision-app-config.yml.j2
@@ -1,0 +1,100 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: gitops-deprovision-app-config
+spec:
+  params:
+    - name: cluster_name
+      type: string
+    - name: account
+      type: string
+    - name: secrets_path
+      type: string
+    - name: mas_instance_id
+      type: string
+    - name: workspace_id
+      type: string
+    - name: git_branch
+      type: string
+    - name: github_org
+      type: string
+    - name: github_repo
+      type: string
+    - name: github_host
+      type: string
+    - name: github_pat
+      type: string
+    - name: force_removal
+      type: string
+    - name: mas_app_id
+      type: string
+  stepTemplate:
+    name: gitops-deprovision-app-config
+    env:
+      - name: CLUSTER_NAME
+        value: $(params.cluster_name)
+      - name: ACCOUNT
+        value: $(params.account)
+      - name: MAS_INSTANCE_ID
+        value: $(params.mas_instance_id)
+      - name: GIT_BRANCH
+        value: $(params.git_branch)
+      - name: GITHUB_ORG
+        value: $(params.github_org)
+      - name: GITHUB_HOST
+        value: $(params.github_host)
+      - name: GITHUB_REPO
+        value: $(params.github_repo)
+      - name: WORKSPACE_ID
+        value: $(params.workspace_id)
+      - name: GITHUB_PAT
+        value: $(params.github_pat) 
+      - name: FORCE_REMOVAL
+        value: $(params.force_removal)
+      - name: MAS_APP_ID
+        value: $(params.mas_app_id)
+  steps:
+    - args:
+      - |-
+
+        mkdir -p /tmp/deprovision-app-config
+
+        git config --global user.name "MAS Automation"
+        git config --global user.email "you@example.com"
+        git config --global user.password $GITHUB_PAT
+
+        ROSA_CONFIG=/workspace/configs/tmp-rosa/rosa-$(params.cluster_name)-details.yaml
+        export OCP_SERVER=$(cat $ROSA_CONFIG | yq -r '.data.api_url')
+        export OCP_USERNAME=$(cat $ROSA_CONFIG | yq -r '.data.username')
+        export ROSA_CLUSTER_ADMIN_PASSWORD=$(cat $ROSA_CONFIG | yq -r '.data.admin_password')
+        oc login -u $OCP_USERNAME -p $ROSA_CLUSTER_ADMIN_PASSWORD $OCP_SERVER --insecure-skip-tls-verify
+        OC_RC=$?
+        if [ $OC_RC -ne 0 ]; then
+          echo "oc login failed so assume there is no app config to deprovision, exiting.."
+          exit 0
+        fi
+        echo "Set k8s context"
+        export K8S_AUTH_CONTEXT=$(oc whoami -c)
+
+        if [ -z $ARGOCD_URL ] || [ -z $ARGOCD_USERNAME ] || [ -z $ARGOCD_PASSWORD ]; then
+          export ARGOCD_URL=$(oc get route  openshift-gitops-server -n openshift-gitops -ojsonpath='{.spec.host}' --context $K8S_AUTH_CONTEXT)
+          export ARGOCD_USERNAME=admin
+          export ARGOCD_PASSWORD=$(oc get secret openshift-gitops-cluster -n openshift-gitops -ojsonpath='{.data.admin\.password}' --context $K8S_AUTH_CONTEXT | base64 -d ; echo)
+        fi
+
+        mas gitops-deprovision-app-config -a $ACCOUNT -c $CLUSTER_NAME \
+        --dir /tmp/deprovision-app-config \
+        --github-push \
+        --github-host $GITHUB_HOST \
+        --github-org $GITHUB_ORG \
+        --github-repo $GITHUB_REPO \
+        --git-branch $GIT_BRANCH
+      command:
+        - /bin/sh
+        - -c
+      name: gitops-deprovision-app-config
+      imagePullPolicy: Always
+      image: quay.io/ibmmas/cli:7.10.0-pre.gitops
+  workspaces:
+    - name: configs

--- a/tekton/src/tasks/gitops/gitops-deprovision-app-config.yml.j2
+++ b/tekton/src/tasks/gitops/gitops-deprovision-app-config.yml.j2
@@ -13,7 +13,7 @@ spec:
       type: string
     - name: mas_instance_id
       type: string
-    - name: workspace_id
+    - name: mas_workspace_id
       type: string
     - name: git_branch
       type: string
@@ -46,8 +46,8 @@ spec:
         value: $(params.github_host)
       - name: GITHUB_REPO
         value: $(params.github_repo)
-      - name: WORKSPACE_ID
-        value: $(params.workspace_id)
+      - name: MAS_WORKSPACE_ID
+        value: $(params.mas_workspace_id)
       - name: GITHUB_PAT
         value: $(params.github_pat) 
       - name: FORCE_REMOVAL

--- a/tekton/src/tasks/gitops/gitops-deprovision-app-install.yml.j2
+++ b/tekton/src/tasks/gitops/gitops-deprovision-app-install.yml.j2
@@ -91,6 +91,6 @@ spec:
         - -c
       name: gitops-deprovision-app-install
       imagePullPolicy: Always
-      image: quay.io/ibmmas/cli:7.10.0-pre.gitops
+      image: quay.io/ibmmas/cli:7.10.0-pre.mascore-63
   workspaces:
     - name: configs

--- a/tekton/src/tasks/gitops/gitops-deprovision-app-install.yml.j2
+++ b/tekton/src/tasks/gitops/gitops-deprovision-app-install.yml.j2
@@ -1,0 +1,96 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: gitops-deprovision-app-install
+spec:
+  params:
+    - name: cluster_name
+      type: string
+    - name: account
+      type: string
+    - name: secrets_path
+      type: string
+    - name: mas_instance_id
+      type: string
+    - name: git_branch
+      type: string
+    - name: github_org
+      type: string
+    - name: github_repo
+      type: string
+    - name: github_host
+      type: string
+    - name: github_pat
+      type: string
+    - name: force_removal
+      type: string
+    - name: mas_app_id
+      type: string
+  stepTemplate:
+    name: gitops-deprovision-app-install
+    env:
+      - name: CLUSTER_NAME
+        value: $(params.cluster_name)
+      - name: ACCOUNT
+        value: $(params.account)
+      - name: MAS_INSTANCE_ID
+        value: $(params.mas_instance_id)
+      - name: GIT_BRANCH
+        value: $(params.git_branch)
+      - name: GITHUB_ORG
+        value: $(params.github_org)
+      - name: GITHUB_HOST
+        value: $(params.github_host)
+      - name: GITHUB_REPO
+        value: $(params.github_repo)
+      - name: GITHUB_PAT
+        value: $(params.github_pat) 
+      - name: FORCE_REMOVAL
+        value: $(params.force_removal)
+      - name: MAS_APP_ID
+        value: $(params.mas_app_id)
+  steps:
+    - args:
+      - |-
+
+        mkdir -p /tmp/deprovision-app-install
+
+        git config --global user.name "MAS Automation"
+        git config --global user.email "you@example.com"
+        git config --global user.password $GITHUB_PAT
+
+        ROSA_CONFIG=/workspace/configs/tmp-rosa/rosa-$(params.cluster_name)-details.yaml
+        export OCP_SERVER=$(cat $ROSA_CONFIG | yq -r '.data.api_url')
+        export OCP_USERNAME=$(cat $ROSA_CONFIG | yq -r '.data.username')
+        export ROSA_CLUSTER_ADMIN_PASSWORD=$(cat $ROSA_CONFIG | yq -r '.data.admin_password')
+        oc login -u $OCP_USERNAME -p $ROSA_CLUSTER_ADMIN_PASSWORD $OCP_SERVER --insecure-skip-tls-verify
+        OC_RC=$?
+        if [ $OC_RC -ne 0 ]; then
+          echo "oc login failed so assume there is no app to deprovision, exiting.."
+          exit 0
+        fi
+        echo "Set k8s context"
+        export K8S_AUTH_CONTEXT=$(oc whoami -c)
+
+        if [ -z $ARGOCD_URL ] || [ -z $ARGOCD_USERNAME ] || [ -z $ARGOCD_PASSWORD ]; then
+          export ARGOCD_URL=$(oc get route  openshift-gitops-server -n openshift-gitops -ojsonpath='{.spec.host}' --context $K8S_AUTH_CONTEXT)
+          export ARGOCD_USERNAME=admin
+          export ARGOCD_PASSWORD=$(oc get secret openshift-gitops-cluster -n openshift-gitops -ojsonpath='{.data.admin\.password}' --context $K8S_AUTH_CONTEXT | base64 -d ; echo)
+        fi
+
+        mas gitops-deprovision-app-install -a $ACCOUNT -c $CLUSTER_NAME \
+        --dir /tmp/deprovision-app-install \
+        --github-push \
+        --github-host $GITHUB_HOST \
+        --github-org $GITHUB_ORG \
+        --github-repo $GITHUB_REPO \
+        --git-branch $GIT_BRANCH
+      command:
+        - /bin/sh
+        - -c
+      name: gitops-deprovision-app-install
+      imagePullPolicy: Always
+      image: quay.io/ibmmas/cli:7.10.0-pre.gitops
+  workspaces:
+    - name: configs


### PR DESCRIPTION
Adds mas-apps deprovision pipeline and functions. Logic is that if we have a workspace_Action still as activate and no channel then we don't remove the app as we need to deactivate the workspace. Apps are structued to be removed in reverse of the order of installing i.e. remove monitor before iot. Pipeline can be used to deactivate a workspace for an app but still keep the app installed if required.

https://jsw.ibm.com/browse/MASCORE-63 