### PR TITLE
[patch] change log file variable to match name in utils

### DIFF
--- a/image/cli/install-ansible/install-ansible-collections.sh
+++ b/image/cli/install-ansible/install-ansible-collections.sh
@@ -1,8 +1,0 @@
-#!/bin/bash
-
-ansible-galaxy collection install -r /tmp/install-ansible/requirements.yml -p $ANSIBLE_COLLECTIONS_PATH
-
-if [[ -e /tmp/install-ansible/ibm-mas_devops.tar.gz ]]
-then ansible-galaxy collection install /tmp/install-ansible/ibm-mas_devops.tar.gz -p $ANSIBLE_COLLECTIONS_PATH
-else ansible-galaxy collection install ibm.mas_devops
-fi

--- a/image/cli/mascli/functions/must_gather
+++ b/image/cli/mascli/functions/must_gather
@@ -185,8 +185,8 @@ function mustgather() {
   OUTPUT_FILENAME=must-gather-${TIMESTAMP}.tgz
   OUTPUT_FILE=${MG_DIR}/${OUTPUT_FILENAME}
 
-  LOG_FILE=${OUTPUT_DIR}/must-gather.log
-  exec > >(tee ${LOG_FILE}) 2>&1
+  LOGFILE=${OUTPUT_DIR}/must-gather.log
+  exec > >(tee ${LOGFILE}) 2>&1
 
   echo "Must gather will be saved to: $OUTPUT_FILE"
 


### PR DESCRIPTION
change log file variable to match name in utils 
the must gather was giving error like:
[4mCollect Reconcile Logs(B[m
/mascli/must-gather/../functions/internal/utils: line 60: $LOGFILE: ambiguous redirect