### PR TITLE
[minor] Implement Manage Black/White list

### DIFF
--- a/image/cli/masfvt/fvt-manage.yml
+++ b/image/cli/masfvt/fvt-manage.yml
@@ -15,8 +15,9 @@
     fvt_digest_manage: "{{ lookup('env', 'FVT_DIGEST_MANAGE') }}"
     fvt_digest_manage_pytest: "{{ lookup('env', 'FVT_DIGEST_MANAGE_PYTEST') }}"
     ivt_digest_core: "{{ lookup('env', 'IVT_DIGEST_CORE') }}"
-    # Tests
-    fvt_manage_automation_version: "{{ lookup('env', 'FVT_MANAGE_AUTOMATION_VERSION') }}"
+    # Black and white listing
+    fvt_blacklist: "{{ lookup('env', 'FVT_BLACKLIST') }}"
+    fvt_whitelist: "{{ lookup('env', 'FVT_WHITELIST') }}"
     # Pipeline Run Info
     pipelinerun_name: "{{ lookup('env', 'PIPELINERUN_NAME') | default('mas-fvt-manage', True) }}"
     pipelinerun_namespace: "{{ lookup('env', 'PIPELINERUN_NAMESPACE') | default('mas-' ~ mas_instance_id ~ '-pipelines', True) }}"
@@ -38,7 +39,8 @@
           - "fvt_digest_manage_pytest ........ {{ fvt_digest_manage_pytest }}"
           - "ivt_digest_core ................. {{ ivt_digest_core }}"
           - ""
-          - "fvt_manage_automation_version ... {{ fvt_manage_automation_version }}"
+          - "fvt_blacklist ................... {{ fvt_blacklist }}"
+          - "fvt_whitelist ................... {{ fvt_whitelist }}"
 
     - name: "Start fvt-manage pipeline"
       kubernetes.core.k8s:

--- a/image/cli/masfvt/templates/mas-fvt-manage.yml.j2
+++ b/image/cli/masfvt/templates/mas-fvt-manage.yml.j2
@@ -39,9 +39,6 @@ spec:
       value: "{{ fvt_digest_manage_pytest }}"
     - name: ivt_digest_core
       value: "{{ ivt_digest_core }}"
-    # Test data
-    - name: fvt_manage_automation_version
-      value: "{{ fvt_manage_automation_version }}"
 
   workspaces:
     # The generated configuration files

--- a/tekton/src/params/fvt.yml.j2
+++ b/tekton/src/params/fvt.yml.j2
@@ -11,15 +11,6 @@
   type: string
   default: ""
 
-# FVT Upload files (Optional)
-- name: devops_cos_crn
-  type: string
-  default: ""
-- name: devops_ibmcloud_apikey
-  type: string
-  default: ""
-
-
 # FVT Digests
 - name: fvt_digest_iot
   type: string

--- a/tekton/src/pipelines/fvt-manage-is.yml.j2
+++ b/tekton/src/pipelines/fvt-manage-is.yml.j2
@@ -46,20 +46,6 @@ spec:
       type: string
       default: ""
 
-    # Support for upload to Cloud Object Storage
-    # TODO: Can we not replace this with the must-gather in Artifactory, why do we need a seperate system (which costs $$$$) for Manage FVT?
-    - name: devops_cos_crn
-      type: string
-      description: Object Storage Resource Instance Id in IBM Cloud (optional)
-      default: ""
-    - name: devops_cos_upload_folder
-      type: string
-      description: Directory inside container that will be uploaded to Object Storage (optional)
-      default: ""
-    - name: devops_ibmcloud_apikey
-      description: IBM Cloud API Key to access Object Storage resource (optional)
-      default: ""
-
     # Image Digests
     - name: fvt_digest_manage
       type: string

--- a/tekton/src/pipelines/fvt-manage-regr.yml.j2
+++ b/tekton/src/pipelines/fvt-manage-regr.yml.j2
@@ -47,20 +47,6 @@ spec:
       type: string
       default: ""
 
-    # Support for upload to Cloud Object Storage
-    # TODO: Can we not replace this with the must-gather in Artifactory, why do we need a seperate system (which costs $$$$) for Manage FVT?
-    - name: devops_cos_crn
-      type: string
-      description: Object Storage Resource Instance Id in IBM Cloud (optional)
-      default: ""
-    - name: devops_cos_upload_folder
-      type: string
-      description: Directory inside container that will be uploaded to Object Storage (optional)
-      default: ""
-    - name: devops_ibmcloud_apikey
-      description: IBM Cloud API Key to access Object Storage resource (optional)
-      default: ""
-
     # TODO: Consolidate these FVT images already!!
     - name: fvt_digest_manage
       type: string

--- a/tekton/src/pipelines/fvt-manage.yml.j2
+++ b/tekton/src/pipelines/fvt-manage.yml.j2
@@ -46,20 +46,6 @@ spec:
       type: string
       default: ""
 
-    # Support for upload to Cloud Object Storage
-    # TODO: Can we not replace this with the must-gather in Artifactory, why do we need a seperate system (which costs $$$$) for Manage FVT?
-    - name: devops_cos_crn
-      type: string
-      description: Object Storage Resource Instance Id in IBM Cloud (optional)
-      default: ""
-    - name: devops_cos_upload_folder
-      type: string
-      description: Directory inside container that will be uploaded to Object Storage (optional)
-      default: ""
-    - name: devops_ibmcloud_apikey
-      description: IBM Cloud API Key to access Object Storage resource (optional)
-      default: ""
-
     # Image Digests
     - name: fvt_digest_manage
       type: string

--- a/tekton/src/pipelines/fvt-optimizer.yml.j2
+++ b/tekton/src/pipelines/fvt-optimizer.yml.j2
@@ -56,13 +56,6 @@ spec:
       description: IVT Digest - Core
       default: ""
 
-    - name: devops_cos_crn
-      type: string
-      default: ""
-    - name: devops_ibmcloud_apikey
-      type: string
-      default: ""
-
   tasks:
     # 1. Core x Optimizer
     # -------------------------------------------------------------------------
@@ -149,11 +142,6 @@ spec:
         - name: mas_workspace_id
           value: $(params.mas_workspace_id)
 
-        - name: devops_cos_crn
-          value: $(params.devops_cos_crn)
-        - name: devops_ibmcloud_apikey
-          value: $(params.devops_ibmcloud_apikey)
-
         - name: fvt_image_registry
           value: $(params.fvt_image_registry)
         - name: fvt_image_namespace
@@ -205,10 +193,6 @@ spec:
           value: $(params.mas_instance_id)
         - name: mas_workspace_id
           value: $(params.mas_workspace_id)
-        - name: devops_cos_crn
-          value: $(params.devops_cos_crn)
-        - name: devops_ibmcloud_apikey
-          value: $(params.devops_ibmcloud_apikey)
         - name: fvt_image_registry
           value: $(params.fvt_image_registry)
         - name: fvt_image_namespace
@@ -255,10 +239,6 @@ spec:
           value: $(params.mas_instance_id)
         - name: mas_workspace_id
           value: $(params.mas_workspace_id)
-        - name: devops_cos_crn
-          value: $(params.devops_cos_crn)
-        - name: devops_ibmcloud_apikey
-          value: $(params.devops_ibmcloud_apikey)
         - name: fvt_image_registry
           value: $(params.fvt_image_registry)
         - name: fvt_image_namespace

--- a/tekton/src/pipelines/taskdefs/fvt-apps/ivt.yml.j2
+++ b/tekton/src/pipelines/taskdefs/fvt-apps/ivt.yml.j2
@@ -26,10 +26,6 @@
       value: $(params.mas_app_channel_monitor)
     - name: mas_appws_components
       value: $(params.mas_appws_components)
-    - name: devops_cos_crn
-      value: $(params.devops_cos_crn)
-    - name: devops_ibmcloud_apikey
-      value: $(params.devops_ibmcloud_apikey)
   taskRef:
     kind: Task
     name: mas-ivt-manage-monitor-dd

--- a/tekton/src/pipelines/taskdefs/fvt-manage-addons/common/params-manage-civil.yml.j2
+++ b/tekton/src/pipelines/taskdefs/fvt-manage-addons/common/params-manage-civil.yml.j2
@@ -2,10 +2,6 @@
   value: $(params.mas_instance_id)
 - name: mas_workspace_id
   value: $(params.mas_workspace_id)
-- name: devops_cos_crn
-  value: $(params.devops_cos_crn)
-- name: devops_ibmcloud_apikey
-  value: $(params.devops_ibmcloud_apikey)
 - name: fvt_image_registry
   value: $(params.fvt_image_registry)
 - name: fvt_image_namespace

--- a/tekton/src/pipelines/taskdefs/fvt-manage/api/params.yml.j2
+++ b/tekton/src/pipelines/taskdefs/fvt-manage/api/params.yml.j2
@@ -2,10 +2,6 @@
   value: $(params.mas_instance_id)
 - name: mas_workspace_id
   value: $(params.mas_workspace_id)
-- name: devops_cos_crn
-  value: $(params.devops_cos_crn)
-- name: devops_ibmcloud_apikey
-  value: $(params.devops_ibmcloud_apikey)
 - name: fvt_image_registry
   value: $(params.fvt_image_registry)
 - name: fvt_image_namespace

--- a/tekton/src/tasks/fvt-launcher/launchfvt-manage.yml.j2
+++ b/tekton/src/tasks/fvt-launcher/launchfvt-manage.yml.j2
@@ -98,12 +98,18 @@ spec:
               name: mas-fvt-manage
               key: IVT_DIGEST_CORE
               optional: false
-        # Test Data
-        - name: FVT_MANAGE_AUTOMATION_VERSION
+        # Black and white listing
+        - name: FVT_BLACKLIST
           valueFrom:
             secretKeyRef:
               name: mas-fvt-manage
-              key: FVT_MANAGE_AUTOMATION_VERSION
+              key: FVT_BLACKLIST
+              optional: false
+        - name: FVT_WHITELIST
+          valueFrom:
+            secretKeyRef:
+              name: mas-fvt-manage
+              key: FVT_WHITELIST
               optional: false
 
     - name: wait-for-pipelinerun

--- a/tekton/src/tasks/fvt-launcher/launchfvt-optimizer.yml.j2
+++ b/tekton/src/tasks/fvt-launcher/launchfvt-optimizer.yml.j2
@@ -105,19 +105,6 @@ spec:
               key: IVT_DIGEST_CORE
               optional: false
 
-        - name: DEVOPS_COS_CRN
-          valueFrom:
-            secretKeyRef:
-              name: mas-fvt-optimizer
-              key: DEVOPS_COS_CRN
-              optional: false
-        - name: DEVOPS_IBMCLOUD_APIKEY
-          valueFrom:
-            secretKeyRef:
-              name: mas-fvt-optimizer
-              key: DEVOPS_IBMCLOUD_APIKEY
-              optional: false
-
     - name: wait-for-pipelinerun
       image: quay.io/ibmmas/cli:latest
       imagePullPolicy: $(params.image_pull_policy)

--- a/tekton/src/tasks/fvt/fvt-manage-directprint.yml.j2
+++ b/tekton/src/tasks/fvt/fvt-manage-directprint.yml.j2
@@ -62,23 +62,12 @@ spec:
       type: string
       description: kafka provider used during installation (ibm, aws or redhat)
       default: ""
-    - name: devops_cos_crn
-      type: string
-      description: Object Storage Resource Instance Id in IBM Cloud (optional)
-      default: ""
-    - name: devops_cos_upload_folder
-      type: string
-      description: Directory inside container that will be uploaded to Object Storage (optional)
-      default: ""
-    - name: devops_ibmcloud_apikey
-      description: IBM Cloud API Key to access Object Storage resource (optional)
-      default: ""
 
     # Test-specific Information (all optional)
     # -------------------------------------------------------------------------
     - name: artifactory_token
       type: string
-      description: Artifactory API Key (required by fvt-ibm-mas-manage to pull test container content)
+      description: Artifactory API Key (required by fvt-ibm-mas-manage to upload test framework logs)
       default: ""
 
   stepTemplate:
@@ -107,9 +96,6 @@ spec:
             key: DEVOPS_BUILD_NUMBER
             optional: true
 
-      - name: IBMADMIN_ENABLED
-        value: "true"
-
       - name: NAMESPACE
         value: "mas-$(params.mas_instance_id)-core"
       - name: INSTANCE_ID
@@ -127,6 +113,20 @@ spec:
         value: $(params.fvt_test_suite)
       - name: FVT_MAS_APPWS_COMPONENT
         value: $(params.fvt_mas_appws_component)
+      
+      # Black and white listing
+      - name: FVT_BLACKLIST
+        valueFrom:
+          secretKeyRef:
+            name: mas-fvt-manage
+            key: FVT_BLACKLIST
+            optional: false
+      - name: FVT_WHITELIST
+        valueFrom:
+          secretKeyRef:
+            name: mas-fvt-manage
+            key: FVT_WHITELIST
+            optional: false
       
       # If this secret exists (with both ARTIFACTORY_TOKEN and ARTIFACTORY_UPLOAD_DIR keys set) Maximo Automation Framework logs will be automatically uploaded
       - name: ARTIFACTORY_TOKEN

--- a/tekton/src/tasks/fvt/fvt-manage-last-phase.yml.j2
+++ b/tekton/src/tasks/fvt/fvt-manage-last-phase.yml.j2
@@ -62,31 +62,6 @@ spec:
       type: string
       description: kafka provider used during installation (ibm, aws or redhat)
       default: ""
-    - name: devops_cos_crn
-      type: string
-      description: Object Storage Resource Instance Id in IBM Cloud (optional)
-      default: ""
-    - name: devops_cos_upload_folder
-      type: string
-      description: Directory inside container that will be uploaded to Object Storage (optional)
-      default: ""
-    - name: devops_ibmcloud_apikey
-      description: IBM Cloud API Key to access Object Storage resource (optional)
-      default: ""
-
-    # Black and white listing
-      - name: FVT_BLACKLIST
-        valueFrom:
-          secretKeyRef:
-            name: mas-fvt-manage
-            key: FVT_BLACKLIST
-            optional: false
-      - name: FVT_WHITELIST
-        valueFrom:
-          secretKeyRef:
-            name: mas-fvt-manage
-            key: FVT_WHITELIST
-            optional: false
 
     # Test-specific Information (all optional)
     # -------------------------------------------------------------------------

--- a/tekton/src/tasks/fvt/fvt-manage-last-phase.yml.j2
+++ b/tekton/src/tasks/fvt/fvt-manage-last-phase.yml.j2
@@ -74,11 +74,25 @@ spec:
       description: IBM Cloud API Key to access Object Storage resource (optional)
       default: ""
 
+    # Black and white listing
+      - name: FVT_BLACKLIST
+        valueFrom:
+          secretKeyRef:
+            name: mas-fvt-manage
+            key: FVT_BLACKLIST
+            optional: false
+      - name: FVT_WHITELIST
+        valueFrom:
+          secretKeyRef:
+            name: mas-fvt-manage
+            key: FVT_WHITELIST
+            optional: false
+
     # Test-specific Information (all optional)
     # -------------------------------------------------------------------------
     - name: artifactory_token
       type: string
-      description: Artifactory API Key (required by fvt-ibm-mas-manage to pull test container content)
+      description: Artifactory API Key (required by fvt-ibm-mas-manage to upload test framework logs)
       default: ""
 
   stepTemplate:
@@ -127,6 +141,20 @@ spec:
         value: $(params.fvt_test_suite)
       - name: FVT_MAS_APPWS_COMPONENT
         value: $(params.fvt_mas_appws_component)
+      
+      # Black and white listing
+      - name: FVT_BLACKLIST
+        valueFrom:
+          secretKeyRef:
+            name: mas-fvt-manage
+            key: FVT_BLACKLIST
+            optional: false
+      - name: FVT_WHITELIST
+        valueFrom:
+          secretKeyRef:
+            name: mas-fvt-manage
+            key: FVT_WHITELIST
+            optional: false
       
       # If this secret exists (with both ARTIFACTORY_TOKEN and ARTIFACTORY_UPLOAD_DIR keys set) Maximo Automation Framework logs will be automatically uploaded
       - name: ARTIFACTORY_TOKEN

--- a/tekton/src/tasks/fvt/fvt-manage-pytest.yml.j2
+++ b/tekton/src/tasks/fvt/fvt-manage-pytest.yml.j2
@@ -62,17 +62,6 @@ spec:
     - name: mas_workspace_id
       type: string
       description: Workspace ID in MAS to use for running the tests
-    - name: devops_cos_crn
-      type: string
-      description: Object Storage Resource Instance Id in IBM Cloud (optional)
-      default: ""
-    - name: devops_cos_upload_folder
-      type: string
-      description: Directory inside container that will be uploaded to Object Storage (optional)
-      default: ""
-    - name: devops_ibmcloud_apikey
-      description: IBM Cloud API Key to access Object Storage resource (optional)
-      default: ""
 
     # Test-specific Information (all optional)
     # -------------------------------------------------------------------------
@@ -126,13 +115,6 @@ spec:
 
       - name: ARTIFACTORY_TOKEN
         value: $(params.artifactory_token)
-
-      - name: DEVOPS_COS_CRN
-        value: $(params.devops_cos_crn)
-      - name: DEVOPS_COS_UPLOAD_FOLDER
-        value: $(params.devops_cos_upload_folder)
-      - name: DEVOPS_IBMCLOUD_APIKEY
-        value: $(params.devops_ibmcloud_apikey)
       
       # Black and white listing
       - name: FVT_BLACKLIST

--- a/tekton/src/tasks/fvt/fvt-manage-pytest.yml.j2
+++ b/tekton/src/tasks/fvt/fvt-manage-pytest.yml.j2
@@ -133,6 +133,20 @@ spec:
         value: $(params.devops_cos_upload_folder)
       - name: DEVOPS_IBMCLOUD_APIKEY
         value: $(params.devops_ibmcloud_apikey)
+      
+      # Black and white listing
+      - name: FVT_BLACKLIST
+        valueFrom:
+          secretKeyRef:
+            name: mas-fvt-manage
+            key: FVT_BLACKLIST
+            optional: false
+      - name: FVT_WHITELIST
+        valueFrom:
+          secretKeyRef:
+            name: mas-fvt-manage
+            key: FVT_WHITELIST
+            optional: false
 
   steps:
     - image: '$(params.fvt_image_registry)/$(params.fvt_image_namespace)/$(params.fvt_image_name)@$(params.fvt_image_digest)'

--- a/tekton/src/tasks/fvt/fvt-manage.yml.j2
+++ b/tekton/src/tasks/fvt/fvt-manage.yml.j2
@@ -111,6 +111,20 @@ spec:
       - name: FVT_MAS_APPWS_COMPONENT
         value: $(params.fvt_mas_appws_component)
       
+      # Black and white listing
+      - name: FVT_BLACKLIST
+        valueFrom:
+          secretKeyRef:
+            name: mas-fvt-manage
+            key: FVT_BLACKLIST
+            optional: false
+      - name: FVT_WHITELIST
+        valueFrom:
+          secretKeyRef:
+            name: mas-fvt-manage
+            key: FVT_WHITELIST
+            optional: false
+      
       # If this secret exists (with both ARTIFACTORY_TOKEN and ARTIFACTORY_UPLOAD_DIR keys set) Maximo Automation Framework logs will be automatically uploaded
       - name: ARTIFACTORY_TOKEN
         valueFrom:

--- a/tekton/src/tasks/fvt/fvt-run-suite.yml.j2
+++ b/tekton/src/tasks/fvt/fvt-run-suite.yml.j2
@@ -50,17 +50,6 @@ spec:
     - name: mas_workspace_id
       type: string
       description: Workspace ID in MAS to use for running the tests
-    - name: devops_cos_crn
-      type: string
-      description: Object Storage Resource Instance Id in IBM Cloud (optional)
-      default: ""
-    - name: devops_cos_upload_folder
-      type: string
-      description: Directory inside container that will be uploaded to Object Storage (optional)
-      default: ""
-    - name: devops_ibmcloud_apikey
-      description: IBM Cloud API Key to access Object Storage resource (optional)
-      default: ""
 
     # Test-specific Information (all optional)
     # -------------------------------------------------------------------------
@@ -180,13 +169,6 @@ spec:
 
       - name: ARTIFACTORY_TOKEN
         value: $(params.artifactory_token)
-
-      - name: DEVOPS_COS_CRN
-        value: $(params.devops_cos_crn)
-      - name: DEVOPS_COS_UPLOAD_FOLDER
-        value: $(params.devops_cos_upload_folder)
-      - name: DEVOPS_IBMCLOUD_APIKEY
-        value: $(params.devops_ibmcloud_apikey)
 
       # Assist Specific information
       - name: BROWSERSTACK_TESTSERVER

--- a/tekton/src/tasks/ivt/ivt-manage-monitor-dd.yml.j2
+++ b/tekton/src/tasks/ivt/ivt-manage-monitor-dd.yml.j2
@@ -94,12 +94,6 @@ spec:
         value: $(params.fvt_mas_appws_component)
       - name: MAS_APPWS_COMPONENTS
         value: $(params.mas_appws_components)
-      - name: FVT_MANAGE_AUTOMATION_VERSION
-        valueFrom:
-          secretKeyRef:
-            name: mas-fvt-manage
-            key: FVT_MANAGE_AUTOMATION_VERSION
-            optional: true
       - name: DEVOPS_COS_CRN
         value: $(params.devops_cos_crn)
       - name: DEVOPS_COS_UPLOAD_FOLDER

--- a/tekton/src/tasks/ivt/ivt-manage-monitor-dd.yml.j2
+++ b/tekton/src/tasks/ivt/ivt-manage-monitor-dd.yml.j2
@@ -55,17 +55,6 @@ spec:
       type: string
       description: Manage Workspace component list so ISs tasks can decide if it should be executed base on what is configured
       default: ""
-    - name: devops_cos_crn
-      type: string
-      description: Object Storage Resource Instance Id in IBM Cloud (optional)
-      default: ""
-    - name: devops_cos_upload_folder
-      type: string
-      description: Directory inside container that will be uploaded to Object Storage (optional)
-      default: ""
-    - name: devops_ibmcloud_apikey
-      description: IBM Cloud API Key to access Object Storage resource (optional)
-      default: ""
 
     # Common Test Framework Specific information
     # -------------------------------------------------------------------------
@@ -94,12 +83,6 @@ spec:
         value: $(params.fvt_mas_appws_component)
       - name: MAS_APPWS_COMPONENTS
         value: $(params.mas_appws_components)
-      - name: DEVOPS_COS_CRN
-        value: $(params.devops_cos_crn)
-      - name: DEVOPS_COS_UPLOAD_FOLDER
-        value: $(params.devops_cos_upload_folder)
-      - name: DEVOPS_IBMCLOUD_APIKEY
-        value: $(params.devops_ibmcloud_apikey)
 
       # Common Test Framework Specific information
       # -------------------------------------------------------------------------


### PR DESCRIPTION
Tests

- [x] Add `setup` in white list (and empty black list)

Logs:

```
-------------------------------------------------------------------------
Check if test must run
-------------------------------------------------------------------------

>>>> Automation version to run: release

>>>> White list enabled: setup

>>>> setup is in the white list so will be ran

>>>> Manage installed components: base,health

>>>> The component base has been configured in Manage Workspace.

```
- [x] Try to run a test that is not in the white list

Logs:
```
-------------------------------------------------------------------------
Check if test must run
-------------------------------------------------------------------------
>>>> Automation version to run: release
>>>> White list enabled: setup
Test execution skipped. Saving Results...
Reason: A testsuite whitelist was provided and classification is not in it
>>>> Skipping classification
>>>> Reason: A testsuite whitelist was provided and classification is not in it
```

- [x] Update to white = ‘’ e black = `classification` e try to run `classification`
Logs:
```
-------------------------------------------------------------------------
Check if test must run
-------------------------------------------------------------------------
>>>> Automation version to run: release
>>>> Black list enabled: classification
>>>> classification is in the black list so will be skipped
Test execution skipped. Saving Results...
Reason: A testsuite blacklist was provided and classification is in it
>>>> Skipping classification
>>>> Reason: A testsuite blacklist was provided and classification is in it
```
- [x] Try to run another that that is not in blacklist (tried escalation-action)

```
>>>> Automation to run against base component depends on the version installed of Manage
>>>> Checking Manage version
>>>> Manage version identified: 9.0.0-pre.dev
-------------------------------------------------------------------------
Check if test must run
-------------------------------------------------------------------------
>>>> Automation version to run: release
>>>> Black list enabled: classification
>>>> Manage installed components: base,health
>>>> The component base has been configured in Manage Workspace.
find: '/workspace/configs/managedata/datafiles/testcases/bvt': No such file or directory
>>>> escalation-action depends on setup and setup did not finish successfully in this environment.
Test was not allowed to run. Saving Results...
Reason: escalation-action depends on a successfull run of core-setup
```

Even though test did not run, it was meant to run now - but as setup was still running it did not proceed. It passed thru black/white lists validation though. 
