### PR TITLE
[patch] [mascore-2802] - create AWS SM with artifactory username and token

### DIFF
--- a/tekton/src/pipelines/gitops/gitops-mas-initiator.yml.j2
+++ b/tekton/src/pipelines/gitops/gitops-mas-initiator.yml.j2
@@ -98,6 +98,12 @@ spec:
     - name: fvt_ansible_version
       type: string
       default: ""
+    - name: artifactory_username
+      type: string
+      default: ""
+    - name: artifactory_token
+      type: string
+      default: ""
   tasks:
 {% if wait_for_provision == true %}
     # 0. Wait for the provsion pipeline to complete
@@ -180,6 +186,10 @@ spec:
           value: $(params.cli_version)
         - name: fvt_ansible_version
           value: $(params.fvt_ansible_version)
+        - name: artifactory_username
+          value: $(params.artifactory_username)
+        - name: artifactory_token
+          value: $(params.artifactory_token)
       taskRef:
         kind: Task
         name: gitops-mas-initiator

--- a/tekton/src/tasks/gitops/gitops-mas-initiator.yml.j2
+++ b/tekton/src/tasks/gitops/gitops-mas-initiator.yml.j2
@@ -182,26 +182,6 @@ spec:
           set -e -o pipefail
         fi
 
-        if [[ -n "${ARTIFACTORY_USERNAME}" && -n "${ARTIFACTORY_TOKEN}" ]]; then
-
-          export SECRET_NAME=${ACCOUNT}${SECRETS_KEY_SEPERATOR}${CLUSTER_NAME}${SECRETS_KEY_SEPERATOR}artifactory
-          export SECRET_VALUE="{\"artifactory_username\":\"${ARTIFACTORY_USERNAME}\",\"artifactory_token\":\"${ARTIFACTORY_TOKEN}\"}"
-
-          aws configure set aws_access_key_id ${SM_AWS_ACCESS_KEY_ID}
-          aws configure set aws_secret_access_key ${SM_AWS_SECRET_ACCESS_KEY}
-          aws configure set default.region $SM_AWS_REGION
-          export AWS_REGION=$SM_AWS_REGION
-          aws configure list
-          set +e +o pipefail
-          aws secretsmanager delete-secret --force-delete-without-recovery --secret-id ${SECRET_NAME} --region $SM_AWS_REGION --output json 2> /dev/null
-          aws secretsmanager describe-secret --secret-id ${SECRET_NAME} --region $SM_AWS_REGION --output json 2> /dev/null
-          aws secretsmanager create-secret --name ${SECRET_NAME} --region $SM_AWS_REGION --secret-string "${SECRET_VALUE}" || exit 1
-
-          echo "created AWS secret secret ${SECRET_NAME} with value ${SECRET_VALUE:0:6}<snip> in region $SM_AWS_REGION"
-          set -e -o pipefail
-        fi
-
-
         export TARGET_LOCAL_DIR="/tmp/target_repo"
         mkdir -p $TARGET_LOCAL_DIR
         cd $TARGET_LOCAL_DIR
@@ -249,6 +229,40 @@ spec:
           fi
         fi
 
+        #customizationList customizationArchive credentials
+        if [ -f "gitops/$ACCOUNT/$REGION/$CLUSTER_NAME/fvtsaas/appws_spec_manage.yaml" ]; then
+
+          MAS_APPWS_SPEC_YAML=gitops/$ACCOUNT/$REGION/$CLUSTER_NAME/fvtsaas/appws_spec_manage.yaml
+          secret_names=$(/usr/bin/yq eval '.mas_appws_spec.settings.customizationList | to_entries | .[].value.customizationArchiveCredentials.secretName' ${MAS_APPWS_SPEC_YAML})
+          for customization_archive_secret_name in ${secret_names[@]}; do
+
+            export CUSTOMIZATION_ARCHIVE_SECRET=${ACCOUNT_ID}${SECRETS_KEY_SEPERATOR}${CLUSTER_NAME}${SECRETS_KEY_SEPERATOR}fvtsaas${SECRETS_KEY_SEPERATOR}
+            export CUSTOMIZATION_ARCHIVE_SECRET_NAME=${CUSTOMIZATION_ARCHIVE_SECRET}${customization_archive_secret_name}
+            echo "gitops-mas-initiator: creating AWS SM with name :: ${CUSTOMIZATION_ARCHIVE_SECRET_NAME}"
+
+            if [[ -n "${ARTIFACTORY_USERNAME}" && -n "${ARTIFACTORY_TOKEN}" ]]; then
+              export SECRET_VALUE="{\"username\":\"${ARTIFACTORY_USERNAME}\",\"password\":\"${ARTIFACTORY_TOKEN}\"}"
+
+              aws configure set aws_access_key_id ${SM_AWS_ACCESS_KEY_ID}
+              aws configure set aws_secret_access_key ${SM_AWS_SECRET_ACCESS_KEY}
+              aws configure set default.region $SM_AWS_REGION
+              export AWS_REGION=$SM_AWS_REGION
+              aws configure list
+              set +e +o pipefail
+              aws secretsmanager delete-secret --force-delete-without-recovery --secret-id ${CUSTOMIZATION_ARCHIVE_SECRET_NAME} --region $SM_AWS_REGION --output json 2> /dev/null
+              aws secretsmanager describe-secret --secret-id ${CUSTOMIZATION_ARCHIVE_SECRET_NAME} --region $SM_AWS_REGION --output json 2> /dev/null
+              aws secretsmanager create-secret --name ${CUSTOMIZATION_ARCHIVE_SECRET_NAME} --region $SM_AWS_REGION --secret-string "${SECRET_VALUE}" || exit 1
+
+              echo "created AWS secret secret ${CUSTOMIZATION_ARCHIVE_SECRET_NAME} with value ${SECRET_VALUE:0:6}<snip> in region $SM_AWS_REGION"
+              set -e -o pipefail
+            else
+              echo "gitops-mas-initiator: ARTIFACTORY_USERNAME and/or ARTIFACTORY_TOKEN not set, exit with error"
+              exit 1
+            fi
+
+          done
+
+        fi
         # Update the app channels in the mas-apps-params.yaml. Assume fvtsaas here
         if [ -n $MAS_APP_CHANNEL_ASSIST ]; then
           yq --arg MAS_APP_CHANNEL_ASSIST $MAS_APP_CHANNEL_ASSIST -iY '(. | select(has("assist")?).assist.app_channel)= $MAS_APP_CHANNEL_ASSIST' gitops/$ACCOUNT/$REGION/$CLUSTER_NAME/fvtsaas/mas-apps-params.yaml

--- a/tekton/src/tasks/gitops/gitops-mas-initiator.yml.j2
+++ b/tekton/src/tasks/gitops/gitops-mas-initiator.yml.j2
@@ -73,6 +73,12 @@ spec:
     - name: fvt_ansible_version
       type: string
       default: ""
+    - name: artifactory_username
+      type: string
+      default: ""
+    - name: artifactory_token
+      type: string
+      default: ""
   stepTemplate:
     name: gitops-mas-initiator
     env:
@@ -138,6 +144,10 @@ spec:
         value: $(params.cli_version)
       - name: FVT_ANSIBLE_VERSION
         value: $(params.fvt_ansible_version)
+      - name: ARTIFACTORY_USERNAME
+        value: $(params.artifactory_username)
+      - name: ARTIFACTORY_TOKEN
+        value: $(params.artifactory_token)
   steps:
     - args:
       - |-
@@ -157,6 +167,25 @@ spec:
 
           export SECRET_NAME=${ACCOUNT}${SECRETS_KEY_SEPERATOR}${CLUSTER_NAME}${SECRETS_KEY_SEPERATOR}cis
           export SECRET_VALUE="{\"ibm_apikey\":\"$IBMCLOUD_APIKEY\"}"
+
+          aws configure set aws_access_key_id ${SM_AWS_ACCESS_KEY_ID}
+          aws configure set aws_secret_access_key ${SM_AWS_SECRET_ACCESS_KEY}
+          aws configure set default.region $SM_AWS_REGION
+          export AWS_REGION=$SM_AWS_REGION
+          aws configure list
+          set +e +o pipefail
+          aws secretsmanager delete-secret --force-delete-without-recovery --secret-id ${SECRET_NAME} --region $SM_AWS_REGION --output json 2> /dev/null
+          aws secretsmanager describe-secret --secret-id ${SECRET_NAME} --region $SM_AWS_REGION --output json 2> /dev/null
+          aws secretsmanager create-secret --name ${SECRET_NAME} --region $SM_AWS_REGION --secret-string "${SECRET_VALUE}" || exit 1
+
+          echo "created AWS secret secret ${SECRET_NAME} with value ${SECRET_VALUE:0:6}<snip> in region $SM_AWS_REGION"
+          set -e -o pipefail
+        fi
+
+        if [[ -n "${ARTIFACTORY_USERNAME}" && -n "${ARTIFACTORY_TOKEN}" ]]; then
+
+          export SECRET_NAME=${ACCOUNT}${SECRETS_KEY_SEPERATOR}${CLUSTER_NAME}${SECRETS_KEY_SEPERATOR}artifactory
+          export SECRET_VALUE="{\"artifactory_username\":\"${ARTIFACTORY_USERNAME}\",\"artifactory_token\":\"${ARTIFACTORY_TOKEN}\"}"
 
           aws configure set aws_access_key_id ${SM_AWS_ACCESS_KEY_ID}
           aws configure set aws_secret_access_key ${SM_AWS_SECRET_ACCESS_KEY}


### PR DESCRIPTION
Issue - https://jsw.ibm.com/browse/MASCORE-2802

What changed in this PR:
 - Add the artifactory username and token to AWS secret manager in cli/tekton/src/pipelines/gitops/gitops-mas-initiator.yml.j2
