### PR TITLE
Update db2u_database and db2u_deprovision_database scripts to use new shared config file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,4 @@ image/cli/mascli/gitops-mas-deploy-merged.sh
 image/cli/mascli/tmp-suite-deprovision
 image/cli/mascli/fyre-dev.noble3.tgke-env.sh
 image/cli/mascli/tmp-mas-config
+image/cli/mascli/fyre-dev.noble3.tgke-db2u-manage-env.sh

--- a/image/cli/mascli/functions/gitops_db2u_database
+++ b/image/cli/mascli/functions/gitops_db2u_database
@@ -304,7 +304,12 @@ function gitops_db2u_database() {
 
   mkdir -p ${GITOPS_WORKING_DIR}
   rm -rf $GITOPS_WORKING_DIR/$GITHUB_REPO
-  GITOPS_INSTANCE_DIR=${GITOPS_WORKING_DIR}/${GITHUB_REPO}/${ACCOUNT_ID}/${REGION}/${CLUSTER_ID}/${MAS_INSTANCE_ID}/db2-databases
+  GITOPS_INSTANCE_DIR=${GITOPS_WORKING_DIR}/${GITHUB_REPO}/${ACCOUNT_ID}/${REGION}/${CLUSTER_ID}/${MAS_INSTANCE_ID}
+  CONFIGS_FILE="${GITOPS_INSTANCE_DIR}/ibm-db2u-databases.yaml"
+
+  # NOTE: must align with lock branch name used by gitops_deprovision_db2u_database script
+  # as both of these scrtipts modify the same file
+  GIT_LOCK_BRANCH=$(git_lock_branch_name "gitops-db2u-database" "${ACCOUNT_ID}" "${REGION_ID}" "${CLUSTER_ID}" "${MAS_INSTANCE_ID}")
 
   #Defaults
   if [[ -z $DB2_DBNAME ]]; then
@@ -413,6 +418,7 @@ DB2_WORKLOAD: '${DB2_WORKLOAD}'"
     echo_reset_dim "Organization .......................... ${COLOR_MAGENTA}${GITHUB_ORG}"
     echo_reset_dim "Repository ............................ ${COLOR_MAGENTA}${GITHUB_REPO}"
     echo_reset_dim "Branch ................................ ${COLOR_MAGENTA}${GIT_BRANCH}"
+    echo_reset_dim "Lock Branch ........................... ${COLOR_MAGENTA}${GIT_LOCK_BRANCH}"
   else
     echo_h2 "GitOps Target" "    "
     echo_reset_dim "Automatic Push ........................ ${COLOR_RED}Disabled"
@@ -471,8 +477,7 @@ DB2_WORKLOAD: '${DB2_WORKLOAD}'"
 
   export SECRET_KEY_CLUSTER_DOMAIN=${ACCOUNT_ID}${SECRETS_KEY_SEPERATOR}${CLUSTER_ID}${SECRETS_KEY_SEPERATOR}cluster_domain#cluster_domain
 
-  CURRENT_DIR=$PWD
-  TEMP_DIR=$CURRENT_DIR/tmp-db2u-database
+  TEMP_DIR=$GITOPS_WORKING_DIR/tmp-db2u-database
   mkdir -p $TEMP_DIR
 
   # Getting provided db2cluster configs
@@ -510,42 +515,64 @@ DB2_WORKLOAD: '${DB2_WORKLOAD}'"
   # Clone github target repo
   # ---------------------------------------------------------------------------
   if [ "$GITHUB_PUSH" == "true" ]; then
-    echo
-    echo_h2 "Cloning GitHub repo $GITHUB_ORG $GITHUB_REPO"
+    # only create the lock branch if we plan to actually push changes to git
+    clone_and_lock_target_git_repo  "${GITHUB_HOST}" "${GITHUB_ORG}" "${GITHUB_REPO}" "${GIT_BRANCH}" "${GITOPS_WORKING_DIR}" "${GIT_SSH}" "${GIT_LOCK_BRANCH}"
+  else
+    # even though we don't want to push anything to git,
+    # because this script modifies the existing suite-configs.yaml file, we still need to checkout the repo
     clone_target_git_repo $GITHUB_HOST $GITHUB_ORG $GITHUB_REPO $GIT_BRANCH $GITOPS_WORKING_DIR $GIT_SSH
   fi
   mkdir -p ${GITOPS_INSTANCE_DIR}
-
-  # wait till CRD db2uclusters.db2u.databases.ibm.com NamesAccepted=True 
-  # This is now performed as a presync hook in the ibm-db2u-database chart
-  # as a workaround for the fact that we can no longer directly call the cluster
-  # See: https://jsw.ibm.com/browse/MASCORE-1425
-  # wait_for_db2ucluster_crd
-
-  GITOPS_TMP_DIR=${GITOPS_CLUSTER_DIR}/tmp
-  mkdir -p ${GITOPS_TMP_DIR}
 
   # Generate ArgoApps
   # ---------------------------------------------------------------------------
   echo
   echo_h2 "Generating DB2U Database Configuraton"
   echo
-  GENERATED_CONFIG_FILE="${GITOPS_INSTANCE_DIR}/${DB2_INSTANCE_NAME}.ibm-db2u-database.yaml"
-  echo_reset_dim "- Generating DB2U Database file ${GENERATED_CONFIG_FILE}"
-  jinja -X .+ $CLI_DIR/templates/gitops/appset-configs/cluster/instance/db2-databases/ibm-db2u-database.yaml.j2 -o ${GENERATED_CONFIG_FILE}
+  # GENERATED_CONFIG_FILE="${GITOPS_INSTANCE_DIR}/${DB2_INSTANCE_NAME}.ibm-db2u-database.yaml"
+  # echo_reset_dim "- Generating DB2U Database file ${GENERATED_CONFIG_FILE}"
+  # jinja -X .+ $CLI_DIR/templates/gitops/appset-configs/cluster/instance/db2-databases/ibm-db2u-database.yaml.j2 -o ${GENERATED_CONFIG_FILE}
+
+    # If the file doesn't exist, create a blank one
+  if ! [ -f ${CONFIGS_FILE} ]; then
+    jinja -X .+ $CLI_DIR/templates/gitops/appset-configs/cluster/instance/db2-databases/ibm-db2u-database-common.yaml.j2 > $CONFIGS_FILE
+  fi
+
+  # Remove any existing config with this name
+  /usr/bin/yq 'del(.ibm_db2u_databases[] | select(.db2_instance_name == "'${DB2_INSTANCE_NAME}'"))' $CONFIGS_FILE > $TEMP_DIR/configs.yaml
+
+  # Render the appropriate template for the config into a new file
+  jinja -X .+ $CLI_DIR/templates/gitops/appset-configs/cluster/instance/db2-databases/ibm-db2u-database.yaml.j2 | /usr/bin/yq '{"ibm_db2u_databases": [] + .}' > ${TEMP_DIR}/newconfig.yaml
+
+  # Merge the two files
+  /usr/bin/yq eval-all '. as $item ireduce ({}; . *+ $item)' $TEMP_DIR/configs.yaml ${TEMP_DIR}/newconfig.yaml > $CONFIGS_FILE
+
+  # sort the configs by db2_instance_name.
+  # This way, we maintain the same ordering of configs in the file (even though we may have deleted and recreated a config if it's an update)
+  # This eliminates confusing commits to gitops-envs and allows us to determine if anything has actually changed
+  # (which we use, in this case, to determine if we need to update the db2_settings_applied secret)
+  /usr/bin/yq -i '.ibm_db2u_databases |= sort_by(.db2_instance_name)' $CONFIGS_FILE
+
+
+  echo_h2 "Updated configuration file (${CONFIGS_FILE})"
+  if [ -f ${CONFIGS_FILE} ]; then
+    cat $CONFIGS_FILE
+  else
+    echo "<file was deleted>"
+  fi
 
   # Commit and push to github target repo
   # ---------------------------------------------------------------------------
   if [ "$GITHUB_PUSH" == "true" ]; then
     echo
     echo_h2 "Commit and push changes to GitHub repo $GITHUB_ORG $GITHUB_REPO"
-    save_to_target_git_repo $GITHUB_HOST $GITHUB_ORG $GITHUB_REPO $GIT_BRANCH $GITOPS_INSTANCE_DIR "${GIT_COMMIT_MSG}"
-    echo "git: Added ${FILES_ADDED} files"
+    save_and_unlock_target_git_repo "${GITHUB_REPO}" "${GIT_BRANCH}" "${GITOPS_WORKING_DIR}" "${GIT_COMMIT_MSG}" "${GIT_LOCK_BRANCH}"
+    DB2_CONFIG_CHANGED="$?"
 
     # The DB2CFG_SETTINGS_APPLIED secret is read by the postsync hook in the ibm-db2u-database chart
     # Since we have made changes to the db2u-database config here, we want the postsync hook to rerun,
     # so set the secret to false
-    if [[ "$FILES_ADDED" != "0" ]]; then
+    if [[ "$DB2_CONFIG_CHANGED" != "0" ]]; then
       echo_h2 "setting DB2CFG_SETTINGS_APPLIED to false to prompt postsync hooks to run"
       export DB2CFG_SETTINGS_APPLIED="false"
       export DB2CFG_SETTINGS_APPLIED_SECRET=${ACCOUNT_ID}${SECRETS_KEY_SEPERATOR}${CLUSTER_ID}${SECRETS_KEY_SEPERATOR}${MAS_INSTANCE_ID}${SECRETS_KEY_SEPERATOR}db2${SECRETS_KEY_SEPERATOR}${DB2_INSTANCE_NAME}/settings_applied
@@ -554,21 +581,10 @@ DB2_WORKLOAD: '${DB2_WORKLOAD}'"
       [ $rc -ne 0 ] && exit $rc
     fi
 
-    if [ "${ARGOCD_CHECK}" == "true" ]; then
-      argocd_login
-      argocd_sync "${INSTANCE_ROOT_APP}" ## trigger the db2-db appset to pick up the new config files
-      check_argo_app_synced "${INSTANCE_ROOT_APP}" "${CLUSTER_ROOT_APP}" # wait for the instance root app to sync
 
-      argocd_hard_refresh "${DB2_DATABASE_APP}"
-      check_argo_app_synced "${DB2_DATABASE_APP}" "${INSTANCE_ROOT_APP}"
-      check_argo_app_healthy "${DB2_DATABASE_APP}" "${INSTANCE_ROOT_APP}"
-    fi
-
-
-  fi
-  
-  if [ "$GITHUB_PUSH" == "true" ]; then
+  else
     remove_git_repo_clone $GITOPS_WORKING_DIR/$GITHUB_REPO
   fi
-  exit 0
+
+
 }

--- a/image/cli/mascli/functions/gitops_deprovision_db2u_database
+++ b/image/cli/mascli/functions/gitops_deprovision_db2u_database
@@ -156,7 +156,12 @@ function gitops_deprovision_db2u_database() {
   fi
 
   mkdir -p ${GITOPS_WORKING_DIR}
-  GITOPS_INSTANCE_DIR=${GITOPS_WORKING_DIR}/${GITHUB_REPO}/${ACCOUNT_ID}/${REGION}/${CLUSTER_ID}/${MAS_INSTANCE_ID}/db2-databases
+  GITOPS_INSTANCE_DIR=${GITOPS_WORKING_DIR}/${GITHUB_REPO}/${ACCOUNT_ID}/${REGION}/${CLUSTER_ID}/${MAS_INSTANCE_ID}
+  CONFIGS_FILE="${GITOPS_INSTANCE_DIR}/ibm-db2u-databases.yaml"
+
+  # NOTE: must align with lock branch name used by gitops_db2u_database script
+  # as both of these scrtipts modify the same file
+  GIT_LOCK_BRANCH=$(git_lock_branch_name "gitops-db2u-database" "${ACCOUNT_ID}" "${REGION_ID}" "${CLUSTER_ID}" "${MAS_INSTANCE_ID}")
 
   echo
   reset_colors
@@ -192,6 +197,7 @@ function gitops_deprovision_db2u_database() {
     echo_reset_dim "Organization .......................... ${COLOR_MAGENTA}${GITHUB_ORG}"
     echo_reset_dim "Repository ............................ ${COLOR_MAGENTA}${GITHUB_REPO}"
     echo_reset_dim "Branch ................................ ${COLOR_MAGENTA}${GIT_BRANCH}"
+    echo_reset_dim "Lock Branch ........................... ${COLOR_MAGENTA}${GIT_LOCK_BRANCH}"
   else
     echo_h2 "GitOps Target" "    "
     echo_reset_dim "Automatic Push ........................ ${COLOR_RED}Disabled"
@@ -212,9 +218,7 @@ function gitops_deprovision_db2u_database() {
   echo_reset_dim "DB2 settings-applied flag secret......... ${COLOR_MAGENTA}${DB2CFG_SETTINGS_APPLIED_SECRET}"
   reset_colors
 
-  CURRENT_DIR=$PWD
-  TEMP_DIR=$CURRENT_DIR/tmp-suite-db2u-database-deprovision
-  rm -rf $TEMP_DIR
+  TEMP_DIR=$GITOPS_WORKING_DIR/tmp-deprovision-db2u-database
   mkdir -p $TEMP_DIR
 
   if [ -z $GIT_SSH ]; then
@@ -227,8 +231,11 @@ function gitops_deprovision_db2u_database() {
   # Clone github target repo
   # ---------------------------------------------------------------------------
   if [ "$GITHUB_PUSH" == "true" ]; then
-    echo
-    echo_h2 "Cloning GitHub repo $GITHUB_ORG $GITHUB_REPO"
+    # only create the lock branch if we plan to actually push changes to git
+    clone_and_lock_target_git_repo  "${GITHUB_HOST}" "${GITHUB_ORG}" "${GITHUB_REPO}" "${GIT_BRANCH}" "${GITOPS_WORKING_DIR}" "${GIT_SSH}" "${GIT_LOCK_BRANCH}"
+  else
+    # even though we don't want to push anything to git,
+    # because this script modifies the existing suite-configs.yaml file, we still need to checkout the repo
     clone_target_git_repo $GITHUB_HOST $GITHUB_ORG $GITHUB_REPO $GIT_BRANCH $GITOPS_WORKING_DIR $GIT_SSH
   fi
   mkdir -p ${GITOPS_INSTANCE_DIR}
@@ -236,36 +243,51 @@ function gitops_deprovision_db2u_database() {
 
   # Delete config file that triggers db2-db appset to render the Application for this DB2 instance
   # ---------------------------------------------------------------------------
-  GENERATED_CONFIG_FILE="${GITOPS_INSTANCE_DIR}/${DB2_INSTANCE_NAME}.ibm-db2u-database.yaml"
-  echo "- Deleting ${GENERATED_CONFIG_FILE}"
-  rm ${GENERATED_CONFIG_FILE}
+  echo
+  echo_h2 "Removing DB2U Database Configuraton for ${DB2_INSTANCE_NAME}"
+  echo
+  # If the file doesn't exist, nothing to remove, so no-op
+  if [ -f ${CONFIGS_FILE} ]; then
+    /usr/bin/yq 'del(.ibm_db2u_databases[] | select(.db2_instance_name == "'${DB2_INSTANCE_NAME}'"))' $CONFIGS_FILE > ${TEMP_DIR}/configs.yaml
+    cp ${TEMP_DIR}/configs.yaml ${CONFIGS_FILE}
+
+    # If the file is there, but the configs are empty, delete the file
+    CONFIGS_COUNT=$(/usr/bin/yq '.ibm_db2u_databases | length' $CONFIGS_FILE)
+    if [ "${CONFIGS_COUNT}" == "0" ]; then
+      rm $CONFIGS_FILE
+    fi
+  fi
+
+
+
+  echo_h2 "Updated configuration file (${CONFIGS_FILE})"
+  if [ -f ${CONFIGS_FILE} ]; then
+    cat $CONFIGS_FILE
+  else
+    echo "<file was deleted>"
+  fi
+
 
   # Commit and push to github target repo
   # ---------------------------------------------------------------------------
   if [ "$GITHUB_PUSH" == "true" ]; then
     echo
     echo_h2 "Commit and push changes to GitHub repo $GITHUB_ORG $GITHUB_REPO"
-    save_to_target_git_repo $GITHUB_HOST $GITHUB_ORG $GITHUB_REPO $GIT_BRANCH $GITOPS_INSTANCE_DIR "${GIT_COMMIT_MSG}"
+    save_and_unlock_target_git_repo "${GITHUB_REPO}" "${GIT_BRANCH}" "${GITOPS_WORKING_DIR}" "${GIT_COMMIT_MSG}" "${GIT_LOCK_BRANCH}"
+
+    # These will both be deleted via a PostDelete hook once https://jsw.ibm.com/browse/MASCORE-2122 is complete
+    # Delete the DB2CFG_SETTINGS_APPLIED secret for the db2u-database instance
+    echo "Deleting ${DB2CFG_SETTINGS_APPLIED_SECRET} secret from AWS"
+    sm_delete_secret ${DB2CFG_SETTINGS_APPLIED_SECRET}
+
+    # Delete the DB2 config secret created by the postsync hook
+    echo "Deleting ${DB2_CONFIG_SECRET} secret from AWS"
+    sm_delete_secret ${DB2_CONFIG_SECRET}
+
+  else
     remove_git_repo_clone $GITOPS_WORKING_DIR/$GITHUB_REPO
-
-    if [ "${ARGOCD_CHECK}" == "true" ]; then
-      INSTANCE_ROOT_APP="instance.${ACCOUNT_ID}.${REGION}.${CLUSTER_ID}.${MAS_INSTANCE_ID}"
-      DB2_DATABASE_APP="db2-db.${ACCOUNT_ID}.${REGION}.${CLUSTER_ID}.${MAS_INSTANCE_ID}.${MAS_APP_ID}"
-
-      argocd_login
-      argocd_prune_sync "${INSTANCE_ROOT_APP}" ## trigger the instance root app to notice the deletion of the config file
-      
-      # The DB2 app generated by the appset should disappear
-      check_argo_app_deleted ${DB2_DATABASE_APP} "mas"
-    fi
-
   fi
-  # TODO - PK: Should this delete secret move to post sync ?
-  # Delete the DB2CFG_SETTINGS_APPLIED secret for the db2u-database instance
-  echo "Deleting ${DB2CFG_SETTINGS_APPLIED_SECRET} secret from AWS"
-  sm_delete_secret ${DB2CFG_SETTINGS_APPLIED_SECRET}
 
-  # Delete the DB2 config secret created by the postsync hook
-  echo "Deleting ${DB2_CONFIG_SECRET} secret from AWS"
-  sm_delete_secret ${DB2_CONFIG_SECRET}
+
+
 }

--- a/image/cli/mascli/functions/gitops_utils
+++ b/image/cli/mascli/functions/gitops_utils
@@ -381,6 +381,7 @@ function clone_and_lock_target_git_repo() {
 # Intended to be called at the end of a script that uses the clone_and_lock_target_git_repo function above
 # after modifications to config files have been applied to the local clone
 # This pushes the changes to the lock branch (GIT_LOCK_BRANCH), and squash merges them to the main branch (GIT_BRANCH)
+# returns 1 if there are changes in GIT_LOCK_BRANCH that are not in GIT_BRANCH, or 0 otherwise
 function save_and_unlock_target_git_repo {
   GITHUB_REPO=$1
   GIT_BRANCH=$2
@@ -402,6 +403,8 @@ function save_and_unlock_target_git_repo {
   # Merge back to master
   git -C "${GITOPS_REPO_DIR}" switch "${GIT_BRANCH}"
   git -C "${GITOPS_REPO_DIR}" merge --squash "${GIT_LOCK_BRANCH}"
+  local GIT_STATUS=$(git -C "${GITOPS_REPO_DIR}" status --porcelain=v1)
+
   git -C "${GITOPS_REPO_DIR}" commit -m "${GIT_COMMIT_MSG}" 
   git -C "${GITOPS_REPO_DIR}" push -u origin "${GIT_BRANCH}"
 
@@ -411,6 +414,13 @@ function save_and_unlock_target_git_repo {
   # (note since this will also delete the repo dir from the system, when the exit trap reruns this script
   # it won't repeat the branch delete (which could cause problems since another process could have since re-created the lock branch))
   unlock_git_repo "${GIT_LOCK_BRANCH}" "${GITOPS_REPO_DIR}"
+
+
+  if [[ -n "$GIT_STATUS" ]]; then
+    return 1
+  else
+    return 0
+  fi
 
 }
 

--- a/image/cli/mascli/templates/gitops/appset-configs/cluster/instance/db2-databases/ibm-db2u-database-common.yaml.j2
+++ b/image/cli/mascli/templates/gitops/appset-configs/cluster/instance/db2-databases/ibm-db2u-database-common.yaml.j2
@@ -1,0 +1,2 @@
+merge-key: "{{ ACCOUNT_ID }}/{{ REGION_ID }}/{{ CLUSTER_ID }}/{{ MAS_INSTANCE_ID }}"
+ibm_db2u_databases: []


### PR DESCRIPTION
The old configs appset:
![image](https://github.com/ibm-mas/cli/assets/7372253/461f5b66-5636-4c4e-8fb8-25573838fa8e)

has been replaced by a helm template that generates "ordinary" applications dynamically using a range loop in a helm template.
![image](https://github.com/ibm-mas/cli/assets/7372253/7e6e38c3-d216-4281-a29b-9a83d22dcde5)

This is so that:
 - syncstate / health of generated db2u-database applications can influence syncwaves, meaning that e.g. MAS apps (in a later syncwave) will start being deployed before the DB2 databases that they depend upon are stood up (this does not work in ArgoCD for applications generated by appsets).
 
 - PostDelete hooks (which we want for DB2) do not work on Applications generated directly by application sets due to a bug in ArgoCD (see https://github.com/argoproj/argo-cd/issues/17181)

For this to work, we have to combine all DB2 Database configurations into a list in a single file. This PR updates the gitops_db2u_database and gitops_deprovision_db2u_database scripts accordingly. It uses techniques and code developed under https://github.com/ibm-mas/cli/pull/862 to achieve this.

[MASCORE-2339](https://jsw.ibm.com/browse/MASCORE-2339)

Related PR: https://github.com/ibm-mas/gitops/pull/47 should be merged at the same time as this one.