### PR TITLE
[patch] Include mongodb_replicas parameter into 

### DIFF
--- a/image/cli/mascli/functions/update
+++ b/image/cli/mascli/functions/update
@@ -764,7 +764,6 @@ function update() {
   # MongoDB Community Edition
   if [ "$MONGODB_NAMESPACE" != "" ]; then
     echo_reset_dim "MongoDb Community Edition .................. ${COLOR_GREEN}Yes - ${MONGODB_CURRENT_VERSION} to ${MONGODB_TARGET_VERSION} ($MONGODB_NAMESPACE)${TEXT_RESET}"
-    echo_reset_dim "MongoDb Replicas ........................... ${COLOR_GREEN}${MONGODB_REPLICAS}${TEXT_RESET}"
   else
     echo_reset_dim "MongoDb Community Edition .................. ${COLOR_RED}No${TEXT_RESET}"
   fi

--- a/image/cli/mascli/functions/update
+++ b/image/cli/mascli/functions/update
@@ -82,6 +82,8 @@ function validate_existing_mongo() {
 
   if [ "$SNO_MODE" == true ]; then
     MONGODB_REPLICAS=1
+  else
+    MONGODB_REPLICAS=3
   fi 
 
   if [ -z "$MONGODB_NAMESPACE" ]; then

--- a/image/cli/mascli/functions/update
+++ b/image/cli/mascli/functions/update
@@ -79,6 +79,11 @@ function validate_existing_cert_manager() {
 # Validates the existance of installed MongoDB Community Edition in the target cluster
 # and prints a warning message if MongoDB is supposed to be upgraded
 function validate_existing_mongo() {
+
+  if [ "$SNO_MODE" == true ]; then
+    MONGODB_REPLICAS=1
+  fi 
+
   if [ -z "$MONGODB_NAMESPACE" ]; then
     echo -e "${COLOR_YELLOW}Verifying current MongoDB deployment..."
     MONGODB_NAMESPACE=`oc get mongodbcommunity.mongodbcommunity.mongodb.com -A -o jsonpath='{.items[0].metadata.namespace}' 2> /dev/null`
@@ -481,6 +486,9 @@ function validate_update() {
     exit 1
   fi
 
+  # Detect if cluster is SNO
+  detect_sno
+
   # Validates Red Hat Cerficate Manager migration only if January catalog or more recent used
   validate_existing_cert_manager
 
@@ -683,6 +691,8 @@ function update() {
   export DB2_NAMESPACE
   export MONGODB_NAMESPACE
   export MONGODB_V5_UPGRADE
+  export MONGODB_V6_UPGRADE
+  export MONGODB_REPLICAS
   export MONGODB_VERSION
   export KAFKA_NAMESPACE
   export KAFKA_PROVIDER
@@ -752,6 +762,7 @@ function update() {
   # MongoDB Community Edition
   if [ "$MONGODB_NAMESPACE" != "" ]; then
     echo_reset_dim "MongoDb Community Edition .................. ${COLOR_GREEN}Yes - ${MONGODB_CURRENT_VERSION} to ${MONGODB_TARGET_VERSION} ($MONGODB_NAMESPACE)${TEXT_RESET}"
+    echo_reset_dim "MongoDb Replicas ........................... ${COLOR_GREEN}${MONGODB_REPLICAS}${TEXT_RESET}"
   else
     echo_reset_dim "MongoDb Community Edition .................. ${COLOR_RED}No${TEXT_RESET}"
   fi

--- a/image/cli/mascli/functions/update
+++ b/image/cli/mascli/functions/update
@@ -80,7 +80,7 @@ function validate_existing_cert_manager() {
 # and prints a warning message if MongoDB is supposed to be upgraded
 function validate_existing_mongo() {
 
-  if [ "$SNO_MODE" == true ]; then
+  if [[ "$SNO_MODE" == "true" ]]; then
     MONGODB_REPLICAS=1
   else
     MONGODB_REPLICAS=3

--- a/image/cli/mascli/templates/pipelinerun-update.yaml
+++ b/image/cli/mascli/templates/pipelinerun-update.yaml
@@ -27,6 +27,10 @@ spec:
       value: '$MONGODB_NAMESPACE'
     - name: mongodb_v5_upgrade
       value: '$MONGODB_V5_UPGRADE'
+    - name: mongodb_v6_upgrade
+      value: '$MONGODB_V6_UPGRADE'
+    - name: mongodb_replicas
+      value: '$MONGODB_REPLICAS'
     - name: kafka_namespace
       value: '$KAFKA_NAMESPACE'
     - name: kafka_provider

--- a/tekton/src/pipelines/update.yml.j2
+++ b/tekton/src/pipelines/update.yml.j2
@@ -89,6 +89,14 @@ spec:
       type: string
       description: Approves the MongoDb upgrade to version 5 if needed
       default: ""
+    - name: mongodb_v6_upgrade
+      type: string
+      description: Approves the MongoDb upgrade to version 6 if needed
+      default: ""
+    - name: mongodb_replicas
+      type: string
+      description: Optional configuration for mongodb replicas
+      default: ""
 
     # kafka update
     - name: kafka_action

--- a/tekton/src/pipelines/update.yml.j2
+++ b/tekton/src/pipelines/update.yml.j2
@@ -353,6 +353,10 @@ spec:
           value: $(params.mongodb_namespace)
         - name: mongodb_v5_upgrade
           value: $(params.mongodb_v5_upgrade)
+        - name: mongodb_v6_upgrade
+          value: $(params.mongodb_v6_upgrade)
+        - name: mongodb_replicas
+          value: $(params.mongodb_replicas)
 
     - name: update-kafka
       taskRef:

--- a/tekton/src/tasks/dependencies/mongodb.yml.j2
+++ b/tekton/src/tasks/dependencies/mongodb.yml.j2
@@ -52,7 +52,7 @@ spec:
       default: ""
     - name: mongodb_v6_upgrade
       type: string
-      description: Approves the MongoDb upgrade to version 5 if needed
+      description: Approves the MongoDb upgrade to version 6 if needed
       default: ""
 
     # Dependencies - IBM Cloud MongoDb

--- a/tekton/src/tasks/dependencies/mongodb.yml.j2
+++ b/tekton/src/tasks/dependencies/mongodb.yml.j2
@@ -50,6 +50,10 @@ spec:
       type: string
       description: Approves the MongoDb upgrade to version 5 if needed
       default: ""
+    - name: mongodb_v6_upgrade
+      type: string
+      description: Approves the MongoDb upgrade to version 5 if needed
+      default: ""
 
     # Dependencies - IBM Cloud MongoDb
     # -------------------------------------------------------------------------
@@ -109,6 +113,8 @@ spec:
         value: $(params.mongodb_version)
       - name: MONGODB_V5_UPGRADE
         value: $(params.mongodb_v5_upgrade)
+      - name: MONGODB_V6_UPGRADE
+        value: $(params.mongodb_v6_upgrade)
 
       # Dependencies - IBM Cloud MongoDb
       - name: IBM_MONGO_NAME


### PR DESCRIPTION
This PR fixes the issue where mongodb was defaulting to 3 mongo replicas during mas update in SNO environments.