### PR TITLE
[patch] Don't specify OCP patch version for FYRE

### DIFF
--- a/image/cli/mascli/functions/provision_fyre
+++ b/image/cli/mascli/functions/provision_fyre
@@ -140,7 +140,7 @@ function provision_fyre_interactive() {
       export OCP_VERSION=4.12
       ;;
     2|4.14)
-      export OCP_VERSION=4.14.12
+      export OCP_VERSION=4.14
       ;;
     *)
       # Print out a warning as there could be a typo


### PR DESCRIPTION
For aws and roks we don't specify the patch version of ocp. Nor do we for 4.12 in fyre.

Fyre has removed the option for 4.14.12 so doesn't make sense for us to default to it.