### PR TITLE
[patch] Removed Manage's autoscript-adddeletewo

### DIFF
--- a/tekton/src/pipelines/taskdefs/fvt-manage/phase3.yml.j2
+++ b/tekton/src/pipelines/taskdefs/fvt-manage/phase3.yml.j2
@@ -1,7 +1,6 @@
 # -------------------------------------------------------------
 # PHASE 3
 # - fvt-manage-escalation-action (selenium)
-# - fvt-manage-autoscript-adddeletewo (selenium)
 # - fvt-manage-jms-inbound (selenium)
 # - fvt-manage-mif-kafka-setup (selenium)
 # - fvt-manage-birt-report (selenium)
@@ -22,27 +21,6 @@
       value: base
     - name: fvt_test_suite
       value: escalation-action
-  runAfter:
-    - fvt-manage-classification
-    - fvt-manage-helplinks
-    - fvt-manage-wo-basic
-    - fvt-manage-ancestors
-    - fvt-manage-automationscripts
-    - fvt-manage-mif-setup
-    - fvt-manage-crontask
-    - fvt-manage-endpoint
-    - fvt-manage-mas-navigation
-
-# Manage FVT AutoScript to Add Delete WorkOrder
-- name: fvt-manage-autoscript-adddeletewo
-  {{ lookup('template', 'taskdefs/fvt-manage/ui/taskref.yml.j2') | indent(2) }}
-  {{ lookup('template', 'taskdefs/fvt-manage/ui/when.yml.j2') | indent(2) }}
-  params:
-    {{ lookup('template', 'taskdefs/fvt-manage/ui/params.yml.j2') | indent(4) }}
-    - name: fvt_test_suite_prefix
-      value: base
-    - name: fvt_test_suite
-      value: autoscript-adddeletewo
   runAfter:
     - fvt-manage-classification
     - fvt-manage-helplinks

--- a/tekton/src/pipelines/taskdefs/fvt-manage/phase4.yml.j2
+++ b/tekton/src/pipelines/taskdefs/fvt-manage/phase4.yml.j2
@@ -20,7 +20,6 @@
       value: sec-audit-log
   runAfter:
     - fvt-manage-escalation-action
-    - fvt-manage-autoscript-adddeletewo
     - fvt-manage-jms-inbound
     - fvt-manage-mif-kafka-setup
     - fvt-manage-birt-report
@@ -42,7 +41,6 @@
       value: sec-inactive-auth
   runAfter:
     - fvt-manage-escalation-action
-    - fvt-manage-autoscript-adddeletewo
     - fvt-manage-jms-inbound
     - fvt-manage-mif-kafka-setup
     - fvt-manage-birt-report
@@ -64,7 +62,6 @@
       value: mif-kafka-inbound
   runAfter:
     - fvt-manage-escalation-action
-    - fvt-manage-autoscript-adddeletewo
     - fvt-manage-jms-inbound
     - fvt-manage-mif-kafka-setup
     - fvt-manage-birt-report
@@ -86,7 +83,6 @@
       value: wo-doclink
   runAfter:
     - fvt-manage-escalation-action
-    - fvt-manage-autoscript-adddeletewo
     - fvt-manage-jms-inbound
     - fvt-manage-mif-kafka-setup
     - fvt-manage-birt-report
@@ -106,7 +102,6 @@
     {{ lookup('template', 'taskdefs/fvt-manage/ui/params.yml.j2') | indent(4) }}
   runAfter:
     - fvt-manage-escalation-action
-    - fvt-manage-autoscript-adddeletewo
     - fvt-manage-jms-inbound
     - fvt-manage-mif-kafka-setup
     - fvt-manage-birt-report
@@ -128,7 +123,6 @@
       value: adhoc
   runAfter:
     - fvt-manage-escalation-action
-    - fvt-manage-autoscript-adddeletewo
     - fvt-manage-jms-inbound
     - fvt-manage-mif-kafka-setup
     - fvt-manage-birt-report


### PR DESCRIPTION
As per comments in issue https://jsw.ibm.com/browse/MASISMIG-51666, selenium test `autoscript-adddeletewo` has been covered by pytest `base-automationscripts`, which is already running in the pipeline.