### PR TITLE
[minor] support option to --skip-grafana-install in mas install function

### DIFF
--- a/image/cli/mascli/functions/help/install_help
+++ b/image/cli/mascli/functions/help/install_help
@@ -119,12 +119,13 @@ Manage Application - Advanced Configuration (Optional):
       --manage-override-encryption-secrets                                                    Override any existing Manage database encryption keys (a backup of the original is taken).
 
 Other Commands:
-      --dev-mode            Enable developer mode (e.g. for access to pre-release builds)
-      --no-wait-for-pvcs    If you are using using storage classes that utilize 'WaitForFirstConsumer' binding mode use this flag
-      --no-confirm          Launch the install without prompting for confirmation
-      --accept-license      Accept the licenses for IBM Maximo Application Suite and Maximo IT
-      --skip-pre-check      Skips the 'pre-install-check' task in the install pipeline
-  -h, --help                Show this help message
+      --dev-mode              Enable developer mode (e.g. for access to pre-release builds)
+      --no-wait-for-pvcs      If you are using using storage classes that utilize 'WaitForFirstConsumer' binding mode use this flag
+      --no-confirm            Launch the install without prompting for confirmation
+      --accept-license        Accept the licenses for IBM Maximo Application Suite and Maximo IT
+      --skip-pre-check        Skips the 'pre-install-check' task in the install pipeline
+      --skip-grafana-install  Skips Grafana install action
+  -h, --help                  Show this help message
 
 
 EOM

--- a/image/cli/mascli/functions/install
+++ b/image/cli/mascli/functions/install
@@ -744,18 +744,24 @@ function install() {
       --dev-mode)
         DEV_MODE=true
         ;;
+      --skip-grafana-install)
+        GRAFANA_ACTION="none"
+        ;;
       -h|--help)
         install_help
         ;;
     esac
   done
 
-  # Determine whether Grafana is available in the cluster based on the available of the operator package
-  oc get packagemanifest grafana-operator &> /dev/null
-  if [[ "$?" == "1" ]]; then
-    GRAFANA_ACTION="none"
-  else
-    GRAFANA_ACTION="install"
+  if [[ -z $GRAFANA_ACTION ]] || [[  "$GRAFANA_ACTION" != "none" ]]; then
+    # Determine whether Grafana is available in the cluster based on the available of the operator package
+    oc get packagemanifest grafana-operator &> /dev/null
+    if [[ "$?" == "1" ]]; then
+      GRAFANA_ACTION="none"
+      echo_warning "Grafana is not available in the cluster based on the available operator packages. Grafana installation will be skipped."
+    else
+      GRAFANA_ACTION="install"
+    fi
   fi
 
   if [[ "$INTERACTIVE_MODE" == "true" ]]; then


### PR DESCRIPTION
This PR adds the option `--skip-grafana-install` that allows skipping grafana by avoiding to check if Grafana is available in the cluster based on the available of the operator package. and sets GRAFANA_ACTION="none"

This has been implemented in:

mas install