### PR TITLE
[patch] Check for null rather than ""

### DIFF
--- a/image/cli/mascli/functions/install
+++ b/image/cli/mascli/functions/install
@@ -39,7 +39,7 @@ function validate_catalog_source {
     catalogVersion=v8-amd64
   fi
 
-  if [[ "$catalogImage" != "" ]] && [[ "$catalogId" != "$MAS_CATALOG_VERSION" ]]; then
+  if [[ "$catalogImage" != "null" ]] && [[ "$catalogId" != "$MAS_CATALOG_VERSION" ]]; then
     echo
     echo_warning "Error: IBM Maximo Operator Catalog $catalogVersion is already installed on this cluster."
     echo_warning "If you wish to install a new MAS instance using the $MAS_CATALOG_VERSION catalog please first run \"mas update\" to switch to this catalog, this will ensure the appropriate actions are performed as part of the catalog update."


### PR DESCRIPTION
Fixes rogue error message when running `mas install` and there's no catalog source installed; the validation check was set to "" but should have been checking for "null" to detect the "no catalog already installed" scenario.

![image](https://github.com/ibm-mas/cli/assets/4400618/a881f729-c758-48ea-a625-ebea7ba4d5e3)
