### PR TITLE
[patch] Add spreadtopology setting in fvt-manage pipeline

### DIFF
--- a/image/cli/masfvt/templates/mas-fvt-manage.yml.j2
+++ b/image/cli/masfvt/templates/mas-fvt-manage.yml.j2
@@ -1,5 +1,5 @@
 ---
-apiVersion: tekton.dev/v1beta1
+apiVersion: tekton.dev/v1
 kind: PipelineRun
 metadata:
   name: "{{ pipelinerun_name }}"
@@ -10,7 +10,17 @@ spec:
   pipelineRef:
     name: mas-fvt-manage
 
-  serviceAccountName: pipeline
+  taskRunTemplate:
+    serviceAccountName: pipeline
+    podTemplate:
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: ibm-cloud.kubernetes.io/worker-id
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector: 
+            matchLabels:
+              tekton.dev/task: mas-fvt-manage
+
   timeouts:
     pipeline: "8h"
 


### PR DESCRIPTION
Part of the attempts to prevent selenium tests to hang, this change spread selenium workload across different nodes in the cluster.

----

Tests: https://dashboard.masdev.wiotp.sl.hursley.ibm.com/tests/pfvtspreadt
Workload mapping: https://ibm.ent.box.com/file/1419411851713

After spread topology see same colors spread across different nodes):
<img width="333" alt="image" src="https://github.com/ibm-mas/cli/assets/15021471/2fad3489-0aef-4fde-87a4-ffad543a17df">
