### PR TITLE
[patch] Correct standard support date for OCP 4.12

### DIFF
--- a/docs/catalogs/v8-240130-amd64.md
+++ b/docs/catalogs/v8-240130-amd64.md
@@ -85,7 +85,7 @@ A further 6 months support is available to purchase as an Extended Update Suppor
   <tr>
     <td class="firstColumn">4.12</td>
     <td>January 17, 2023</td>
-    <td>August 17, 2024</td>
+    <td>July 17, 2024</td>
     <td>January 17, 2025</td>
     <td>8.10 - 8.11</td>
   </tr>

--- a/docs/catalogs/v8-240227-amd64.md
+++ b/docs/catalogs/v8-240227-amd64.md
@@ -84,7 +84,7 @@ A further 6 months support is available to purchase as an Extended Update Suppor
   <tr>
     <td class="firstColumn">4.12</td>
     <td>January 17, 2023</td>
-    <td>August 17, 2024</td>
+    <td>July 17, 2024</td>
     <td>January 17, 2025</td>
     <td>8.10 - 8.11</td>
   </tr>


### PR DESCRIPTION
The correct date for end of standard support for OCP 4.12 is July 2024, not August.