### PR TITLE
[minor] Capture db2 and kafka versions

### DIFF
--- a/image/cli/app-root/src/finalizer.py
+++ b/image/cli/app-root/src/finalizer.py
@@ -97,6 +97,21 @@ def buildContext(texts):
     }
 
 
+# Get Kafka Provider and Version
+# -------------------------------------------------------------------------
+def getKafkaVersion(namespace):
+    try:
+        crs = dynClient.resources.get(api_version="kafka.strimzi.io/v1beta2", kind="Kafka")
+        cr = crs.get(name=f"mas-{instanceId}-system", namespace=f"{namespace}")
+        if cr.status and cr.status.kafkaVersion:
+            return cr.status.kafkaVersion
+        else:
+            print(f"Unable to determine kafka version: status.KafkaVersion unavailable")
+    except Exception as e:
+        print(f"Unable to determine kafka version: {e}")
+    return "unknown"
+
+
 # Script start
 # -----------------------------------------------------------------------------
 if __name__ == "__main__":
@@ -277,7 +292,69 @@ if __name__ == "__main__":
     except Exception as e:
         print(f"Unable to determine Maximo Process Automation Engine (MPAE) version: {e}")
 
-    # Connect to mongoDb
+    # Get DB2 CLuster Version
+    # -------------------------------------------------------------------------
+    try:
+        crs = dynClient.resources.get(api_version="db2u.databases.ibm.com/v1", kind="Db2uCluster")
+        cr = crs.get(name=f"mas-{instanceId}-system", namespace="db2u")
+        if cr.status and cr.status.version:
+                db2ClusterVersion = cr.status.version
+
+                setObject[f"target.db2ClusterVersion"] = db2ClusterVersion
+        else:
+            print(f"Unable to determine DB2 cluster version: status.version unavailable")
+    except Exception as e:
+        print(f"Unable to determine DB2 cluster version: {e}")
+
+    # Lookup DB2 operator version
+    # -------------------------------------------------------------------------
+    try:
+        
+        csvl = dynClient.resources.get(api_version="operators.coreos.com/v1alpha1", kind="ClusterServiceVersion")
+        csv = csvl.get(namespace=f"db2u",label_selector=f'operators.coreos.com/db2u-operator.db2u')
+        
+        if csv is None or csv.items is None or len(csv.items) == 0:
+            print(f"Unable to determine DB2 operator version: component unavailable")
+        else:
+            db2OperatorVersion= (csv.items[0].metadata.name).lstrip('db2u-operator.') 
+            setObject[f"target.db2OperatorVersion"] = db2OperatorVersion
+    except Exception as e:
+        print(f"Unable to determine DB2 operator version: {e}")
+   
+    # Get Kafka Provider and Version
+    # -------------------------------------------------------------------------
+    namespace=''
+    try:
+        crs = dynClient.resources.get(api_version="config.mas.ibm.com/v1", kind="KafkaCfg")
+        cr = crs.get(name=f"{instanceId}-kafka-system", namespace=f"mas-{instanceId}-core")
+        if cr.status and cr.status.config.hosts:
+                firstBroker = cr.status.config.hosts[0].host
+                print(firstBroker)
+                if firstBroker.find('eventstreams') != -1:
+                    setObject[f"target.kafkaProvider"] = 'External'
+                    print('External')
+                elif firstBroker.find('amq-streams') != -1:
+                    setObject[f"target.kafkaProvider"] = 'AMQ'
+                    namespace="amq-streams"
+                    print('amq-streams')
+                elif firstBroker.find('strimzi') != -1:
+                    setObject[f"target.kafkaProvider"] = 'STRIMZI'
+                    namespace="strimzi"
+                    print('strimzi')
+                else: 
+                    print(f"Unable to determine kafka provider using broker host")
+                # check if we need to get the kafka version, this will happen with AMQ and STRIMZI    
+                if namespace != '':
+                    #setObject[f"target.kafkaVersion"] = getKafkaVersion(namespace)
+                    print(getKafkaVersion(namespace))
+                else:
+                    setObject[f"target.kafkaVersion"] = 'unknown'
+        else:
+            print(f"Unable to determine kafka provider: status.config.hosts unavailable")
+    except Exception as e:
+        print(f"Unable to determine kafka provider and version: {e}")
+
+   # Connect to mongoDb
     # -------------------------------------------------------------------------
     client = MongoClient(os.getenv("DEVOPS_MONGO_URI"))
     db = client.masfvt

--- a/image/cli/app-root/src/finalizer.py
+++ b/image/cli/app-root/src/finalizer.py
@@ -329,24 +329,19 @@ if __name__ == "__main__":
         cr = crs.get(name=f"{instanceId}-kafka-system", namespace=f"mas-{instanceId}-core")
         if cr.status and cr.status.config.hosts:
                 firstBroker = cr.status.config.hosts[0].host
-                print(firstBroker)
                 if firstBroker.find('eventstreams') != -1:
                     setObject[f"target.kafkaProvider"] = 'External'
-                    print('External')
                 elif firstBroker.find('amq-streams') != -1:
                     setObject[f"target.kafkaProvider"] = 'AMQ'
                     namespace="amq-streams"
-                    print('amq-streams')
                 elif firstBroker.find('strimzi') != -1:
                     setObject[f"target.kafkaProvider"] = 'STRIMZI'
                     namespace="strimzi"
-                    print('strimzi')
                 else: 
                     print(f"Unable to determine kafka provider using broker host")
                 # check if we need to get the kafka version, this will happen with AMQ and STRIMZI    
                 if namespace != '':
-                    #setObject[f"target.kafkaVersion"] = getKafkaVersion(namespace)
-                    print(getKafkaVersion(namespace))
+                    setObject[f"target.kafkaVersion"] = getKafkaVersion(namespace)
                 else:
                     setObject[f"target.kafkaVersion"] = 'unknown'
         else:
@@ -354,7 +349,7 @@ if __name__ == "__main__":
     except Exception as e:
         print(f"Unable to determine kafka provider and version: {e}")
 
-   # Connect to mongoDb
+    # Connect to mongoDb
     # -------------------------------------------------------------------------
     client = MongoClient(os.getenv("DEVOPS_MONGO_URI"))
     db = client.masfvt


### PR DESCRIPTION
Added code to get db2 cluster version and db2 operator version, also added code to find the kafka provider and its version.
I will add test evidence once we run the code in the pipeline, local tests work as expected.
I had to recreate the PR since I renamed the branch to all lowercase letters to fix the build issue. (lesson learned hopefully). 

Summarizing the  previous comments from the old PR https://github.com/ibm-mas/cli/pull/855

@alequint @durera the code is ready. If you could please review so that I can work on the changes to have them ready for when the build works. Thank you

@creyesibm let's redirect to he PR to managephase5 and we can test that in fvtnocpd. Then you can check if your version of dashboard will visualize the versions as expected. If that work we can go ahead and merge dashboard changes 👍

