### PR TITLE
[patch] fixing art params for mobile task

### DIFF
--- a/tekton/src/tasks/fvt/fvt-mobile.yml.j2
+++ b/tekton/src/tasks/fvt/fvt-mobile.yml.j2
@@ -49,17 +49,6 @@ spec:
       description: Workspace ID in MAS to use for running the tests
       default: "masdev"
 
-    # Test-specific Information (all optional)
-    # -------------------------------------------------------------------------
-    - name: artifactory_token
-      type: string
-      description: Artifactory Token (required by fvt-ibm-mas-mobile to pull/push test container content)
-      default: ""
-    - name: artifactory_upload_dir
-      type: string
-      description: Artifactory upload directory
-      default: ""
-
     # Mobile Specific information
     - name: mobile_device_type
       type: string


### PR DESCRIPTION
Removing artifactory params so values are fetched directly from mas-devops secret as expected