### PR TITLE
[minor] support option to --skip-grafana-install

### DIFF
--- a/image/cli/mascli/functions/help/install_help
+++ b/image/cli/mascli/functions/help/install_help
@@ -124,6 +124,7 @@ Other Commands:
       --no-confirm          Launch the install without prompting for confirmation
       --accept-license      Accept the licenses for IBM Maximo Application Suite and Maximo IT
       --skip-pre-check      Skips the 'pre-install-check' task in the install pipeline
+      --skip-grafana-install        Skips the Grafana install 
   -h, --help                Show this help message
 
 

--- a/image/cli/mascli/functions/install
+++ b/image/cli/mascli/functions/install
@@ -753,8 +753,9 @@ function install() {
     esac
   done
 
-  if [ $SKIP_GRAFANA_INSTALL == "true" ]; then
+  if [[ "$SKIP_GRAFANA_INSTALL" == "true" ]]; then
     CLUSTER_MONITORING_INCLUDE_GRAFANA="False"
+    echo "Skipping Grafana..."
   else
     # Determine whether Grafana is available in the cluster based on the available of the operator package
     oc get packagemanifest grafana-operator &> /dev/null
@@ -764,6 +765,8 @@ function install() {
       CLUSTER_MONITORING_INCLUDE_GRAFANA="True"
     fi
   fi
+
+  echo "Grafana env var(CLUSTER_MONITORING_INCLUDE_GRAFANA) = ${CLUSTER_MONITORING_INCLUDE_GRAFANA}"
 
   if [[ "$INTERACTIVE_MODE" == "true" ]]; then
     load_config

--- a/image/cli/mascli/functions/install
+++ b/image/cli/mascli/functions/install
@@ -449,9 +449,6 @@ function install_noninteractive() {
         ;;
 
       # Other Commands
-      --skip-grafana-install)
-        export CLUSTER_MONITORING_INCLUDE_GRAFANA="False"
-        ;;
       --skip-pre-check)
         SKIP_PRE_CHECK=true
         ;;

--- a/image/cli/mascli/functions/install
+++ b/image/cli/mascli/functions/install
@@ -449,6 +449,9 @@ function install_noninteractive() {
         ;;
 
       # Other Commands
+      --skip-grafana-install)
+        SKIP_GRAFANA_INSTALL=true
+        ;;
       --skip-pre-check)
         SKIP_PRE_CHECK=true
         ;;
@@ -750,12 +753,16 @@ function install() {
     esac
   done
 
-  # Determine whether Grafana is available in the cluster based on the available of the operator package
-  oc get packagemanifest grafana-operator &> /dev/null
-  if [[ "$?" == "1" ]]; then
+  if [ $SKIP_GRAFANA_INSTALL == "true" ]; then
     CLUSTER_MONITORING_INCLUDE_GRAFANA="False"
   else
-    CLUSTER_MONITORING_INCLUDE_GRAFANA="True"
+    # Determine whether Grafana is available in the cluster based on the available of the operator package
+    oc get packagemanifest grafana-operator &> /dev/null
+    if [[ "$?" == "1" ]]; then
+      CLUSTER_MONITORING_INCLUDE_GRAFANA="False"
+    else
+      CLUSTER_MONITORING_INCLUDE_GRAFANA="True"
+    fi
   fi
 
   if [[ "$INTERACTIVE_MODE" == "true" ]]; then

--- a/image/cli/mascli/functions/install
+++ b/image/cli/mascli/functions/install
@@ -747,6 +747,9 @@ function install() {
       --dev-mode)
         DEV_MODE=true
         ;;
+      --skip-grafana-install)
+        SKIP_GRAFANA_INSTALL=true
+        ;;
       -h|--help)
         install_help
         ;;

--- a/image/cli/mascli/functions/install
+++ b/image/cli/mascli/functions/install
@@ -449,6 +449,9 @@ function install_noninteractive() {
         ;;
 
       # Other Commands
+      --skip-grafana-install)
+        export CLUSTER_MONITORING_INCLUDE_GRAFANA="False"
+        ;;
       --skip-pre-check)
         SKIP_PRE_CHECK=true
         ;;
@@ -745,7 +748,7 @@ function install() {
         DEV_MODE=true
         ;;
       --skip-grafana-install)
-        SKIP_GRAFANA_INSTALL=true
+        CLUSTER_MONITORING_INCLUDE_GRAFANA="False"
         ;;
       -h|--help)
         install_help
@@ -753,9 +756,7 @@ function install() {
     esac
   done
 
-  if [[ "$SKIP_GRAFANA_INSTALL" == "true" ]]; then
-    CLUSTER_MONITORING_INCLUDE_GRAFANA="False"
-  else
+  if [[ -z $CLUSTER_MONITORING_INCLUDE_GRAFANA ]] || [[  "$CLUSTER_MONITORING_INCLUDE_GRAFANA" != "False" ]]; then
     # Determine whether Grafana is available in the cluster based on the available of the operator package
     oc get packagemanifest grafana-operator &> /dev/null
     if [[ "$?" == "1" ]]; then

--- a/image/cli/mascli/functions/install
+++ b/image/cli/mascli/functions/install
@@ -449,9 +449,6 @@ function install_noninteractive() {
         ;;
 
       # Other Commands
-      --skip-grafana-install)
-        SKIP_GRAFANA_INSTALL=true
-        ;;
       --skip-pre-check)
         SKIP_PRE_CHECK=true
         ;;
@@ -758,7 +755,6 @@ function install() {
 
   if [[ "$SKIP_GRAFANA_INSTALL" == "true" ]]; then
     CLUSTER_MONITORING_INCLUDE_GRAFANA="False"
-    echo "Skipping Grafana..."
   else
     # Determine whether Grafana is available in the cluster based on the available of the operator package
     oc get packagemanifest grafana-operator &> /dev/null
@@ -768,8 +764,6 @@ function install() {
       CLUSTER_MONITORING_INCLUDE_GRAFANA="True"
     fi
   fi
-
-  echo "Grafana env var(CLUSTER_MONITORING_INCLUDE_GRAFANA) = ${CLUSTER_MONITORING_INCLUDE_GRAFANA}"
 
   if [[ "$INTERACTIVE_MODE" == "true" ]]; then
     load_config


### PR DESCRIPTION
This PR adds the argument `--skip-grafana-install` that allows skipping grafana  but avoiding to check if Grafana is available in the cluster based on the available of the operator package. and sets `CLUSTER_MONITORING_INCLUDE_GRAFANA=False`

This has been implemented in:

mas install