### PR TITLE
[patch] Support for pod Template test case moved from fvt to ivt

### DIFF
--- a/tekton/src/pipelines/fvt-iot.yml.j2
+++ b/tekton/src/pipelines/fvt-iot.yml.j2
@@ -69,6 +69,8 @@ spec:
           operator: notin
           values: [""]
       workspaces:
+        - name: configs
+          workspace: shared-configs
         - name: pod-templates
           workspace: shared-pod-templates
 

--- a/tekton/src/pipelines/fvt-iot.yml.j2
+++ b/tekton/src/pipelines/fvt-iot.yml.j2
@@ -68,6 +68,9 @@ spec:
         - input: "$(params.mas_app_channel_iot)"
           operator: notin
           values: [""]
+      workspaces:
+        - name: pod-templates
+          workspace: shared-pod-templates
 
 
     # 2. IoT FVT
@@ -98,8 +101,6 @@ spec:
       workspaces:
         - name: configs
           workspace: shared-configs
-        - name: pod-templates
-          workspace: shared-pod-templates
 
   finally:
     # 3. Run CV

--- a/tekton/src/tasks/fvt/fvt-iot.yml.j2
+++ b/tekton/src/tasks/fvt/fvt-iot.yml.j2
@@ -88,5 +88,3 @@ spec:
 
   workspaces:
     - name: configs
-    - name: pod-templates
-      optional: true

--- a/tekton/src/tasks/ivt/ivt-core.yml.j2
+++ b/tekton/src/tasks/ivt/ivt-core.yml.j2
@@ -118,3 +118,5 @@ spec:
 
   workspaces:
     - name: configs
+    - name: pod-templates
+      optional: true


### PR DESCRIPTION
Support for podTemplates validation test case to fetch the podTemplates secret is moved from fvt to ivt.
Current apps: IoT

Ref Tasks:
https://jsw.ibm.com/browse/MASCORE-1964
https://jsw.ibm.com/browse/MASCORE-2433

Testing:
Verified the test case by running fvt-personal

<img width="1728" alt="Screenshot 2024-04-24 at 00 01 27" src="https://media.github.ibm.com/user/456520/files/49ce47fb-f639-417f-a8a2-d33131579319">