### PR TITLE
[patch] create PR action to fail if local ansible collection is present

### DIFF
--- a/.github/workflows/verify-cli-pr.yml
+++ b/.github/workflows/verify-cli-pr.yml
@@ -1,0 +1,19 @@
+name: Verify CLI Image
+
+on:
+  pull_request:
+    branches: [ "master" ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v3
+
+      - name: Fail if local Ansible collection is present in PR to master
+        run: |
+          if [[ -e $GITHUB_WORKSPACE/image/cli/ibm-mas_devops.tar.gz ]]; then
+            echo "Found a local Ansible collection($GITHUB_WORKSPACE/image/cli/install-ansible/ibm-mas_devops.tar.gz) in this PR, Local ansible collection is not allowed in master branch. Failing build."
+            exit 1
+          fi


### PR DESCRIPTION
This action will be triggered when a PR is raised to master.
If will fail status check if local ansible collection is detected in the PR.
this will prevent local ansible collection to get merged accidentally 