### PR TITLE
[patch] [mascore-2307] flag to control deploy with cis (only for fvtsaas)

### DIFF
--- a/tekton/src/pipelines/gitops/gitops-mas-initiator.yml.j2
+++ b/tekton/src/pipelines/gitops/gitops-mas-initiator.yml.j2
@@ -86,7 +86,9 @@ spec:
     - name: secrets_key_seperator
       type: string
       default: "/"
-      
+    - name: deployment_day_with_cis
+      type: string
+      default: ""
 
   tasks:
 {% if wait_for_provision == true %}
@@ -162,6 +164,8 @@ spec:
           value: $(params.mas_app_channel_visualinspection)
         - name: github_pat
           value: $(params.github_pat)
+        - name: deployment_day_with_cis
+          value: $(params.deployment_day_with_cis)
       taskRef:
         kind: Task
         name: gitops-mas-initiator

--- a/tekton/src/tasks/gitops/gitops-mas-initiator.yml.j2
+++ b/tekton/src/tasks/gitops/gitops-mas-initiator.yml.j2
@@ -62,6 +62,9 @@ spec:
     - name: ibmcloud_apikey
       type: string
       default: ""
+    - name: deployment_day_with_cis
+      type: string
+      default: ""
   stepTemplate:
     name: gitops-mas-initiator
     env:
@@ -119,6 +122,8 @@ spec:
         value: $(params.secrets_key_seperator)
       - name: IBMCLOUD_APIKEY
         value: $(params.ibmcloud_apikey)
+      - name: DEPLOYMENT_DAY_WITH_CIS
+        value: $(params.deployment_day_with_cis)
   steps:
     - args:
       - |-
@@ -184,6 +189,20 @@ spec:
 
         # Update the channel in the mas-instance-params.yaml. Assume fvtsaas here
         yq --arg MAS_CHANNEL $MAS_CHANNEL -iY '.mas_instance.channel= $MAS_CHANNEL' gitops/$ACCOUNT/$REGION/$CLUSTER_NAME/fvtsaas/mas-instance-params.yaml
+
+        # Set dns.provider as empty in the mas-instance-params.yaml if deployment with cis is not enabled for that deployment day.  Assume fvtsaas here
+        export DNS_PROVIDER=$(yq -sr '.[0].dns.provider' gitops/$ACCOUNT/$REGION/$CLUSTER_NAME/fvtsaas/mas-instance-params.yaml)
+        export CURRENT_DATE=$(date +"%u")
+        export EMPTY_DNS_PROVIDER=""
+        echo "gitops-mas-initiator: DNS_PROVIDER=${DNS_PROVIDER} CURRENT_DATE=${CURRENT_DATE} DEPLOYMENT_DAY_WITH_CIS=$DEPLOYMENT_DAY_WITH_CIS"
+
+        if [ "$DNS_PROVIDER" == "cis" ]; then
+          if [[ -n $DEPLOYMENT_DAY_WITH_CIS && "$DEPLOYMENT_DAY_WITH_CIS" != "CURRENT_DATE" ]]; then
+            yq --arg EMPTY_DNS_PROVIDER "${EMPTY_DNS_PROVIDER}" -iY '(. | select(has("dns")?).dns.provider)= $EMPTY_DNS_PROVIDER' gitops/$ACCOUNT/$REGION/$CLUSTER_NAME/fvtsaas/mas-instance-params.yaml
+            yq -iY 'del(.dns.cis)' gitops/$ACCOUNT/$REGION/$CLUSTER_NAME/fvtsaas/mas-instance-params.yaml
+            echo "gitops-mas-initiator: set .dns.provider to empty & remove .dns.cis"
+          fi
+        fi
 
         # Update the app channels in the mas-apps-params.yaml. Assume fvtsaas here
         if [ -n $MAS_APP_CHANNEL_ASSIST ]; then

--- a/tekton/src/tasks/gitops/gitops-mas-initiator.yml.j2
+++ b/tekton/src/tasks/gitops/gitops-mas-initiator.yml.j2
@@ -193,14 +193,12 @@ spec:
         # Set dns.provider as empty in the mas-instance-params.yaml if deployment with cis is not enabled for that deployment day.  Assume fvtsaas here
         export DNS_PROVIDER=$(yq -sr '.[0].dns.provider' gitops/$ACCOUNT/$REGION/$CLUSTER_NAME/fvtsaas/mas-instance-params.yaml)
         export CURRENT_DATE=$(date +"%u")
-        export EMPTY_DNS_PROVIDER=""
         echo "gitops-mas-initiator: DNS_PROVIDER=${DNS_PROVIDER} CURRENT_DATE=${CURRENT_DATE} DEPLOYMENT_DAY_WITH_CIS=$DEPLOYMENT_DAY_WITH_CIS"
 
         if [ "$DNS_PROVIDER" == "cis" ]; then
           if [[ -n $DEPLOYMENT_DAY_WITH_CIS && "$DEPLOYMENT_DAY_WITH_CIS" != "CURRENT_DATE" ]]; then
-            yq --arg EMPTY_DNS_PROVIDER "${EMPTY_DNS_PROVIDER}" -iY '(. | select(has("dns")?).dns.provider)= $EMPTY_DNS_PROVIDER' gitops/$ACCOUNT/$REGION/$CLUSTER_NAME/fvtsaas/mas-instance-params.yaml
-            yq -iY 'del(.dns.cis)' gitops/$ACCOUNT/$REGION/$CLUSTER_NAME/fvtsaas/mas-instance-params.yaml
-            echo "gitops-mas-initiator: set .dns.provider to empty & remove .dns.cis"
+            yq -iY 'del(.dns)' gitops/$ACCOUNT/$REGION/$CLUSTER_NAME/fvtsaas/mas-instance-params.yaml
+            echo "gitops-mas-initiator: removed .dns node"
           fi
         fi
 


### PR DESCRIPTION
Issue: https://jsw.ibm.com/browse/MASCORE-2307?filter=-1

Letsencrypt has rate limit and to avoid this (ref:- https://letsencrypt.org/docs/rate-limits/) we will deploy fvtsaas instance only once a week using cis.

What is changed in this PR:

Added logic to remove `dns` node in `gitops/$ACCOUNT/$REGION/$CLUSTER_NAME/fvtsaas/mas-instance-params.yaml` if the file has `dns.provider` as `cis` and deployment date happens to be a day other than the one set in travis (env `GITOPS_DEPLOYMENT_DAY_WITH_CIS`). 
