### PR TITLE
[patch] Improve OCP support doc

### DIFF
--- a/docs/catalogs/v8-240130-amd64.md
+++ b/docs/catalogs/v8-240130-amd64.md
@@ -67,18 +67,27 @@ IBM Maximo Application Suite will run anywhere that you can run a supported Open
 
 For more information about the OCP lifecycle refer to the [Red Hat OpenShift Container Platform Life Cycle Policy](https://access.redhat.com/support/policy/updates/openshift/).
 
+IBM Maximo Application Suite customers receive a standard Red Hat OpenShift Container Platform subscription as part of their purchase. This includes 18 months of maintenance support for each OpenShift minor release (applicable for OpenShift 4.12 releases and newer).
+
+A further 6 months support is available to purchase as an Extended Update Support (EUS) Add-on to x86-64 versions of Red Hat OpenShift Kubernetes Engine, Red Hat OpenShift Container Platform, and Red Hat OpenShift Platform Plus Standard subscriptions.
+
+!!! note
+    Extended Update Support is included with Premium subscriptions of x86-64 versions of Red Hat OpenShift Kubernetes Engine, Red Hat OpenShift Container Platform, and Red Hat OpenShift Platform Plus. Please contact your Red Hat Sales Representative if you are unsure if you have access to EUS and to help decide if it is appropriate for your environment.
+
 <table class="compatabilityMatrix">
   <tr>
     <th>OCP</th><td rowspan="3" class="spacer"></td>
     <th>General Availability</th>
-    <th>End of Support</th>
+    <th>Standard Support</th>
+    <th>Extended Support</th>
     <th>Supported MAS Releases</th>
   </tr>
   <tr>
     <td class="firstColumn">4.12</td>
     <td>January 17, 2023</td>
+    <td>August 17, 2024</td>
     <td>January 17, 2025</td>
-    <td>8.9 - 8.11</td>
+    <td>8.10 - 8.11</td>
   </tr>
 </table>
 

--- a/docs/catalogs/v8-240227-amd64.md
+++ b/docs/catalogs/v8-240227-amd64.md
@@ -14,7 +14,7 @@ Details
 What's New
 -------------------------------------------------------------------------------
 - **Removal of Maximo Application Suite v8.9 Channels** Maximo Application Suite v8.9 support ended with the release of v8.11, customers must upgrade to MAS 8.10 before applying this catalog update.
-- **Migration from IBM User Data Services Operator (UDS) to IBM Data Reporter Operator (DRO)** UDS is being deprecated in June, Starting With [February 2024](v8-240227-amd64.md) Maximo Operator catalog, MAS will be moving to use DRO as a replacement to UDS.  Running `mas update` will automatically migrate and configure all existing MAS 8.10.x and MAS 8.11.x instances from UDS to DRO. 
+- **Migration from IBM User Data Services Operator (UDS) to IBM Data Reporter Operator (DRO)** UDS is being deprecated in June, Starting With [February 2024](v8-240227-amd64.md) Maximo Operator catalog, MAS will be moving to use DRO as a replacement to UDS.  Running `mas update` will automatically migrate and configure all existing MAS 8.10.x and MAS 8.11.x instances from UDS to DRO.
 - **Upgrade from Grafana v4 Operator to v5** Grafana Operator v4 is no longer receiving bug fixes and security updates. As a default v5 will be installed, starting with the [February 2024](v8-240227-amd64.md) Maximo Operator Catalog. Running `mas update` will automatically install Grafana Operator v5, uninstall v4 and update all MAS grafana dashboards to be compatible with v5.
 - **Security updates and bug fixes**
     - IBM Maximo Application Suite Core Platform v8.10 and v8.11
@@ -66,16 +66,25 @@ IBM Maximo Application Suite will run anywhere that you can run a supported Open
 
 For more information about the OCP lifecycle refer to the [Red Hat OpenShift Container Platform Life Cycle Policy](https://access.redhat.com/support/policy/updates/openshift/).
 
+IBM Maximo Application Suite customers receive a standard Red Hat OpenShift Container Platform subscription as part of their purchase. This includes 18 months of maintenance support for each OpenShift minor release (applicable for OpenShift 4.12 releases and newer).
+
+A further 6 months support is available to purchase as an Extended Update Support (EUS) Add-on to x86-64 versions of Red Hat OpenShift Kubernetes Engine, Red Hat OpenShift Container Platform, and Red Hat OpenShift Platform Plus Standard subscriptions.
+
+!!! note
+    Extended Update Support is included with Premium subscriptions of x86-64 versions of Red Hat OpenShift Kubernetes Engine, Red Hat OpenShift Container Platform, and Red Hat OpenShift Platform Plus. Please contact your Red Hat Sales Representative if you are unsure if you have access to EUS and to help decide if it is appropriate for your environment.
+
 <table class="compatabilityMatrix">
   <tr>
     <th>OCP</th><td rowspan="3" class="spacer"></td>
     <th>General Availability</th>
-    <th>End of Support</th>
+    <th>Standard Support</th>
+    <th>Extended Support</th>
     <th>Supported MAS Releases</th>
   </tr>
   <tr>
     <td class="firstColumn">4.12</td>
     <td>January 17, 2023</td>
+    <td>August 17, 2024</td>
     <td>January 17, 2025</td>
     <td>8.10 - 8.11</td>
   </tr>


### PR DESCRIPTION
There has been some confusion in the field about whether we are bundling extended OCP support into MAS (which we are not).

Most MAS customers, under their bundled standard OCP subscription, would need to move off OCP 4.12 by July 17th '24.  It is only if a customer has purchased the addon EUS support from Red Hat that they could stay on till Jan 17th '25.