### PR TITLE
[patch] Collect files from maxinst and other db2 pods

### DIFF
--- a/image/cli/mascli/must-gather/mg-collect-manage-logs
+++ b/image/cli/mascli/must-gather/mg-collect-manage-logs
@@ -26,23 +26,35 @@ mkdir -p "$OUTPUT_DIR/resources/$NAMESPACE/pods_files/$APP/files"
 # Copying files to folder
 oc cp $NAMESPACE/$POD_NAME:log $OUTPUT_DIR/resources/$NAMESPACE/pods_files/$APP/files --retries=-1
 
+
 # Getting db2u Pod Files
 # =========================
 echo "- ${COLOR_BLUE} Getting db2u Pod Files${TEXT_RESET}"
-POD_NAME=$(oc -n db2u get pods -l "type=engine" -o jsonpath="{.items[*].metadata.name}")
+ NAMESPACE_LOOKUP=$(oc get namespace db2u --ignore-not-found)
+  if [[ "$NAMESPACE_LOOKUP" != "" ]]; then
+    POD_NAME=$(oc -n $NAMESPACE_LOOKUP get pods -l "type=engine" -o jsonpath="{.items[*].metadata.name}")
+    for POD in ${POD_NAME[@]}; do
+      if [[ "$POD_NAME" == "" ]]; then
+        echo_warning "DB2U pod was not found"
+        exit 1
+      fi
+      # Creating folder(s)
+      INSTANCE_ID=$(echo ${NAMESPACE%-*})
+      INSTANCE_ID=$(echo ${INSTANCE_ID#*-})
+      APP=$(echo ${POD%-*}) #removing 2nd ID
+      APP=$(echo ${APP%-*}) #removing 1st ID
+        if [[ "$APP" == "$INSTANCE_ID" ]]; then
+          APP=$(echo ${POD%-*}) #removing 2nd ID
+        fi
+      # mkdir -p "$OUTPUT_DIR/resources/$NAMESPACE/pods/$APP/logs" #it will be overwritten when a new Pods folder will be created to keeps pods info (yaml, txt and logs)
+      mkdir -p "$OUTPUT_DIR/resources/$NAMESPACE_LOOKUP/pods_files/$APP/files" 
 
-if [[ "$POD_NAME" == "" ]]; then
-  echo_warning "db2u pod was not found"
-  exit 1
-fi
-
-# Creating folder
-APP=$(echo ${POD_NAME%-*}) #removing 2nd ID
-APP=$(echo ${APP%-*}) #removing 1st ID
-mkdir -p "$OUTPUT_DIR/resources/$NAMESPACE/pods_files/$APP/files" 
-
-# Copying files to folder
-oc cp $NAMESPACE/$POD_NAME:log $OUTPUT_DIR/resources/$NAMESPACE/pods_files/$APP/files --retries=-1
+      # Copying files to folder
+      oc cp $NAMESPACE_LOOKUP/$POD:logs $OUTPUT_DIR/resources/$NAMESPACE_LOOKUP/pods_files/$APP/files --retries=-1
+    done
+  else
+    echo_highlight "Unable to find db2u namespace"
+  fi
 
 
 # # Getting Server Bundle Pod Files
@@ -67,5 +79,5 @@ oc cp $NAMESPACE/$POD_NAME:log $OUTPUT_DIR/resources/$NAMESPACE/pods_files/$APP/
 
 #   # Copying files to folder
 #   oc cp $NAMESPACE/$POD:logs $OUTPUT_DIR/resources/$NAMESPACE/pods_files/$APP/files --retries=-1
-done
+# done
 exit 0

--- a/image/cli/mascli/must-gather/mg-collect-manage-logs
+++ b/image/cli/mascli/must-gather/mg-collect-manage-logs
@@ -6,15 +6,27 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 NAMESPACE=$1
 OUTPUT_DIR=$2
-MAXINST_POD=$(oc -n $NAMESPACE get pods -l "mas.ibm.com/appType: maxinstudb" -o jsonpath="{.items[*].metadata.name}")
+
+# =========================
+MAXINST_POD=$(oc -n $NAMESPACE get pods -l "mas.ibm.com/appType= maxinstudb" -o jsonpath="{.items[*].metadata.name}")
 
 echo "Maxinst pod $MAXINST_POD"
-# oc cp mas-codesmtp-manage/codesmtp-masdev-all-7874d45bf9-gtx9t:/logs /Users/alicenahas/Github/ibm-mas_cli/tst2
 
-echo "oc cp -n $NAMESPACE/$MAXINST_POD:/log /$OUTPUT_DIR/$MAXINST_POD/alice"
+echo "oc cp $NAMESPACE/$MAXINST_POD:log $OUTPUT_DIR/$MAXINST_POD/logs"
 
-oc cp -n $NAMESPACE/$MAXINST_POD:/log /$OUTPUT_DIR/$MAXINST_POD/alice
+mkdir -p "$OUTPUT_DIR/$MAXINST_POD/logs"
 
+oc cp $NAMESPACE/$MAXINST_POD:log $OUTPUT_DIR/$MAXINST_POD/logs
+# =========================
+SERVER_POD=$(oc -n $NAMESPACE get pods -l "mas.ibm.com/appType= serverBundle" -o jsonpath="{.items[*].metadata.name}")
+
+echo "Maxinst pod $SERVER_POD"
+
+echo "oc cp $NAMESPACE/$SERVER_POD:logs $OUTPUT_DIR/$SERVER_POD/logs"
+
+mkdir -p "$OUTPUT_DIR/$SERVER_POD/logs"
+
+oc cp $NAMESPACE/$SERVER_POD:logs $OUTPUT_DIR/$SERVER_POD/logs
 
 
 

--- a/image/cli/mascli/must-gather/mg-collect-manage-logs
+++ b/image/cli/mascli/must-gather/mg-collect-manage-logs
@@ -29,17 +29,19 @@ oc cp $NAMESPACE/$POD_NAME:log $OUTPUT_DIR/resources/$NAMESPACE/pods_files/$APP/
 # Getting Server Bundle Pod Files
 # =========================
 POD_NAME=$(oc -n $NAMESPACE get pods -l "mas.ibm.com/appType= serverBundle" -o jsonpath="{.items[*].metadata.name}")
+for POD in ${POD_NAME[@]}; do
+  if [[ "$POD_NAME" == "" ]]; then
+    echo_warning "Server Bundle pod was not found"
+    exit 1
+  fi
 
-if [[ "$POD_NAME" == "" ]]; then
-  echo_warning "Server Bundle pod was not found"
-  exit 1
-fi
+  # Creating folder
+  APP=$(echo ${POD%-*}) #removing 2nd ID
+  APP=$(echo ${APP%-*}) #removing 1st ID
+  # mkdir -p "$OUTPUT_DIR/resources/$NAMESPACE/pods/$APP/logs" #it will be overwritten when a new Pods folder will be created to keeps pods info (yaml, txt and logs)
+  mkdir -p "$OUTPUT_DIR/resources/$NAMESPACE/pods_files/$APP/files" 
 
-# Creating folder
-APP=$(echo ${POD_NAME%-*}) #removing 2nd ID
-APP=$(echo ${APP%-*}) #removing 1st ID
-# mkdir -p "$OUTPUT_DIR/resources/$NAMESPACE/pods/$APP/logs" #it will be overwritten when a new Pods folder will be created to keeps pods info (yaml, txt and logs)
-mkdir -p "$OUTPUT_DIR/resources/$NAMESPACE/pods_files/$APP/files" 
-
-# Copying files to folder
-oc cp $NAMESPACE/$POD_NAME:log $OUTPUT_DIR/resources/$NAMESPACE/pods_files/$APP/files
+  # Copying files to folder
+  oc cp $NAMESPACE/$POD:logs $OUTPUT_DIR/resources/$NAMESPACE/pods_files/$APP/files
+done
+exit 0

--- a/image/cli/mascli/must-gather/mg-collect-manage-logs
+++ b/image/cli/mascli/must-gather/mg-collect-manage-logs
@@ -1,0 +1,54 @@
+#!/bin/bash
+set -e
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+. $DIR/../functions/internal/utils
+
+NAMESPACE=$1
+OUTPUT_DIR=$2
+MAXINST_POD=$(oc -n $NAMESPACE get pods -l "mas.ibm.com/appType: maxinstudb" -o jsonpath="{.items[*].metadata.name}")
+
+echo "Maxinst pod $MAXINST_POD"
+# oc cp mas-codesmtp-manage/codesmtp-masdev-all-7874d45bf9-gtx9t:/logs /Users/alicenahas/Github/ibm-mas_cli/tst2
+
+echo "oc cp -n $NAMESPACE/$MAXINST_POD:/log /$OUTPUT_DIR/$MAXINST_POD/alice"
+
+oc cp -n $NAMESPACE/$MAXINST_POD:/log /$OUTPUT_DIR/$MAXINST_POD/alice
+
+
+
+
+# for MBGX_POD in $MBGX_PODS
+# do
+#   set +e
+#   LOGFILES=$(oc -n $NAMESPACE exec $MBGX_POD -- find /var/messagesight/diag/logs/ -name *.log 2>/dev/null)
+#   if [[ "$?" == "1" ]]; then
+#     exit 0
+#   fi
+#   set -e
+
+#   MBGX_LOG_DESTINATION_DIR=${OUTPUT_DIR}/resources/${NAMESPACE}/mbgx-logs/$MBGX_POD
+#   mkdir -p $MBGX_LOG_DESTINATION_DIR
+
+#   echo "Collecting mbgx logs from '$MBGX_POD'"
+#   set +e # the tar command may give warnings if files no longer exist, and they get cycled by the operator.
+#   oc -n $NAMESPACE exec $MBGX_POD -- tar -czf - $LOGFILES > $MBGX_LOG_DESTINATION_DIR/mbgx-logs-$MBGX_POD.tgz 2> /dev/null
+#   if [[ "$?" != "0" ]]; then
+#     echo_dim "- Incomplete mbgx logs from $MBGX_POD"
+#   fi
+#   tar -xf $MBGX_LOG_DESTINATION_DIR/mbgx-logs-$MBGX_POD.tgz -C $MBGX_LOG_DESTINATION_DIR 2> /dev/null
+
+#   if [[ "$?" == "0" ]]; then
+#     # Move the MBGX log files to the correct place in the must gather directory structure
+#     #
+#     mv $MBGX_LOG_DESTINATION_DIR/var/messagesight/diag/logs/* $MBGX_LOG_DESTINATION_DIR
+#     rm $MBGX_LOG_DESTINATION_DIR/mbgx-logs-$MBGX_POD.tgz
+#     rm -r $MBGX_LOG_DESTINATION_DIR/var
+
+#   else
+#     echo_dim "- Unable to get mbgx logs from $MBGX_POD"
+#   fi
+#   set -e
+
+# done  # MBGX_POD
+

--- a/image/cli/mascli/must-gather/mg-collect-manage-logs
+++ b/image/cli/mascli/must-gather/mg-collect-manage-logs
@@ -7,50 +7,39 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 NAMESPACE=$1
 OUTPUT_DIR=$2
 
+# Getting Maxinst Pod Files
 # =========================
 POD_NAME=$(oc -n $NAMESPACE get pods -l "mas.ibm.com/appType= maxinstudb" -o jsonpath="{.items[*].metadata.name}")
 
 if [[ "$POD_NAME" == "" ]]; then
-  echo_warning "POD $POD_NAME was not found"
+  echo_warning "Maxinst pod was not found"
   exit 1
 fi
 
-echo "POD NAME $POD_NAME"
+# Creating folder
+APP=$(echo ${POD_NAME%-*}) #removing 2nd ID
+APP=$(echo ${APP%-*}) #removing 1st ID
+# mkdir -p "$OUTPUT_DIR/resources/$NAMESPACE/pods/$APP/logs" #it will be overwritten when a new Pods folder will be created to keeps pods info (yaml, txt and logs)
+mkdir -p "$OUTPUT_DIR/resources/$NAMESPACE/pods_files/$APP/files" 
 
-# echo "oc cp $NAMESPACE/$MAXINST_POD:log $OUTPUT_DIR/$MAXINST_POD/logs"
-# mkdir -p "$OUTPUT_DIR/$MAXINST_POD/logs"
+# Copying files to folder
+oc cp $NAMESPACE/$POD_NAME:log $OUTPUT_DIR/resources/$NAMESPACE/pods_files/$APP/files
 
-# Creating folder on the same pattern as mg-collect-pods
-# -----------------------------------------------------------------------------
 
-APP="$(oc -n "${NAMESPACE}" get "${POD_NAME}" -o jsonpath='{.metadata.labels.app}')"
-echo "APP 1 $APP"
+# Getting Server Bundle Pod Files
+# =========================
+POD_NAME=$(oc -n $NAMESPACE get pods -l "mas.ibm.com/appType= serverBundle" -o jsonpath="{.items[*].metadata.name}")
 
-  if [[ "$APP" == "" ]]; then
-    INSTANCE_ID=$(echo ${NAMESPACE%-*})
-    INSTANCE_ID=$(echo ${INSTANCE_ID#*-})
-    APP=$(echo ${POD_NAME%-*}) #removing 2nd ID
-    APP=$(echo ${APP%-*}) #removing 1st ID
+if [[ "$POD_NAME" == "" ]]; then
+  echo_warning "Server Bundle pod was not found"
+  exit 1
+fi
 
-    if [[ "$APP" == "$INSTANCE_ID" ]]; then
-      APP=$(echo ${POD_NAME%-*}) #removing 2nd ID only
-    fi
-  fi
+# Creating folder
+APP=$(echo ${POD_NAME%-*}) #removing 2nd ID
+APP=$(echo ${APP%-*}) #removing 1st ID
+# mkdir -p "$OUTPUT_DIR/resources/$NAMESPACE/pods/$APP/logs" #it will be overwritten when a new Pods folder will be created to keeps pods info (yaml, txt and logs)
+mkdir -p "$OUTPUT_DIR/resources/$NAMESPACE/pods_files/$APP/files" 
 
-mkdir -p "$OUTPUT_DIR/resources/$NAMESPACE/pods/$APP/logs"
-echo "mkdir -p $OUTPUT_DIR/resources/$NAMESPACE/pods/$APP/logs"
-
-oc cp $NAMESPACE/$POD_NAME:log $OUTPUT_DIR/resources/$NAMESPACE/pods/$APP/logs
-echo "oc cp $NAMESPACE/$POD_NAME:log $OUTPUT_DIR/resources/$NAMESPACE/pods/$APP/logs"
-
-# oc cp $NAMESPACE/$MAXINST_POD:log $OUTPUT_DIR/$MAXINST_POD/logs
-# # =========================
-# SERVER_POD=$(oc -n $NAMESPACE get pods -l "mas.ibm.com/appType= serverBundle" -o jsonpath="{.items[*].metadata.name}")
-
-# echo "Maxinst pod $SERVER_POD"
-
-# echo "oc cp $NAMESPACE/$SERVER_POD:logs $OUTPUT_DIR/$SERVER_POD/logs"
-
-# mkdir -p "$OUTPUT_DIR/$SERVER_POD/logs"
-
-# oc cp $NAMESPACE/$SERVER_POD:logs $OUTPUT_DIR/$SERVER_POD/logs
+# Copying files to folder
+oc cp $NAMESPACE/$POD_NAME:log $OUTPUT_DIR/resources/$NAMESPACE/pods_files/$APP/files

--- a/image/cli/mascli/must-gather/mg-collect-manage-logs
+++ b/image/cli/mascli/must-gather/mg-collect-manage-logs
@@ -8,59 +8,49 @@ NAMESPACE=$1
 OUTPUT_DIR=$2
 
 # =========================
-MAXINST_POD=$(oc -n $NAMESPACE get pods -l "mas.ibm.com/appType= maxinstudb" -o jsonpath="{.items[*].metadata.name}")
+POD_NAME=$(oc -n $NAMESPACE get pods -l "mas.ibm.com/appType= maxinstudb" -o jsonpath="{.items[*].metadata.name}")
 
-echo "Maxinst pod $MAXINST_POD"
+if [[ "$POD_NAME" == "" ]]; then
+  echo_warning "POD $POD_NAME was not found"
+  exit 1
+fi
 
-echo "oc cp $NAMESPACE/$MAXINST_POD:log $OUTPUT_DIR/$MAXINST_POD/logs"
+echo "POD NAME $POD_NAME"
 
-mkdir -p "$OUTPUT_DIR/$MAXINST_POD/logs"
+# echo "oc cp $NAMESPACE/$MAXINST_POD:log $OUTPUT_DIR/$MAXINST_POD/logs"
+# mkdir -p "$OUTPUT_DIR/$MAXINST_POD/logs"
 
-oc cp $NAMESPACE/$MAXINST_POD:log $OUTPUT_DIR/$MAXINST_POD/logs
-# =========================
-SERVER_POD=$(oc -n $NAMESPACE get pods -l "mas.ibm.com/appType= serverBundle" -o jsonpath="{.items[*].metadata.name}")
+# Creating folder on the same pattern as mg-collect-pods
+# -----------------------------------------------------------------------------
 
-echo "Maxinst pod $SERVER_POD"
+APP="$(oc -n "${NAMESPACE}" get "${POD_NAME}" -o jsonpath='{.metadata.labels.app}')"
+echo "APP 1 $APP"
 
-echo "oc cp $NAMESPACE/$SERVER_POD:logs $OUTPUT_DIR/$SERVER_POD/logs"
+  if [[ "$APP" == "" ]]; then
+    INSTANCE_ID=$(echo ${NAMESPACE%-*})
+    INSTANCE_ID=$(echo ${INSTANCE_ID#*-})
+    APP=$(echo ${POD_NAME%-*}) #removing 2nd ID
+    APP=$(echo ${APP%-*}) #removing 1st ID
 
-mkdir -p "$OUTPUT_DIR/$SERVER_POD/logs"
+    if [[ "$APP" == "$INSTANCE_ID" ]]; then
+      APP=$(echo ${POD_NAME%-*}) #removing 2nd ID only
+    fi
+  fi
 
-oc cp $NAMESPACE/$SERVER_POD:logs $OUTPUT_DIR/$SERVER_POD/logs
+mkdir -p "$OUTPUT_DIR/resources/$NAMESPACE/pods/$APP/logs"
+echo "mkdir -p $OUTPUT_DIR/resources/$NAMESPACE/pods/$APP/logs"
 
+oc cp $NAMESPACE/$POD_NAME:log $OUTPUT_DIR/resources/$NAMESPACE/pods/$APP/logs
+echo "oc cp $NAMESPACE/$POD_NAME:log $OUTPUT_DIR/resources/$NAMESPACE/pods/$APP/logs"
 
+# oc cp $NAMESPACE/$MAXINST_POD:log $OUTPUT_DIR/$MAXINST_POD/logs
+# # =========================
+# SERVER_POD=$(oc -n $NAMESPACE get pods -l "mas.ibm.com/appType= serverBundle" -o jsonpath="{.items[*].metadata.name}")
 
-# for MBGX_POD in $MBGX_PODS
-# do
-#   set +e
-#   LOGFILES=$(oc -n $NAMESPACE exec $MBGX_POD -- find /var/messagesight/diag/logs/ -name *.log 2>/dev/null)
-#   if [[ "$?" == "1" ]]; then
-#     exit 0
-#   fi
-#   set -e
+# echo "Maxinst pod $SERVER_POD"
 
-#   MBGX_LOG_DESTINATION_DIR=${OUTPUT_DIR}/resources/${NAMESPACE}/mbgx-logs/$MBGX_POD
-#   mkdir -p $MBGX_LOG_DESTINATION_DIR
+# echo "oc cp $NAMESPACE/$SERVER_POD:logs $OUTPUT_DIR/$SERVER_POD/logs"
 
-#   echo "Collecting mbgx logs from '$MBGX_POD'"
-#   set +e # the tar command may give warnings if files no longer exist, and they get cycled by the operator.
-#   oc -n $NAMESPACE exec $MBGX_POD -- tar -czf - $LOGFILES > $MBGX_LOG_DESTINATION_DIR/mbgx-logs-$MBGX_POD.tgz 2> /dev/null
-#   if [[ "$?" != "0" ]]; then
-#     echo_dim "- Incomplete mbgx logs from $MBGX_POD"
-#   fi
-#   tar -xf $MBGX_LOG_DESTINATION_DIR/mbgx-logs-$MBGX_POD.tgz -C $MBGX_LOG_DESTINATION_DIR 2> /dev/null
+# mkdir -p "$OUTPUT_DIR/$SERVER_POD/logs"
 
-#   if [[ "$?" == "0" ]]; then
-#     # Move the MBGX log files to the correct place in the must gather directory structure
-#     #
-#     mv $MBGX_LOG_DESTINATION_DIR/var/messagesight/diag/logs/* $MBGX_LOG_DESTINATION_DIR
-#     rm $MBGX_LOG_DESTINATION_DIR/mbgx-logs-$MBGX_POD.tgz
-#     rm -r $MBGX_LOG_DESTINATION_DIR/var
-
-#   else
-#     echo_dim "- Unable to get mbgx logs from $MBGX_POD"
-#   fi
-#   set -e
-
-# done  # MBGX_POD
-
+# oc cp $NAMESPACE/$SERVER_POD:logs $OUTPUT_DIR/$SERVER_POD/logs

--- a/image/cli/mascli/must-gather/mg-collect-manage-logs
+++ b/image/cli/mascli/must-gather/mg-collect-manage-logs
@@ -32,7 +32,8 @@ oc cp $NAMESPACE/$POD_NAME:log $OUTPUT_DIR/resources/$NAMESPACE/pods_files/$APP/
 echo "- ${COLOR_BLUE} Getting db2u Pod Files${TEXT_RESET}"
  NAMESPACE_LOOKUP=$(oc get namespace db2u --ignore-not-found)
   if [[ "$NAMESPACE_LOOKUP" != "" ]]; then
-    POD_NAME=$(oc -n $NAMESPACE_LOOKUP get pods -l "type=engine" -o jsonpath="{.items[*].metadata.name}")
+    NAMESPACE=$(oc get namespace db2u -o jsonpath='{.metadata.name}'
+    POD_NAME=$(oc -n $NAMESPACE get pods -l "type=engine" -o jsonpath="{.items[*].metadata.name}")
     for POD in ${POD_NAME[@]}; do
       if [[ "$POD_NAME" == "" ]]; then
         echo_warning "DB2U pod was not found"
@@ -46,11 +47,10 @@ echo "- ${COLOR_BLUE} Getting db2u Pod Files${TEXT_RESET}"
         if [[ "$APP" == "$INSTANCE_ID" ]]; then
           APP=$(echo ${POD%-*}) #removing 2nd ID
         fi
-      # mkdir -p "$OUTPUT_DIR/resources/$NAMESPACE/pods/$APP/logs" #it will be overwritten when a new Pods folder will be created to keeps pods info (yaml, txt and logs)
-      mkdir -p "$OUTPUT_DIR/resources/$NAMESPACE_LOOKUP/pods_files/$APP/files" 
+      mkdir -p "$OUTPUT_DIR/resources/$NAMESPACE/pods_files/$APP/files" 
 
       # Copying files to folder
-      oc cp $NAMESPACE_LOOKUP/$POD:logs $OUTPUT_DIR/resources/$NAMESPACE_LOOKUP/pods_files/$APP/files --retries=-1
+      oc cp $NAMESPACE/$POD:tmp $OUTPUT_DIR/resources/$NAMESPACE/pods_files/$APP/files --retries=-1
     done
   else
     echo_highlight "Unable to find db2u namespace"

--- a/image/cli/mascli/must-gather/mg-collect-manage-logs
+++ b/image/cli/mascli/must-gather/mg-collect-manage-logs
@@ -23,7 +23,7 @@ APP=$(echo ${APP%-*}) #removing 1st ID
 mkdir -p "$OUTPUT_DIR/resources/$NAMESPACE/pods_files/$APP/files" 
 
 # Copying files to folder
-oc cp $NAMESPACE/$POD_NAME:log $OUTPUT_DIR/resources/$NAMESPACE/pods_files/$APP/files
+oc cp $NAMESPACE/$POD_NAME:log $OUTPUT_DIR/resources/$NAMESPACE/pods_files/$APP/files --retries=-1
 
 
 # Getting Server Bundle Pod Files
@@ -36,12 +36,17 @@ for POD in ${POD_NAME[@]}; do
   fi
 
   # Creating folder
+  INSTANCE_ID=$(echo ${NAMESPACE%-*})
+  INSTANCE_ID=$(echo ${INSTANCE_ID#*-})
   APP=$(echo ${POD%-*}) #removing 2nd ID
   APP=$(echo ${APP%-*}) #removing 1st ID
+    if [[ "$APP" == "$INSTANCE_ID" ]]; then
+       APP=$(echo ${POD%-*}) #removing 2nd ID
+    fi
   # mkdir -p "$OUTPUT_DIR/resources/$NAMESPACE/pods/$APP/logs" #it will be overwritten when a new Pods folder will be created to keeps pods info (yaml, txt and logs)
   mkdir -p "$OUTPUT_DIR/resources/$NAMESPACE/pods_files/$APP/files" 
 
   # Copying files to folder
-  oc cp $NAMESPACE/$POD:logs $OUTPUT_DIR/resources/$NAMESPACE/pods_files/$APP/files
+  oc cp $NAMESPACE/$POD:logs $OUTPUT_DIR/resources/$NAMESPACE/pods_files/$APP/files --retries=-1
 done
 exit 0

--- a/image/cli/mascli/must-gather/mg-collect-manage-logs
+++ b/image/cli/mascli/must-gather/mg-collect-manage-logs
@@ -9,6 +9,7 @@ OUTPUT_DIR=$2
 
 # Getting Maxinst Pod Files
 # =========================
+echo "- ${COLOR_BLUE} Getting Maxinst Pod Files${TEXT_RESET}"
 POD_NAME=$(oc -n $NAMESPACE get pods -l "mas.ibm.com/appType= maxinstudb" -o jsonpath="{.items[*].metadata.name}")
 
 if [[ "$POD_NAME" == "" ]]; then
@@ -28,14 +29,14 @@ oc cp $NAMESPACE/$POD_NAME:log $OUTPUT_DIR/resources/$NAMESPACE/pods_files/$APP/
 
 # Getting Server Bundle Pod Files
 # =========================
+echo "- ${COLOR_BLUE} Getting Server Bundle Pod Files${TEXT_RESET}"
 POD_NAME=$(oc -n $NAMESPACE get pods -l "mas.ibm.com/appType= serverBundle" -o jsonpath="{.items[*].metadata.name}")
 for POD in ${POD_NAME[@]}; do
   if [[ "$POD_NAME" == "" ]]; then
     echo_warning "Server Bundle pod was not found"
     exit 1
   fi
-
-  # Creating folder
+  # Creating folder(s)
   INSTANCE_ID=$(echo ${NAMESPACE%-*})
   INSTANCE_ID=$(echo ${INSTANCE_ID#*-})
   APP=$(echo ${POD%-*}) #removing 2nd ID

--- a/image/cli/mascli/must-gather/mg-collect-manage-logs
+++ b/image/cli/mascli/must-gather/mg-collect-manage-logs
@@ -26,28 +26,46 @@ mkdir -p "$OUTPUT_DIR/resources/$NAMESPACE/pods_files/$APP/files"
 # Copying files to folder
 oc cp $NAMESPACE/$POD_NAME:log $OUTPUT_DIR/resources/$NAMESPACE/pods_files/$APP/files --retries=-1
 
-
-# Getting Server Bundle Pod Files
+# Getting db2u Pod Files
 # =========================
-echo "- ${COLOR_BLUE} Getting Server Bundle Pod Files${TEXT_RESET}"
-POD_NAME=$(oc -n $NAMESPACE get pods -l "mas.ibm.com/appType= serverBundle" -o jsonpath="{.items[*].metadata.name}")
-for POD in ${POD_NAME[@]}; do
-  if [[ "$POD_NAME" == "" ]]; then
-    echo_warning "Server Bundle pod was not found"
-    exit 1
-  fi
-  # Creating folder(s)
-  INSTANCE_ID=$(echo ${NAMESPACE%-*})
-  INSTANCE_ID=$(echo ${INSTANCE_ID#*-})
-  APP=$(echo ${POD%-*}) #removing 2nd ID
-  APP=$(echo ${APP%-*}) #removing 1st ID
-    if [[ "$APP" == "$INSTANCE_ID" ]]; then
-       APP=$(echo ${POD%-*}) #removing 2nd ID
-    fi
-  # mkdir -p "$OUTPUT_DIR/resources/$NAMESPACE/pods/$APP/logs" #it will be overwritten when a new Pods folder will be created to keeps pods info (yaml, txt and logs)
-  mkdir -p "$OUTPUT_DIR/resources/$NAMESPACE/pods_files/$APP/files" 
+echo "- ${COLOR_BLUE} Getting db2u Pod Files${TEXT_RESET}"
+POD_NAME=$(oc -n db2u get pods -l "type=engine" -o jsonpath="{.items[*].metadata.name}")
 
-  # Copying files to folder
-  oc cp $NAMESPACE/$POD:logs $OUTPUT_DIR/resources/$NAMESPACE/pods_files/$APP/files --retries=-1
+if [[ "$POD_NAME" == "" ]]; then
+  echo_warning "db2u pod was not found"
+  exit 1
+fi
+
+# Creating folder
+APP=$(echo ${POD_NAME%-*}) #removing 2nd ID
+APP=$(echo ${APP%-*}) #removing 1st ID
+mkdir -p "$OUTPUT_DIR/resources/$NAMESPACE/pods_files/$APP/files" 
+
+# Copying files to folder
+oc cp $NAMESPACE/$POD_NAME:log $OUTPUT_DIR/resources/$NAMESPACE/pods_files/$APP/files --retries=-1
+
+
+# # Getting Server Bundle Pod Files
+# # =========================
+# echo "- ${COLOR_BLUE} Getting Server Bundle Pod Files${TEXT_RESET}"
+# POD_NAME=$(oc -n $NAMESPACE get pods -l "mas.ibm.com/appType= serverBundle" -o jsonpath="{.items[*].metadata.name}")
+# for POD in ${POD_NAME[@]}; do
+#   if [[ "$POD_NAME" == "" ]]; then
+#     echo_warning "Server Bundle pod was not found"
+#     exit 1
+#   fi
+#   # Creating folder(s)
+#   INSTANCE_ID=$(echo ${NAMESPACE%-*})
+#   INSTANCE_ID=$(echo ${INSTANCE_ID#*-})
+#   APP=$(echo ${POD%-*}) #removing 2nd ID
+#   APP=$(echo ${APP%-*}) #removing 1st ID
+#     if [[ "$APP" == "$INSTANCE_ID" ]]; then
+#        APP=$(echo ${POD%-*}) #removing 2nd ID
+#     fi
+#   # mkdir -p "$OUTPUT_DIR/resources/$NAMESPACE/pods/$APP/logs" #it will be overwritten when a new Pods folder will be created to keeps pods info (yaml, txt and logs)
+#   mkdir -p "$OUTPUT_DIR/resources/$NAMESPACE/pods_files/$APP/files" 
+
+#   # Copying files to folder
+#   oc cp $NAMESPACE/$POD:logs $OUTPUT_DIR/resources/$NAMESPACE/pods_files/$APP/files --retries=-1
 done
 exit 0

--- a/image/cli/mascli/must-gather/mg-collect-manage-logs
+++ b/image/cli/mascli/must-gather/mg-collect-manage-logs
@@ -7,48 +7,46 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 NAMESPACE=$1
 OUTPUT_DIR=$2
 
+createFolder () {
+  INSTANCE_ID=$(echo ${NAMESPACE%-*})
+  INSTANCE_ID=$(echo ${INSTANCE_ID#*-})
+  APP=$(echo ${POD%-*}) #removing 2nd ID
+  APP=$(echo ${APP%-*}) #removing 1st ID
+     if [[ "$APP" == "$INSTANCE_ID" ]]; then
+       APP=$(echo ${POD%-*}) #removing 2nd ID
+     fi
+  mkdir -p "$OUTPUT_DIR/resources/$NAMESPACE/pods_files/$APP/files"
+}
+
 # Getting Maxinst Pod Files
 # =========================
 echo "- ${COLOR_BLUE} Getting Maxinst Pod Files${TEXT_RESET}"
-POD_NAME=$(oc -n $NAMESPACE get pods -l "mas.ibm.com/appType= maxinstudb" -o jsonpath="{.items[*].metadata.name}")
+POD=$(oc -n $NAMESPACE get pods -l "mas.ibm.com/appType= maxinstudb" -o jsonpath="{.items[*].metadata.name}")
 
-if [[ "$POD_NAME" == "" ]]; then
+if [[ "$POD" == "" ]]; then
   echo_warning "Maxinst pod was not found"
   exit 1
 fi
-
-# Creating folder
-APP=$(echo ${POD_NAME%-*}) #removing 2nd ID
-APP=$(echo ${APP%-*}) #removing 1st ID
-# mkdir -p "$OUTPUT_DIR/resources/$NAMESPACE/pods/$APP/logs" #it will be overwritten when a new Pods folder will be created to keeps pods info (yaml, txt and logs)
-mkdir -p "$OUTPUT_DIR/resources/$NAMESPACE/pods_files/$APP/files" 
+createFolder 
 
 # Copying files to folder
-oc cp $NAMESPACE/$POD_NAME:log $OUTPUT_DIR/resources/$NAMESPACE/pods_files/$APP/files --retries=-1
+oc cp $NAMESPACE/$POD:log $OUTPUT_DIR/resources/$NAMESPACE/pods_files/$APP/files --retries=-1
 
 
 # Getting db2u Pod Files
 # =========================
 echo "- ${COLOR_BLUE} Getting db2u Pod Files${TEXT_RESET}"
- NAMESPACE_LOOKUP=$(oc get namespace db2u --ignore-not-found)
-  if [[ "$NAMESPACE_LOOKUP" != "" ]]; then
-    NAMESPACE=$(oc get namespace db2u -o jsonpath='{.metadata.name}'
+#  NAMESPACE_LOOKUP=$(oc get namespace db2u --ignore-not-found)
+ NAMESPACE=$(oc get namespace db2u -o jsonpath='{.metadata.name}' --ignore-not-found)
+  if [[ "$NAMESPACE" != "" ]]; then
     POD_NAME=$(oc -n $NAMESPACE get pods -l "type=engine" -o jsonpath="{.items[*].metadata.name}")
     for POD in ${POD_NAME[@]}; do
       if [[ "$POD_NAME" == "" ]]; then
         echo_warning "DB2U pod was not found"
         exit 1
       fi
-      # Creating folder(s)
-      INSTANCE_ID=$(echo ${NAMESPACE%-*})
-      INSTANCE_ID=$(echo ${INSTANCE_ID#*-})
-      APP=$(echo ${POD%-*}) #removing 2nd ID
-      APP=$(echo ${APP%-*}) #removing 1st ID
-        if [[ "$APP" == "$INSTANCE_ID" ]]; then
-          APP=$(echo ${POD%-*}) #removing 2nd ID
-        fi
-      mkdir -p "$OUTPUT_DIR/resources/$NAMESPACE/pods_files/$APP/files" 
-
+      createFolder
+      
       # Copying files to folder
       oc cp $NAMESPACE/$POD:tmp $OUTPUT_DIR/resources/$NAMESPACE/pods_files/$APP/files --retries=-1
     done

--- a/image/cli/mascli/must-gather/mg-collect-manage-logs
+++ b/image/cli/mascli/must-gather/mg-collect-manage-logs
@@ -54,28 +54,4 @@ echo "- ${COLOR_BLUE} Getting db2u Pod Files${TEXT_RESET}"
     echo_highlight "Unable to find db2u namespace"
   fi
 
-
-# # Getting Server Bundle Pod Files
-# # =========================
-# echo "- ${COLOR_BLUE} Getting Server Bundle Pod Files${TEXT_RESET}"
-# POD_NAME=$(oc -n $NAMESPACE get pods -l "mas.ibm.com/appType= serverBundle" -o jsonpath="{.items[*].metadata.name}")
-# for POD in ${POD_NAME[@]}; do
-#   if [[ "$POD_NAME" == "" ]]; then
-#     echo_warning "Server Bundle pod was not found"
-#     exit 1
-#   fi
-#   # Creating folder(s)
-#   INSTANCE_ID=$(echo ${NAMESPACE%-*})
-#   INSTANCE_ID=$(echo ${INSTANCE_ID#*-})
-#   APP=$(echo ${POD%-*}) #removing 2nd ID
-#   APP=$(echo ${APP%-*}) #removing 1st ID
-#     if [[ "$APP" == "$INSTANCE_ID" ]]; then
-#        APP=$(echo ${POD%-*}) #removing 2nd ID
-#     fi
-#   # mkdir -p "$OUTPUT_DIR/resources/$NAMESPACE/pods/$APP/logs" #it will be overwritten when a new Pods folder will be created to keeps pods info (yaml, txt and logs)
-#   mkdir -p "$OUTPUT_DIR/resources/$NAMESPACE/pods_files/$APP/files" 
-
-#   # Copying files to folder
-#   oc cp $NAMESPACE/$POD:logs $OUTPUT_DIR/resources/$NAMESPACE/pods_files/$APP/files --retries=-1
-# done
 exit 0

--- a/image/cli/mascli/must-gather/mg-collect-mas-manage
+++ b/image/cli/mascli/must-gather/mg-collect-mas-manage
@@ -1,15 +1,12 @@
 #!/bin/bash
 set -e
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-. $DIR/../functions/internal/utils
 
 NAMESPACE=$1
 OUTPUT_DIR=$2
 
 # Collect Reconcile Logs
 # -----------------------------------------------------------------------------
-echo_h4 "Collect Reconcile Logs"
-
 # Operators
 $DIR/mg-collect-reconcile-logs $NAMESPACE control-plane ibm-mas-manage $OUTPUT_DIR
 $DIR/mg-collect-reconcile-logs $NAMESPACE mas.ibm.com/appType imagestitching-entitymgr-operator $OUTPUT_DIR

--- a/image/cli/mascli/must-gather/mg-collect-mas-manage
+++ b/image/cli/mascli/must-gather/mg-collect-mas-manage
@@ -1,6 +1,7 @@
 #!/bin/bash
 set -e
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+. $DIR/../functions/internal/utils
 
 NAMESPACE=$1
 OUTPUT_DIR=$2

--- a/image/cli/mascli/must-gather/mg-collect-mas-manage
+++ b/image/cli/mascli/must-gather/mg-collect-mas-manage
@@ -6,8 +6,14 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 NAMESPACE=$1
 OUTPUT_DIR=$2
 
+# Collect Maxinst Logs
+# -----------------------------------------------------------------------------
+echo_h4 "Collect Maxinst Logs"
+$DIR/mg-collect-manage-logs $NAMESPACE $OUTPUT_DIR
+
 # Collect Reconcile Logs
 # -----------------------------------------------------------------------------
+echo_h4 "Collect Reconcile Logs"
 # Operators
 $DIR/mg-collect-reconcile-logs $NAMESPACE control-plane ibm-mas-manage $OUTPUT_DIR
 $DIR/mg-collect-reconcile-logs $NAMESPACE mas.ibm.com/appType imagestitching-entitymgr-operator $OUTPUT_DIR

--- a/image/cli/mascli/must-gather/mg-collect-mas-manage
+++ b/image/cli/mascli/must-gather/mg-collect-mas-manage
@@ -1,7 +1,7 @@
 #!/bin/bash
-
 set -e
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+. $DIR/../functions/internal/utils
 
 NAMESPACE=$1
 OUTPUT_DIR=$2

--- a/image/cli/mascli/must-gather/mg-collect-mas-manage
+++ b/image/cli/mascli/must-gather/mg-collect-mas-manage
@@ -8,7 +8,7 @@ OUTPUT_DIR=$2
 
 # Collect Maxinst Logs
 # -----------------------------------------------------------------------------
-echo_h4 "Collect Maxinst Logs"
+echo_h4 "Collect Manage Logs"
 $DIR/mg-collect-manage-logs $NAMESPACE $OUTPUT_DIR
 
 # Collect Reconcile Logs

--- a/image/cli/mascli/must-gather/mg-collect-mas-manage
+++ b/image/cli/mascli/must-gather/mg-collect-mas-manage
@@ -8,7 +8,7 @@ OUTPUT_DIR=$2
 
 # Collect Maxinst Logs
 # -----------------------------------------------------------------------------
-echo_h4 "Collect Manage Logs"
+echo_h4 "Collect Manage Files"
 $DIR/mg-collect-manage-logs $NAMESPACE $OUTPUT_DIR
 
 # Collect Reconcile Logs

--- a/image/cli/mascli/must-gather/mg-collect-mas-manage
+++ b/image/cli/mascli/must-gather/mg-collect-mas-manage
@@ -6,7 +6,7 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 NAMESPACE=$1
 OUTPUT_DIR=$2
 
-# Collect Maxinst Logs
+# Collect Manage Logs
 # -----------------------------------------------------------------------------
 echo_h4 "Collect Manage Files"
 $DIR/mg-collect-manage-logs $NAMESPACE $OUTPUT_DIR

--- a/image/cli/mascli/must-gather/mg-collect-mas-manage
+++ b/image/cli/mascli/must-gather/mg-collect-mas-manage
@@ -9,6 +9,7 @@ OUTPUT_DIR=$2
 # Collect Reconcile Logs
 # -----------------------------------------------------------------------------
 echo_h4 "Collect Reconcile Logs"
+
 # Operators
 $DIR/mg-collect-reconcile-logs $NAMESPACE control-plane ibm-mas-manage $OUTPUT_DIR
 $DIR/mg-collect-reconcile-logs $NAMESPACE mas.ibm.com/appType imagestitching-entitymgr-operator $OUTPUT_DIR


### PR DESCRIPTION
**Description:** Implementing the stories
1. [MASISMIG-49566](https://jsw.ibm.com/browse/MASISMIG-49566) - To collect the files that are available under logs folder for Manage/Maxinst pod
2. [MASISMIG-49867](https://jsw.ibm.com/browse/MASISMIG-49867) - To collect the files that are available under temp folder for db2u/c-db2wh-manage-db2u-0 and db2u/c-db2w-shared-db2u-0

**Scripts execution:** scripts were executed locally against ocp13 (Rabbit's Cluster) and IVT90-x1 environment. No problems were found. Attached resumed ivt execution log.
[must-gather-01_23.zip](https://github.com/ibm-mas/cli/files/14029050/must-gather-01_23.zip)
