### PR TITLE
Allow target namespace for root applications to be configured

### DIFF
--- a/image/cli/mascli/functions/gitops_bootstrap
+++ b/image/cli/mascli/functions/gitops_bootstrap
@@ -11,8 +11,9 @@ Where ${COLOR_YELLOW}specified${TEXT_RESET} each option may also be defined by s
 When no options are specified on the command line, interactive-mode will be enabled by default.
 
 Options:
-  -a, --account-id ${COLOR_YELLOW}ACCOUNT_ID${TEXT_RESET}          Account ID
-      --app-revision ${COLOR_YELLOW}APP_REVISION${TEXT_RESET}      Revision (branch or tag) of ibm-mas/gitops to use
+  -a, --account-id ${COLOR_YELLOW}ACCOUNT_ID${TEXT_RESET}                Account ID
+      --app-revision ${COLOR_YELLOW}APP_REVISION${TEXT_RESET}            Revision (branch or tag) of ibm-mas/gitops to use
+      --argoapp-namespace ${COLOR_YELLOW}ARGOAPP_NAMESPACE${TEXT_RESET}  Namespace in the ArgoCD worker cluster to create ArgoCD Application and ApplicationSet resources (defaults to 'openshift-gitops)
 
 AWS Secrets Manager Configuration:
       --sm-aws-secret-region ${COLOR_YELLOW}SM_AWS_REGION${TEXT_RESET}          Region of the AWS Secrets Manager to use
@@ -34,6 +35,8 @@ EOM
 function gitops_bootstrap_noninteractive() {
   AVP_TYPE=aws
 
+  export ARGOAPP_NAMESPACE=${ARGOAPP_NAMESPACE:-"openshift-gitops"}
+
   while [[ $# -gt 0 ]]
   do
     key="$1"
@@ -44,6 +47,10 @@ function gitops_bootstrap_noninteractive() {
         ;;
       --app-revision)
         export APP_REVISION=$1 && shift
+        ;;
+
+      --argoapp-namespace)
+        export ARGOAPP_NAMESPACE=$1 && shift
         ;;
 
       # AWS Secrets Manager Configuration
@@ -111,6 +118,7 @@ function gitops_bootstrap() {
   echo_h2 "Target" "    "
   echo_reset_dim "Account ID ..................... ${COLOR_MAGENTA}${ACCOUNT_ID}"
   echo_reset_dim "Applicaton Revision ............ ${COLOR_MAGENTA}${APP_REVISION}"
+  echo_reset_dim "Argo Application Namespace ..... ${COLOR_MAGENTA}${ARGOAPP_NAMESPACE}"
   reset_colors
 
   echo ""
@@ -128,6 +136,7 @@ function gitops_bootstrap() {
   echo_reset_dim "Repository Revision ............ ${COLOR_MAGENTA}${APP_REPO_REVISION}"
   echo_reset_dim "Personal Access Token .......... ${COLOR_MAGENTA}${APP_REPO_PAT:0:4}<snip>"
   reset_colors
+
 
   # 1. Install Openshift GitOps Operator
   echo

--- a/image/cli/mascli/templates/gitops/bootstrap/root-application.yaml.j2
+++ b/image/cli/mascli/templates/gitops/bootstrap/root-application.yaml.j2
@@ -3,10 +3,10 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   name: root.{{ ACCOUNT_ID }}
-  namespace: openshift-gitops
+  namespace: {{ ARGOAPP_NAMESPACE }}
 spec:
   destination:
-    namespace: openshift-gitops
+    namespace: {{ ARGOAPP_NAMESPACE }}
     server: 'https://kubernetes.default.svc'
   project: mas
   source:
@@ -25,7 +25,8 @@ spec:
           },
           "source": {
             "targetRevision": "{{ APP_REVISION }}"
-          }
+          },
+          "argoapp_namespace": "{{ ARGOAPP_NAMESPACE }}"
         }
   syncPolicy:
     automated: {}


### PR DESCRIPTION
At present our root applications always targets the openshift-gitops namespace, e.g. https://github.com/ibm-mas/gitops/blob/fa480bc16bc03f2d1654d24a947cbc9c2f0efc29/root-applications/ibm-mas-account-root/templates/000-cluster-appset.yaml#L8

However, this is not always the namespace we need to use. E.g. in MCSP we need "argocd-worker". 

This PR adds --argoapp-namespace parameter to gitops_bootstrap script and corresponding fields into root application template.
Defaults to openshift-gitops for backwards compatibility.

Accompanying PR: https://github.com/ibm-mas/gitops/pull/38

Tested by running script and verifying that the parameter behaves as expected, and that the generated root application manifest is correct. 

MASCORE-2037