### PR TITLE
[patch] [MASCORE-2307]Secrets Manager can't find the specified secret

### DIFF
--- a/tekton/src/tasks/gitops/gitops-mas-initiator.yml.j2
+++ b/tekton/src/tasks/gitops/gitops-mas-initiator.yml.j2
@@ -150,10 +150,11 @@ spec:
           export AWS_REGION=$SM_AWS_REGION
           aws configure list
 
-          aws secretsmanager delete-secret --force-delete-without-recovery --secret-id ${SECRET_NAME} --output json 2> /dev/null
-          aws secretsmanager create-secret --name ${SECRET_NAME} --secret-string "${SECRET_VALUE}" || exit 1
+          aws secretsmanager delete-secret --force-delete-without-recovery --secret-id ${SECRET_NAME} --region $SM_AWS_REGION --output json 2> /dev/null
+          aws secretsmanager describe-secret --secret-id ${SECRET_NAME} --region $SM_AWS_REGION --output json 2> /dev/null
+          aws secretsmanager create-secret --name ${SECRET_NAME} --region $SM_AWS_REGION --secret-string "${SECRET_VALUE}" || exit 1
 
-          echo "created AWS secret secret ${SECRET_NAME} with value ${SECRET_NAME:0:6}<snip> in region $(params.avp_aws_secret_region)"
+          echo "created AWS secret secret ${SECRET_NAME} with value ${SECRET_NAME:0:6}<snip> in region $SM_AWS_REGION"
 
         fi
 

--- a/tekton/src/tasks/gitops/gitops-mas-initiator.yml.j2
+++ b/tekton/src/tasks/gitops/gitops-mas-initiator.yml.j2
@@ -154,7 +154,7 @@ spec:
           aws secretsmanager describe-secret --secret-id ${SECRET_NAME} --region $SM_AWS_REGION --output json 2> /dev/null
           aws secretsmanager create-secret --name ${SECRET_NAME} --region $SM_AWS_REGION --secret-string "${SECRET_VALUE}" || exit 1
 
-          echo "created AWS secret secret ${SECRET_NAME} with value ${SECRET_NAME:0:6}<snip> in region $SM_AWS_REGION"
+          echo "created AWS secret secret ${SECRET_NAME} with value ${SECRET_VALUE:0:6}<snip> in region $SM_AWS_REGION"
 
         fi
 


### PR DESCRIPTION

Issue:  https://jsw.ibm.com/browse/MASCORE-2307?filter=-1

 - Invoking `create-secret ` after calling `delete-secret` is failing with below error 
 
` An error occurred (InvalidRequestException) when calling the CreateSecret operation: You can't create this secret because a secret with this name is already scheduled for deletion. `


What get fixed in this PR 
 - Invoke `describe-secret`  after `delete-secret` followed by  `create-secret `
 - Ref: https://repost.aws/knowledge-center/delete-secrets-manager-secret
