### PR TITLE
[patch] - Manage file collection for Must-Gather

### DIFF
--- a/image/cli/mascli/must-gather/mg-collect-manage-logs
+++ b/image/cli/mascli/must-gather/mg-collect-manage-logs
@@ -28,7 +28,7 @@ if [[ "$POD" != "" ]]; then
   if [[ "$FILE" != "" ]]; then
     createFolder
     oc -n $NAMESPACE exec -it $POD -- cp /tmp/route_manager.log /opt/ansible/route_manager.log
-    oc cp $NAMESPACE/$POD:route_manager.log $OUTPUT_DIR/resources/$NAMESPACE/pods_files/$APP/files/route_manager.log --retries 50
+    oc cp $NAMESPACE/$POD:route_manager.log $OUTPUT_DIR/resources/$NAMESPACE/pods_files/$APP/files/route_manager.log --retries 20
   else
     echo_warning "route_manager.log not available on $POD pod"
   fi
@@ -43,7 +43,7 @@ POD=$(oc -n $NAMESPACE get pods -l "mas.ibm.com/appType= maxinstudb" -o jsonpath
 
 if [[ "$POD" != "" ]]; then
   createFolder 
-  oc cp $NAMESPACE/$POD:log $OUTPUT_DIR/resources/$NAMESPACE/pods_files/$APP/files --retries 50
+  oc cp $NAMESPACE/$POD:log $OUTPUT_DIR/resources/$NAMESPACE/pods_files/$APP/files --retries 20
 else
   echo_warning "Maxinst pod was not found"
 fi
@@ -57,7 +57,7 @@ echo "- ${COLOR_BLUE} Getting db2u Pod Files${TEXT_RESET}"
     if [[ "$POD_NAME" != "" ]]; then
       for POD in ${POD_NAME[@]}; do
         createFolder
-        oc cp $NAMESPACE/$POD:tmp $OUTPUT_DIR/resources/$NAMESPACE/pods_files/$APP/files --retries 50
+        oc cp $NAMESPACE/$POD:tmp $OUTPUT_DIR/resources/$NAMESPACE/pods_files/$APP/files --retries 20
       done
     else
       echo_warning "DB2U pod was not found"
@@ -75,7 +75,7 @@ if [[ "$POD_NAME" != "" ]]; then
   for POD in ${POD_NAME[@]}; do
     createFolder
     oc -n $NAMESPACE exec -it $POD -- /bin/sh -c "cp -R ./logs ./tmp/bundle"
-    oc cp $NAMESPACE/$POD:tmp/bundle $OUTPUT_DIR/resources/$NAMESPACE/pods_files/$APP/files --retries 50
+    oc cp $NAMESPACE/$POD:tmp/bundle $OUTPUT_DIR/resources/$NAMESPACE/pods_files/$APP/files --retries 20
     oc -n $NAMESPACE exec -it $POD -- /bin/sh -c "rm -rf ./tmp/bundle"
   done
 else

--- a/image/cli/mascli/must-gather/mg-collect-manage-logs
+++ b/image/cli/mascli/must-gather/mg-collect-manage-logs
@@ -18,40 +18,68 @@ createFolder () {
   mkdir -p "$OUTPUT_DIR/resources/$NAMESPACE/pods_files/$APP/files"
 }
 
+# Getting route_manager.log from EntityMgr-WS Pod
+# ==================================================
+echo "- ${COLOR_BLUE} Getting route_manager.log from EntityMgr-WS Pod ${TEXT_RESET}"
+NAMESPACE=$1
+POD=$(oc -n $NAMESPACE get pods -l "mas.ibm.com/appType= entitymgr-ws-operator" -o jsonpath="{.items[*].metadata.name}")
+if [[ "$POD" != "" ]]; then
+  FILE="$(oc -n $NAMESPACE exec -it $POD -c manager -- find /tmp -iname 'route_manager*' -type f)"
+  if [[ "$FILE" != "" ]]; then
+    createFolder
+    oc -n $NAMESPACE exec -it $POD -- cp /tmp/route_manager.log /opt/ansible/route_manager.log
+    oc cp $NAMESPACE/$POD:route_manager.log $OUTPUT_DIR/resources/$NAMESPACE/pods_files/$APP/files/route_manager.log --retries 50
+  else
+    echo_warning "route_manager.log not available on $POD pod"
+  fi
+else
+  echo_warning "$POD pod was not found"
+fi
+
 # Getting Maxinst Pod Files
 # =========================
 echo "- ${COLOR_BLUE} Getting Maxinst Pod Files${TEXT_RESET}"
 POD=$(oc -n $NAMESPACE get pods -l "mas.ibm.com/appType= maxinstudb" -o jsonpath="{.items[*].metadata.name}")
 
-if [[ "$POD" == "" ]]; then
+if [[ "$POD" != "" ]]; then
+  createFolder 
+  oc cp $NAMESPACE/$POD:log $OUTPUT_DIR/resources/$NAMESPACE/pods_files/$APP/files --retries 50
+else
   echo_warning "Maxinst pod was not found"
-  exit 1
 fi
-createFolder 
-
-# Copying files to folder
-oc cp $NAMESPACE/$POD:log $OUTPUT_DIR/resources/$NAMESPACE/pods_files/$APP/files --retries=-1
-
 
 # Getting db2u Pod Files
 # =========================
 echo "- ${COLOR_BLUE} Getting db2u Pod Files${TEXT_RESET}"
-#  NAMESPACE_LOOKUP=$(oc get namespace db2u --ignore-not-found)
  NAMESPACE=$(oc get namespace db2u -o jsonpath='{.metadata.name}' --ignore-not-found)
   if [[ "$NAMESPACE" != "" ]]; then
     POD_NAME=$(oc -n $NAMESPACE get pods -l "type=engine" -o jsonpath="{.items[*].metadata.name}")
-    for POD in ${POD_NAME[@]}; do
-      if [[ "$POD_NAME" == "" ]]; then
-        echo_warning "DB2U pod was not found"
-        exit 1
-      fi
-      createFolder
-      
-      # Copying files to folder
-      oc cp $NAMESPACE/$POD:tmp $OUTPUT_DIR/resources/$NAMESPACE/pods_files/$APP/files --retries=-1
-    done
+    if [[ "$POD_NAME" != "" ]]; then
+      for POD in ${POD_NAME[@]}; do
+        createFolder
+        oc cp $NAMESPACE/$POD:tmp $OUTPUT_DIR/resources/$NAMESPACE/pods_files/$APP/files --retries 50
+      done
+    else
+      echo_warning "DB2U pod was not found"
+    fi
   else
     echo_highlight "Unable to find db2u namespace"
   fi
+
+# Getting Server Bundle Pod Files
+# =========================
+echo "- ${COLOR_BLUE} Getting Server Bundle Pod Files${TEXT_RESET}"
+NAMESPACE=$1
+POD_NAME=$(oc -n $NAMESPACE get pods -l "mas.ibm.com/appType= serverBundle" -o jsonpath="{.items[*].metadata.name}")
+if [[ "$POD_NAME" != "" ]]; then
+  for POD in ${POD_NAME[@]}; do
+    createFolder
+    oc -n $NAMESPACE exec -it $POD -- /bin/sh -c "cp -R ./logs ./tmp/bundle"
+    oc cp $NAMESPACE/$POD:tmp/bundle $OUTPUT_DIR/resources/$NAMESPACE/pods_files/$APP/files --retries 50
+    oc -n $NAMESPACE exec -it $POD -- /bin/sh -c "rm -rf ./tmp/bundle"
+  done
+else
+  echo_warning "Server Bundle pod was not found"
+fi
 
 exit 0


### PR DESCRIPTION
This is a request to Manage team, to have Must-Gather collecting besides Manage logs, some files as well. 
Those files come from different folders  and they are needed to help debugging problems. On this story [MASISMIG-49567](https://jsw.ibm.com/browse/MASISMIG-49567) we're collecting the logs from the server bundles : 

![server2](https://github.com/ibm-mas/cli/assets/32779810/d25a9a46-0c86-4491-b922-43f16bc79827)

and a single log from entitymgr-ws pod:

![route](https://github.com/ibm-mas/cli/assets/32779810/7679a37d-73c6-40e7-afa2-50abfb331513)

This code has been tested against some enviroments on Rabbits cluster and also IVT90x-01. Below attached today's execution from IVT90x-01.

[20240209-125744 2.zip](https://github.com/ibm-mas/cli/files/14224005/20240209-125744.2.zip)
