### PR TITLE
[patch] fix shared-certificates not found in pipeline run

### DIFF
--- a/image/cli/mascli/templates/pipelinerun-install.yaml
+++ b/image/cli/mascli/templates/pipelinerun-install.yaml
@@ -524,3 +524,9 @@ spec:
     - name: shared-pod-templates
       secret:
         secretName: pipeline-pod-templates
+    
+    # Certificates configurations
+    # -------------------------------------------------------------------------
+    - name: shared-certificates
+      secret:
+        secretName: pipeline-certificates


### PR DESCRIPTION
**Description:**

A client is encountering an issue when doing a new installation with MAS CLI 9.0.0, receiving this error in the PipelineRuns:
User error] PipelineRun mas-test-pipelines/test-install-x4r65 doesn't bind Pipeline mas-test-pipelines/mas-install's Workspaces correctly: pipeline requires workspace with name "shared-certificates" be provided by pipelinerun

**Issue can be found in cli 9.0.0 and 9.0.1**