### PR TITLE
[patch] Move IoT install to after suite-db2-setup-system

### DIFF
--- a/tekton/src/pipelines/install-with-fvt.yml.j2
+++ b/tekton/src/pipelines/install-with-fvt.yml.j2
@@ -282,9 +282,12 @@ spec:
     # 6. Install & Configure IoT
     # -------------------------------------------------------------------------
     # 6.1 Install IoT
+    #
+    # Note: In the case of manage using the shared Db2 instance only start the
+    # IoT install *after* any Manage database preparation has completed
     {{ lookup('template', 'taskdefs/apps/iot-app.yml.j2') | indent(4) }}
       runAfter:
-        - suite-config-db2
+        - suite-db2-setup-system
         - suite-config-kafka
 
     # 6.2 Configure IoT workspace
@@ -484,7 +487,7 @@ spec:
           values: ["true", "True"]
       runAfter:
         - app-cfg-manage
-    
+
     # 18. Application FVT - Manage Civil
     # -------------------------------------------------------------------------
     # 22. Application FVT - Civil
@@ -504,7 +507,7 @@ spec:
           values: ["true", "True"]
       runAfter:
         - launchfvt-manage
-    
+
     # 19. Application FVT - Manage IS (Industry Solutions)
     # -------------------------------------------------------------------------
     - name: launchfvt-manage-is

--- a/tekton/src/pipelines/install.yml.j2
+++ b/tekton/src/pipelines/install.yml.j2
@@ -217,9 +217,12 @@ spec:
     # 6. Install & Configure IoT
     # -------------------------------------------------------------------------
     # 6.1 Install IoT
+    #
+    # Note: In the case of manage using the shared Db2 instance only start the
+    # IoT install *after* any Manage database preparation has completed
     {{ lookup('template', 'taskdefs/apps/iot-app.yml.j2') | indent(4) }}
       runAfter:
-        - suite-config-db2
+        - suite-db2-setup-system
         - suite-config-kafka
 
     # 6.2 Configure IoT workspace


### PR DESCRIPTION
More a working theory than anything, but this change will delay the start of IoT installation until after any system database preparation for Manage has been completed.