### PR TITLE
[patch] fix default DRO issue.

### DIFF
--- a/image/cli/mascli/functions/install
+++ b/image/cli/mascli/functions/install
@@ -750,10 +750,6 @@ function install() {
     esac
   done
 
-  # Determine whether UDS, SUDS, or DRO will be installed
-  # If DRO is being installed, any existing UDS install will be removed first
-  uds_action_selection
-
   # Determine whether Grafana is available in the cluster based on the available of the operator package
   oc get packagemanifest grafana-operator &> /dev/null
   if [[ "$?" == "1" ]]; then
@@ -779,6 +775,10 @@ function install() {
     pipelines_install_operator
     install_config_additional_configs
   fi
+
+  # Determine if UDS or DRO will be installed
+  # DRO is installed by default on latest catalog version, for catalogs older than 240227 install UDS
+  uds_action_selection
 
   # Prepare and launch the Tekton pipeline
   install_pipelinerun_prepare


### PR DESCRIPTION
https://github.com/ibm-mas/cli/issues/935

the function to check uds selection ` uds_action_selection` was in the wrong place. I have moved it so that it gets the correct value of catalog version to determine if UDS or DRO needs to be installed. 

Testing successful 

uds_action now carries `install-dro` on mas pipeline run

![image](https://github.com/ibm-mas/cli/assets/110647904/c436cbc1-5ba9-4195-a764-667c5f3a316e)
