### PR TITLE
[patch] disable error on aws sm delete-secret describe-secret calls

### DIFF
--- a/tekton/src/tasks/gitops/gitops-mas-initiator.yml.j2
+++ b/tekton/src/tasks/gitops/gitops-mas-initiator.yml.j2
@@ -149,13 +149,13 @@ spec:
           aws configure set default.region $SM_AWS_REGION
           export AWS_REGION=$SM_AWS_REGION
           aws configure list
-
+          set +e +o pipefail
           aws secretsmanager delete-secret --force-delete-without-recovery --secret-id ${SECRET_NAME} --region $SM_AWS_REGION --output json 2> /dev/null
           aws secretsmanager describe-secret --secret-id ${SECRET_NAME} --region $SM_AWS_REGION --output json 2> /dev/null
           aws secretsmanager create-secret --name ${SECRET_NAME} --region $SM_AWS_REGION --secret-string "${SECRET_VALUE}" || exit 1
 
           echo "created AWS secret secret ${SECRET_NAME} with value ${SECRET_VALUE:0:6}<snip> in region $SM_AWS_REGION"
-
+          set -e -o pipefail
         fi
 
 


### PR DESCRIPTION
Issue: noticed aws describe-secret fails with 254 if secret was not found. 