### PR TITLE
[patch] lookup mongo version not default during mas update

### DIFF
--- a/image/cli/mascli/functions/update
+++ b/image/cli/mascli/functions/update
@@ -92,7 +92,7 @@ function validate_existing_mongo() {
     if [[ $MONGODB_CURRENT_VERSION != "" ]]; then
     
       # Target mongo version will be defined by chosen catalog/casebundle
-      MONGODB_TARGET_VERSION=`yq -r .mongo_extras_version_default ansible-devops/common_vars/casebundles/${MAS_CATALOG_VERSION}.yml`
+      MONGODB_TARGET_VERSION=`yq -r .mongo_extras_version ansible-devops/common_vars/casebundles/${MAS_CATALOG_VERSION}.yml`
 
       MONGODB_CURRENT_MAJORMINOR_VERSION=${MONGODB_CURRENT_VERSION:0:3}
       MONGODB_TARGET_MAJORMINOR_VERSION=${MONGODB_TARGET_VERSION:0:3}


### PR DESCRIPTION
The mas update command was looking up the mongo_extras_version_default in the casebundle which is always set to v5 for the current catalogs. What this should be doing is look up the mongo_extras_version which is the value of MONGODB_VERSION (or if not set then the default).

Without this fix the error message during mas update when you have a v6 mongodb is: 
```
MongoDB Community Edition is currently running on version 6.0.10 and cannot be downgraded to target version 5.0.23, which is the MongoDB version you would get when choosing MAS catalog 'v8-240405-amd64'
```