### PR TITLE
[patch] Workaround for minimizing Manage Phase 2 session issues

### DIFF
--- a/tekton/src/pipelines/fvt-manage.yml.j2
+++ b/tekton/src/pipelines/fvt-manage.yml.j2
@@ -99,6 +99,7 @@ spec:
     {{ lookup('template', 'taskdefs/fvt-manage/phase0.yml.j2') | indent(4) }}
     {{ lookup('template', 'taskdefs/fvt-manage/phase1.yml.j2') | indent(4) }}
     {{ lookup('template', 'taskdefs/fvt-manage/phase2.yml.j2') | indent(4) }}
+    {{ lookup('template', 'taskdefs/fvt-manage/phase2-5.yml.j2') | indent(4) }}
 
     # Phases 2-5 disabled.  Focus on getting phase 0 & 1 suites 100% reliable
     # -------------------------------------------------------------------------

--- a/tekton/src/pipelines/taskdefs/fvt-manage/phase2-5.yml.j2
+++ b/tekton/src/pipelines/taskdefs/fvt-manage/phase2-5.yml.j2
@@ -1,0 +1,32 @@
+# -------------------------------------------------------------
+# PHASE 2.5 (temporary workaround) - one after the other
+# - fvt-manage-mas-navigation (selenium)
+# - fvt-manage-mif-setup (selenium)
+# -------------------------------------------------------------
+
+# Manage FVT Mas Navigation Scenario
+- name: fvt-manage-mas-navigation
+  {{ lookup('template', 'taskdefs/fvt-manage/ui/taskref.yml.j2') | indent(2) }}
+  {{ lookup('template', 'taskdefs/fvt-manage/ui/when.yml.j2') | indent(2) }}
+  params:
+    {{ lookup('template', 'taskdefs/fvt-manage/ui/params.yml.j2') | indent(4) }}
+    - name: fvt_test_suite_prefix
+      value: base
+    - name: fvt_test_suite
+      value: mas-navigation
+  runAfter:
+    - fvt-manage-setup
+    - fvt-manage-monitoring
+
+# Manage MIF setup
+- name: fvt-manage-mif-setup
+  {{ lookup('template', 'taskdefs/fvt-manage/ui/taskref.yml.j2') | indent(2) }}
+  {{ lookup('template', 'taskdefs/fvt-manage/ui/when.yml.j2') | indent(2) }}
+  params:
+    {{ lookup('template', 'taskdefs/fvt-manage/ui/params.yml.j2') | indent(4) }}
+    - name: fvt_test_suite_prefix
+      value: base
+    - name: fvt_test_suite
+      value: mif-setup
+  runAfter:
+    - fvt-manage-mas-navigation

--- a/tekton/src/pipelines/taskdefs/fvt-manage/phase2.yml.j2
+++ b/tekton/src/pipelines/taskdefs/fvt-manage/phase2.yml.j2
@@ -1,27 +1,13 @@
 # -------------------------------------------------------------
 # PHASE 2
-# - fvt-manage-mas-navigation (selenium)
+# - fvt-manage-mas-navigation (selenium) (temp moved to 2-5.yml.j2)
 # - fvt-manage-classification (selenium)
 # - fvt-manage-helplinks (selenium)
-# - fvt-manage-mif-setup (selenium)
+# - fvt-manage-mif-setup (selenium) (temp moved to 2-5.yml.j2)
 # - fvt-manage-wo-basic (selenium)
 # - fvt-manage-ancestors (pytest)
 # - fvt-manage-automationscripts (pytest)
 # -------------------------------------------------------------
-
-# Manage FVT Mas Navigation Scenario
-- name: fvt-manage-mas-navigation
-  {{ lookup('template', 'taskdefs/fvt-manage/ui/taskref.yml.j2') | indent(2) }}
-  {{ lookup('template', 'taskdefs/fvt-manage/ui/when.yml.j2') | indent(2) }}
-  params:
-    {{ lookup('template', 'taskdefs/fvt-manage/ui/params.yml.j2') | indent(4) }}
-    - name: fvt_test_suite_prefix
-      value: base
-    - name: fvt_test_suite
-      value: mas-navigation
-  runAfter:
-    - fvt-manage-setup
-    - fvt-manage-monitoring
     
 # Manage FVT Classification
 - name: fvt-manage-classification
@@ -47,20 +33,6 @@
       value: base
     - name: fvt_test_suite
       value: helplinks
-  runAfter:
-    - fvt-manage-setup
-    - fvt-manage-monitoring
-
-# Manage MIF setup
-- name: fvt-manage-mif-setup
-  {{ lookup('template', 'taskdefs/fvt-manage/ui/taskref.yml.j2') | indent(2) }}
-  {{ lookup('template', 'taskdefs/fvt-manage/ui/when.yml.j2') | indent(2) }}
-  params:
-    {{ lookup('template', 'taskdefs/fvt-manage/ui/params.yml.j2') | indent(4) }}
-    - name: fvt_test_suite_prefix
-      value: base
-    - name: fvt_test_suite
-      value: mif-setup
   runAfter:
     - fvt-manage-setup
     - fvt-manage-monitoring


### PR DESCRIPTION
`mas-navigation` and `mif-setup` has been isolated from phase 2 and now they run one after the other before phase 3. It proved a good move in fvtnocpd, where no session was reproduced in phase 2 selenium tests. Goal is keep that run across all the pipelines with we don't have an answer back from docker-selenium team: https://github.com/SeleniumHQ/docker-selenium/issues/2129