### PR TITLE
[patch] Removed pod-templates for edgeconfig-configui

### DIFF
--- a/image/cli/mascli/templates/pod-templates/best-effort/ibm-mas-iot-edgeconfig.yml
+++ b/image/cli/mascli/templates/pod-templates/best-effort/ibm-mas-iot-edgeconfig.yml
@@ -4,10 +4,6 @@
 # assigned a QoS class of BestEffort. More can be found here:
 # https://kubernetes.io/docs/tasks/configure-pod-container/quality-service-pod
 podTemplates:
-  - name: edgeconfig-configui
-    containers:
-      - name: edgeconfig-configui
-        resources: {}
   - name: edgeconfig-server
     containers:
       - name: edgeconfig-server

--- a/image/cli/mascli/templates/pod-templates/guaranteed/ibm-mas-iot-edgeconfig.yml
+++ b/image/cli/mascli/templates/pod-templates/guaranteed/ibm-mas-iot-edgeconfig.yml
@@ -4,16 +4,6 @@
 # assigned a QoS class of Guaranteed. More can be found here:
 # https://kubernetes.io/docs/tasks/configure-pod-container/quality-service-pod
 podTemplates:
-  - name: edgeconfig-configui
-    containers:
-      - name: edgeconfig-configui
-        resources:
-          requests:
-            cpu: 2
-            memory: 2Gi
-          limits:
-            cpu: 2
-            memory: 2Gi
   - name: edgeconfig-server
     containers:
       - name: edgeconfig-server


### PR DESCRIPTION
### Description:
Removed best effort and guaranteed pod templates for edgeconfig-configui since it is removed in MAS 9.0

### Related links:
https://jsw.ibm.com/browse/IBMIOT-447

### Testing:
Tested the test_podtemplates test case for IoT via personal-fvt

<img width="1728" alt="Screenshot 2024-05-22 at 19 37 33" src="https://github.com/ibm-mas/cli/assets/31183552/330f8696-9c82-4a09-9ca1-b7240f8694bb">

<img width="1728" alt="Screenshot 2024-05-22 at 19 37 49" src="https://github.com/ibm-mas/cli/assets/31183552/90f1d5cf-221f-405a-9248-88772910c8c6">
