### PR TITLE
[patch] Prevent MAS install changing catalog source

### DIFF
--- a/image/cli/mascli/functions/help/install_help
+++ b/image/cli/mascli/functions/help/install_help
@@ -1,0 +1,131 @@
+function install_help() {
+  [[ -n "$1" ]] && echo_warning "$1"
+  reset_colors
+  cat << EOM
+Usage:
+  mas install [options]
+
+Catalog Selection (Required):
+  -c, --mas-catalog-version ${COLOR_YELLOW}MAS_CATALOG_VERSION${TEXT_RESET}            IBM Maximo Operator Catalog to install (e.g. v8-amd64)
+
+Entitlement & Licensing (Required):
+      --ibm-entitlement-key ${COLOR_YELLOW}IBM_ENTITLEMENT_KEY${TEXT_RESET}            IBM entitlement key
+      --license-file ${COLOR_YELLOW}SLS_LICENSE_FILE_LOCAL${TEXT_RESET}                Path to MAS license file
+      --uds-email ${COLOR_YELLOW}UDS_CONTACT_EMAIL${TEXT_RESET}                        Contact e-mail address
+      --uds-firstname ${COLOR_YELLOW}UDS_CONTACT_FIRSTNAME${TEXT_RESET}                Contact first name
+      --uds-lastname ${COLOR_YELLOW}UDS_CONTACT_LASTNAME${TEXT_RESET}                  Contact last name
+
+Entitlement & Licensing (Only required up to v8-230414-amd64):
+      --license-id ${COLOR_YELLOW}SLS_LICENSE_ID${TEXT_RESET}                          MAS license ID. Required for SLS 3.6.0 and below
+
+Storage Class Selection (Required):
+      --storage-rwo ${COLOR_YELLOW}STORAGE_CLASS_RWO${TEXT_RESET}                      Read Write Once (RWO) storage class (e.g. ibmc-block-gold)
+      --storage-rwx ${COLOR_YELLOW}STORAGE_CLASS_RWX${TEXT_RESET}                      Read Write Many (RWX) storage class (e.g. ibmc-file-gold-gid)
+      --storage-pipeline ${COLOR_YELLOW}PIPELINE_STORAGE_CLASS${TEXT_RESET}            Install pipeline storage class (e.g. ibmc-file-gold-gid)
+      --storage-accessmode ${COLOR_YELLOW}PIPELINE_STORAGE_ACCESSMODE${TEXT_RESET}     Install pipeline storage class access mode (ReadWriteMany or ReadWriteOnce)
+
+Maximo Application Suite Instance (Required):
+  -i, --mas-instance-id ${COLOR_YELLOW}MAS_INSTANCE_ID${TEXT_RESET}                    MAS Instance ID
+  -w, --mas-workspace-id ${COLOR_YELLOW}MAS_WORKSPACE_ID${TEXT_RESET}                  MAS Workspace ID
+  -W, --mas-workspace-name ${COLOR_YELLOW}MAS_WORKSPACE_ID${TEXT_RESET}                MAS Workspace Name
+
+Advanced MAS Configuration (Optional):
+      --additional-configs ${COLOR_YELLOW}LOCAL_MAS_CONFIG_DIR${TEXT_RESET}            Path to a directory containing additional configuration files to be applied
+      --non-prod                                           Install MAS in Non-production mode
+      --mas-trust-default-cas ${COLOR_YELLOW}MAS_TRUST_DEFAULT_CAS${TEXT_RESET}        Trust certificates signed by well-known CAs
+      --workload-scale-profile ${COLOR_YELLOW}MAS_WORKLOAD_SCALE_PROFILE${TEXT_RESET}  Set a pre-defined workload scale profile [Burstable, BestEffort, Guaranteed]
+      --mas-pod-templates-dir ${COLOR_YELLOW}MAS_POD_TEMPLATES_DIR${TEXT_RESET}        Path to directory containing custom podTemplates configuration files to be applied. Takes precedence over --workload-scale-profile
+
+Maximo Application Suite Core Platform (Required):
+      --mas-channel ${COLOR_YELLOW}MAS_CHANNEL${TEXT_RESET}                            Subscription channel for the Core Platform
+
+Maximo Application Suite Application Selection (Optional):
+      --iot-channel ${COLOR_YELLOW}MAS_APP_CHANNEL_IOT${TEXT_RESET}                            Subscription channel for Maximo IoT
+      --monitor-channel ${COLOR_YELLOW}MAS_APP_CHANNEL_MONITOR${TEXT_RESET}                    Subscription channel for Maximo Monitor
+      --manage-channel ${COLOR_YELLOW}MAS_APP_CHANNEL_MANAGE${TEXT_RESET}                      Subscription channel for Maximo Manage
+      --manage-jdbc ${COLOR_YELLOW}MAS_APPWS_BINDINGS_JDBC_MANAGE${TEXT_RESET}                 Configure Maximo Manage JDBC binding (workspace-application or system)
+      --predict-channel ${COLOR_YELLOW}MAS_APP_CHANNEL_PREDICT${TEXT_RESET}                    Subscription channel for Maximo Predict
+      --assist-channel ${COLOR_YELLOW}MAS_APP_CHANNEL_ASSIST${TEXT_RESET}                      Subscription channel for Maximo Assist
+      --visualinspection-channel ${COLOR_YELLOW}MAS_APP_CHANNEL_VISUALINSPECTION${TEXT_RESET}  Subscription channel for Maximo Visual Inspection
+      --optimizer-channel ${COLOR_YELLOW}MAS_APP_CHANNEL_OPTIMIZER${TEXT_RESET}                Subscription channel for Maximo optimizer
+      --optimizer-plan ${COLOR_YELLOW}MAS_APP_PLAN_OPTIMIZER${TEXT_RESET}                      Installation plan for Maximo Optimizer (full or limited)
+
+IBM Cloud Pak for Data (Required when installing Predict or Assist):
+      --cp4d-version ${COLOR_YELLOW}CP4D_VERSION${TEXT_RESET}          Product version of IBM Cloud Pak for Data to use
+      --cp4d-install-spss                  Include SPSS service to be installed as part of IBM Cloud Pak for Data (Optional if Predict is being installed)
+      --cp4d-install-openscale             Include Watson Openscale service to be installed as part of IBM Cloud Pak for Data (Optional if Predict is being installed)
+      --cp4d-install-cognos                Include Cognos Analytics service to be installed as part of IBM Cloud Pak for Data (Optional if Manage is being installed)
+
+Kafka (Required to install Maximo IoT thus if not set, a default Kafka provider will be installed):
+      --kafka-provider ${COLOR_YELLOW}KAFKA_PROVIDER${TEXT_RESET}      Set Kafka provider. Supported options are 'redhat' (Red Hat AMQ Streams), 'strimzi', 'ibm' (IBM Cloud Event Streams) and 'aws' (AWS MSK)
+
+Kafka (Optional, applicable for Strimzi and Red Hat AMQ Streams only):
+      --kafka-namespace ${COLOR_YELLOW}KAFKA_NAMESPACE${TEXT_RESET}    Set Strimzi and Red Hat AMQ Streams namespace
+      --kafka-version ${COLOR_YELLOW}KAFKA_VERSION${TEXT_RESET}        Set version of the Kafka cluster that the Strimzi or AMQ Streams operator will create
+
+Kafka (Required for IBM Cloud Event Streams only):
+      --ibmcloud-apikey ${COLOR_YELLOW}IBMCLOUD_APIKEY${TEXT_RESET}                            Set IBM Cloud API Key. Required to provision IBM Cloud services
+      --eventstreams-resource-group ${COLOR_YELLOW}EVENTSTREAMS_RESOURCEGROUP${TEXT_RESET}     Set IBM Cloud resource group to target the Event Streams instance provisioning (Only applicable if installing IBM Cloud Event Streams)
+      --eventstreams-instance-name ${COLOR_YELLOW}EVENTSTREAMS_NAME${TEXT_RESET}               Set IBM Event Streams instance name (Only applicable if installing IBM Event Streams)
+      --eventstreams-instance-location ${COLOR_YELLOW}EVENTSTREAMS_LOCATION${TEXT_RESET}       Set IBM Event Streams instance location (Only applicable if installing IBM Event Streams)
+
+IBM Db2 (Optional, required to use IBM Db2 Universal Operator):
+      --db2u-channel ${COLOR_YELLOW}DB2_CHANNEL${TEXT_RESET}           Subscription channel for Db2u (e.g. v110508.0)
+      --db2u-system                        Install a shared Db2u instance for MAS (required by IoT & Monitor, supported by Manage)
+      --db2u-manage                        Install a dedicated Db2u instance for Maximo Manage (supported by Manage)
+
+Advanced Db2u Universal Operator Configuration (Optional):
+      --db2u-namespace ${COLOR_YELLOW}DB2_NAMESPACE${TEXT_RESET}       Change namespace where Db2u instances will be created
+
+Advanced Db2u Universal Operator Configuration - Node Scheduling (Optional):
+      --db2u-affinity-key ${COLOR_YELLOW}DB2_AFFINITY_KEY${TEXT_RESET}           Set a node label to declare affinity to
+      --db2u-affinity-value ${COLOR_YELLOW}DB2_AFFINITY_VALUE${TEXT_RESET}       Set the value of the node label to affine with
+      --db2u-tolerate-key ${COLOR_YELLOW}DB2_TOLERATE_KEY${TEXT_RESET}           Set a node taint to tolerate
+      --db2u-tolerate-value ${COLOR_YELLOW}DB2_TOLERATE_VALUE${TEXT_RESET}       Set the value of the taint to tolerate
+      --db2u-tolerate-effect ${COLOR_YELLOW}DB2_TOLERATE_EFFECT${TEXT_RESET}     Set the effect that will be tolerated (NoSchedule, PreferNoSchedule, or NoExecute)
+
+Advanced Db2u Universal Operator Configuration - Resource Requests (Optional):
+      --db2u-cpu-request ${COLOR_YELLOW}DB2_CPU_REQUESTS${TEXT_RESET}            Customize Db2 CPU request
+      --db2u-cpu-limit ${COLOR_YELLOW}DB2_CPU_LIMITS${TEXT_RESET}                Customize Db2 CPU limit
+      --db2u-memory-request ${COLOR_YELLOW}DB2_MEMORY_REQUESTS${TEXT_RESET}      Customize Db2 memory request
+      --db2u-memory-limit ${COLOR_YELLOW}DB2_MEMORY_LIMITS${TEXT_RESET}          Customize Db2 memory limit
+
+Advanced Db2u Universal Operator Configuration - Storage (Optional):
+      --db2u-backup-storage ${COLOR_YELLOW}DB2_BACKUP_STORAGE_SIZE${TEXT_RESET}  Customize Db2 storage capacity
+      --db2u-data-storage ${COLOR_YELLOW}DB2_DATA_STORAGE_SIZE${TEXT_RESET}      Customize Db2 storage capacity
+      --db2u-logs-storage ${COLOR_YELLOW}DB2_LOGS_STORAGE_SIZE${TEXT_RESET}      Customize Db2 storage capacity
+      --db2u-meta-storage ${COLOR_YELLOW}DB2_META_STORAGE_SIZE${TEXT_RESET}      Customize Db2 storage capacity
+      --db2u-temp-storage ${COLOR_YELLOW}DB2_TEMP_STORAGE_SIZE${TEXT_RESET}      Customize Db2 storage capacity
+
+Advanced MongoDB Configuration (Optional):
+      --mongodb-namespace ${COLOR_YELLOW}MONGODB_NAMESPACE${TEXT_RESET}          Change namespace where MongoCE operator and instance will be created
+
+Cloud Provider Commands:
+      --ibmcloud-apikey ${COLOR_YELLOW}IBMCLOUD_APIKEY${TEXT_RESET}              Set IBM Cloud API Key (Required to provision IBM Cloud services)
+
+Manage Application - Advanced Configuration (Optional):
+      --manage-demodata                                                                       Enables demo data for Manage application
+      --manage-jms                                                                            Enables JMS queues using local persistent volumes
+      --manage-server-bundle-size ${COLOR_YELLOW}MAS_APP_SETTINGS_SERVER_BUNDLES_SIZE${TEXT_RESET}                        Set Manage server bundle size configuration i.e 'dev', 'small', 'jms' or 'snojms'
+      --manage-components ${COLOR_YELLOW}MAS_APPWS_COMPONENTS${TEXT_RESET}                                                Set Manage Components to be installed i.e 'base=latest,health=latest,civil=latest'
+      --manage-customization-archive-name ${COLOR_YELLOW}MAS_APP_SETTINGS_CUSTOMIZATION_ARCHIVE_NAME${TEXT_RESET}         Set Manage Archive name
+      --manage-customization-archive-url ${COLOR_YELLOW}MAS_APP_SETTINGS_CUSTOMIZATION_ARCHIVE_URL${TEXT_RESET}           Set Manage Archive URL
+      --manage-customization-archive-username ${COLOR_YELLOW}MAS_APP_SETTINGS_CUSTOMIZATION_ARCHIVE_USERNAME${TEXT_RESET} Set Manage Archive username, in case URL requires basic authentication to pull the archive
+      --manage-customization-archive-password ${COLOR_YELLOW}MAS_APP_SETTINGS_CUSTOMIZATION_ARCHIVE_PASSWORD${TEXT_RESET} Set Manage Archive password, in case URL requires basic authentication to download the archive
+      --manage-crypto-key ${COLOR_YELLOW}MAS_APP_SETTINGS_CRYPTO_KEY${TEXT_RESET}                                         Customize your Manage database encryption keys
+      --manage-cryptox-key ${COLOR_YELLOW}MAS_APP_SETTINGS_CRYPTOX_KEY${TEXT_RESET}                                       Customize your Manage database encryption keys
+      --manage-old-crypto-key ${COLOR_YELLOW}MAS_APP_SETTINGS_OLD_CRYPTO_KEY${TEXT_RESET}                                 Customize your Manage database encryption keys
+      --manage-old-cryptox-key ${COLOR_YELLOW}MAS_APP_SETTINGS_OLD_CRYPTOX_KEY${TEXT_RESET}                               Customize your Manage database encryption keys
+      --manage-override-encryption-secrets                                                    Override any existing Manage database encryption keys (a backup of the original is taken).
+
+Other Commands:
+      --dev-mode            Enable developer mode (e.g. for access to pre-release builds)
+      --no-wait-for-pvcs    If you are using using storage classes that utilize 'WaitForFirstConsumer' binding mode use this flag
+      --no-confirm          Launch the install without prompting for confirmation
+      --accept-license      Accept the licenses for IBM Maximo Application Suite and Maximo IT
+  -h, --help                Show this help message
+
+
+EOM
+  [[ -n "$1" ]] && exit 1 || exit 0
+}

--- a/image/cli/mascli/functions/install
+++ b/image/cli/mascli/functions/install
@@ -18,138 +18,36 @@
 . $CLI_DIR/functions/internal/install_pipelinerun_preview
 . $CLI_DIR/functions/internal/install_pipelinerun_create
 
-
-function install_help() {
-  [[ -n "$1" ]] && echo_warning "$1"
-  reset_colors
-  cat << EOM
-Usage:
-  mas install [options]
-
-Catalog Selection (Required):
-  -c, --mas-catalog-version ${COLOR_YELLOW}MAS_CATALOG_VERSION${TEXT_RESET}            IBM Maximo Operator Catalog to install (e.g. v8-amd64)
-
-Entitlement & Licensing (Required):
-      --ibm-entitlement-key ${COLOR_YELLOW}IBM_ENTITLEMENT_KEY${TEXT_RESET}            IBM entitlement key
-      --license-file ${COLOR_YELLOW}SLS_LICENSE_FILE_LOCAL${TEXT_RESET}                Path to MAS license file
-      --uds-email ${COLOR_YELLOW}UDS_CONTACT_EMAIL${TEXT_RESET}                        Contact e-mail address
-      --uds-firstname ${COLOR_YELLOW}UDS_CONTACT_FIRSTNAME${TEXT_RESET}                Contact first name
-      --uds-lastname ${COLOR_YELLOW}UDS_CONTACT_LASTNAME${TEXT_RESET}                  Contact last name
-
-Entitlement & Licensing (Only required up to v8-230414-amd64):
-      --license-id ${COLOR_YELLOW}SLS_LICENSE_ID${TEXT_RESET}                          MAS license ID. Required for SLS 3.6.0 and below
-
-Storage Class Selection (Required):
-      --storage-rwo ${COLOR_YELLOW}STORAGE_CLASS_RWO${TEXT_RESET}                      Read Write Once (RWO) storage class (e.g. ibmc-block-gold)
-      --storage-rwx ${COLOR_YELLOW}STORAGE_CLASS_RWX${TEXT_RESET}                      Read Write Many (RWX) storage class (e.g. ibmc-file-gold-gid)
-      --storage-pipeline ${COLOR_YELLOW}PIPELINE_STORAGE_CLASS${TEXT_RESET}            Install pipeline storage class (e.g. ibmc-file-gold-gid)
-      --storage-accessmode ${COLOR_YELLOW}PIPELINE_STORAGE_ACCESSMODE${TEXT_RESET}     Install pipeline storage class access mode (ReadWriteMany or ReadWriteOnce)
-
-Maximo Application Suite Instance (Required):
-  -i, --mas-instance-id ${COLOR_YELLOW}MAS_INSTANCE_ID${TEXT_RESET}                    MAS Instance ID
-  -w, --mas-workspace-id ${COLOR_YELLOW}MAS_WORKSPACE_ID${TEXT_RESET}                  MAS Workspace ID
-  -W, --mas-workspace-name ${COLOR_YELLOW}MAS_WORKSPACE_ID${TEXT_RESET}                MAS Workspace Name
-
-Advanced MAS Configuration (Optional):
-      --additional-configs ${COLOR_YELLOW}LOCAL_MAS_CONFIG_DIR${TEXT_RESET}            Path to a directory containing additional configuration files to be applied
-      --non-prod                                           Install MAS in Non-production mode
-      --mas-trust-default-cas ${COLOR_YELLOW}MAS_TRUST_DEFAULT_CAS${TEXT_RESET}        Trust certificates signed by well-known CAs
-      --workload-scale-profile ${COLOR_YELLOW}MAS_WORKLOAD_SCALE_PROFILE${TEXT_RESET}  Set a pre-defined workload scale profile [Burstable, BestEffort, Guaranteed]
-      --mas-pod-templates-dir ${COLOR_YELLOW}MAS_POD_TEMPLATES_DIR${TEXT_RESET}        Path to directory containing custom podTemplates configuration files to be applied. Takes precedence over --workload-scale-profile
-
-Maximo Application Suite Core Platform (Required):
-      --mas-channel ${COLOR_YELLOW}MAS_CHANNEL${TEXT_RESET}                            Subscription channel for the Core Platform
-
-Maximo Application Suite Application Selection (Optional):
-      --iot-channel ${COLOR_YELLOW}MAS_APP_CHANNEL_IOT${TEXT_RESET}                            Subscription channel for Maximo IoT
-      --monitor-channel ${COLOR_YELLOW}MAS_APP_CHANNEL_MONITOR${TEXT_RESET}                    Subscription channel for Maximo Monitor
-      --manage-channel ${COLOR_YELLOW}MAS_APP_CHANNEL_MANAGE${TEXT_RESET}                      Subscription channel for Maximo Manage
-      --manage-jdbc ${COLOR_YELLOW}MAS_APPWS_BINDINGS_JDBC_MANAGE${TEXT_RESET}                 Configure Maximo Manage JDBC binding (workspace-application or system)
-      --predict-channel ${COLOR_YELLOW}MAS_APP_CHANNEL_PREDICT${TEXT_RESET}                    Subscription channel for Maximo Predict
-      --assist-channel ${COLOR_YELLOW}MAS_APP_CHANNEL_ASSIST${TEXT_RESET}                      Subscription channel for Maximo Assist
-      --visualinspection-channel ${COLOR_YELLOW}MAS_APP_CHANNEL_VISUALINSPECTION${TEXT_RESET}  Subscription channel for Maximo Visual Inspection
-      --optimizer-channel ${COLOR_YELLOW}MAS_APP_CHANNEL_OPTIMIZER${TEXT_RESET}                Subscription channel for Maximo optimizer
-      --optimizer-plan ${COLOR_YELLOW}MAS_APP_PLAN_OPTIMIZER${TEXT_RESET}                      Installation plan for Maximo Optimizer (full or limited)
-
-IBM Cloud Pak for Data (Required when installing Predict or Assist):
-      --cp4d-version ${COLOR_YELLOW}CP4D_VERSION${TEXT_RESET}          Product version of IBM Cloud Pak for Data to use
-      --cp4d-install-spss                  Include SPSS service to be installed as part of IBM Cloud Pak for Data (Optional if Predict is being installed)
-      --cp4d-install-openscale             Include Watson Openscale service to be installed as part of IBM Cloud Pak for Data (Optional if Predict is being installed)
-      --cp4d-install-cognos                Include Cognos Analytics service to be installed as part of IBM Cloud Pak for Data (Optional if Manage is being installed)
-
-Kafka (Required to install Maximo IoT thus if not set, a default Kafka provider will be installed):
-      --kafka-provider ${COLOR_YELLOW}KAFKA_PROVIDER${TEXT_RESET}      Set Kafka provider. Supported options are 'redhat' (Red Hat AMQ Streams), 'strimzi', 'ibm' (IBM Cloud Event Streams) and 'aws' (AWS MSK)
-
-Kafka (Optional, applicable for Strimzi and Red Hat AMQ Streams only):
-      --kafka-namespace ${COLOR_YELLOW}KAFKA_NAMESPACE${TEXT_RESET}    Set Strimzi and Red Hat AMQ Streams namespace
-      --kafka-version ${COLOR_YELLOW}KAFKA_VERSION${TEXT_RESET}        Set version of the Kafka cluster that the Strimzi or AMQ Streams operator will create
-
-Kafka (Required for IBM Cloud Event Streams only):
-      --ibmcloud-apikey ${COLOR_YELLOW}IBMCLOUD_APIKEY${TEXT_RESET}                            Set IBM Cloud API Key. Required to provision IBM Cloud services
-      --eventstreams-resource-group ${COLOR_YELLOW}EVENTSTREAMS_RESOURCEGROUP${TEXT_RESET}     Set IBM Cloud resource group to target the Event Streams instance provisioning (Only applicable if installing IBM Cloud Event Streams)
-      --eventstreams-instance-name ${COLOR_YELLOW}EVENTSTREAMS_NAME${TEXT_RESET}               Set IBM Event Streams instance name (Only applicable if installing IBM Event Streams)
-      --eventstreams-instance-location ${COLOR_YELLOW}EVENTSTREAMS_LOCATION${TEXT_RESET}       Set IBM Event Streams instance location (Only applicable if installing IBM Event Streams)
-
-IBM Db2 (Optional, required to use IBM Db2 Universal Operator):
-      --db2u-channel ${COLOR_YELLOW}DB2_CHANNEL${TEXT_RESET}           Subscription channel for Db2u (e.g. v110508.0)
-      --db2u-system                        Install a shared Db2u instance for MAS (required by IoT & Monitor, supported by Manage)
-      --db2u-manage                        Install a dedicated Db2u instance for Maximo Manage (supported by Manage)
-
-Advanced Db2u Universal Operator Configuration (Optional):
-      --db2u-namespace ${COLOR_YELLOW}DB2_NAMESPACE${TEXT_RESET}       Change namespace where Db2u instances will be created
-
-Advanced Db2u Universal Operator Configuration - Node Scheduling (Optional):
-      --db2u-affinity-key ${COLOR_YELLOW}DB2_AFFINITY_KEY${TEXT_RESET}           Set a node label to declare affinity to
-      --db2u-affinity-value ${COLOR_YELLOW}DB2_AFFINITY_VALUE${TEXT_RESET}       Set the value of the node label to affine with
-      --db2u-tolerate-key ${COLOR_YELLOW}DB2_TOLERATE_KEY${TEXT_RESET}           Set a node taint to tolerate
-      --db2u-tolerate-value ${COLOR_YELLOW}DB2_TOLERATE_VALUE${TEXT_RESET}       Set the value of the taint to tolerate
-      --db2u-tolerate-effect ${COLOR_YELLOW}DB2_TOLERATE_EFFECT${TEXT_RESET}     Set the effect that will be tolerated (NoSchedule, PreferNoSchedule, or NoExecute)
-
-Advanced Db2u Universal Operator Configuration - Resource Requests (Optional):
-      --db2u-cpu-request ${COLOR_YELLOW}DB2_CPU_REQUESTS${TEXT_RESET}            Customize Db2 CPU request
-      --db2u-cpu-limit ${COLOR_YELLOW}DB2_CPU_LIMITS${TEXT_RESET}                Customize Db2 CPU limit
-      --db2u-memory-request ${COLOR_YELLOW}DB2_MEMORY_REQUESTS${TEXT_RESET}      Customize Db2 memory request
-      --db2u-memory-limit ${COLOR_YELLOW}DB2_MEMORY_LIMITS${TEXT_RESET}          Customize Db2 memory limit
-
-Advanced Db2u Universal Operator Configuration - Storage (Optional):
-      --db2u-backup-storage ${COLOR_YELLOW}DB2_BACKUP_STORAGE_SIZE${TEXT_RESET}  Customize Db2 storage capacity
-      --db2u-data-storage ${COLOR_YELLOW}DB2_DATA_STORAGE_SIZE${TEXT_RESET}      Customize Db2 storage capacity
-      --db2u-logs-storage ${COLOR_YELLOW}DB2_LOGS_STORAGE_SIZE${TEXT_RESET}      Customize Db2 storage capacity
-      --db2u-meta-storage ${COLOR_YELLOW}DB2_META_STORAGE_SIZE${TEXT_RESET}      Customize Db2 storage capacity
-      --db2u-temp-storage ${COLOR_YELLOW}DB2_TEMP_STORAGE_SIZE${TEXT_RESET}      Customize Db2 storage capacity
-
-Advanced MongoDB Configuration (Optional):
-      --mongodb-namespace ${COLOR_YELLOW}MONGODB_NAMESPACE${TEXT_RESET}          Change namespace where MongoCE operator and instance will be created
-
-Cloud Provider Commands:
-      --ibmcloud-apikey ${COLOR_YELLOW}IBMCLOUD_APIKEY${TEXT_RESET}              Set IBM Cloud API Key (Required to provision IBM Cloud services)
-
-Manage Application - Advanced Configuration (Optional):
-      --manage-demodata                                                                       Enables demo data for Manage application
-      --manage-jms                                                                            Enables JMS queues using local persistent volumes
-      --manage-server-bundle-size ${COLOR_YELLOW}MAS_APP_SETTINGS_SERVER_BUNDLES_SIZE${TEXT_RESET}                        Set Manage server bundle size configuration i.e 'dev', 'small', 'jms' or 'snojms'
-      --manage-components ${COLOR_YELLOW}MAS_APPWS_COMPONENTS${TEXT_RESET}                                                Set Manage Components to be installed i.e 'base=latest,health=latest,civil=latest'
-      --manage-customization-archive-name ${COLOR_YELLOW}MAS_APP_SETTINGS_CUSTOMIZATION_ARCHIVE_NAME${TEXT_RESET}         Set Manage Archive name
-      --manage-customization-archive-url ${COLOR_YELLOW}MAS_APP_SETTINGS_CUSTOMIZATION_ARCHIVE_URL${TEXT_RESET}           Set Manage Archive URL
-      --manage-customization-archive-username ${COLOR_YELLOW}MAS_APP_SETTINGS_CUSTOMIZATION_ARCHIVE_USERNAME${TEXT_RESET} Set Manage Archive username, in case URL requires basic authentication to pull the archive
-      --manage-customization-archive-password ${COLOR_YELLOW}MAS_APP_SETTINGS_CUSTOMIZATION_ARCHIVE_PASSWORD${TEXT_RESET} Set Manage Archive password, in case URL requires basic authentication to download the archive
-      --manage-crypto-key ${COLOR_YELLOW}MAS_APP_SETTINGS_CRYPTO_KEY${TEXT_RESET}                                         Customize your Manage database encryption keys
-      --manage-cryptox-key ${COLOR_YELLOW}MAS_APP_SETTINGS_CRYPTOX_KEY${TEXT_RESET}                                       Customize your Manage database encryption keys
-      --manage-old-crypto-key ${COLOR_YELLOW}MAS_APP_SETTINGS_OLD_CRYPTO_KEY${TEXT_RESET}                                 Customize your Manage database encryption keys
-      --manage-old-cryptox-key ${COLOR_YELLOW}MAS_APP_SETTINGS_OLD_CRYPTOX_KEY${TEXT_RESET}                               Customize your Manage database encryption keys
-      --manage-override-encryption-secrets                                                    Override any existing Manage database encryption keys (a backup of the original is taken).
-
-Other Commands:
-      --dev-mode            Enable developer mode (e.g. for access to pre-release builds)
-      --no-wait-for-pvcs    If you are using using storage classes that utilize 'WaitForFirstConsumer' binding mode use this flag
-      --no-confirm          Launch the install without prompting for confirmation
-      --accept-license      Accept the licenses for IBM Maximo Application Suite and Maximo IT
-  -h, --help                Show this help message
+. $CLI_DIR/functions/help/install_help
 
 
-EOM
-  [[ -n "$1" ]] && exit 1 || exit 0
+# Check for existing catalog
+# - If existing MAS catalog is installed, then user must install from that one
+# - If existing MAS catalog is too old, direct user to run mas update command to bring the cluster up to date
+# Otherwise, allow the user to choose the catalog source to install into the cluster
+function validate_catalog_source {
+  catalogDisplayName=$(oc -n openshift-marketplace get catalogsource ibm-operator-catalog -o yaml --ignore-not-found=true | yq -r ".spec.displayName")
+  catalogImage=$(oc -n openshift-marketplace get catalogsource ibm-operator-catalog -o yaml --ignore-not-found=true | yq -r ".spec.image")
+
+  if [[ "$catalogDisplayName" =~ .+(v8-[0-9]+-amd64) ]]; then
+    # catalogId = v8-yymmdd-amd64
+    # catalogVersion = yymmdd
+    catalogId=$(sed -E "s/.+\\((v8-[0-9]+-amd64)\\)/\1/" <<< $catalogDisplayName)
+    catalogVersion=$(sed -E "s/.+\\(v8-([0-9]+)-amd64\\)/\1/" <<< $catalogDisplayName)
+  elif [[ "$catalogDisplayName" =~ .+(v8-amd64) ]]; then
+    catalogId=v8-amd64
+    catalogVersion=v8-amd64
+  fi
+
+  if [[ "$catalogImage" != "" ]] && [[ "$catalogId" != "$MAS_CATALOG_VERSION" ]]; then
+    echo
+    echo_warning "Error: IBM Maximo Operator Catalog $catalogVersion is already installed on this cluster."
+    echo_warning "If you wish to install a new MAS instance using the $MAS_CATALOG_VERSION catalog please first run \"mas update\" to switch to this catalog, this will ensure the appropriate actions are performed as part of the catalog update."
+    echo
+    exit 1
+  fi
 }
+
 
 function install_noninteractive() {
   NON_INTERACTIVE=true
@@ -562,8 +460,10 @@ function install_noninteractive() {
     SLS_ICR_CPOPEN=icr.io/cpopen
   fi
 
-  # Present a the MAS license information
-  # ---------------------------------------------------------------------------
+  # Ensure that install will not trigger a change in the catalog source
+  validate_catalog_source
+
+  # Present the MAS license information
   license_prompt
 
   # Work out which SLS var to use for bootstrap
@@ -574,6 +474,7 @@ function install_noninteractive() {
     export SLS_ENTITLEMENT_FILE="/workspace/entitlement/$(basename $SLS_LICENSE_FILE_LOCAL)"
   fi
 }
+
 
 function install_interactive() {
   echo_h2 "IBM Maximo Operator Catalog Selection"
@@ -620,6 +521,9 @@ function install_interactive() {
     # Static Catalog Source (Disconnected Install)
     choose_mas_version
   fi
+
+  # Ensure that install will not trigger a change in the catalog source
+  validate_catalog_source
 
   # Determine SLS version specific prompts
   sls_prompt_selection
@@ -771,8 +675,6 @@ function install_interactive() {
     SLS_ENTITLEMENT_FILE="/workspace/entitlement/$(basename $SLS_LICENSE_FILE_LOCAL)"
   fi
 
-  # Check for DRO support in MAS
-  # ---------------------------------------------------------------------------
   echo ""
   echo_h2 "Configure UDS"
   prompt_for_input "UDS Contact Email" UDS_CONTACT_EMAIL


### PR DESCRIPTION
Today, it's possible for a `mas install` command to change the release of the IBM Maximo Operator Catalog that is installed in a cluster, which will bypass the update pipeline/process.

This update adds a check to the install function which ensures that if there is a catalog source installed already and the user chooses to install using a different catalog source they are presented with an error message and instructions to run `mas update` first, as below:

![image](https://github.com/ibm-mas/cli/assets/4400618/b2dd1647-688d-44dc-bb5a-4be13a631311)
