### PR TITLE
[patch] Mongo remove upgrade assert

### DIFF
--- a/image/cli/mascli/functions/update
+++ b/image/cli/mascli/functions/update
@@ -110,7 +110,7 @@ function validate_existing_mongo() {
     # Check that current mongo version is lower or equal than target mongo version, if not block user from downgrading mongo
     if [ ! "$(printf '%s\n' "$MONGODB_CURRENT_VERSION" "$MONGODB_TARGET_VERSION" | sort -V | head -n1)" = "$MONGODB_CURRENT_VERSION" ]; then
         echo
-        echo -e "${COLOR_RED}MongoDB Community Edition is currently running on version ${MONGODB_CURRENT_VERSION} and cannot be downgraded to version ${MONGODB_TARGET_VERSION}"
+        echo -e "${COLOR_RED}MongoDB Community Edition is currently running on version ${MONGODB_CURRENT_VERSION} and cannot be downgraded to target version ${MONGODB_TARGET_VERSION}, which is the MongoDB version you would get when choosing MAS catalog '$MAS_CATALOG_VERSION'"
         exit 1
     fi
   fi

--- a/image/cli/mascli/functions/update
+++ b/image/cli/mascli/functions/update
@@ -81,7 +81,7 @@ function validate_existing_mongo() {
     # Lookup existing MongoDb instance
     MONGODB_CURRENT_VERSION=`oc get mongodbcommunity.mongodbcommunity.mongodb.com -A -o jsonpath='{.items[0].status.version}' 2> /dev/null`
     # Target mongo version will be defined by chosen catalog/casebundle
-    MONGODB_TARGET_VERSION=`yq -r .mongo_extras_version_default ansible-devops/common_vars/casebundles/${MAS_CATALOG_VERSION}.yml` || echo -e "Not able to find MongoDB version from '$MAS_CATALOG_VERSION', make sure you are choosing a valid MAS catalog!" && exit 1
+    MONGODB_TARGET_VERSION=`yq -r .mongo_extras_version_default ansible-devops/common_vars/casebundles/${MAS_CATALOG_VERSION}.yml`
 
     MONGODB_CURRENT_MAJORMINOR_VERSION=${MONGODB_CURRENT_VERSION:0:3}
     MONGODB_TARGET_MAJORMINOR_VERSION=${MONGODB_TARGET_VERSION:0:3}

--- a/image/cli/mascli/functions/update
+++ b/image/cli/mascli/functions/update
@@ -102,9 +102,16 @@ function validate_existing_mongo() {
         echo
         echo -e "${COLOR_RED}By choosing '$MAS_CATALOG_VERSION' catalog, you must confirm MongoDB upgrade to version 5.${TEXT_RESET}"
         echo -e "${COLOR_RED}Add '--mongodb-v5-upgrade' argument to the 'mas update' command in order to continue.${TEXT_RESET}"
-        exit 1
+        # exit 1
         fi
       fi
+    fi
+
+    # Check that current mongo version is lower or equal than target mongo version, if not block user from downgrading mongo
+    if [ ! "$(printf '%s\n' "$MONGODB_CURRENT_VERSION" "$MONGODB_TARGET_VERSION" | sort -V | head -n1)" = "$MONGODB_CURRENT_VERSION" ]; then
+        echo
+        echo -e "${COLOR_RED}MongoDB Community Edition is currently running on version ${MONGODB_CURRENT_VERSION} and cannot be downgraded to version ${MONGODB_TARGET_VERSION}"
+        exit 1
     fi
   fi
 }

--- a/image/cli/mascli/functions/update
+++ b/image/cli/mascli/functions/update
@@ -102,7 +102,7 @@ function validate_existing_mongo() {
         echo
         echo -e "${COLOR_RED}By choosing '$MAS_CATALOG_VERSION' catalog, you must confirm MongoDB upgrade to version 5.${TEXT_RESET}"
         echo -e "${COLOR_RED}Add '--mongodb-v5-upgrade' argument to the 'mas update' command in order to continue.${TEXT_RESET}"
-        # exit 1
+        exit 1
         fi
       fi
     fi

--- a/image/cli/mascli/functions/update
+++ b/image/cli/mascli/functions/update
@@ -81,7 +81,7 @@ function validate_existing_mongo() {
     # Lookup existing MongoDb instance
     MONGODB_CURRENT_VERSION=`oc get mongodbcommunity.mongodbcommunity.mongodb.com -A -o jsonpath='{.items[0].status.version}' 2> /dev/null`
     # Target mongo version will be defined by chosen catalog/casebundle
-    MONGODB_TARGET_VERSION=`yq -r .mongo_extras_version_default ansible-devops/common_vars/casebundles/${MAS_CATALOG_VERSION}.yml`
+    MONGODB_TARGET_VERSION=`yq -r .mongo_extras_version_default ansible-devops/common_vars/casebundles/${MAS_CATALOG_VERSION}.yml` || echo -e "Not able to find MongoDB version from '$MAS_CATALOG_VERSION', make sure you are choosing a valid MAS catalog!" && exit 1
 
     MONGODB_CURRENT_MAJORMINOR_VERSION=${MONGODB_CURRENT_VERSION:0:3}
     MONGODB_TARGET_MAJORMINOR_VERSION=${MONGODB_TARGET_VERSION:0:3}
@@ -98,7 +98,7 @@ function validate_existing_mongo() {
         MONGODB_V5_UPGRADE=true
         echo
       else
-        if [[ -z "$MONGODB_V5_UPGRADE" ]] ; then # if 'mas update -c v8-231128-amd64 --no-confirm' but no '--mongodb-v5-upgrade' then we fail as user must consent about the mongodb upgrade
+        if [[ -z "$MONGODB_V5_UPGRADE" ]] ; then # if 'mas update -c v8-240130-amd64 --no-confirm' but no '--mongodb-v5-upgrade' then we fail as user must consent about the mongodb upgrade
         echo
         echo -e "${COLOR_RED}By choosing '$MAS_CATALOG_VERSION' catalog, you must confirm MongoDB upgrade to version 5.${TEXT_RESET}"
         echo -e "${COLOR_RED}Add '--mongodb-v5-upgrade' argument to the 'mas update' command in order to continue.${TEXT_RESET}"

--- a/image/cli/mascli/functions/update
+++ b/image/cli/mascli/functions/update
@@ -89,13 +89,22 @@ function validate_existing_mongo() {
     # Let users know that Mongo will be upgraded if existing MongoDb major.minor version is lower than the target major version
     # We don't show this message for normal updates, e.g. 5.0.1 to 5.0.2
     if [ ! "$(printf '%s\n' "$MONGODB_TARGET_MAJORMINOR_VERSION" "$MONGODB_CURRENT_MAJORMINOR_VERSION" | sort -V | head -n1)" = "$MONGODB_TARGET_MAJORMINOR_VERSION" ]; then
-      echo_highlight "Dependency Upgrade Notice!"
-      echo_highlight "MongoDB Community Edition is currently running on version ${MONGODB_CURRENT_VERSION} and will be upgraded to version ${MONGODB_TARGET_VERSION}"
-      echo
-      echo_highlight "It is recommended that you backup your MongoDB instance before proceeding:"
-      echo -e "${COLOR_CYAN}${TEXT_UNDERLINE}https://www.ibm.com/docs/en/mas-cd/continuous-delivery?topic=suite-backing-up-mongodb-maximo-application${TEXT_RESET}"
-      MONGODB_V5_UPGRADE=true
-      echo
+      if [[ -z "$NO_CONFIRM" ]] ; then # if 'mas update -c v8-231128-amd64', but '--no--confirm' is not set, then we proceed and warn user of the mongodb upgrade, users will still have a chance to abort
+        echo_highlight "Dependency Upgrade Notice!"
+        echo_highlight "MongoDB Community Edition is currently running on version ${MONGODB_CURRENT_VERSION} and will be upgraded to version ${MONGODB_TARGET_VERSION}"
+        echo
+        echo_highlight "It is recommended that you backup your MongoDB instance before proceeding:"
+        echo -e "${COLOR_CYAN}${TEXT_UNDERLINE}https://www.ibm.com/docs/en/mas-cd/continuous-delivery?topic=suite-backing-up-mongodb-maximo-application${TEXT_RESET}"
+        MONGODB_V5_UPGRADE=true
+        echo
+      else
+        if [[ -z "$MONGODB_V5_UPGRADE" ]] ; then # if 'mas update -c v8-231128-amd64 --no-confirm' but no '--mongodb-v5-upgrade' then we fail as user must consent about the mongodb upgrade
+        echo
+        echo -e "${COLOR_RED}By choosing '$MAS_CATALOG_VERSION' catalog, you must confirm MongoDB upgrade to version 5.${TEXT_RESET}"
+        echo -e "${COLOR_RED}Add '--mongodb-v5-upgrade' argument to the 'mas update' command in order to continue.${TEXT_RESET}"
+        exit 1
+        fi
+      fi
     fi
   fi
 }
@@ -228,22 +237,7 @@ function validate_update() {
   validate_existing_cert_manager
 
   # Validates MongoDB upgrade is confirmed while using November catalog
-  MAS_CATALOG_DATE=${MAS_CATALOG_VERSION:3:6}
-  if [[ $MAS_CATALOG_DATE -ge 231128 ]]; then # checks if MAS catalog >= November 2023
-    if [[ -z "$NO_CONFIRM" ]] ; then # if 'mas update -c v8-231128-amd64', then we proceed and check existing mongo and warn user of the mongodb upgrade
-      validate_existing_mongo
-    else
-      if [[ -z "$MONGODB_V5_UPGRADE" ]] ; then # if 'mas update -c v8-231128-amd64 --no-confirm' but no '--mongodb-v5-upgrade' then we fail as user must consent about the mongodb upgrade
-        echo
-        echo -e "${COLOR_RED}By choosing '$MAS_CATALOG_VERSION' catalog, you must confirm MongoDB upgrade to version 5.${TEXT_RESET}"
-        echo -e "${COLOR_RED}Add '--mongodb-v5-upgrade' argument to the 'mas update' command in order to continue.${TEXT_RESET}"
-        exit 1
-      else # if 'mas update -c v8-231128-amd64 --mongodb-v5-upgrade --no-confirm' then we proceed and check existing mongo and warn user of the mongodb upgrade
-        validate_existing_mongo
-      fi
-    fi
-  fi
-
+  validate_existing_mongo
 
   # Validates UDS to DRO migration only if UDS is running and January catalog or more recent is used
   validate_dro_migration


### PR DESCRIPTION
This PR fixes a problem where we were expecting `--mongo-v5-upgrade` to be passed in when using `--no-confirm` flag even if the Mongo was already upgraded to v5. The condition to enforce `--mongo-v5-upgrade` is now inside the parent condition that checks if MongoDB version needs upgrading.

Tests to prove it's working well now:

**1. Upgrade Mongo v4 to v5**

Interactive mode, warning will still be shown to let users know about the upgrade:
<img width="1500" alt="image" src="https://github.com/ibm-mas/cli/assets/31037381/d1aff2f6-ddb2-4006-8c8e-0775f86f163a">

Non-interactive with `--no-confirm` - it must fail as `--mongo-v5-upgrade` was not set:

<img width="1426" alt="image" src="https://github.com/ibm-mas/cli/assets/31037381/abf3eadc-af7b-4f17-8674-aa68b49e2600">

Non-interactive with `--no-confirm --mongo-v5-upgrade` - it must install update pipeline directly:

<img width="1683" alt="image" src="https://github.com/ibm-mas/cli/assets/31037381/0432fa4c-2a5f-41a1-ab0a-4d9d760d2ea5">


**2. Upgrade Mongo v5 to v5:**

Interactive mode - no warning as no update needed:
<img width="1321" alt="image" src="https://github.com/ibm-mas/cli/assets/31037381/0adc8821-e098-4d17-a279-e3e7ccd8298d">

Non-interactive with `--no-confirm` - it must **NOT** ask for `--mongo-v5-upgrade` as no update needed:

<img width="1616" alt="image" src="https://github.com/ibm-mas/cli/assets/31037381/7af77f46-bc45-4650-9961-5d0bea1a08d7">


- Also added an assert to fail early and do not allow Mongo downgrades (currently it's already prevented in ansible-devops but we don't want to get there to fail):