### PR TITLE
[minor] [mascore-2417] Add support for Manage customizationList

### DIFF
--- a/image/cli/mascli/functions/gitops_suite_app_config
+++ b/image/cli/mascli/functions/gitops_suite_app_config
@@ -35,9 +35,11 @@ Maximo Application Suite:
   --mas-manual-cert-mgmt ${COLOR_YELLOW}MAS_MANUAL_CERT_MGMT${TEXT_RESET}                                 MAS Manual Cert Management
 
 Maximo Manage:
-  --mas-app-server-bundles-combined-add-server-config-yaml ${COLOR_YELLOW}MAS_APP_SERVER_BUNDLES_COMBINED_ADD_SERVER_CONFIG_YAML${TEXT_RESET}  yaml file location containing Combined additional Server Configuration for server bundles
-  Below is a sample yaml file template ( key: << value base64 encoded content of server config xml >>) where key is secret name and value will be base64 encoded of the server config xml file with which the k8s secret needs to be created
+  --mas-app-server-bundles-combined-add-server-config-yaml ${COLOR_YELLOW}MAS_APP_SERVER_BUNDLES_COMBINED_ADD_SERVER_CONFIG_YAML${TEXT_RESET} yaml file location containing Combined additional Server Configuration for server bundles
+  Below is a sample yaml file template representing mas_app_server_bundles_combined_add_server_config dictionary ( key: << value base64 encoded content of server config xml >>) 
+  where key is secret name and value will be base64 encoded of the server config xml file with which the k8s secret needs to be created
 
+    mas_app_server_bundles_combined_add_server_config:
       masdev-manage-d-sb0ascsn: <<base64 encoded content of masdev-manage-dsb0asc-sn.xml>>
       masdev-manage-d-sb1ascsn: <<base64 encoded content of masdev-manage-dsb1asc-sn.xml>>
       ...
@@ -443,7 +445,7 @@ function gitops_suite_app_config() {
     fi
   fi
 
-  # The combined YAML file will have key: value where key is secret name and value is base64 encoded content of server config xml file with which k8s secret will be created
+  # The combined YAML file will have mas_app_server_bundles_combined_add_server_config dict with key as secret name and value as  base64 encoded content of server config xml file with which k8s secret will be created
   if [[ -n "$MAS_APP_SERVER_BUNDLES_COMBINED_ADD_SERVER_CONFIG_YAML" ]] && [[ -s "$MAS_APP_SERVER_BUNDLES_COMBINED_ADD_SERVER_CONFIG_YAML" ]]; then
     echo
     echo_h2 "Server bundles Combined additional server config provided for $MAS_APP_ID at $MAS_APP_SERVER_BUNDLES_COMBINED_ADD_SERVER_CONFIG_YAML"

--- a/image/cli/mascli/functions/gitops_suite_app_config
+++ b/image/cli/mascli/functions/gitops_suite_app_config
@@ -386,6 +386,7 @@ function gitops_suite_app_config() {
     export GIT_SSH="false"
   fi
 
+  export CUSTOMIZATION_ARCHIVE_SECRET=${ACCOUNT_ID}${SECRETS_KEY_SEPERATOR}${CLUSTER_ID}${SECRETS_KEY_SEPERATOR}${MAS_INSTANCE_ID}${SECRETS_KEY_SEPERATOR}
 
   # Set and Validate App Names
   # ---------------------------------------------------------------------------
@@ -410,6 +411,10 @@ function gitops_suite_app_config() {
 
   # Getting app spec, either default or provided
   # ---------------------------------------------------------------------------
+
+
+  export ADDITIONAL_JINJA_PARAMS_FILE="$TEMP_DIR/additional-jinja-params.yaml"
+  echo "{}" > $ADDITIONAL_JINJA_PARAMS_FILE
 
   if [ "$MAS_APP_ID" == "predict" ]; then
     echo "- Configuring for Predict App"
@@ -457,6 +462,7 @@ function gitops_suite_app_config() {
     echo
     echo_h2 "Using application spec provided for $MAS_APP_ID at $MAS_APPWS_SPEC_YAML"
     export MAS_APPWS_SPEC=$(cat ${MAS_APPWS_SPEC_YAML} | yq -r '.' --yaml-output)
+    /usr/bin/yq eval '.mas_appws_spec.settings.customizationList  | to_entries | .[].value.customizationArchiveCredentials.secretName | [] + .' ${MAS_APPWS_SPEC_YAML} | /usr/bin/yq '{"CUSTOMIZATION_ARCHIVE_SECRET_NAMES": [] + .}'  > $ADDITIONAL_JINJA_PARAMS_FILE
   else
     echo
     echo_h2 "Using default application spec for $MAS_APP_ID"
@@ -511,7 +517,7 @@ function gitops_suite_app_config() {
   /usr/bin/yq 'del(.ibm_mas_masapp_configs[] | select(.mas_app_id == "'${MAS_APP_ID}'" and .mas_workspace_id == "'${MAS_WORKSPACE_ID}'"))' $CONFIGS_FILE > $TEMP_DIR/configs.yaml
 
   # Render the appropriate template for the config into a new file
-  jinja -X .+ $CLI_DIR/templates/gitops/appset-configs/cluster/instance/masapp/ibm-mas-masapp-config.yaml.j2 | /usr/bin/yq '{"ibm_mas_masapp_configs": [] + .}' > ${TEMP_DIR}/newconfig.yaml
+  jinja -X .+ -d $ADDITIONAL_JINJA_PARAMS_FILE $CLI_DIR/templates/gitops/appset-configs/cluster/instance/masapp/ibm-mas-masapp-config.yaml.j2 | /usr/bin/yq '{"ibm_mas_masapp_configs": [] + .}' > ${TEMP_DIR}/newconfig.yaml
 
   # Merge the two files
   /usr/bin/yq eval-all '. as $item ireduce ({}; . *+ $item)' $TEMP_DIR/configs.yaml ${TEMP_DIR}/newconfig.yaml > $CONFIGS_FILE

--- a/image/cli/mascli/templates/gitops/appset-configs/cluster/instance/masapp/ibm-mas-masapp-config.yaml.j2
+++ b/image/cli/mascli/templates/gitops/appset-configs/cluster/instance/masapp/ibm-mas-masapp-config.yaml.j2
@@ -5,9 +5,10 @@ mas_app_ws_apiversion: {{ MAS_APPWS_API_VERSION }}
 mas_app_ws_kind: {{ MAS_APPWS_KIND }}
 mas_workspace_id: {{ MAS_WORKSPACE_ID }}
 
-{% if MAS_APP_SERVER_BUNDLES_COMBINED_ADD_SERVER_CONFIG %}
-mas_app_server_bundles_combined_add_server_config: {{ MAS_APP_SERVER_BUNDLES_COMBINED_ADD_SERVER_CONFIG }}
+{% if MAS_APP_SERVER_BUNDLES_COMBINED_ADD_SERVER_CONFIG is defined and MAS_APP_SERVER_BUNDLES_COMBINED_ADD_SERVER_CONFIG !='' %}
+{{ MAS_APP_SERVER_BUNDLES_COMBINED_ADD_SERVER_CONFIG | indent(2) }}
 {% endif %}
+
 {{ MAS_APPWS_SPEC | indent(2) }}
 
 mas_manual_cert_mgmt: {{ MAS_MANUAL_CERT_MGMT }}

--- a/image/cli/mascli/templates/gitops/appset-configs/cluster/instance/masapp/ibm-mas-masapp-config.yaml.j2
+++ b/image/cli/mascli/templates/gitops/appset-configs/cluster/instance/masapp/ibm-mas-masapp-config.yaml.j2
@@ -9,6 +9,15 @@ mas_workspace_id: {{ MAS_WORKSPACE_ID }}
 {{ MAS_APP_SERVER_BUNDLES_COMBINED_ADD_SERVER_CONFIG | indent(2) }}
 {% endif %}
 
+{%- if CUSTOMIZATION_ARCHIVE_SECRET_NAMES is defined and CUSTOMIZATION_ARCHIVE_SECRET_NAMES !='' %}
+customization_archive_secret_names:
+{%- for customization_archive_secret_name in CUSTOMIZATION_ARCHIVE_SECRET_NAMES %}
+  - secret_name: {{ customization_archive_secret_name }}
+    password: <path:{{ SECRETS_PATH }}:{{ CUSTOMIZATION_ARCHIVE_SECRET }}{{ customization_archive_secret_name }}#password>
+    username: <path:{{ SECRETS_PATH }}:{{ CUSTOMIZATION_ARCHIVE_SECRET }}{{ customization_archive_secret_name }}#username>
+{%- endfor %}
+{%- endif %}
+
 {{ MAS_APPWS_SPEC | indent(2) }}
 
 mas_manual_cert_mgmt: {{ MAS_MANUAL_CERT_MGMT }}


### PR DESCRIPTION
Issue: https://jsw.ibm.com/browse/MASCORE-2417?filter=-1

What changed in this PR:

Added support to read secretName from manage mas_appws_spec, and created K8S secret.
mas_appws_spec will only have the secret name.
The actual secret with the username and password will be pre-created by SRE team following the below naming convention. 

`arn:aws:secretsmanager:<<region>>:<<aws_account>>:secret:<<account>>/<<cluster>>/<<mas_instance>/<<secret_name>>
`

The ManageWorkspace CR can have a customizationList section like this:

```
    customizationList:
      - customizationArchiveCredentials:
          secretName: masdev-manage-cl0--cac--sn
        customizationArchiveName: fvtcustomarchive
        customizationArchiveUrl: >-
          https://na.artifactory.swg-devops.com/artifactory/wiotp-generic-release/maximoappsuite/fvt-ibm-mas-manage/latest/fvt-manage-custom-archive-latest.zip
```


