### PR TITLE
[patch] Add errors for trying to provision quickburn fyre cluster outside svl

### DIFF
--- a/image/cli/mascli/functions/provision_fyre
+++ b/image/cli/mascli/functions/provision_fyre
@@ -108,6 +108,8 @@ function provision_fyre_noninteractive() {
   if [[ -z "$FYRE_SITE" ]]; then
     FYRE_SITE=svl
   fi
+
+  [[ "$FYRE_SITE" != "svl" && "$FYRE_QUOTA_TYPE" == "quick_burn" ]] && provision_fyre_help "Quickburn is only available in svl"
 }
 
 function provision_fyre_interactive() {
@@ -159,6 +161,10 @@ function provision_fyre_interactive() {
     prompt_for_number "Worker Node Memory (max 64)" FYRE_WORKER_MEMORY
   else
     FYRE_QUOTA_TYPE="quick_burn"
+    if [[ "$FYRE_SITE" != "svl" ]]; then 
+      echo -e "${COLOR_RED}Usage Error: QuickBurn is only supported in svl${TEXT_RESET}\n"
+      exit 1
+    fi
   fi
 
   prompt_for_input "Configure Storage (ODF)" FYRE_CONFIG_STORAGE


### PR DESCRIPTION
Quickburn is only supported in fyre svl, so setting the site to anything else causes problems for anything else using the site value. We should be throwing an error so that people know what they have asked for isn't possible.