### PR TITLE
[patch] make DRO install default on newer versions of cli and mas catalog

### DIFF
--- a/image/cli/mascli/functions/internal/catalog_utils
+++ b/image/cli/mascli/functions/internal/catalog_utils
@@ -125,15 +125,12 @@ function choose_mas_version() {
 # We automatically select the UDS or DRO operator to install in the
 # cluster based on the version of the catalog that is being used
 function uds_action_selection() {
-  case $MAS_CATALOG_VERSION in
-    v8-amd64|v8-240227-amd64|v8-240326-amd64|v8-240405-amd64)
-      # UDS_ACTION=install-dro will result in any existing install of UDS being removed, and DRO being installed in it's place
-      UDS_ACTION="install-dro"
-      ;;
-    *)
-      UDS_ACTION="install"
-      ;;
-  esac
+  MAS_CATALOG_DATE=${MAS_CATALOG_VERSION:3:6}
+  if [[ ($MAS_CATALOG_DATE -ge 240227) || ($MAS_CATALOG_DATE == "amd64") || ($MAS_CATALOG_DATE == "master") ]]; then
+    UDS_ACTION="install-dro"
+  else
+    UDS_ACTION="install"
+  fi
 }
 
 # Determine the version of Db2u Operator to use

--- a/image/cli/mascli/functions/update
+++ b/image/cli/mascli/functions/update
@@ -135,7 +135,7 @@ function validate_dro_migration() {
   # warn about DRO migration if UDS is running and MAS catalog is January 2024 or newer
   MAS_CATALOG_DATE=${MAS_CATALOG_VERSION:3:6}
 
-  if [[ $MAS_CATALOG_DATE -ge 240227 ]]; then
+  if [[ ($MAS_CATALOG_DATE -ge 240227) || ($MAS_CATALOG_DATE == "amd64") || ($MAS_CATALOG_DATE == "master") ]]; then
     if [[ "$NO_CONFIRM" != "true" ]] && [[ -z "${DRO_MIGRATION}" ]]; then
       prompt_for_confirm_default_yes "Do you want to proceed with uninstalling UDS and migrate to DRO?" DRO_MIGRATION
     fi


### PR DESCRIPTION
- make DRO install default on newer version of cli and mas catalog
- enhance the DRO migration condition to support default catalog versions