### PR TITLE
[minor] capture SLS version 

### DIFF
--- a/image/cli/app-root/src/finalizer.py
+++ b/image/cli/app-root/src/finalizer.py
@@ -349,6 +349,20 @@ if __name__ == "__main__":
     except Exception as e:
         print(f"Unable to determine kafka provider and version: {e}")
 
+    # Lookup SLS version
+    # -------------------------------------------------------------------------
+    try:
+        crs = dynClient.resources.get(api_version="sls.ibm.com/v1", kind="LicenseService")
+        cr = crs.get(name=f"sls", namespace="ibm-sls")
+        if cr.status and cr.status.versions:
+                slsVersion = cr.status.versions.reconciled
+                print(slsVersion)
+                setObject[f"target.slsVersion"] = slsVersion
+        else:
+            print(f"Unable to determine SLS version: status.versions unavailable")
+    except Exception as e:
+        print(f"Unable to determine SLS version: {e}")
+   
     # Connect to mongoDb
     # -------------------------------------------------------------------------
     client = MongoClient(os.getenv("DEVOPS_MONGO_URI"))


### PR DESCRIPTION
Added code to capture the SLS version from the CR instance. Tested the code locally and this is how it looks in the dashboard. 
![image](https://github.com/ibm-mas/cli/assets/129990814/2ec4dd48-9718-4cf7-a315-fd99bb07993d)

For environments where we have not capture SLS (all the rest) it shows like this: 
![image](https://github.com/ibm-mas/cli/assets/129990814/d1efea65-4df0-4a9f-9ade-7d693ee291aa)
