### PR TITLE
[patch] move cvscan to finally block in fvt-iot pipeline

### DIFF
--- a/tekton/src/pipelines/fvt-iot.yml.j2
+++ b/tekton/src/pipelines/fvt-iot.yml.j2
@@ -69,21 +69,6 @@ spec:
           operator: notin
           values: [""]
 
-    - name: cv-iot
-      {{ lookup('template', 'taskdefs/ivt-core/common/taskref.yml.j2') | indent(6) }}
-      params:
-        {{ lookup('template', 'taskdefs/ivt-core/common/params.yml.j2') | indent(8) }}
-        - name: product_id
-          value: ibm-mas-iot
-        - name: product_channel
-          value: $(params.mas_app_channel_iot)
-        - name: fvt_test_suite
-          value: contentverification
-      when:
-        - input: "$(params.ivt_digest_core)"
-          operator: notin
-          values: [""]
-
 
     # 2. IoT FVT
     # -----------------------------------------------------------------------------
@@ -110,9 +95,26 @@ spec:
           values: [""]
       runAfter:
         - ivtcore-iot
-        - cv-iot
       workspaces:
         - name: configs
           workspace: shared-configs
         - name: pod-templates
           workspace: shared-pod-templates
+
+  finally:
+    # 3. Run CV
+    # -----------------------------------------------------------------------------
+    - name: cv-iot
+      {{ lookup('template', 'taskdefs/ivt-core/common/taskref.yml.j2') | indent(6) }}
+      params:
+        {{ lookup('template', 'taskdefs/ivt-core/common/params.yml.j2') | indent(8) }}
+        - name: product_id
+          value: ibm-mas-iot
+        - name: product_channel
+          value: $(params.mas_app_channel_iot)
+        - name: fvt_test_suite
+          value: contentverification
+      when:
+        - input: "$(params.ivt_digest_core)"
+          operator: notin
+          values: [""]


### PR DESCRIPTION
There is a conflict in test cases between cvscan and podtemplates. Resources need to be reset before cv-scan, hence, moving the cv-scan to finally block in the fvt-iot pipeline. 

Infact, moved cv-scan task in all fvt pipelines to finally block and ran fvt for core and iot. Few test cases failed in core, hence, as part of the below bug, updating only fvt-iot pipeline at the moment. Will create a new task to address for all other pipelines.

Ref bug (Jira): IBMIOT-238

Test: Ran fvt-personal with changes
    Branch: pfvtiotb238
    CLI version: 7.16.1-pre.iotb238
    FVT_VERSION_IOT=1.3.2-pre.iotb238

https://<dashboard_url>/tests/pfvtiotb238 
Builds (2193 & 2198)
<img width="718" alt="image" src="https://github.com/ibm-mas/cli/assets/54737838/5fe25f9d-3202-4e2c-91af-38aceee2e00c">

