### PR TITLE
Get dro url from secrest manager

### DIFF
--- a/image/cli/mascli/functions/gitops_suite_config
+++ b/image/cli/mascli/functions/gitops_suite_config
@@ -28,7 +28,6 @@ MongoDb Provider Selection:
       --mongo-provider ${COLOR_YELLOW}MONGODB_PROVIDER${TEXT_RESET}  The mongodb provider to install. Only "aws" is supported
 
 DRO Configuration:
-      --dro-url ${COLOR_YELLOW}DRO_URL${TEXT_RESET}                                 The URL for the DRO instance
       --dro-contact-email ${COLOR_YELLOW}DRO_CONTACT_EMAIL${TEXT_RESET}             The email address to register with DRO
       --dro-contact-firstname ${COLOR_YELLOW}DRO_CONTACT_FIRSTNAME${TEXT_RESET}     The first name to register with DRO
       --dro-contact-lastname ${COLOR_YELLOW}DRO_CONTACT_LASTNAME${TEXT_RESET}       The last name to register with DRO
@@ -86,9 +85,6 @@ function gitops_suite_config_noninteractive() {
         ;;
 
       # DRO
-      --dro-url)
-        export DRO_URL=$1 && shift
-        ;;
       --dro-contact-email)
         export DRO_CONTACT_EMAIL=$1 && shift
         ;;
@@ -151,7 +147,6 @@ function gitops_suite_config_noninteractive() {
       esac
   done
 
-  [[ -z "$DRO_URL" ]] && gitops_suite_config_help "DRO_URL is not set"
   [[ -z "$DRO_CONTACT_EMAIL" ]] && gitops_suite_config_help "DRO_CONTACT_EMAIL is not set"
   [[ -z "$DRO_CONTACT_FIRSTNAME" ]] && gitops_suite_config_help "DRO_CONTACT_FIRSTNAME is not set"
   [[ -z "$DRO_CONTACT_LASTNAME" ]] && gitops_suite_config_help "DRO_CONTACT_LASTNAME is not set"
@@ -216,7 +211,6 @@ function gitops_suite_config() {
 
   echo "${TEXT_DIM}"
   echo_h4 "DRO" "    "
-  echo_reset_dim "DRO Url  ....................... ${COLOR_MAGENTA}${DRO_URL}"
   echo_reset_dim "DRO Contact Email  ............. ${COLOR_MAGENTA}${DRO_CONTACT_EMAIL}"
   echo_reset_dim "DRO Contact First Name  ........ ${COLOR_MAGENTA}${DRO_CONTACT_FIRSTNAME}"
   echo_reset_dim "DRO Contact Last Name  ......... ${COLOR_MAGENTA}${DRO_CONTACT_LASTNAME}"
@@ -250,6 +244,8 @@ function gitops_suite_config() {
   # Note that these cluster-level secrets are set up by gitops-mongo
   export SECRET_KEY_MONGO_INFO=${ACCOUNT_ID}${SECRETS_KEY_SEPERATOR}${CLUSTER_ID}${SECRETS_KEY_SEPERATOR}mongo#info
   export SECRET_KEY_DRO_API_TOKEN=${ACCOUNT_ID}${SECRETS_KEY_SEPERATOR}${CLUSTER_ID}${SECRETS_KEY_SEPERATOR}dro#dro_api_token
+  export SECRET_KEY_DRO_URL=${ACCOUNT_ID}${SECRETS_KEY_SEPERATOR}${CLUSTER_ID}${SECRETS_KEY_SEPERATOR}dro#dro_url
+
   export DRO_CA_CERTIFICATE=$(cat ${DRO_CA_CERTIFICATE_FILE})
 
   # Get the cluster-level secrets used

--- a/image/cli/mascli/templates/gitops/appset-configs/cluster/instance/configs/ibm-mas-bas-config.yaml.j2
+++ b/image/cli/mascli/templates/gitops/appset-configs/cluster/instance/configs/ibm-mas-bas-config.yaml.j2
@@ -8,7 +8,7 @@ mas_config_api_version: "config.mas.ibm.com"
 
 mas_instance_id: {{ MAS_INSTANCE_ID }}
 dro_api_token: <path:{{ SECRETS_PATH }}:{{ SECRET_KEY_DRO_API_TOKEN }}>
-dro_endpoint_url: {{ DRO_URL }}
+dro_endpoint_url: <path:{{ SECRETS_PATH }}:{{ SECRET_KEY_DRO_URL }}>
 dro_contact:
   email: {{ DRO_CONTACT_EMAIL }}
   first_name: {{ DRO_CONTACT_FIRSTNAME }}

--- a/tekton/src/pipelines/gitops/provision-mas-instance.yml.j2
+++ b/tekton/src/pipelines/gitops/provision-mas-instance.yml.j2
@@ -76,9 +76,6 @@ spec:
       type: string
       default: add
 
-    - name: dro_url
-      type: string
-      default: ""
     - name: dro_contact_email
       type: string
     - name: dro_contact_firstname
@@ -391,8 +388,6 @@ spec:
           value: $(params.github_pat)
         - name: avp_aws_secret_region
           value: $(params.avp_aws_secret_region)
-        - name: dro_url
-          value: $(params.dro_url)
         - name: dro_contact_email
           value: $(params.dro_contact_email)
         - name: dro_contact_firstname

--- a/tekton/src/tasks/gitops/gitops-suite-config.yml.j2
+++ b/tekton/src/tasks/gitops/gitops-suite-config.yml.j2
@@ -26,9 +26,6 @@ spec:
       type: string
     - name: avp_aws_secret_region
       type: string
-    - name: dro_url
-      type: string
-      default: ""
     - name: dro_contact_email
       type: string
     - name: dro_contact_firstname
@@ -74,8 +71,6 @@ spec:
         value: $(params.avp_aws_secret_region)
       - name: REGION_ID
         value: $(params.avp_aws_secret_region)
-      - name: DRO_URL
-        value: $(params.dro_url)
       - name: DRO_CONTACT_EMAIL
         value: $(params.dro_contact_email)
       - name: DRO_CONTACT_FIRSTNAME


### PR DESCRIPTION
The dro url is now stored in secrets manger like the api token. Get the dro url form secrets manager rather than let it be passed in. 