### PR TITLE
[patch] Add selenium as mg's extra-namespace

### DIFF
--- a/tekton/src/tasks/must-gather.yml.j2
+++ b/tekton/src/tasks/must-gather.yml.j2
@@ -19,6 +19,8 @@ spec:
         - must-gather
         - --directory
         - $(params.base_output_dir)
+        - --extra-namespaces
+        - selenium
       image: quay.io/ibmmas/cli:latest
       imagePullPolicy: $(params.image_pull_policy)
       env:


### PR DESCRIPTION
Considering protection against not found namespaces here: https://github.com/ibm-mas/cli/blob/master/image/cli/mascli/functions/must_gather#L355, the only change needed to enable mg in selenium namespace is via `--extra-namespaces`

Test

- Collecting `selenium` extra namespace

<img width="672" alt="image" src="https://github.com/ibm-mas/cli/assets/15021471/59da32c8-8fa1-469a-9e9f-4f591bd8f54c">

- `selenium` details as collected by mg:

<img width="452" alt="image" src="https://github.com/ibm-mas/cli/assets/15021471/37a693ef-328e-47c0-8df4-411d803c2782">

