### PR TITLE
[patch] Add mongodb_version to update pipelinerun

### DIFF
--- a/image/cli/mascli/templates/pipelinerun-update.yaml
+++ b/image/cli/mascli/templates/pipelinerun-update.yaml
@@ -27,6 +27,8 @@ spec:
       value: '$MONGODB_NAMESPACE'
     - name: mongodb_v5_upgrade
       value: '$MONGODB_V5_UPGRADE'
+    - name: mongodb_version
+      value: '$MONGODB_VERSION'
     - name: kafka_namespace
       value: '$KAFKA_NAMESPACE'
     - name: kafka_provider

--- a/tekton/src/pipelines/update.yml.j2
+++ b/tekton/src/pipelines/update.yml.j2
@@ -89,6 +89,10 @@ spec:
       type: string
       description: Approves the MongoDb upgrade to version 5 if needed
       default: ""
+    - name: mongodb_version
+      type: string
+      description: MongoDb version to update too
+      default: ""
 
     # kafka update
     - name: kafka_action
@@ -345,6 +349,8 @@ spec:
           value: $(params.mongodb_namespace)
         - name: mongodb_v5_upgrade
           value: $(params.mongodb_v5_upgrade)
+        - name: mongodb_version
+          value: $(params.mongodb_version)
 
     - name: update-kafka
       taskRef:


### PR DESCRIPTION
The mongodb_version was missing from the pipelinerun for update, so when the cli sets it here https://github.com/ibm-mas/cli/blob/c602b9db623448dc8dd324da76c4ae3433db4032/image/cli/mascli/functions/update#L686 it is then not set in the pipelinerun for update as it was missing.