### PR TITLE
Make save_and_unlock_target_git_repo tolerant of changes being pushed concurrently to other files in the repo

### DIFF
--- a/image/cli/mascli/functions/gitops_utils
+++ b/image/cli/mascli/functions/gitops_utils
@@ -320,15 +320,9 @@ function clone_and_lock_target_git_repo() {
   GITOPS_REPO_DIR="${LOCAL_DIR}/${GITHUB_REPO}"
   LOCKFILE_NAME='.lock'
 
-
-  echo ""
-  echo ""
-  echo "clone_and_lock_git_repo: (${GIT_LOCK_BRANCH})"
-
   for (( c=1; c<="${RETRIES}"; c++ )); do
     echo ""
-    echo "clone_and_lock_git_repo: retry ${c} of ${RETRIES}"
-
+    echo " - clone_and_lock_git_repo: retry ${c} of ${RETRIES}"
 
     # Remove any clones created by prior attempts
     rm -rf "${GITOPS_REPO_DIR}"
@@ -336,10 +330,12 @@ function clone_and_lock_target_git_repo() {
     clone_target_git_repo "${GITHUB_HOST}" "${GITHUB_ORG}" "${GITHUB_REPO}" "${GIT_BRANCH}" "${LOCAL_DIR}" "${SSH_PATH}"
 
 
-    # If the lock branch exists currently on the remote, return after a delay
+    # If the lock branch exists currently on the remote, retry after a delay
+    echo
+    echo "git: ls-remote --heads origin ${GIT_LOCK_BRANCH}"
     LS_REMOTE_STDOUT=$(git -C "${GITOPS_REPO_DIR}" ls-remote --heads origin ${GIT_LOCK_BRANCH})
     if [[ -n "${LS_REMOTE_STDOUT}"  ]]; then
-      echo "Lock branch ${GIT_LOCK_BRANCH} currently in use by another process, retry in ${RETRY_DELAY_SECONDS}s"
+      echo " - clone_and_lock_git_repo: Lock branch ${GIT_LOCK_BRANCH} currently in use by another process, retry in ${RETRY_DELAY_SECONDS}s"
       sleep ${RETRY_DELAY_SECONDS}
       continue
     fi
@@ -349,14 +345,25 @@ function clone_and_lock_target_git_repo() {
     # there is sufficient desynchronization between parallel runs of this script
 
     # Create the lock branch locally
+    echo
+    echo "git: checkout -b ${GIT_LOCK_BRANCH}"
     git -C "${GITOPS_REPO_DIR}" checkout -b "${GIT_LOCK_BRANCH}"
 
     # To definitively acquire the "lock", we create and commit a temporary "lock file";
     # This will mean that, amongst n scripts running in parallel and in sync (i.e. where all invokations have passed the initial git ls-remote check),
     # at most 1 invokation will be able to successfully perform the push below.
     touch "${GITOPS_REPO_DIR}/${LOCKFILE_NAME}"
+
+    echo
+    echo "git: add ${LOCKFILE_NAME}"
     git -C "${GITOPS_REPO_DIR}" add ${LOCKFILE_NAME}
+
+    echo
+    echo "git: commit -m 'Acquire lock branch'"
     git -C "${GITOPS_REPO_DIR}" commit -m 'Acquire lock branch'
+
+    echo
+    echo "git: push --atomic -u origin ${GIT_LOCK_BRANCH}"
     git -C "${GITOPS_REPO_DIR}" push --atomic -u origin "${GIT_LOCK_BRANCH}"
     GIT_PUSH_RC=$?
 
@@ -365,17 +372,17 @@ function clone_and_lock_target_git_repo() {
       # Register an exit trap to ensure we delete the remote branch whatever happens
       trap "unlock_git_repo ${GIT_LOCK_BRANCH} ${GITOPS_REPO_DIR}" EXIT
       echo ""
-      echo "clone_and_lock_git_repo: Acquired lock on branch ${GIT_LOCK_BRANCH}; proceeding..."
+      echo " - clone_and_lock_git_repo: Acquired lock on branch ${GIT_LOCK_BRANCH}; proceeding..."
       return 0
     fi 
 
     echo ""
-    echo "clone_and_lock_git_repo: Failed to acquire Lock branch ${GIT_LOCK_BRANCH}, retry in ${RETRY_DELAY_SECONDS}s"
+    echo " - clone_and_lock_git_repo: Failed to acquire Lock branch ${GIT_LOCK_BRANCH}, retry in ${RETRY_DELAY_SECONDS}s"
     sleep ${RETRY_DELAY_SECONDS}
 
   done
 
-  echo "!!! Failed clone_and_lock_git_repo after ${RETRIES} retries... giving up"
+  echo " - clone_and_lock_git_repo: !!! Failed clone_and_lock_git_repo after ${RETRIES} retries... giving up"
   exit 1
 
 }
@@ -391,6 +398,8 @@ function clone_and_lock_target_git_repo() {
 #     echo "Configuration was modified"
 #   fi
 function save_and_unlock_target_git_repo {
+  echo
+  echo " - save_and_unlock_target_git_repo"
   GITHUB_REPO="$1"
   GIT_BRANCH="$2"
   LOCAL_DIR="$3"
@@ -405,13 +414,32 @@ function save_and_unlock_target_git_repo {
   rm "${GITOPS_REPO_DIR}/${LOCKFILE_NAME}"
 
   # commit and push all changes
+  echo
+  echo "git: add -v ."
   git -C "${GITOPS_REPO_DIR}" add -v .
-  git -C "${GITOPS_REPO_DIR}" commit -m "${GIT_COMMIT_MSG}" 
+
+  echo
+  echo "git: commit -m ${GIT_COMMIT_MSG} "
+  git -C "${GITOPS_REPO_DIR}" commit -m "${GIT_COMMIT_MSG}"
+
+  echo
+  echo "git: push -u origin ${GIT_LOCK_BRANCH} "
   git -C "${GITOPS_REPO_DIR}" push -u origin "${GIT_LOCK_BRANCH}"
 
   # Merge back to master
+  echo
+  echo "git: switch ${GIT_BRANCH}"
   git -C "${GITOPS_REPO_DIR}" switch "${GIT_BRANCH}"
+
+  echo
+  echo "git: pull origin $GIT_BRANCH --rebase"
+  git -C "${GITOPS_REPO_DIR}" pull origin $GIT_BRANCH --rebase
+
+  echo
+  echo "git: merge --squash ${GIT_LOCK_BRANCH}"
   git -C "${GITOPS_REPO_DIR}" merge --squash "${GIT_LOCK_BRANCH}"
+
+
   if [[ -n "${RETURNVARNAME_MODIFIED}" ]]; then
     local -n RETURNVAR_MODIFIED="${RETURNVARNAME_MODIFIED}"
     local GIT_STATUS=$(git -C "${GITOPS_REPO_DIR}" status --porcelain=v1)
@@ -422,7 +450,12 @@ function save_and_unlock_target_git_repo {
     fi
   fi
 
+  echo
+  echo "git: commit -m ${GIT_COMMIT_MSG}"
   git -C "${GITOPS_REPO_DIR}" commit -m "${GIT_COMMIT_MSG}" 
+
+  echo
+  echo "git: push -u origin ${GIT_BRANCH}"
   git -C "${GITOPS_REPO_DIR}" push -u origin "${GIT_BRANCH}"
 
   # unlock_git_repo exit trap function registered in clone_and_lock_target_git_repo


### PR DESCRIPTION


by running:
```
git -C "${GITOPS_REPO_DIR}" pull origin $GIT_BRANCH --rebase
```
after switching back to the main branch, before squash merging in the lock branch.

also improves logging

[MASCORE2366](https://jsw.ibm.com/browse/MASCORE-2366)