### PR TITLE
[patch] [mascore-1110] adding must-gather finally block

### DIFF
--- a/tekton/src/pipelines/fvt-launcher.yml.j2
+++ b/tekton/src/pipelines/fvt-launcher.yml.j2
@@ -279,3 +279,17 @@ spec:
           values: ["true", "True"]
       runAfter:
         - launchfvt-manage
+
+  finally:
+    # Collect must-gather
+    # -------------------------------------------------------------------------
+    - name: must-gather
+      taskRef:
+        kind: Task
+        name: mas-devops-must-gather
+      params:
+        - name: base_output_dir
+          value: "/workspace/mustgather/$(context.pipelineRun.name)"
+      workspaces:
+        - name: mustgather
+          workspace: shared-mustgather


### PR DESCRIPTION
Issue - https://jsw.ibm.com/browse/MASCORE-1110?filter=-1

Fix: Adding task `mas-devops-must-gather` to pipeline `mas-fvt-launcher` in `tekton/src/pipelines/fvt-launcher.yml.j2`  
Please note - this pipeline gets invoked by `saas-tekton/.tekton/gitops-mas-fvt-preparer.yaml`
