### PR TITLE
[patch] Typo when setting configmap_value (sync-install)

### DIFF
--- a/image/cli/app-root/src/update-configmap.sh
+++ b/image/cli/app-root/src/update-configmap.sh
@@ -58,6 +58,6 @@ if [[ "$CM_EXISTS" == "0" ]]; then
   exit $?
 else
   echo "Creating new configmap with ${CONFIGMAP_KEY}=${CONFIGMAP_VALUE}"
-  oc -n ${NAMESPACE} create configmap ${CONFIGMAP_NAME} --from-literal=${CONFIGMAP_KEY}=c${CONFIGMAP_VALUE}
+  oc -n ${NAMESPACE} create configmap ${CONFIGMAP_NAME} --from-literal=${CONFIGMAP_KEY}=${CONFIGMAP_VALUE}
   exit $?
 fi


### PR DESCRIPTION
Checking sync-install config-map:

<img width="359" alt="image" src="https://github.com/ibm-mas/cli/assets/15021471/81465628-84c7-421c-b0a6-428b0cc9b61b">
