### PR TITLE
Support for multiple suite workspaces

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,5 @@ image/cli/mascli/tmp-suite-deprovision
 image/cli/mascli/fyre-dev.noble3.tgke-env.sh
 image/cli/mascli/tmp-mas-config
 image/cli/mascli/fyre-dev.noble3.tgke-db2u-manage-env.sh
+image/cli/mascli/tmp-suite-workspace
+image/cli/mascli/tmp-suite-workspace-deprovision

--- a/image/cli/mascli/functions/gitops_deprovision_db2u_database
+++ b/image/cli/mascli/functions/gitops_deprovision_db2u_database
@@ -229,7 +229,7 @@ function gitops_deprovision_db2u_database() {
   mkdir -p ${GITOPS_INSTANCE_DIR}
 
 
-  # Delete config file that triggers db2-db appset to render the Application for this DB2 instance
+  # # Delete config that makes db2-databases root app to generate the ArgoCD application for this DB2 database instance
   # ---------------------------------------------------------------------------
   echo
   echo_h2 "Removing DB2U Database Configuraton for ${DB2_INSTANCE_NAME}"

--- a/image/cli/mascli/functions/gitops_deprovision_suite_workspace
+++ b/image/cli/mascli/functions/gitops_deprovision_suite_workspace
@@ -138,6 +138,17 @@ function gitops_deprovision_suite_workspace() {
   mkdir -p ${GITOPS_WORKING_DIR}
   GITOPS_INSTANCE_DIR=${GITOPS_WORKING_DIR}/${GITHUB_REPO}/${ACCOUNT_ID}/${REGION}/${CLUSTER_ID}/${MAS_INSTANCE_ID}
 
+  # NOTE: must align with lock branch name used by gitops_suite_workspace script
+  # as both of these scripts modify the same file
+  GIT_LOCK_BRANCH=$(git_lock_branch_name "gitops-suite-workspace" "${ACCOUNT_ID}" "${REGION_ID}" "${CLUSTER_ID}" "${MAS_INSTANCE_ID}")
+
+  CONFIGS_FILE="${GITOPS_INSTANCE_DIR}/ibm-mas-workspaces.yaml"
+
+
+  #if not set, use workspace id
+  if [[ -z $MAS_WORKSPACE_NAME ]]; then
+    export MAS_WORKSPACE_NAME=$MAS_WORKSPACE_ID
+  fi
 
   echo
   reset_colors
@@ -166,6 +177,7 @@ function gitops_deprovision_suite_workspace() {
     echo_reset_dim "Organization .......................... ${COLOR_MAGENTA}${GITHUB_ORG}"
     echo_reset_dim "Repository ............................ ${COLOR_MAGENTA}${GITHUB_REPO}"
     echo_reset_dim "Branch ................................ ${COLOR_MAGENTA}${GIT_BRANCH}"
+    echo_reset_dim "Lock Branch ........................... ${COLOR_MAGENTA}${GIT_LOCK_BRANCH}"
   else
     echo_h2 "GitOps Target" "    "
     echo_reset_dim "Automatic Push ........................ ${COLOR_RED}Disabled"
@@ -193,29 +205,47 @@ function gitops_deprovision_suite_workspace() {
   # Clone github target repo
   # ---------------------------------------------------------------------------
   if [ "$GITHUB_PUSH" == "true" ]; then
-    echo
-    echo_h2 "Cloning GitHub repo $GITHUB_ORG $GITHUB_REPO"
+    # only create the lock branch if we plan to actually push changes to git
+    clone_and_lock_target_git_repo  "${GITHUB_HOST}" "${GITHUB_ORG}" "${GITHUB_REPO}" "${GIT_BRANCH}" "${GITOPS_WORKING_DIR}" "${GIT_SSH}" "${GIT_LOCK_BRANCH}"
+  else
+    # even though we don't want to push anything to git,
+    # because this script modifies the existing suite-configs.yaml file, we still need to checkout the repo
     clone_target_git_repo $GITHUB_HOST $GITHUB_ORG $GITHUB_REPO $GIT_BRANCH $GITOPS_WORKING_DIR $GIT_SSH
   fi
   mkdir -p ${GITOPS_INSTANCE_DIR}
 
-  # Delete ArgoApps
+  # Delete config that makes ibm-mas-workspaces root app to generate the ArgoCD application for this workspace
   # ---------------------------------------------------------------------------
-  # Per MAS instance
+  echo
+  echo_h2 "Removing MAS Suite Workspace configuration (${MAS_WORKSPACE_ID})"
+  echo
+  # If the file doesn't exist, nothing to remove, so no-op
+  if [ -f ${CONFIGS_FILE} ]; then
+    /usr/bin/yq 'del(.ibm_mas_workspaces[] | select(.mas_workspace_id == "'${MAS_WORKSPACE_ID}'"))' $CONFIGS_FILE > ${TEMP_DIR}/configs.yaml
+    cp ${TEMP_DIR}/configs.yaml ${CONFIGS_FILE}
 
-  #if not set, use workspace id
-  if [[ -z $MAS_WORKSPACE_NAME ]]; then
-    export MAS_WORKSPACE_NAME=$MAS_WORKSPACE_ID
+    # If the file is there, but the configs are empty, delete the file
+    CONFIGS_COUNT=$(/usr/bin/yq '.ibm_mas_workspaces | length' $CONFIGS_FILE)
+    if [ "${CONFIGS_COUNT}" == "0" ]; then
+      rm $CONFIGS_FILE
+    fi
   fi
-  echo "Deleting IBM Maximo Application Suite Workspace file ${GITOPS_INSTANCE_DIR}/ibm-mas-workspace.yaml"
-  rm ${GITOPS_INSTANCE_DIR}/ibm-mas-workspace.yaml
+
+  echo_h2 "Updated configuration file (${CONFIGS_FILE})"
+  if [ -f ${CONFIGS_FILE} ]; then
+    cat $CONFIGS_FILE
+  else
+    echo "<file was deleted>"
+  fi
+
 
   # Commit and push to github target repo
   # ---------------------------------------------------------------------------
   if [ "$GITHUB_PUSH" == "true" ]; then
     echo
     echo_h2 "Commit and push changes to GitHub repo $GITHUB_ORG $GITHUB_REPO"
-    save_to_target_git_repo $GITHUB_HOST $GITHUB_ORG $GITHUB_REPO $GIT_BRANCH "${GITOPS_WORKING_DIR}/${GITHUB_REPO}" "${GIT_COMMIT_MSG}"
+    save_and_unlock_target_git_repo "${GITHUB_REPO}" "${GIT_BRANCH}" "${GITOPS_WORKING_DIR}" "${GIT_COMMIT_MSG}" "${GIT_LOCK_BRANCH}"
+  else
     remove_git_repo_clone $GITOPS_WORKING_DIR/$GITHUB_REPO
   fi
 

--- a/image/cli/mascli/functions/gitops_suite_workspace
+++ b/image/cli/mascli/functions/gitops_suite_workspace
@@ -44,7 +44,7 @@ function gitops_suite_workspace_noninteractive() {
 
   # TODO: will need to add explicit args to pipeline when we start using this code to deploy to MCSP
   export REGION=${REGION:-${SM_AWS_REGION}}
-  
+
   while [[ $# -gt 0 ]]
   do
     key="$1"
@@ -144,6 +144,17 @@ function gitops_suite_workspace() {
   mkdir -p ${GITOPS_WORKING_DIR}
   GITOPS_INSTANCE_DIR=${GITOPS_WORKING_DIR}/${GITHUB_REPO}/${ACCOUNT_ID}/${REGION}/${CLUSTER_ID}/${MAS_INSTANCE_ID}
 
+  # NOTE: must align with lock branch name used by gitops_deprovision_suite_workspace script
+  # as both of these scripts modify the same file
+  GIT_LOCK_BRANCH=$(git_lock_branch_name "gitops-suite-workspace" "${ACCOUNT_ID}" "${REGION_ID}" "${CLUSTER_ID}" "${MAS_INSTANCE_ID}")
+
+  CONFIGS_FILE="${GITOPS_INSTANCE_DIR}/ibm-mas-workspaces.yaml"
+
+
+  # if not set, use workspace id
+  if [[ -z $MAS_WORKSPACE_NAME ]]; then
+    export MAS_WORKSPACE_NAME=$MAS_WORKSPACE_ID
+  fi
 
   echo
   reset_colors
@@ -172,6 +183,7 @@ function gitops_suite_workspace() {
     echo_reset_dim "Organization .......................... ${COLOR_MAGENTA}${GITHUB_ORG}"
     echo_reset_dim "Repository ............................ ${COLOR_MAGENTA}${GITHUB_REPO}"
     echo_reset_dim "Branch ................................ ${COLOR_MAGENTA}${GIT_BRANCH}"
+    echo_reset_dim "Lock Branch ........................... ${COLOR_MAGENTA}${GIT_LOCK_BRANCH}"
   else
     echo_h2 "GitOps Target" "    "
     echo_reset_dim "Automatic Push ........................ ${COLOR_RED}Disabled"
@@ -201,7 +213,7 @@ function gitops_suite_workspace() {
   # ---------------------------------------------------------------------------
   CLUSTER_ROOT_APP="cluster.${ACCOUNT_ID}.${REGION}.${CLUSTER_ID}"
   INSTANCE_ROOT_APP="instance.${ACCOUNT_ID}.${REGION}.${CLUSTER_ID}.${MAS_INSTANCE_ID}"
-  WORKSPACE_APP="workspace.${ACCOUNT_ID}.${REGION}.${CLUSTER_ID}.${MAS_INSTANCE_ID}"
+  WORKSPACE_APP="${MAS_WORKSPACE_ID}.suite.${ACCOUNT_ID}.${REGION}.${CLUSTER_ID}.${MAS_INSTANCE_ID}"
 
   validate_app_name "${CLUSTER_ROOT_APP}"
   validate_app_name "${INSTANCE_ROOT_APP}"
@@ -211,29 +223,55 @@ function gitops_suite_workspace() {
   # Clone github target repo
   # ---------------------------------------------------------------------------
   if [ "$GITHUB_PUSH" == "true" ]; then
-    echo
-    echo_h2 "Cloning GitHub repo $GITHUB_ORG $GITHUB_REPO"
+    # only create the lock branch if we plan to actually push changes to git
+    clone_and_lock_target_git_repo  "${GITHUB_HOST}" "${GITHUB_ORG}" "${GITHUB_REPO}" "${GIT_BRANCH}" "${GITOPS_WORKING_DIR}" "${GIT_SSH}" "${GIT_LOCK_BRANCH}"
+  else
+    # even though we don't want to push anything to git,
+    # because this script modifies the existing suite-configs.yaml file, we still need to checkout the repo
     clone_target_git_repo $GITHUB_HOST $GITHUB_ORG $GITHUB_REPO $GIT_BRANCH $GITOPS_WORKING_DIR $GIT_SSH
   fi
   mkdir -p ${GITOPS_INSTANCE_DIR}
 
   # Generate ArgoApps
   # ---------------------------------------------------------------------------
-  # Per MAS instance
+  echo
+  echo_h2 "Generating Suite Workspace Configuration (${MAS_WORKSPACE_ID})"
+  echo
 
-  #if not set, use workspace id
-  if [[ -z $MAS_WORKSPACE_NAME ]]; then
-    export MAS_WORKSPACE_NAME=$MAS_WORKSPACE_ID
+
+  # If the file doesn't exist, create a blank one
+  if ! [ -f ${CONFIGS_FILE} ]; then
+    jinja -X .+ $CLI_DIR/templates/gitops/appset-configs/cluster/instance/ibm-mas-workspaces-common.yaml.j2 > $CONFIGS_FILE
   fi
-  echo "Generating IBM Maximo Application Suite Workspace file ${GITOPS_INSTANCE_DIR}/ibm-mas-workspace.yaml"
-  jinja -X .+ $CLI_DIR/templates/gitops/appset-configs/cluster/instance/ibm-mas-workspace.yaml.j2 -o ${GITOPS_INSTANCE_DIR}/ibm-mas-workspace.yaml
+
+  # Remove any existing config with this name
+  /usr/bin/yq 'del(.ibm_mas_workspaces[] | select(.mas_workspace_id == "'${MAS_WORKSPACE_ID}'"))' $CONFIGS_FILE > $TEMP_DIR/configs.yaml
+
+  # Render the appropriate template for the config into a new file
+  jinja -X .+ $CLI_DIR/templates/gitops/appset-configs/cluster/instance/ibm-mas-workspace.yaml.j2 | /usr/bin/yq '{"ibm_mas_workspaces": [] + .}' > ${TEMP_DIR}/newconfig.yaml
+
+  # Merge the two files
+  /usr/bin/yq eval-all '. as $item ireduce ({}; . *+ $item)' $TEMP_DIR/configs.yaml ${TEMP_DIR}/newconfig.yaml > $CONFIGS_FILE
+
+  # sort the configs by mas_workspace_id.
+  # This way, we maintain the same ordering of configs in the file (even though we may have deleted and recreated a config if it's an update)
+  # This eliminates confusing commits to gitops-envs and allows us to determine if anything has actually changed
+  /usr/bin/yq -i '.ibm_mas_workspaces |= sort_by(.mas_workspace_id)' $CONFIGS_FILE
+
+  echo_h2 "Updated configuration file (${CONFIGS_FILE})"
+  if [ -f ${CONFIGS_FILE} ]; then
+    cat $CONFIGS_FILE
+  else
+    echo "<file was deleted>"
+  fi
 
   # Commit and push to github target repo
   # ---------------------------------------------------------------------------
   if [ "$GITHUB_PUSH" == "true" ]; then
     echo
     echo_h2 "Commit and push changes to GitHub repo $GITHUB_ORG $GITHUB_REPO"
-    save_to_target_git_repo $GITHUB_HOST $GITHUB_ORG $GITHUB_REPO $GIT_BRANCH "${GITOPS_WORKING_DIR}/${GITHUB_REPO}" "${GIT_COMMIT_MSG}"
+    save_and_unlock_target_git_repo "${GITHUB_REPO}" "${GIT_BRANCH}" "${GITOPS_WORKING_DIR}" "${GIT_COMMIT_MSG}" "${GIT_LOCK_BRANCH}"
+  else
     remove_git_repo_clone $GITOPS_WORKING_DIR/$GITHUB_REPO
   fi
 

--- a/image/cli/mascli/templates/gitops/appset-configs/cluster/instance/ibm-mas-workspace.yaml.j2
+++ b/image/cli/mascli/templates/gitops/appset-configs/cluster/instance/ibm-mas-workspace.yaml.j2
@@ -1,5 +1,2 @@
-merge-key: "{{ ACCOUNT_ID }}/{{ REGION }}/{{ CLUSTER_ID }}/{{ MAS_INSTANCE_ID }}"
-
-ibm_mas_workspace:
-  mas_workspace_id: {{ MAS_WORKSPACE_ID }}
-  mas_workspace_name: {{ MAS_WORKSPACE_NAME }}
+mas_workspace_id: {{ MAS_WORKSPACE_ID }}
+mas_workspace_name: {{ MAS_WORKSPACE_NAME }}

--- a/image/cli/mascli/templates/gitops/appset-configs/cluster/instance/ibm-mas-workspaces-common.yaml.j2
+++ b/image/cli/mascli/templates/gitops/appset-configs/cluster/instance/ibm-mas-workspaces-common.yaml.j2
@@ -1,0 +1,2 @@
+merge-key: "{{ ACCOUNT_ID }}/{{ REGION_ID }}/{{ CLUSTER_ID }}/{{ MAS_INSTANCE_ID }}"
+ibm_mas_workspaces: []

--- a/tekton/src/tasks/gitops/gitops-mas-fvt-preparer.yml.j2
+++ b/tekton/src/tasks/gitops/gitops-mas-fvt-preparer.yml.j2
@@ -376,7 +376,7 @@ spec:
           SLS_CONFIG_APP="${MAS_INSTANCE_ID}-sls-system.${ACCOUNT_ID}.${REGION_ID}.${CLUSTER_NAME}.${MAS_INSTANCE_ID}"
           SLS_APP_NAME="sls.${ACCOUNT_ID}.${REGION_ID}.${CLUSTER_NAME}.${MAS_INSTANCE_ID}"
           SUITE_APP_NAME="suite.${ACCOUNT_ID}.${REGION_ID}.${CLUSTER_NAME}.${MAS_INSTANCE_ID}"
-          WORKSPACE_APP="workspace.${ACCOUNT_ID}.${REGION_ID}.${CLUSTER_NAME}.${MAS_INSTANCE_ID}"
+          WORKSPACE_APP="${MAS_WORKSPACE_ID}.suite.${ACCOUNT_ID}.${REGION_ID}.${CLUSTER_NAME}.${MAS_INSTANCE_ID}"
 
           check_argo_app_healthy "${MONGO_CONFIG_APP}" 
           check_argo_app_healthy "${SLS_CONFIG_APP}"


### PR DESCRIPTION
MAS workspace config now held as a list in config file `ibm-mas-workspace.yaml`, e.g. the following results in two suite workspaces being created:
```
merge-key: "fyre-dev/us-east-2/noble3/tom"
ibm_mas_workspaces:
  - mas_workspace_id: masdev
    mas_workspace_name: masdev
  - mas_workspace_id: masdev2
    mas_workspace_name: masdev2
```
This is used by new ibm-mas-workspaces instance-level root app to generate an ArgoCD application per suite workspace in the list.

Workspace application name updated from `workspace.{account}.{region}.{cluster}.{instance}` to `{workspace}.suite.{account}.{region}.{cluster}.{instance}`.

The changes above are in the associated PR on gitops: https://github.com/ibm-mas/gitops/pull/73

This PR https://github.com/ibm-mas/cli/pull/948 updates MAS CLI to maintain the workspace list in `ibm-mas-workspace.yaml` and align with the new name for workspace applications.

The associated PR https://github.ibm.com/maximoappsuite/saas-tekton/pull/21
 copies the tekton task updates to saas-envs

https://jsw.ibm.com/browse/MASCORE-2358


#### Testing:
Using the `gitops-suite-workspace` MAS CLI function, I created two workspaces (`masdev` and `masdev2`). The expected commits were made to gitops-envs and the new workspace applications were deployed by ArgoCD as expected:
![image](https://github.com/ibm-mas/gitops/assets/7372253/9616b76e-03e2-4a0b-820c-c7a1b0722014)

and the workspaces showed up in the suite admin UI:
![image](https://github.com/ibm-mas/gitops/assets/7372253/42ce4a52-a4c6-4427-9862-f97c8431fc49)

I then removed these workspaces using the `gitops-deprovision-suite-workspace` function. The expected commits were made to gitops-envs and the applications were torn down by ArgoCD as expected:
![image](https://github.com/ibm-mas/gitops/assets/7372253/fd6739ea-963f-4d77-bd6c-fb2113a162c4)
![image](https://github.com/ibm-mas/gitops/assets/7372253/b35e34b0-8b72-424f-997d-f0dfcfecf4e7)


and the workspaces were no longer seen by MAS (causing me to be redirected to the initial setup page):
![image](https://github.com/ibm-mas/gitops/assets/7372253/c9afe6d1-38c5-4598-92bc-cdab1f16b2b9)

