### PR TITLE
[patch] Fix Backup Maximo Manage script: Maximo Manage Operator group not found error

### DIFF
--- a/image/cli/mascli/backup-restore/manage-backup-restore.sh
+++ b/image/cli/mascli/backup-restore/manage-backup-restore.sh
@@ -143,7 +143,8 @@ if [ "$MODE" == "backup" ]; then
     echo "Starting MAS Managebackup using the instance id $MAS_INSTANCE_ID to $BACKUP_FOLDER"
     mkdir -p $BACKUP_FOLDER
     backupSingleResource Subscription ibm-mas-manage $MAS_MANAGE_NAMESPACE
-    backupSingleResource OperatorGroup ibm-manage-operatorgroup $MAS_MANAGE_NAMESPACE
+    OPERATOR_GROUP=$(oc get operatorgroup -n mas-$MAS_INSTANCE_ID-manage -o name)
+    backupSingleResource OperatorGroup $OPERATOR_GROUP $MAS_MANAGE_NAMESPACE
     backupSingleResource Secret ibm-entitlement $MAS_MANAGE_NAMESPACE
     backupSingleResource Secret $MAS_WORKSPACE_ID-manage-encryptionsecret $MAS_MANAGE_NAMESPACE
     backupSingleResource Secret $MAS_WORKSPACE_ID-manage-encryptionsecret-operator $MAS_MANAGE_NAMESPACE

--- a/image/cli/mascli/backup-restore/manage-backup-restore.sh
+++ b/image/cli/mascli/backup-restore/manage-backup-restore.sh
@@ -143,7 +143,8 @@ if [ "$MODE" == "backup" ]; then
     echo "Starting MAS Managebackup using the instance id $MAS_INSTANCE_ID to $BACKUP_FOLDER"
     mkdir -p $BACKUP_FOLDER
     backupSingleResource Subscription ibm-mas-manage $MAS_MANAGE_NAMESPACE
-    OPERATOR_GROUP=$(oc get operatorgroup -n mas-$MAS_INSTANCE_ID-manage -o name)
+    OPERATOR_GROUP=$(oc get operatorgroup -n mas-$MAS_INSTANCE_ID-manage)
+    echo "OPERATOR_GROUP $OPERATOR_GROUP"
     backupSingleResource OperatorGroup $OPERATOR_GROUP $MAS_MANAGE_NAMESPACE
     backupSingleResource Secret ibm-entitlement $MAS_MANAGE_NAMESPACE
     backupSingleResource Secret $MAS_WORKSPACE_ID-manage-encryptionsecret $MAS_MANAGE_NAMESPACE

--- a/image/cli/mascli/backup-restore/manage-backup-restore.sh
+++ b/image/cli/mascli/backup-restore/manage-backup-restore.sh
@@ -143,9 +143,10 @@ if [ "$MODE" == "backup" ]; then
     echo "Starting MAS Managebackup using the instance id $MAS_INSTANCE_ID to $BACKUP_FOLDER"
     mkdir -p $BACKUP_FOLDER
     backupSingleResource Subscription ibm-mas-manage $MAS_MANAGE_NAMESPACE
-    OPERATOR_GROUP=$(oc get operatorgroup -n mas-$MAS_INSTANCE_ID-manage)
-    echo "OPERATOR_GROUP $OPERATOR_GROUP"
-    backupSingleResource OperatorGroup $OPERATOR_GROUP $MAS_MANAGE_NAMESPACE
+    # backupSingleResource OperatorGroup ibm-manage-operatorgroup $MAS_MANAGE_NAMESPACE
+    OPERATOR_GROUP=$(oc get operatorgroup -n mas-$MAS_INSTANCE_ID-manage -o name)
+    OPERATOR_GROUP_NEW=$(echo "$OPERATOR_GROUP" | sed -E 's/.*\/(.+)/\1/')
+    backupSingleResource OperatorGroup $OPERATOR_GROUP_NEW $MAS_MANAGE_NAMESPACE
     backupSingleResource Secret ibm-entitlement $MAS_MANAGE_NAMESPACE
     backupSingleResource Secret $MAS_WORKSPACE_ID-manage-encryptionsecret $MAS_MANAGE_NAMESPACE
     backupSingleResource Secret $MAS_WORKSPACE_ID-manage-encryptionsecret-operator $MAS_MANAGE_NAMESPACE


### PR DESCRIPTION
Resolved the issue by fetching the operator group and eliminating the reliance on the hardcoded value.

Test Result:

bash-3.2$ bash backup.sh -w main -i auto-qa -f /Users/danninarajesh/BACKUP -m backup
Starting MAS Managebackup using the instance id auto-qa to /Users/danninarajesh/BACKUP
Backing up Subscription/ibm-mas-manage in the mas-auto-qa-manage namespace...
Saving Subscription/ibm-mas-manage to /Users/danninarajesh/BACKUP/Subscription-ibm-mas-manage.yaml
Backing up OperatorGroup/mas-auto-qa-manage-operator-group in the mas-auto-qa-manage namespace...
Saving OperatorGroup/mas-auto-qa-manage-operator-group to /Users/danninarajesh/BACKUP/OperatorGroup-mas-auto-qa-manage-operator-group.yaml
Backing up Secret/ibm-entitlement in the mas-auto-qa-manage namespace...
Saving Secret/ibm-entitlement to /Users/danninarajesh/BACKUP/Secret-ibm-entitlement.yaml
Backing up Secret/main-manage-encryptionsecret in the mas-auto-qa-manage namespace...
Saving Secret/main-manage-encryptionsecret to /Users/danninarajesh/BACKUP/Secret-main-manage-encryptionsecret.yaml
Backing up Secret/main-manage-encryptionsecret-operator in the mas-auto-qa-manage namespace...
Saving Secret/main-manage-encryptionsecret-operator to /Users/danninarajesh/BACKUP/Secret-main-manage-encryptionsecret-operator.yaml
Backing up ManageApp/auto-qa in the mas-auto-qa-manage namespace...
Saving ManageApp/auto-qa to /Users/danninarajesh/BACKUP/ManageApp-auto-qa.yaml
Backing up all ManageWorkspace resources in the mas-auto-qa-manage namespace...
secretList are - secretName: s3secretkey
secret
Backing up Secret/s3secretkey in the mas-auto-qa-manage namespace...
Saving Secret/s3secretkey to /Users/danninarajesh/BACKUP/Secret-s3secretkey.yaml
Saving ManageWorkspace named auto-qa-main to /Users/danninarajesh/BACKUP/ManageWorkspace-auto-qa-main.yaml
Backing up all jdbccfgs resources in the mas-auto-qa-manage namespace...
secretList are - secretName: jdbc-auto-qadb2umanage-credentials
secret
Backing up Secret/jdbc-auto-qadb2umanage-credentials in the mas-auto-qa-core namespace...
Saving Secret/jdbc-auto-qadb2umanage-credentials to /Users/danninarajesh/BACKUP/Secret-jdbc-auto-qadb2umanage-credentials.yaml
Saving JdbcCfg named auto-qa-jdbc-wsapp-main-manage to /Users/danninarajesh/BACKUP/JdbcCfg-auto-qa-jdbc-wsapp-main-manage.yaml
Determining if Manual Certificate Management is enabled...
bash-3.2$ ls
JdbcCfg-auto-qa-jdbc-wsapp-main-manage.yaml		OperatorGroup-mas-auto-qa-manage-operator-group.yaml	Secret-main-manage-encryptionsecret-operator.yaml	Subscription-ibm-mas-manage.yaml
ManageApp-auto-qa.yaml					Secret-ibm-entitlement.yaml				Secret-main-manage-encryptionsecret.yaml		backup.sh
ManageWorkspace-auto-qa-main.yaml			Secret-jdbc-auto-qadb2umanage-credentials.yaml		Secret-s3secretkey.yaml


