### PR TITLE
[patch] Update pipelinerun timeout definitions

### DIFF
--- a/image/cli/mascli/templates/pipelinerun-install.yaml
+++ b/image/cli/mascli/templates/pipelinerun-install.yaml
@@ -10,7 +10,8 @@ spec:
     name: mas-install
 
   serviceAccountName: pipeline
-  timeout: 24h
+  timeouts:
+    pipeline: "24h"
 
   params:
     # Pipeline config

--- a/image/cli/mascli/templates/pipelinerun-rollback.yaml
+++ b/image/cli/mascli/templates/pipelinerun-rollback.yaml
@@ -10,7 +10,8 @@ spec:
     name: mas-rollback
 
   serviceAccountName: pipeline
-  timeout: 1h
+  timeouts:
+    pipeline: "1h"
 
   params:
     - name: mas_instance_id

--- a/image/cli/mascli/templates/pipelinerun-uninstall.yaml
+++ b/image/cli/mascli/templates/pipelinerun-uninstall.yaml
@@ -10,7 +10,8 @@ spec:
     name: mas-uninstall
 
   serviceAccountName: pipeline
-  timeout: 1h
+  timeouts:
+    pipeline: "1h"
 
   params:
     - name: mas_instance_id

--- a/image/cli/mascli/templates/pipelinerun-update.yaml
+++ b/image/cli/mascli/templates/pipelinerun-update.yaml
@@ -10,7 +10,8 @@ spec:
     name: mas-update
 
   serviceAccountName: pipeline
-  timeout: 6h
+  timeouts:
+    pipeline: "6h"
 
   params:
     - name: ibm_entitlement_key
@@ -51,14 +52,14 @@ spec:
       value: '$UDS_ACTION'
     - name: grafana_v5_upgrade
       value: '$GRAFANA_V5_UPGRADE'
-  
+
     # Storage Classes
     # -------------------------------------------------------------------------
     - name: storage_class_rwx
       value: '$STORAGE_CLASS_RWX'
     - name: storage_class_rwo
       value: '$STORAGE_CLASS_RWO'
-    
+
     # Dependencies - CP4D
     # -------------------------------------------------------------------------
     - name: cpd_product_version

--- a/image/cli/mascli/templates/pipelinerun-upgrade.yaml
+++ b/image/cli/mascli/templates/pipelinerun-upgrade.yaml
@@ -10,7 +10,8 @@ spec:
     name: mas-upgrade
 
   serviceAccountName: pipeline
-  timeout: 1h
+  timeouts:
+    pipeline: "1h"
 
   params:
     - name: mas_instance_id


### PR DESCRIPTION
Newer versions of OpenShift Pipelines Operator no longer support the old `spec.timeout` field, we must use `spec.timeouts.pipeline` instead.