### PR TITLE
[patch] fix shared-certificates not found in pipeline run

### DIFF
--- a/image/cli/mascli/functions/internal/install_pipelinerun_prepare
+++ b/image/cli/mascli/functions/internal/install_pipelinerun_prepare
@@ -51,6 +51,7 @@ function install_pipelinerun_prepare() {
   oc -n $PIPELINES_NS delete secret pipeline-additional-configs --ignore-not-found=true &>> $LOGFILE
   oc -n $PIPELINES_NS delete secret pipeline-sls-entitlement --ignore-not-found=true &>> $LOGFILE
   oc -n $PIPELINES_NS delete secret pipeline-pod-templates --ignore-not-found=true &>> $LOGFILE
+  oc -n $PIPELINES_NS delete secret pipeline-certificates --ignore-not-found=true &>> $LOGFILE
 
   # Create new secrets
   if [ "$LOCAL_MAS_CONFIG_DIR" != "" ]; then
@@ -61,6 +62,9 @@ function install_pipelinerun_prepare() {
   fi
 
   oc -n $PIPELINES_NS create secret generic pipeline-sls-entitlement --from-file=$SLS_LICENSE_FILE_LOCAL &>> $LOGFILE
+
+  # pipeline-certificates must exist. It could be an empty secret at the first place before customer configure it
+  oc -n $PIPELINES_NS create secret generic pipeline-certificates &>> $LOGFILE 
 
   if [ "MAS_POD_TEMPLATES_DIR" != "" ]; then
     oc -n $PIPELINES_NS create secret generic pipeline-pod-templates \

--- a/image/cli/mascli/templates/pipelinerun-install.yaml
+++ b/image/cli/mascli/templates/pipelinerun-install.yaml
@@ -528,3 +528,5 @@ spec:
     # Certificates configurations
     # -------------------------------------------------------------------------
     - name: shared-certificates
+      secret:
+        secretName: pipeline-certificates

--- a/image/cli/mascli/templates/pipelinerun-install.yaml
+++ b/image/cli/mascli/templates/pipelinerun-install.yaml
@@ -528,5 +528,3 @@ spec:
     # Certificates configurations
     # -------------------------------------------------------------------------
     - name: shared-certificates
-      secret:
-        secretName: pipeline-certificates

--- a/image/cli/mascli/templates/pipelinerun-install.yaml
+++ b/image/cli/mascli/templates/pipelinerun-install.yaml
@@ -524,3 +524,9 @@ spec:
     - name: shared-pod-templates
       secret:
         secretName: pipeline-pod-templates
+    
+    # Certificates configurations
+    # -------------------------------------------------------------------------
+    - name: shared-certificates
+      secret:
+        secretName: pipeline-certificates


### PR DESCRIPTION
**Description:**

A client is encountering an issue when doing a new installation with MAS CLI 9.0.0, receiving this error in the PipelineRuns:
User error] PipelineRun mas-test-pipelines/test-install-x4r65 doesn't bind Pipeline mas-test-pipelines/mas-install's Workspaces correctly: pipeline requires workspace with name "shared-certificates" be provided by pipelinerun

**Issue can be found in cli 9.0.0 and 9.0.1**