### PR TITLE
[patch] add missing finally section to uninstall pipeline

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -90,6 +90,13 @@ For `major` and `minor` pull requests mainly, make sure you follow the standard 
 
 - Ensure you have tested your changes and they do what is supposed to from an "end-to-end" perspective. Attaching screenshots of the end goal in your `pull request` are always welcome so everyone knows what to expect by the change, and that it does not break existing role functionalities around your change (basic regression test).
 - Ensure that a MAS install test runs successfully from an `end-to-end` via cli (basic regression test). See more information about it in [MAS CLI documentation](https://github.com/ibm-mas/cli).
+- If tekton tasks were modified please use the following test procedure from a linux environment that has ansible installed, the `oc` command and access to modified cli repo (your test branch):
+  - Change directory to the cli/tekton directory
+  - login to your cluster (oc login command)
+  - Execute `ansible-playbook generate-tekton-tasks.yml`
+  - Execute `ansible-playbook generate-tekton-pipelines.yml`
+  - Execute `./test.sh`  This will try to create or recreate all the tekton resources in the default pipeline, make sure there are no errors. 
+
 
 Here's how you could get started with a new pull request from your branch:
 

--- a/tekton/src/pipelines/fvt-uninstall-after.yml.j2
+++ b/tekton/src/pipelines/fvt-uninstall-after.yml.j2
@@ -384,3 +384,27 @@ spec:
           values: ["uninstall"]
       runAfter:
         - uninstall-ibm-catalogs
+
+
+  # In FVT only this is the time to take a must-gather and finalize the result
+  # ---------------------------------------------------------------------------
+  finally:
+    # Collect must-gather
+    # -------------------------------------------------------------------------
+    - name: must-gather
+      taskRef:
+        kind: Task
+        name: mas-devops-must-gather
+      params:
+        - name: base_output_dir
+          value: "/workspace/mustgather/$(context.pipelineRun.name)"
+      workspaces:
+        - name: mustgather
+          workspace: shared-mustgather
+
+    # Finalize the record in the FVT database
+    # -------------------------------------------------------------------------
+    - name: finalize
+      taskRef:
+        kind: Task
+        name: mas-fvt-finalize

--- a/tekton/src/pipelines/fvt-uninstall-after.yml.j2
+++ b/tekton/src/pipelines/fvt-uninstall-after.yml.j2
@@ -4,6 +4,10 @@ kind: Pipeline
 metadata:
   name: mas-fvt-uninstall-after
 spec:
+  workspaces:
+    # Shared storage to hold mustgather output for tasks
+    - name: shared-mustgather
+
   params:
     # Name of the PipelineRun to wait for
     - name: pipelinerun_name


### PR DESCRIPTION
"Finally" section in the uninstall pipeline was not defined therefore it was not gathering logs and the pipeline seems to never finalize on the dashboard even when all task completed.
executed cli/tekton/test.sh and all tasks were added successfully, in this case here is the proof for the task modified under this PR.
![image](https://github.com/ibm-mas/cli/assets/129990814/0a0490a8-307d-44b2-b841-3e0fb4e26986)
March 18 uninstall pipeline containing this change ran successfully https://dashboard.masdev.wiotp.sl.hursley.ibm.com/tests/fvtuninstall