### PR TITLE
[patch] Adding env for pytest upload issue

### DIFF
--- a/tekton/src/tasks/fvt/fvt-manage-pytest.yml.j2
+++ b/tekton/src/tasks/fvt/fvt-manage-pytest.yml.j2
@@ -108,7 +108,17 @@ spec:
         value: "$(params.fvt_enable_debug)"
 
       - name: ARTIFACTORY_TOKEN
-        value: $(params.artifactory_token)
+        valueFrom:
+          secretKeyRef:
+            name: mas-devops
+            key: ARTIFACTORY_TOKEN
+            optional: true
+      - name: ARTIFACTORY_UPLOAD_DIR
+        valueFrom:
+          secretKeyRef:
+            name: mas-devops
+            key: ARTIFACTORY_UPLOAD_DIR
+            optional: true
       
       # Black and white listing
       - name: FVT_BLACKLIST


### PR DESCRIPTION
The Manage pytest logs were not getting uploaded due to missing env ARTIFACTORY_UPLOAD_DIR. 

This change should fix this issue.