### PR TITLE
[patch] Include certificates in standard must-gather

### DIFF
--- a/image/cli/mascli/functions/must_gather
+++ b/image/cli/mascli/functions/must_gather
@@ -55,7 +55,7 @@ function genericMustGather() {
   echo
   echo_h4 "Collect Standard Kubernetes Resources"
   ADDITIONAL_RESOURCES=$(echo "$2" | tr "," " ")
-  for RESOURCE in $ADDITIONAL_RESOURCES configmaps services routes deployments jobs pvc operatorconditions clusterserviceversions installplans subscriptions serviceaccounts roles rolebindings
+  for RESOURCE in $ADDITIONAL_RESOURCES configmaps services routes deployments jobs pvc operatorconditions clusterserviceversions installplans subscriptions serviceaccounts roles rolebindings certificates
   do
     $MG_SCRIPT_DIR/mg-collect-resources -n $1 -r $RESOURCE -d $OUTPUT_DIR/resources $NO_DETAIL_FLAG
   done


### PR DESCRIPTION
Must-gather currently ignores `certificate` resources, which can be the cause of install/update failures, this update addresses that omission.