### PR TITLE
[patch] Fix verify-cli-pr git action to be trigger on push

### DIFF
--- a/.github/workflows/verify-cli-pr.yml
+++ b/.github/workflows/verify-cli-pr.yml
@@ -1,8 +1,9 @@
 name: Verify CLI Image
 
 on:
-  pull_request:
-    branches: [ "master" ]
+  push:
+    branches:
+      - master
 
 jobs:
   build:


### PR DESCRIPTION
Changing the new recent `verify-cli-pr` github action to be triggered on pushes instead of PR creations.

Before the fix it was failing during the code push:

<img width="835" alt="image" src="https://github.com/ibm-mas/cli/assets/31037381/cc8df6d3-a968-46ff-a784-4f894d61846d">

After the fix - we skip push verification on dev branches:

<img width="1233" alt="image" src="https://github.com/ibm-mas/cli/assets/31037381/2ab53fe8-419b-44ec-a739-c143a4502b72">
