### PR TITLE
[minor] fvt core - test the uicustomizations api

### DIFF
--- a/tekton/src/pipelines/fvt-core.yml.j2
+++ b/tekton/src/pipelines/fvt-core.yml.j2
@@ -87,7 +87,7 @@ spec:
     # Phase 2
     # -------------------------------------------------------------------------
     # Suites that take less than 25 minutes
-    {{ lookup('template', 'taskdefs/fvt-core/phase2-under30min.yml.j2', template_vars={'runAfter': [ 'ibmadminissuer', 'adoptionusageapi', 'coreapi-apikeymgmt', 'coreapi-mobileapi', 'coreapi-messages', 'coreapi-graphiteconfigtool', 'coreapi-scimv2']}) | indent(4) }}
+    {{ lookup('template', 'taskdefs/fvt-core/phase2-under30min.yml.j2', template_vars={'runAfter': [ 'ibmadminissuer', 'adoptionusageapi', 'coreapi-apikeymgmt', 'coreapi-mobileapi', 'coreapi-messages', 'coreapi-graphiteconfigtool', 'coreapi-scimv2', 'coreapi-uicustomizations']}) | indent(4) }}
 
     # Phase 3
     # -------------------------------------------------------------------------

--- a/tekton/src/pipelines/taskdefs/fvt-core/phase1-under5min.yml.j2
+++ b/tekton/src/pipelines/taskdefs/fvt-core/phase1-under5min.yml.j2
@@ -92,6 +92,16 @@
       value: coreapi-uiresources
   runAfter: {{ runAfter }}
 
+# coreapi-uicustomizations ~5m
+# -----------------------------------------------------------------------------
+- name: coreapi-uicustomizations
+  {{ lookup('template', 'taskdefs/fvt-core/common/taskref.yml.j2') | indent(2) }}
+  params:
+    {{ lookup('template', 'taskdefs/fvt-core/common/params.yml.j2') | indent(4) }}
+    - name: fvt_test_suite
+      value: coreapi-uicustomizations
+  runAfter: {{ runAfter }}
+
 # coreapi-messages ~5m
 # -----------------------------------------------------------------------------
 - name: coreapi-messages


### PR DESCRIPTION
## Description
Include tests in the core fvt pipeline to test the api to store and retrieve UI resources under `/customizations` api root.

## Related Issues
https://jsw.ibm.com/browse/MASCORE-1372

## Backporting
This is a new feature for MAS 9.0

## Testing
Successfully run the new suite in personal fvt: https://dashboard.masdev.wiotp.sl.hursley.ibm.com/tests/pfvtpds
![image](https://media.github.ibm.com/user/109/files/81ac0d99-cde0-44f2-86a6-2e13cc6a0333)
