### PR TITLE
[minor] Removed metric api

### DIFF
--- a/tekton/src/pipelines/taskdefs/fvt-manage/phase2.yml.j2
+++ b/tekton/src/pipelines/taskdefs/fvt-manage/phase2.yml.j2
@@ -4,7 +4,6 @@
 # - fvt-manage-classification
 # - fvt-manage-helplinks
 # - fvt-manage-mif-setup
-# - fvt-manage-metrics-api
 # - fvt-manage-wo-basic
 # - fvt-manage-ancestors
 # - fvt-manage-automationscripts
@@ -62,20 +61,6 @@
       value: core
     - name: fvt_test_suite
       value: mif-setup
-  runAfter:
-    - fvt-manage-setup
-    - fvt-manage-monitoring
-
-# Manage FVT Metrics API
-- name: fvt-manage-metrics-api
-  {{ lookup('template', 'taskdefs/fvt-manage/ui/taskref.yml.j2') | indent(2) }}
-  {{ lookup('template', 'taskdefs/fvt-manage/ui/when.yml.j2') | indent(2) }}
-  params:
-    {{ lookup('template', 'taskdefs/fvt-manage/ui/params.yml.j2') | indent(4) }}
-    - name: fvt_test_suite_prefix
-      value: core
-    - name: fvt_test_suite
-      value: metrics-api
   runAfter:
     - fvt-manage-setup
     - fvt-manage-monitoring

--- a/tekton/src/pipelines/taskdefs/fvt-manage/phase3.yml.j2
+++ b/tekton/src/pipelines/taskdefs/fvt-manage/phase3.yml.j2
@@ -26,7 +26,6 @@
     - fvt-manage-classification
     - fvt-manage-helplinks
     - fvt-manage-mif-setup
-    - fvt-manage-metrics-api
     - fvt-manage-wo-basic
     - fvt-manage-ancestors
     - fvt-manage-automationscripts
@@ -46,7 +45,6 @@
     - fvt-manage-classification
     - fvt-manage-helplinks
     - fvt-manage-mif-setup
-    - fvt-manage-metrics-api
     - fvt-manage-wo-basic
     - fvt-manage-ancestors
     - fvt-manage-automationscripts
@@ -66,7 +64,6 @@
     - fvt-manage-classification
     - fvt-manage-helplinks
     - fvt-manage-mif-setup
-    - fvt-manage-metrics-api
     - fvt-manage-wo-basic
     - fvt-manage-ancestors
     - fvt-manage-automationscripts
@@ -102,7 +99,6 @@
     - fvt-manage-classification
     - fvt-manage-helplinks
     - fvt-manage-mif-setup
-    - fvt-manage-metrics-api
     - fvt-manage-wo-basic
     - fvt-manage-ancestors
     - fvt-manage-automationscripts
@@ -122,7 +118,6 @@
     - fvt-manage-classification
     - fvt-manage-helplinks
     - fvt-manage-mif-setup
-    - fvt-manage-metrics-api
     - fvt-manage-wo-basic
     - fvt-manage-ancestors
     - fvt-manage-automationscripts
@@ -142,7 +137,6 @@
     - fvt-manage-classification
     - fvt-manage-helplinks
     - fvt-manage-mif-setup
-    - fvt-manage-metrics-api
     - fvt-manage-wo-basic
     - fvt-manage-ancestors
     - fvt-manage-automationscripts
@@ -162,7 +156,6 @@
     - fvt-manage-classification
     - fvt-manage-helplinks
     - fvt-manage-mif-setup
-    - fvt-manage-metrics-api
     - fvt-manage-wo-basic
     - fvt-manage-ancestors
     - fvt-manage-automationscripts
@@ -182,7 +175,6 @@
     - fvt-manage-classification
     - fvt-manage-helplinks
     - fvt-manage-mif-setup
-    - fvt-manage-metrics-api
     - fvt-manage-wo-basic
     - fvt-manage-ancestors
     - fvt-manage-automationscripts
@@ -202,7 +194,6 @@
     - fvt-manage-classification
     - fvt-manage-helplinks
     - fvt-manage-mif-setup
-    - fvt-manage-metrics-api
     - fvt-manage-wo-basic
     - fvt-manage-ancestors
     - fvt-manage-automationscripts


### PR DESCRIPTION
**fvt-manage-metrics-api** - This is a selenium framework-based API test that gets the token from the browser cache store and then hits the endpoint to validate the Prometheus metrics. Currently, failing while getting into Manage. 

**fvt-manage-monitoring** - This is an alternative to metric-api test that already validates the same thing directly in the cluster using open shift APIs. 

Hence, this change will no longer keep metric-api in CLI.

![image](https://github.com/ibm-mas/cli/assets/131964221/b899294d-927f-4e7d-a19e-9df36f9fb2d5)
