### PR TITLE
[patch] Increase core test timeout

### DIFF
--- a/image/cli/masfvt/templates/mas-fvt-core.yml.j2
+++ b/image/cli/masfvt/templates/mas-fvt-core.yml.j2
@@ -12,7 +12,7 @@ spec:
 
   serviceAccountName: pipeline
   timeouts:
-    pipeline: "8h"
+    pipeline: "10h"
 
   params:
     # Pull Policy

--- a/tekton/src/tasks/fvt-launcher/launchfvt-core.yml.j2
+++ b/tekton/src/tasks/fvt-launcher/launchfvt-core.yml.j2
@@ -170,13 +170,13 @@ spec:
     - name: wait-for-pipelinerun
       image: quay.io/ibmmas/cli:latest
       imagePullPolicy: $(params.image_pull_policy)
-      # 50 retries at 10 minute intervals = just over 8 hours
+      # 65 retries at 10 minute intervals = just over 10 hours
       command:
         - /opt/app-root/src/wait-for-pipelinerun.sh
         - --delay
         - "600"
         - --max-retries
-        - "50"
+        - "65"
         - --ignore-failure
       env:
         - name: PIPELINERUN_NAME


### PR DESCRIPTION
IDP test suites are bloating the runtime significantly, we need to allow more time for core tests to run until the team can address the underlying problems that mean it takes 3 hours to run just 25 LDAP-related testcases!