### PR TITLE
[patch] Fixing some error messages for Manage on Must-Gather log

### DIFF
--- a/image/cli/mascli/must-gather/mg-collect-manage-logs
+++ b/image/cli/mascli/must-gather/mg-collect-manage-logs
@@ -57,7 +57,10 @@ echo "- ${COLOR_BLUE} Getting db2u Pod Files${TEXT_RESET}"
     if [[ "$POD_NAME" != "" ]]; then
       for POD in ${POD_NAME[@]}; do
         createFolder
-        oc cp $NAMESPACE/$POD:tmp $OUTPUT_DIR/resources/$NAMESPACE/pods_files/$APP/files --retries 20
+        FILES=$(oc -n db2u exec -i $POD -- /bin/sh -c "find tmp -type f -not -name 'ks*' -not -name 'tmp*'")
+        for FILE in ${FILES[@]}; do
+          oc cp $NAMESPACE/$POD:$FILE $OUTPUT_DIR/resources/$NAMESPACE/pods_files/$APP/files/$FILE --retries 20
+        done
       done
     else
       echo_warning "DB2U pod was not found"

--- a/image/cli/mascli/must-gather/mg-collect-manage-logs
+++ b/image/cli/mascli/must-gather/mg-collect-manage-logs
@@ -7,7 +7,6 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 NAMESPACE=$1
 OUTPUT_DIR=$2
 
-
 createFolder () {
   INSTANCE_ID=$(echo ${NAMESPACE%-*})
   INSTANCE_ID=$(echo ${INSTANCE_ID#*-})

--- a/image/cli/mascli/must-gather/mg-collect-manage-logs
+++ b/image/cli/mascli/must-gather/mg-collect-manage-logs
@@ -59,7 +59,7 @@ echo "- ${COLOR_BLUE} Getting db2u Pod Files${TEXT_RESET}"
         createFolder
         FILES=$(oc -n db2u exec -i $POD -- /bin/sh -c "find tmp -type f -not -name 'ks*' -not -name 'tmp*'")
         for FILE in ${FILES[@]}; do
-          oc cp $NAMESPACE/$POD:$FILE $OUTPUT_DIR/resources/$NAMESPACE/pods_files/$APP/files/$FILE --retries 20
+          oc cp $NAMESPACE/$POD:$FILE $OUTPUT_DIR/resources/$NAMESPACE/pods_files/$APP/files/$FILE --retries 20  > /dev/null 2>&1
         done
       done
     else
@@ -77,9 +77,9 @@ POD_NAME=$(oc -n $NAMESPACE get pods -l "mas.ibm.com/appType= serverBundle" -o j
 if [[ "$POD_NAME" != "" ]]; then
   for POD in ${POD_NAME[@]}; do
     createFolder
-    oc -n $NAMESPACE exec -i $POD -- /bin/sh -c "cp -R ./logs ./tmp/bundle"
-    oc cp $NAMESPACE/$POD:tmp/bundle $OUTPUT_DIR/resources/$NAMESPACE/pods_files/$APP/files --retries 20
-    oc -n $NAMESPACE exec -i $POD -- /bin/sh -c "rm -rf ./tmp/bundle"
+    oc -n $NAMESPACE exec -i $POD -- /bin/sh -c "cp -R ./logs ./tmp/bundle"  > /dev/null 2>&1
+    oc cp $NAMESPACE/$POD:tmp/bundle $OUTPUT_DIR/resources/$NAMESPACE/pods_files/$APP/files --retries 20  > /dev/null 2>&1
+    oc -n $NAMESPACE exec -i $POD -- /bin/sh -c "rm -rf ./tmp/bundle"  > /dev/null 2>&1
   done
 else
   echo_warning "Server Bundle pod was not found"

--- a/image/cli/mascli/must-gather/mg-collect-manage-logs
+++ b/image/cli/mascli/must-gather/mg-collect-manage-logs
@@ -85,4 +85,5 @@ else
   echo_warning "Server Bundle pod was not found"
 fi
 
+
 exit 0

--- a/image/cli/mascli/must-gather/mg-collect-manage-logs
+++ b/image/cli/mascli/must-gather/mg-collect-manage-logs
@@ -53,15 +53,15 @@ fi
 # Getting db2u Pod Files
 # =========================
 echo "- ${COLOR_BLUE} Getting db2u Pod Files${TEXT_RESET}"
- NAMESPACE=$(oc get namespace db2u -o jsonpath='{.metadata.name}' --ignore-not-found 2> /dev/null)
+ NAMESPACE=$(oc get namespace db2u -o jsonpath='{.metadata.name}' --ignore-not-found)
   if [[ "$NAMESPACE" != "" ]]; then
-    POD_NAME=$(oc -n $NAMESPACE get pods -l "type=engine" -o jsonpath="{.items[*].metadata.name}" 2> /dev/null)
+    POD_NAME=$(oc -n $NAMESPACE get pods -l "type=engine" -o jsonpath="{.items[*].metadata.name}")
     if [[ "$POD_NAME" != "" ]]; then
       for POD in ${POD_NAME[@]}; do
         createFolder
-        FILES=$(oc -n db2u exec -i $POD -- /bin/sh -c "find tmp -type f -not -name 'ks*' -not -name 'tmp*'" 2> /dev/null)
+        FILES=$(oc -n db2u exec -i $POD -- /bin/sh -c "find tmp -type f -not -name 'ks*' -not -name 'tmp*'")
         for FILE in ${FILES[@]}; do
-          oc cp $NAMESPACE/$POD:$FILE $OUTPUT_DIR/resources/$NAMESPACE/pods_files/$APP/files/$FILE --retries 20 2> /dev/null
+          oc cp $NAMESPACE/$POD:$FILE $OUTPUT_DIR/resources/$NAMESPACE/pods_files/$APP/files/$FILE --retries 20 > /dev/null 2>&1
         done
       done
     else
@@ -75,13 +75,13 @@ echo "- ${COLOR_BLUE} Getting db2u Pod Files${TEXT_RESET}"
 # =========================
 echo "- ${COLOR_BLUE} Getting Server Bundle Pod Files${TEXT_RESET}"
 NAMESPACE=$1
-POD_NAME=$(oc -n $NAMESPACE get pods -l "mas.ibm.com/appType= serverBundle" -o jsonpath="{.items[*].metadata.name}" 2> /dev/null)
+POD_NAME=$(oc -n $NAMESPACE get pods -l "mas.ibm.com/appType= serverBundle" -o jsonpath="{.items[*].metadata.name}")
 if [[ "$POD_NAME" != "" ]]; then
   for POD in ${POD_NAME[@]}; do
     createFolder
-    oc -n $NAMESPACE exec -i $POD -- /bin/sh -c "cp -R ./logs ./tmp/bundle"  2> /dev/null
-    oc cp $NAMESPACE/$POD:tmp/bundle $OUTPUT_DIR/resources/$NAMESPACE/pods_files/$APP/files --retries 20  2> /dev/null
-    oc -n $NAMESPACE exec -i $POD -- /bin/sh -c "rm -rf ./tmp/bundle"  2> /dev/null
+    oc -n $NAMESPACE exec -i $POD -- /bin/sh -c "cp -R ./logs ./tmp/bundle" > /dev/null 2>&1
+    oc cp $NAMESPACE/$POD:tmp/bundle $OUTPUT_DIR/resources/$NAMESPACE/pods_files/$APP/files --retries 20 > /dev/null 2>&1
+    oc -n $NAMESPACE exec -i $POD -- /bin/sh -c "rm -rf ./tmp/bundle" > /dev/null 2>&1
   done
 else
   echo_warning "Server Bundle pod was not found"

--- a/image/cli/mascli/must-gather/mg-collect-manage-logs
+++ b/image/cli/mascli/must-gather/mg-collect-manage-logs
@@ -7,6 +7,7 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 NAMESPACE=$1
 OUTPUT_DIR=$2
 
+
 createFolder () {
   INSTANCE_ID=$(echo ${NAMESPACE%-*})
   INSTANCE_ID=$(echo ${INSTANCE_ID#*-})
@@ -84,6 +85,5 @@ if [[ "$POD_NAME" != "" ]]; then
 else
   echo_warning "Server Bundle pod was not found"
 fi
-
 
 exit 0

--- a/image/cli/mascli/must-gather/mg-collect-manage-logs
+++ b/image/cli/mascli/must-gather/mg-collect-manage-logs
@@ -24,10 +24,10 @@ echo "- ${COLOR_BLUE} Getting route_manager.log from EntityMgr-WS Pod ${TEXT_RES
 NAMESPACE=$1
 POD=$(oc -n $NAMESPACE get pods -l "mas.ibm.com/appType= entitymgr-ws-operator" -o jsonpath="{.items[*].metadata.name}")
 if [[ "$POD" != "" ]]; then
-  FILE="$(oc -n $NAMESPACE exec -it $POD -c manager -- find /tmp -iname 'route_manager*' -type f)"
+  FILE="$(oc -n $NAMESPACE exec -i $POD -c manager -- find /tmp -iname 'route_manager*' -type f)"
   if [[ "$FILE" != "" ]]; then
     createFolder
-    oc -n $NAMESPACE exec -it $POD -- cp /tmp/route_manager.log /opt/ansible/route_manager.log
+    oc -n $NAMESPACE exec -i $POD -- cp /tmp/route_manager.log /opt/ansible/route_manager.log
     oc cp $NAMESPACE/$POD:route_manager.log $OUTPUT_DIR/resources/$NAMESPACE/pods_files/$APP/files/route_manager.log --retries 20
   else
     echo_warning "route_manager.log not available on $POD pod"
@@ -74,9 +74,9 @@ POD_NAME=$(oc -n $NAMESPACE get pods -l "mas.ibm.com/appType= serverBundle" -o j
 if [[ "$POD_NAME" != "" ]]; then
   for POD in ${POD_NAME[@]}; do
     createFolder
-    oc -n $NAMESPACE exec -it $POD -- /bin/sh -c "cp -R ./logs ./tmp/bundle"
+    oc -n $NAMESPACE exec -i $POD -- /bin/sh -c "cp -R ./logs ./tmp/bundle"
     oc cp $NAMESPACE/$POD:tmp/bundle $OUTPUT_DIR/resources/$NAMESPACE/pods_files/$APP/files --retries 20
-    oc -n $NAMESPACE exec -it $POD -- /bin/sh -c "rm -rf ./tmp/bundle"
+    oc -n $NAMESPACE exec -i $POD -- /bin/sh -c "rm -rf ./tmp/bundle"
   done
 else
   echo_warning "Server Bundle pod was not found"

--- a/image/cli/mascli/must-gather/mg-collect-manage-logs
+++ b/image/cli/mascli/must-gather/mg-collect-manage-logs
@@ -25,11 +25,12 @@ echo "- ${COLOR_BLUE} Getting route_manager.log from EntityMgr-WS Pod ${TEXT_RES
 NAMESPACE=$1
 POD=$(oc -n $NAMESPACE get pods -l "mas.ibm.com/appType= entitymgr-ws-operator" -o jsonpath="{.items[*].metadata.name}")
 if [[ "$POD" != "" ]]; then
-  FILE="$(oc -n $NAMESPACE exec -i $POD -c manager -- find /tmp -iname 'route_manager*' -type f)"
+  FILE=$(oc -n $NAMESPACE exec -i $POD -c manager -- find /tmp -iname 'route_manager*' -type f)
   if [[ "$FILE" != "" ]]; then
     createFolder
     oc -n $NAMESPACE exec -i $POD -- cp /tmp/route_manager.log /opt/ansible/route_manager.log
-    oc cp $NAMESPACE/$POD:route_manager.log $OUTPUT_DIR/resources/$NAMESPACE/pods_files/$APP/files/route_manager.log --retries 20
+    oc cp $NAMESPACE/$POD:route_manager.log $OUTPUT_DIR/resources/$NAMESPACE/pods_files/$APP/files/route_manager.log --retries 20 
+    oc -n $NAMESPACE exec -i $POD -- rm -rf /opt/ansible/route_manager.log
   else
     echo_warning "route_manager.log not available on $POD pod"
   fi
@@ -52,15 +53,15 @@ fi
 # Getting db2u Pod Files
 # =========================
 echo "- ${COLOR_BLUE} Getting db2u Pod Files${TEXT_RESET}"
- NAMESPACE=$(oc get namespace db2u -o jsonpath='{.metadata.name}' --ignore-not-found)
+ NAMESPACE=$(oc get namespace db2u -o jsonpath='{.metadata.name}' --ignore-not-found 2> /dev/null)
   if [[ "$NAMESPACE" != "" ]]; then
-    POD_NAME=$(oc -n $NAMESPACE get pods -l "type=engine" -o jsonpath="{.items[*].metadata.name}")
+    POD_NAME=$(oc -n $NAMESPACE get pods -l "type=engine" -o jsonpath="{.items[*].metadata.name}" 2> /dev/null)
     if [[ "$POD_NAME" != "" ]]; then
       for POD in ${POD_NAME[@]}; do
         createFolder
-        FILES=$(oc -n db2u exec -i $POD -- /bin/sh -c "find tmp -type f -not -name 'ks*' -not -name 'tmp*'")
+        FILES=$(oc -n db2u exec -i $POD -- /bin/sh -c "find tmp -type f -not -name 'ks*' -not -name 'tmp*'" 2> /dev/null)
         for FILE in ${FILES[@]}; do
-          oc cp $NAMESPACE/$POD:$FILE $OUTPUT_DIR/resources/$NAMESPACE/pods_files/$APP/files/$FILE --retries 20  > /dev/null 2>&1
+          oc cp $NAMESPACE/$POD:$FILE $OUTPUT_DIR/resources/$NAMESPACE/pods_files/$APP/files/$FILE --retries 20 2> /dev/null
         done
       done
     else
@@ -74,13 +75,13 @@ echo "- ${COLOR_BLUE} Getting db2u Pod Files${TEXT_RESET}"
 # =========================
 echo "- ${COLOR_BLUE} Getting Server Bundle Pod Files${TEXT_RESET}"
 NAMESPACE=$1
-POD_NAME=$(oc -n $NAMESPACE get pods -l "mas.ibm.com/appType= serverBundle" -o jsonpath="{.items[*].metadata.name}")
+POD_NAME=$(oc -n $NAMESPACE get pods -l "mas.ibm.com/appType= serverBundle" -o jsonpath="{.items[*].metadata.name}" 2> /dev/null)
 if [[ "$POD_NAME" != "" ]]; then
   for POD in ${POD_NAME[@]}; do
     createFolder
-    oc -n $NAMESPACE exec -i $POD -- /bin/sh -c "cp -R ./logs ./tmp/bundle"  > /dev/null 2>&1
-    oc cp $NAMESPACE/$POD:tmp/bundle $OUTPUT_DIR/resources/$NAMESPACE/pods_files/$APP/files --retries 20  > /dev/null 2>&1
-    oc -n $NAMESPACE exec -i $POD -- /bin/sh -c "rm -rf ./tmp/bundle"  > /dev/null 2>&1
+    oc -n $NAMESPACE exec -i $POD -- /bin/sh -c "cp -R ./logs ./tmp/bundle"  2> /dev/null
+    oc cp $NAMESPACE/$POD:tmp/bundle $OUTPUT_DIR/resources/$NAMESPACE/pods_files/$APP/files --retries 20  2> /dev/null
+    oc -n $NAMESPACE exec -i $POD -- /bin/sh -c "rm -rf ./tmp/bundle"  2> /dev/null
   done
 else
   echo_warning "Server Bundle pod was not found"


### PR DESCRIPTION
must-gather.log file is presenting some errors while running for Manage project as shown below. 

![image](https://github.com/ibm-mas/cli/assets/32779810/d9df1228-929f-451b-855b-fc3487113af0)

The related files are being captured as expected however, we'd like to eliminate those messages in order to have a cleaner log. For that, 2 bugs were opened: [MASISMIG-51006](https://jsw.ibm.com/browse/MASISMIG-51006) and [MASISMIG-51505](https://jsw.ibm.com/browse/MASISMIG-51505). 

Several tests were done locally against ivt90x-01 environment and some other personal environments too. Logs are showing better, as below:

Terminal:
![image](https://github.com/ibm-mas/cli/assets/32779810/6b5b76be-0aaa-4fb1-90df-cab03e6810ad)

Must-gather.log: [must-gather.log](https://github.com/ibm-mas/cli/files/14362267/must-gather.log)
![image](https://github.com/ibm-mas/cli/assets/32779810/3b1632e6-b826-4da6-bdac-07e9fd35e12b)


Terminal:
![image](https://github.com/ibm-mas/cli/assets/32779810/264ad725-2fae-41c5-80d1-378d66c705a1)

Must-gather.log:[must-gather.log](https://github.com/ibm-mas/cli/files/14362266/must-gather.log)
![image](https://github.com/ibm-mas/cli/assets/32779810/951b61b5-ee94-45e1-941a-4eabb9250993)


