### PR TITLE
[patch] Allow MONGODB_VERSION to be set on update

### DIFF
--- a/image/cli/mascli/functions/update
+++ b/image/cli/mascli/functions/update
@@ -18,6 +18,7 @@ Update Dependencies (Optional):
   --db2u-namespace ${COLOR_YELLOW}DB2_NAMESPACE${TEXT_RESET}          DB2 namespace where instances update will be performed
   --mongodb-namespace ${COLOR_YELLOW}MONGODB_NAMESPACE${TEXT_RESET}   Namespace where MongoCE operator and instance will be updated
   --mongodb-v5-upgrade ${COLOR_YELLOW}MONGODB_V5_UPGRADE${TEXT_RESET} Confirms that Mongo can be upgraded to version 5 if needed as part of the update
+  --mongodb-version  ${COLOR_YELLOW}MONGODB_VERSION${TEXT_RESET}      Optional. Set Mongo version for the upgrade. Note: This overrides the default MongoDB version defined by the Maximo Operator Catalog version.
   --kafka-namespace ${COLOR_YELLOW}KAFKA_NAMESPACE${TEXT_RESET}       Namespace where Kafka operator and instance will be updated
   --kafka-provider ${COLOR_YELLOW}KAFKA_PROVIDER${TEXT_RESET}         Set Kafka provider. Supported options are 'redhat' (Red Hat AMQ Streams), or 'strimzi'
   --dro-migration  ${COLOR_YELLOW}DRO_MIGRATION${TEXT_RESET}          Confirm the removal of UDS and replacement with DRO as part of the update
@@ -93,8 +94,11 @@ function validate_existing_mongo() {
     # Only check if mongo upgrade is needed if mongo is currently installed
     if [[ $MONGODB_CURRENT_VERSION != "" ]]; then
     
-      # Target mongo version will be defined by chosen catalog/casebundle
-      MONGODB_TARGET_VERSION=`yq -r .mongo_extras_version ansible-devops/common_vars/casebundles/${MAS_CATALOG_VERSION}.yml`
+      # Target mongo version will be defined by chosen catalog/casebundle if MONGODB_VERSION not set
+      MONGODB_TARGET_VERSION=${MONGODB_VERSION}
+      if [[ "$MONGODB_TARGET_VERSION" == "" ]]; then
+        MONGODB_TARGET_VERSION=`yq -r .mongo_extras_version_default ansible-devops/common_vars/casebundles/${MAS_CATALOG_VERSION}.yml 2> /dev/null`
+      fi
 
       MONGODB_CURRENT_MAJORMINOR_VERSION=${MONGODB_CURRENT_VERSION:0:3}
       MONGODB_TARGET_MAJORMINOR_VERSION=${MONGODB_TARGET_VERSION:0:3}
@@ -566,6 +570,9 @@ function update_noninteractive() {
       --mongodb-v5-upgrade)
         MONGODB_V5_UPGRADE=true
         ;;
+      --mongodb-version)
+        MONGODB_VERSION=$1 && shift
+        ;;
       --kafka-namespace)
         KAFKA_NAMESPACE=$1 && shift
         ;;
@@ -676,6 +683,7 @@ function update() {
   export DB2_NAMESPACE
   export MONGODB_NAMESPACE
   export MONGODB_V5_UPGRADE
+  export MONGODB_VERSION
   export KAFKA_NAMESPACE
   export KAFKA_PROVIDER
   export CERT_MANAGER_PROVIDER


### PR DESCRIPTION
If the current installed Mongodb version is above v5 then the check fails as it using the default value in the catalog for mongo which is v5. Ihave added to option similar to CPD_VERSION which allows you to optionally set the target mongodb version so you can set this to v6.

Tested in my env:
```
export MONGODB_VERSION=6.0.12
```

```
Verifying current MongoDB deployment...
Dependency Upgrade Notice!
MongoDB Community Edition is currently running on version 5.0.23 and will be upgraded to version 6.0.12

It is recommended that you backup your MongoDB instance before proceeding:
https://www.ibm.com/docs/en/mas-cd/continuous-delivery?topic=suite-backing-up-mongodb-maximo-application
```

The current code doesn't work as it sets the target_version to be the string "{{ lookup('env', 'MONGODB_VERSION') | default(mongo_extras_version_default, True) }}"