### PR TITLE
[patch] Export missing OCP_RELEASE variable

### DIFF
--- a/image/cli/mascli/functions/configure_mirror
+++ b/image/cli/mascli/functions/configure_mirror
@@ -145,6 +145,7 @@ function configure_ocp_for_mirror() {
 
   export SETUP_REDHAT_CATALOGS
   export OCP_OPERATORHUB_DISABLE_REDHAT_SOURCES
+  export OCP_RELEASE
 
   echo
   reset_colors


### PR DESCRIPTION
`OCP_RELEASE` environment variable is required when `SETUP_REDHAT_CATALOGS` is enabled, however this variable is not being exported, so is not available in the ansible runtime.

- Fixes #716