### PR TITLE
[patch] launchfvt-mobile devops build number

### DIFF
--- a/tekton/src/tasks/fvt-launcher/launchfvt-mobile.yml.j2
+++ b/tekton/src/tasks/fvt-launcher/launchfvt-mobile.yml.j2
@@ -30,6 +30,12 @@ spec:
 
         # Lookups from mas-devops
         # -----------------------------------------------------------------------
+        - name: DEVOPS_BUILD_NUMBER
+          valueFrom:
+            secretKeyRef:
+              name: mas-devops
+              key: DEVOPS_BUILD_NUMBER
+              optional: true
         - name: MAS_INSTANCE_ID
           valueFrom:
             secretKeyRef:
@@ -44,6 +50,12 @@ spec:
             secretKeyRef:
               name: mas-fvt
               key: FVT_IMAGE_REGISTRY
+              optional: false
+        - name: FVT_ARTIFACTORY_USERNAME
+          valueFrom:
+            secretKeyRef:
+              name: mas-fvt
+              key: FVT_ARTIFACTORY_USERNAME
               optional: false
         - name: FVT_ARTIFACTORY_TOKEN
           valueFrom:


### PR DESCRIPTION
Fix for missing build number to mobile fvt pipeline. It is currently using default 0 value
![image](https://github.com/ibm-mas/cli/assets/105313348/22e3974f-de72-4f85-82c5-329916f41782)
