### PR TITLE
[patch] pytest artifactory issue

### DIFF
--- a/tekton/src/tasks/fvt/fvt-manage-pytest.yml.j2
+++ b/tekton/src/tasks/fvt/fvt-manage-pytest.yml.j2
@@ -109,6 +109,13 @@ spec:
 
       - name: ARTIFACTORY_TOKEN
         value: $(params.artifactory_token)
+        
+      - name: ARTIFACTORY_UPLOAD_DIR
+        valueFrom:
+          secretKeyRef:
+            name: mas-devops
+            key: ARTIFACTORY_UPLOAD_DIR
+            optional: true
       
       # Black and white listing
       - name: FVT_BLACKLIST


### PR DESCRIPTION
The Manage pytest logs were not getting uploaded due to missing env ARTIFACTORY_UPLOAD_DIR.

This change should fix this issue.