### PR TITLE
[patch] [mascore-1684] Update deprovision tasks pipelines

### DIFF
--- a/tekton/src/pipelines/gitops/deprovision-cluster.yml.j2
+++ b/tekton/src/pipelines/gitops/deprovision-cluster.yml.j2
@@ -27,10 +27,6 @@ spec:
       type: string
     - name: avp_type
       type: string
-    - name: avp_aws_secret_region
-      type: string
-    - name: avp_aws_secret_key
-      type: string
     - name: avp_aws_access_key
       type: string
 
@@ -68,10 +64,6 @@ spec:
           value: $(params.cluster_name)
         - name: aws_region
           value: $(params.avp_aws_secret_region)
-        - name: aws_secret_access_key
-          value: $(params.avp_aws_secret_key)
-        - name: aws_access_key_id
-          value: $(params.avp_aws_access_key)
         - name: rosa_token
           value: $(params.rosa_token)
         - name: ocp_version

--- a/tekton/src/pipelines/gitops/deprovision-mas-apps.yml.j2
+++ b/tekton/src/pipelines/gitops/deprovision-mas-apps.yml.j2
@@ -22,10 +22,6 @@ spec:
       type: string
     - name: avp_aws_secret_region
       type: string
-    - name: avp_aws_secret_key
-      type: string
-    - name: avp_aws_access_key
-      type: string
 
     # 1. Gitops git Parameters
     # -------------------------------------------------------------------------

--- a/tekton/src/pipelines/gitops/deprovision-mas-instance.yml.j2
+++ b/tekton/src/pipelines/gitops/deprovision-mas-instance.yml.j2
@@ -35,10 +35,6 @@ spec:
       type: string
     - name: avp_aws_secret_region
       type: string
-    - name: avp_aws_secret_key
-      type: string
-    - name: avp_aws_access_key
-      type: string
 
     # 1. Gitops git Parameters
     # -------------------------------------------------------------------------
@@ -250,10 +246,6 @@ spec:
           value: $(params.cluster_name)
         - name: avp_aws_secret_region
           value: $(params.avp_aws_secret_region)
-        - name: avp_aws_secret_key
-          value: $(params.avp_aws_secret_key)
-        - name: avp_aws_access_key
-          value: $(params.avp_aws_access_key)
         - name: mas_instance_id
           value: $(params.mas_instance_id)
         - name: cloud_provider

--- a/tekton/src/tasks/gitops/gitops-delete-kafka-config.yml.j2
+++ b/tekton/src/tasks/gitops/gitops-delete-kafka-config.yml.j2
@@ -26,6 +26,9 @@ spec:
       type: string
     - name: avp_aws_secret_region
       type: string
+    - name: cluster_url
+      type: string
+      default: ""
     - name: argocd_url
       type: string
       default: ""
@@ -55,10 +58,18 @@ spec:
         value: $(params.github_pat)
       - name: SM_AWS_REGION
         value: $(params.avp_aws_secret_region)
+      - name: OCP_SERVER
+        value: $(params.cluster_url)
       - name: ARGOCD_URL
         value: $(params.argocd_url)
       - name: ARGOCD_CHECK
         value: $(params.argocd_check)
+    envFrom:
+      - configMapRef:
+          name: environment-properties
+          optional: true
+      - secretRef:
+          name: secure-properties
   steps:
     - args:
       - |-

--- a/tekton/src/tasks/gitops/gitops-deprovision-app-config.yml.j2
+++ b/tekton/src/tasks/gitops/gitops-deprovision-app-config.yml.j2
@@ -29,6 +29,9 @@ spec:
       type: string
     - name: mas_app_id
       type: string
+    - name: cluster_url
+      type: string
+      default: ""
     - name: argocd_url
       type: string
       default: ""
@@ -60,10 +63,18 @@ spec:
         value: $(params.force_removal)
       - name: MAS_APP_ID
         value: $(params.mas_app_id)
+      - name: OCP_SERVER
+        value: $(params.cluster_url)
       - name: ARGOCD_URL
         value: $(params.argocd_url)
       - name: ARGOCD_CHECK
         value: $(params.argocd_check)
+    envFrom:
+      - configMapRef:
+          name: environment-properties
+          optional: true
+      - secretRef:
+          name: secure-properties
   steps:
     - args:
       - |-

--- a/tekton/src/tasks/gitops/gitops-deprovision-app-install.yml.j2
+++ b/tekton/src/tasks/gitops/gitops-deprovision-app-install.yml.j2
@@ -27,6 +27,9 @@ spec:
       type: string
     - name: mas_app_id
       type: string
+    - name: cluster_url
+      type: string
+      default: ""
     - name: argocd_url
       type: string
       default: ""
@@ -56,10 +59,18 @@ spec:
         value: $(params.force_removal)
       - name: MAS_APP_ID
         value: $(params.mas_app_id)
+      - name: OCP_SERVER
+        value: $(params.cluster_url)
       - name: ARGOCD_URL
         value: $(params.argocd_url)
       - name: ARGOCD_CHECK
         value: $(params.argocd_check)
+    envFrom:
+      - configMapRef:
+          name: environment-properties
+          optional: true
+      - secretRef:
+          name: secure-properties
   steps:
     - args:
       - |-

--- a/tekton/src/tasks/gitops/gitops-deprovision-cluster.yml.j2
+++ b/tekton/src/tasks/gitops/gitops-deprovision-cluster.yml.j2
@@ -26,6 +26,9 @@ spec:
       type: string
     - name: avp_aws_secret_region
       type: string
+    - name: cluster_url
+      type: string
+      default: ""
     - name: argocd_url
       type: string
       default: ""
@@ -55,6 +58,8 @@ spec:
         value: $(params.git_commit_msg)
       - name: SM_AWS_REGION
         value: $(params.avp_aws_secret_region)
+      - name: OCP_SERVER
+        value: $(params.cluster_url)
       - name: ARGOCD_URL
         value: $(params.argocd_url)
       - name: ARGOCD_CHECK

--- a/tekton/src/tasks/gitops/gitops-deprovision-db2u.yml.j2
+++ b/tekton/src/tasks/gitops/gitops-deprovision-db2u.yml.j2
@@ -25,10 +25,9 @@ spec:
       type: string
     - name: avp_aws_secret_region
       type: string
-    - name: avp_aws_secret_key
+    - name: cluster_url
       type: string
-    - name: avp_aws_access_key
-      type: string
+      default: ""
     - name: argocd_url
       type: string
       default: ""
@@ -58,14 +57,18 @@ spec:
         value: $(params.github_pat)  
       - name: SM_AWS_REGION
         value: $(params.avp_aws_secret_region)
-      - name: SM_AWS_SECRET_ACCESS_KEY
-        value: $(params.avp_aws_secret_key)
-      - name: SM_AWS_ACCESS_KEY_ID
-        value: $(params.avp_aws_access_key)
+      - name: OCP_SERVER
+        value: $(params.cluster_url)
       - name: ARGOCD_URL
         value: $(params.argocd_url)
       - name: ARGOCD_CHECK
         value: $(params.argocd_check)
+    envFrom:
+      - configMapRef:
+          name: environment-properties
+          optional: true
+      - secretRef:
+          name: secure-properties
   steps:
     - args:
       - |-

--- a/tekton/src/tasks/gitops/gitops-deprovision-efs.yml.j2
+++ b/tekton/src/tasks/gitops/gitops-deprovision-efs.yml.j2
@@ -25,6 +25,12 @@ spec:
         value: $(params.mas_instance_id)
       - name: CLOUD_PROVIDER
         value: $(params.cloud_provider)
+    envFrom:
+      - configMapRef:
+          name: environment-properties
+          optional: true
+      - secretRef:
+          name: secure-properties
   steps:
     - args:
       - |-

--- a/tekton/src/tasks/gitops/gitops-deprovision-suite-config.yml.j2
+++ b/tekton/src/tasks/gitops/gitops-deprovision-suite-config.yml.j2
@@ -25,12 +25,11 @@ spec:
       type: string
     - name: avp_aws_secret_region
       type: string
-    - name: avp_aws_secret_key
-      type: string
-    - name: avp_aws_access_key
-      type: string
     - name: force_removal
       type: string
+    - name: cluster_url
+      type: string
+      default: ""
     - name: argocd_url
       type: string
       default: ""
@@ -60,16 +59,20 @@ spec:
         value: $(params.github_pat)
       - name: SM_AWS_REGION
         value: $(params.avp_aws_secret_region)
-      - name: SM_AWS_SECRET_ACCESS_KEY
-        value: $(params.avp_aws_secret_key)
-      - name: SM_AWS_ACCESS_KEY_ID
-        value: $(params.avp_aws_access_key)
       - name: FORCE_REMOVAL
         value: $(params.force_removal)
+      - name: OCP_SERVER
+        value: $(params.cluster_url)
       - name: ARGOCD_URL
         value: $(params.argocd_url)
       - name: ARGOCD_CHECK
         value: $(params.argocd_check)
+    envFrom:
+      - configMapRef:
+          name: environment-properties
+          optional: true
+      - secretRef:
+          name: secure-properties
   steps:
     - args:
       - |-

--- a/tekton/src/tasks/gitops/gitops-deprovision-suite-idp-config.yml.j2
+++ b/tekton/src/tasks/gitops/gitops-deprovision-suite-idp-config.yml.j2
@@ -25,12 +25,11 @@ spec:
       type: string
     - name: avp_aws_secret_region
       type: string
-    - name: avp_aws_secret_key
-      type: string
-    - name: avp_aws_access_key
-      type: string
     - name: force_removal
       type: string
+    - name: cluster_url
+      type: string
+      default: ""
     - name: argocd_url
       type: string
       default: ""
@@ -60,16 +59,20 @@ spec:
         value: $(params.github_pat)
       - name: SM_AWS_REGION
         value: $(params.avp_aws_secret_region)
-      - name: SM_AWS_SECRET_ACCESS_KEY
-        value: $(params.avp_aws_secret_key)
-      - name: SM_AWS_ACCESS_KEY_ID
-        value: $(params.avp_aws_access_key)
       - name: FORCE_REMOVAL
         value: $(params.force_removal)
+      - name: OCP_SERVER
+        value: $(params.cluster_url)
       - name: ARGOCD_URL
         value: $(params.argocd_url)
       - name: ARGOCD_CHECK
         value: $(params.argocd_check)
+    envFrom:
+      - configMapRef:
+          name: environment-properties
+          optional: true
+      - secretRef:
+          name: secure-properties
   steps:
     - args:
       - |-

--- a/tekton/src/tasks/gitops/gitops-deprovision-suite-objectstorage-config.yml.j2
+++ b/tekton/src/tasks/gitops/gitops-deprovision-suite-objectstorage-config.yml.j2
@@ -25,12 +25,11 @@ spec:
       type: string
     - name: avp_aws_secret_region
       type: string
-    - name: avp_aws_secret_key
-      type: string
-    - name: avp_aws_access_key
-      type: string
     - name: force_removal
       type: string
+    - name: cluster_url
+      type: string
+      default: ""
     - name: argocd_url
       type: string
       default: ""
@@ -60,16 +59,20 @@ spec:
         value: $(params.github_pat)
       - name: SM_AWS_REGION
         value: $(params.avp_aws_secret_region)
-      - name: SM_AWS_SECRET_ACCESS_KEY
-        value: $(params.avp_aws_secret_key)
-      - name: SM_AWS_ACCESS_KEY_ID
-        value: $(params.avp_aws_access_key)
       - name: FORCE_REMOVAL
         value: $(params.force_removal)
+      - name: OCP_SERVER
+        value: $(params.cluster_url)
       - name: ARGOCD_URL
         value: $(params.argocd_url)
       - name: ARGOCD_CHECK
         value: $(params.argocd_check)
+    envFrom:
+      - configMapRef:
+          name: environment-properties
+          optional: true
+      - secretRef:
+          name: secure-properties
   steps:
     - args:
       - |-

--- a/tekton/src/tasks/gitops/gitops-deprovision-suite-smtp-config.yml.j2
+++ b/tekton/src/tasks/gitops/gitops-deprovision-suite-smtp-config.yml.j2
@@ -25,12 +25,11 @@ spec:
       type: string
     - name: avp_aws_secret_region
       type: string
-    - name: avp_aws_secret_key
-      type: string
-    - name: avp_aws_access_key
-      type: string
     - name: force_removal
       type: string
+    - name: cluster_url
+      type: string
+      default: ""
     - name: argocd_url
       type: string
       default: ""
@@ -60,16 +59,20 @@ spec:
         value: $(params.github_pat)
       - name: SM_AWS_REGION
         value: $(params.avp_aws_secret_region)
-      - name: SM_AWS_SECRET_ACCESS_KEY
-        value: $(params.avp_aws_secret_key)
-      - name: SM_AWS_ACCESS_KEY_ID
-        value: $(params.avp_aws_access_key)
       - name: FORCE_REMOVAL
         value: $(params.force_removal)
+      - name: OCP_SERVER
+        value: $(params.cluster_url)
       - name: ARGOCD_URL
         value: $(params.argocd_url)
       - name: ARGOCD_CHECK
         value: $(params.argocd_check)
+    envFrom:
+      - configMapRef:
+          name: environment-properties
+          optional: true
+      - secretRef:
+          name: secure-properties
   steps:
     - args:
       - |-

--- a/tekton/src/tasks/gitops/gitops-deprovision-suite-watson-studio-config.yml.j2
+++ b/tekton/src/tasks/gitops/gitops-deprovision-suite-watson-studio-config.yml.j2
@@ -25,12 +25,11 @@ spec:
       type: string
     - name: avp_aws_secret_region
       type: string
-    - name: avp_aws_secret_key
-      type: string
-    - name: avp_aws_access_key
-      type: string
     - name: force_removal
       type: string
+    - name: cluster_url
+      type: string
+      default: ""
     - name: argocd_url
       type: string
       default: ""
@@ -60,16 +59,20 @@ spec:
         value: $(params.github_pat)
       - name: SM_AWS_REGION
         value: $(params.avp_aws_secret_region)
-      - name: SM_AWS_SECRET_ACCESS_KEY
-        value: $(params.avp_aws_secret_key)
-      - name: SM_AWS_ACCESS_KEY_ID
-        value: $(params.avp_aws_access_key)
       - name: FORCE_REMOVAL
         value: $(params.force_removal)
+      - name: OCP_SERVER
+        value: $(params.cluster_url)
       - name: ARGOCD_URL
         value: $(params.argocd_url)
       - name: ARGOCD_CHECK
         value: $(params.argocd_check)
+    envFrom:
+      - configMapRef:
+          name: environment-properties
+          optional: true
+      - secretRef:
+          name: secure-properties
   steps:
     - args:
       - |-

--- a/tekton/src/tasks/gitops/gitops-deprovision-suite-workspace.yml.j2
+++ b/tekton/src/tasks/gitops/gitops-deprovision-suite-workspace.yml.j2
@@ -30,6 +30,9 @@ spec:
       type: string
     - name: force_removal
       type: string
+    - name: cluster_url
+      type: string
+      default: ""
     - name: argocd_url
       type: string
       default: ""
@@ -61,10 +64,18 @@ spec:
         value: $(params.github_pat) 
       - name: FORCE_REMOVAL
         value: $(params.force_removal)
+      - name: OCP_SERVER
+        value: $(params.cluster_url)
       - name: ARGOCD_URL
         value: $(params.argocd_url)
       - name: ARGOCD_CHECK
         value: $(params.argocd_check)
+    envFrom:
+      - configMapRef:
+          name: environment-properties
+          optional: true
+      - secretRef:
+          name: secure-properties
   steps:
     - args:
       - |-

--- a/tekton/src/tasks/gitops/gitops-deprovision-suite.yml.j2
+++ b/tekton/src/tasks/gitops/gitops-deprovision-suite.yml.j2
@@ -28,13 +28,12 @@ spec:
       type: string
     - name: avp_aws_secret_region
       type: string
-    - name: avp_aws_secret_key
-      type: string
-    - name: avp_aws_access_key
-      type: string
     - name: force_removal
       type: string
     - name: argocd_url
+      type: string
+      default: ""
+    - name: cluster_url
       type: string
       default: ""
     - name: argocd_check
@@ -65,16 +64,20 @@ spec:
         value: $(params.github_pat)
       - name: SM_AWS_REGION
         value: $(params.avp_aws_secret_region)
-      - name: SM_AWS_SECRET_ACCESS_KEY
-        value: $(params.avp_aws_secret_key)
-      - name: SM_AWS_ACCESS_KEY_ID
-        value: $(params.avp_aws_access_key)
       - name: FORCE_REMOVAL
         value: $(params.force_removal)
+      - name: OCP_SERVER
+        value: $(params.cluster_url)
       - name: ARGOCD_URL
         value: $(params.argocd_url)
       - name: ARGOCD_CHECK
         value: $(params.argocd_check)
+    envFrom:
+      - configMapRef:
+          name: environment-properties
+          optional: true
+      - secretRef:
+          name: secure-properties
   steps:
     - args:
       - |-


### PR DESCRIPTION
As part of https://jsw.ibm.com/browse/MASCORE-1684?filter=-1

Pipelines changes expected on SaaS env to 

    deprovision-mas-app
    deprovision-mas-instance
    deprovision-mas-cluster (the cluster level resources only rather than the cluster itself)

This fix is only concerning Esstentials Inspection (MAS core and MVI only) 
So ignored db2, cp4d and kafka from these deprovision tasks for now. 