### PR TITLE
[patch] Remove username/passwords from logs

### DIFF
--- a/image/cli/mascli/functions/configure_mirror
+++ b/image/cli/mascli/functions/configure_mirror
@@ -157,11 +157,6 @@ function configure_ocp_for_mirror() {
   echo_reset_dim "CA File ................... ${COLOR_MAGENTA}${REGISTRY_PRIVATE_CA_FILE}"
   echo "${TEXT_RESET}${TEXT_DIM}"
 
-  echo_h4 "Private Registry Authentication" "    "
-  echo_reset_dim "Username .................. ${COLOR_MAGENTA}${REGISTRY_USERNAME:0:2}********"
-  echo_reset_dim "Password .................. ${COLOR_MAGENTA}${REGISTRY_PASSWORD:0:2}********"
-  echo "${TEXT_RESET}${TEXT_DIM}"
-
   echo_h4 "Red Hat Catalog Management" "    "
   if [[ "${SETUP_REDHAT_CATALOGS}" == "true" ]]; then
     echo_reset_dim "Management Mode ........... ${COLOR_MAGENTA}IBM Managed/Configured"

--- a/image/cli/mascli/functions/mirror_images
+++ b/image/cli/mascli/functions/mirror_images
@@ -560,17 +560,12 @@ function mirror_to_registry() {
   echo_h4 "Target Registry" "    "
   echo_reset_dim "Registry Host ....................... ${COLOR_MAGENTA}${REGISTRY_PUBLIC_HOST}"
   echo_reset_dim "Registry Port ....................... ${COLOR_MAGENTA}${REGISTRY_PUBLIC_PORT}"
-  if [[ $MIRROR_MODE != "to-filesystem" ]]; then
-    echo_reset_dim "Registry Username ................... ${COLOR_MAGENTA}${REGISTRY_USERNAME}"
-    echo_reset_dim "Registry Password ................... ${COLOR_MAGENTA}${REGISTRY_PASSWORD:0:4}<snip>"
-  fi
 
   echo
   reset_colors
   echo_h4 "IBM Operator Catalog" "    "
   echo_reset_dim "Catalog Version ..................... ${COLOR_MAGENTA}${MAS_CATALOG_VERSION}"
   echo_reset_dim "MAS Update Channel .................. ${COLOR_MAGENTA}${MAS_CHANNEL}"
-  echo_reset_dim "IBM Authentication .................. ${COLOR_MAGENTA}cp/${IBM_ENTITLEMENT_KEY:0:4}<snip>"
 
   # Core
   echo

--- a/image/cli/mascli/functions/mirror_redhat
+++ b/image/cli/mascli/functions/mirror_redhat
@@ -251,8 +251,6 @@ function mirror_redhat() {
     echo_h4 "Target Registry" "    "
     echo_reset_dim "Registry Host ......................... ${COLOR_MAGENTA}${REGISTRY_PUBLIC_HOST}"
     echo_reset_dim "Registry Port ......................... ${COLOR_MAGENTA}${REGISTRY_PUBLIC_PORT}"
-    echo_reset_dim "Registry Username ..................... ${COLOR_MAGENTA}${REGISTRY_USERNAME:0:2}********"
-    echo_reset_dim "Registry Password ..................... ${COLOR_MAGENTA}${REGISTRY_PASSWORD:0:2}********"
     reset_colors
   fi
 

--- a/image/cli/masfvt/fvt-core.yml
+++ b/image/cli/masfvt/fvt-core.yml
@@ -43,8 +43,8 @@
           - "mas_workspace_id ............ {{ mas_workspace_id }}"
           - ""
           - "fvt_image_registry .......... {{ fvt_image_registry }}"
-          - "fvt_artifactory_username .... {{ fvt_artifactory_username }}"
-          - "fvt_artifactory_token ....... {{ fvt_artifactory_token }}"
+          - "fvt_artifactory_username .... ********"
+          - "fvt_artifactory_token ....... ********"
           - "fvt_digest_core ............. {{ fvt_digest_core }}"
           - "ivt_digest_core ............. {{ ivt_digest_core }}"
           - ""
@@ -52,8 +52,8 @@
           - "fvt_whitelist ............... {{ fvt_whitelist }}"
           - ""
           - "ddp_apikey .................. {{ ddp_apikey }}"
-          - "partium_username ............ {{ partium_username }}"
-          - "partium_password ............ {{ partium_password }}"
+          - "partium_username ............ ********"
+          - "partium_password ............ ********"
 
     - name: "Start FVT-core pipeline"
       kubernetes.core.k8s:


### PR DESCRIPTION
Removes (partial) display of username and passwords from the CLI confirmation screens, previously the confirmation screens would show the first 2 (or 4 in some cases) characters of the username/password in some cases.

Also removes username/password from debug in the fvt-core pipeline launcher.