### PR TITLE
[minor] User defined DRO namespace

### DIFF
--- a/image/cli/mascli/functions/install
+++ b/image/cli/mascli/functions/install
@@ -339,7 +339,7 @@ function install_noninteractive() {
         export UDS_CONTACT_LASTNAME=$1 && shift
         ;;
       # DRO
-      -dro-namespace)
+      --dro-namespace)
         export DRO_NAMESPACE=$1 && shift
         ;;
 
@@ -780,8 +780,8 @@ function install() {
   uds_action_selection
 
   # Select DRO Namespace
-  if [[ "$INTERACTIVE_MODE" == "true" ]] &&[ [ "$UDS_ACTION" == "install-dro" ]]; then
-    prompt_for_input "Provide DRO Namespace [Default:'redhat-marketplace']" DRO_NAMESPACE
+  if [[ "$INTERACTIVE_MODE" == "true" ]] && [[ "$UDS_ACTION" == "install-dro" ]]; then
+    prompt_for_input "Provide DRO Namespace [Default:'redhat-marketplace']" DRO_NAMESPACE "redhat-marketplace"
     echo_highlight "DRO is configured to install in ${DRO_NAMESPACE} namespace"
   fi
 

--- a/image/cli/mascli/functions/install
+++ b/image/cli/mascli/functions/install
@@ -780,9 +780,9 @@ function install() {
   uds_action_selection
 
   # Select DRO Namespace
-  if [[ "$UDS_ACTION" == "install-dro" ]]; then
+  if [[ "$INTERACTIVE_MODE" == "true" ]] &&[ [ "$UDS_ACTION" == "install-dro" ]]; then
     prompt_for_input "Provide DRO Namespace [Default:'redhat-marketplace']" DRO_NAMESPACE
-    echo_highlight "DRO is configured to install in ${DRO_NAMESPACE} "
+    echo_highlight "DRO is configured to install in ${DRO_NAMESPACE} namespace"
   fi
 
   # Prepare and launch the Tekton pipeline

--- a/image/cli/mascli/functions/install
+++ b/image/cli/mascli/functions/install
@@ -65,7 +65,6 @@ function install_noninteractive() {
 
   WAIT_FOR_PVCS=true
   STORAGE_CLASS_PROVIDER=custom
-
   while [[ $# -gt 0 ]]
   do
     key="$1"
@@ -338,6 +337,10 @@ function install_noninteractive() {
         ;;
       --uds-lastname)
         export UDS_CONTACT_LASTNAME=$1 && shift
+        ;;
+      # DRO
+      -dro-namespace)
+        export DRO_NAMESPACE=$1 && shift
         ;;
 
       # MongoDB
@@ -775,6 +778,12 @@ function install() {
   # Determine if UDS or DRO will be installed
   # DRO is installed by default on latest catalog version, for catalogs older than 240227 install UDS
   uds_action_selection
+
+  # Select DRO Namespace
+  if [[ "$UDS_ACTION" == "install-dro" ]]; then
+    prompt_for_input "Provide DRO Namespace [Default:'redhat-marketplace']" DRO_NAMESPACE
+    echo_highlight "DRO is configured to install in ${DRO_NAMESPACE} "
+  fi
 
   # Prepare and launch the Tekton pipeline
   install_pipelinerun_prepare

--- a/image/cli/mascli/functions/update
+++ b/image/cli/mascli/functions/update
@@ -178,7 +178,7 @@ function validate_dro_migration() {
           echo "No storage class selected for DRO"
         fi
         if [[ "$NO_CONFIRM" != "true" ]] && [[ -z "${DRO_NAMESPACE}" ]]; then
-          prompt_for_input "Provide DRO Namespace [Default:'redhat-marketplace']" DRO_NAMESPACE
+          prompt_for_input "Provide DRO Namespace [Default:'redhat-marketplace']" DRO_NAMESPACE "redhat-marketplace"
           echo_highlight "DRO is configured to install in ${DRO_NAMESPACE} namespace"
         fi
 
@@ -215,9 +215,6 @@ function validate_dro_migration() {
       else
         DRO_MIGRATION="false"
         echo -e "${COLOR_YELLOW}UDS does not exist, skipping DRO migration and proceeding with mas update"
-        if [[ -z "${DRO_NAMESPACE}" ]] || [[ "${DRO_NAMESPACE}" == "" ]]; then
-          DRO_NAMESPACE="redhat-marketplace"
-        fi
         DRO_CSV=$(oc get csv -n "${DRO_NAMESPACE}" | grep ibm-data-reporter-operator | awk '{print $1}')
         echo $DRO_CSV
         if [[ -n $DRO_CSV ]]; then
@@ -879,6 +876,7 @@ function update() {
   if [ "$DRO_MIGRATION" = "true" ]; then
     echo_reset_dim "UDS to DRO ................................. ${COLOR_GREEN}Yes"
     echo_reset_dim " - DRO Storage Class ....................... ${COLOR_GREEN}${DRO_STORAGE_CLASS}"
+    echo_reset_dim " - DRO Namespace ........................... ${COLOR_GREEN}${DRO_NAMESPACE}"
   else
     echo_reset_dim "UDS to DRO ................................. ${COLOR_RED}Not Required"
   fi

--- a/image/cli/mascli/functions/update
+++ b/image/cli/mascli/functions/update
@@ -179,7 +179,7 @@ function validate_dro_migration() {
         fi
         if [[ "$NO_CONFIRM" != "true" ]] && [[ -z "${DRO_NAMESPACE}" ]]; then
           prompt_for_input "Provide DRO Namespace [Default:'redhat-marketplace']" DRO_NAMESPACE
-          echo_highlight "DRO is configured to install in ${DRO_NAMESPACE} "
+          echo_highlight "DRO is configured to install in ${DRO_NAMESPACE} namespace"
         fi
 
         ## Check all avaliable Suite Instance's versions, if any of them is 8.9.x cancel the update. Exit mas update throw error.

--- a/image/cli/mascli/functions/update
+++ b/image/cli/mascli/functions/update
@@ -24,6 +24,7 @@ Update Dependencies (Optional):
   --dro-migration  ${COLOR_YELLOW}DRO_MIGRATION${TEXT_RESET}          Confirm the removal of UDS and replacement with DRO as part of the update
   --cp4d-version  ${COLOR_YELLOW}CP4D_VERSION${TEXT_RESET}            Optional. Set Cloud Pak for Data version for the upgrade. Note: This overrides the default CP4D version defined by the Maximo Operator Catalog version.
   --dro-storage-class  ${COLOR_YELLOW}DRO_STORAGE_CLASS${TEXT_RESET}  Set Custom RWO Storage Class name for DRO as part of the update
+  --dro-namespace  ${COLOR_YELLOW}DRO_Namespace${TEXT_RESET}          Set Custom Namespace for DRO(Default: redhat-marketplace)
 Other Commands:
       --skip-pre-check                  Skips the 'pre-update-check' and 'post-update-verify' tasks in the update pipeline
       --no-confirm                      Launch the update without prompting for confirmation
@@ -175,6 +176,10 @@ function validate_dro_migration() {
         else
           DRO_STORAGE_CLASS=""
           echo "No storage class selected for DRO"
+        fi
+        if [[ "$NO_CONFIRM" != "true" ]] && [[ -z "${DRO_NAMESPACE}" ]]; then
+          prompt_for_input "Provide DRO Namespace [Default:'redhat-marketplace']" DRO_NAMESPACE
+          echo_highlight "DRO is configured to install in ${DRO_NAMESPACE} "
         fi
 
         ## Check all avaliable Suite Instance's versions, if any of them is 8.9.x cancel the update. Exit mas update throw error.
@@ -604,6 +609,9 @@ function update_noninteractive() {
       --dro-migration)
         DRO_MIGRATION=true
         ;;
+      --dro-namespace)
+        DRO_NAMESPACE=true
+        ;;
       --dro-storage-class)
         DRO_STORAGE_CLASS=$1 && shift
         ;;
@@ -739,6 +747,7 @@ function update() {
   export SKIP_ENTITLEMENT_KEY_FLAG
   export DRO_STORAGE_CLASS
   export UDS_ACTION
+  export DRO_NAMESPACE
 
   reset_colors
   echo_h2 "Review Settings"

--- a/image/cli/mascli/functions/update
+++ b/image/cli/mascli/functions/update
@@ -24,7 +24,7 @@ Update Dependencies (Optional):
   --dro-migration  ${COLOR_YELLOW}DRO_MIGRATION${TEXT_RESET}          Confirm the removal of UDS and replacement with DRO as part of the update
   --cp4d-version  ${COLOR_YELLOW}CP4D_VERSION${TEXT_RESET}            Optional. Set Cloud Pak for Data version for the upgrade. Note: This overrides the default CP4D version defined by the Maximo Operator Catalog version.
   --dro-storage-class  ${COLOR_YELLOW}DRO_STORAGE_CLASS${TEXT_RESET}  Set Custom RWO Storage Class name for DRO as part of the update
-  --dro-namespace  ${COLOR_YELLOW}DRO_Namespace${TEXT_RESET}          Set Custom Namespace for DRO(Default: redhat-marketplace)
+  --dro-namespace  ${COLOR_YELLOW}DRO_NAMESPACE${TEXT_RESET}          Set Custom Namespace for DRO(Default: redhat-marketplace)
 Other Commands:
       --skip-pre-check                  Skips the 'pre-update-check' and 'post-update-verify' tasks in the update pipeline
       --no-confirm                      Launch the update without prompting for confirmation
@@ -215,7 +215,9 @@ function validate_dro_migration() {
       else
         DRO_MIGRATION="false"
         echo -e "${COLOR_YELLOW}UDS does not exist, skipping DRO migration and proceeding with mas update"
-        DRO_NAMESPACE="redhat-marketplace"
+        if [[ -z "${DRO_NAMESPACE}" ]] || [[ "${DRO_NAMESPACE}" == "" ]]; then
+          DRO_NAMESPACE="redhat-marketplace"
+        fi
         DRO_CSV=$(oc get csv -n "${DRO_NAMESPACE}" | grep ibm-data-reporter-operator | awk '{print $1}')
         echo $DRO_CSV
         if [[ -n $DRO_CSV ]]; then
@@ -610,7 +612,7 @@ function update_noninteractive() {
         DRO_MIGRATION=true
         ;;
       --dro-namespace)
-        DRO_NAMESPACE=true
+        DRO_NAMESPACE=$1 && shift
         ;;
       --dro-storage-class)
         DRO_STORAGE_CLASS=$1 && shift

--- a/image/cli/mascli/templates/pipelinerun-install.yaml
+++ b/image/cli/mascli/templates/pipelinerun-install.yaml
@@ -252,7 +252,8 @@ spec:
       value: '$UDS_CONTACT_LASTNAME'
     - name: uds_action
       value: '$UDS_ACTION'
-
+    - name: dro_namespace
+      value: '$DRO_NAMESPACE'
     # Dependencies - AppConnect
     # -------------------------------------------------------------------------
     - name: appconnect_entitlement_username

--- a/image/cli/mascli/templates/pipelinerun-update.yaml
+++ b/image/cli/mascli/templates/pipelinerun-update.yaml
@@ -48,6 +48,8 @@ spec:
       value: '$DRO_STORAGE_CLASS'
     - name: uds_action
       value: '$UDS_ACTION'
+    - name: dro_namespace
+      value: '$DRO_NAMESPACE'
     - name: grafana_v5_upgrade
       value: '$GRAFANA_V5_UPGRADE'
 

--- a/tekton/src/params/install.yml.j2
+++ b/tekton/src/params/install.yml.j2
@@ -247,6 +247,9 @@
 - name: uds_action
   type: string
   default: ""
+- name: dro_namespace
+  type: string
+  default: ""
 - name: mas_segment_key
   type: string
   default: ""

--- a/tekton/src/pipelines/taskdefs/dependencies/uds.yml.j2
+++ b/tekton/src/pipelines/taskdefs/dependencies/uds.yml.j2
@@ -27,6 +27,8 @@
     # Only used by DRO
     - name: ibm_entitlement_key
       value: $(params.ibm_entitlement_key)
+    - name: DRO_NAMESPACE
+      value: $(params.dro_namespace)
   when:
     - input: "$(params.uds_action)"
       operator: in

--- a/tekton/src/pipelines/update.yml.j2
+++ b/tekton/src/pipelines/update.yml.j2
@@ -128,6 +128,10 @@ spec:
       default: "install-dro"
       type: string
       description: set UDS_ACTION, default is install-dro'
+    - name: dro_namespace
+      default: "redhat-marketplace"
+      type: string
+      description: set custom namespace for DRO, default is redhat-marketplace'
 
     # grafana operator update
     - name: grafana_v5_upgrade

--- a/tekton/src/pipelines/update.yml.j2
+++ b/tekton/src/pipelines/update.yml.j2
@@ -378,6 +378,8 @@ spec:
           value: $(params.uds_storage_class)
         - name: uds_action
           value: $(params.uds_action)
+        - name: DRO_NAMESPACE
+          value: $(params.dro_namespace)
         - name: devops_suite_name
           value: update-uds
 {% if wait_for_install == true %}

--- a/tekton/src/pipelines/update.yml.j2
+++ b/tekton/src/pipelines/update.yml.j2
@@ -131,7 +131,6 @@ spec:
     - name: dro_namespace
       default: "redhat-marketplace"
       type: string
-      description: set custom namespace for DRO, default is redhat-marketplace'
 
     # grafana operator update
     - name: grafana_v5_upgrade

--- a/tekton/src/tasks/dependencies/uds.yml.j2
+++ b/tekton/src/tasks/dependencies/uds.yml.j2
@@ -47,7 +47,7 @@ spec:
       default: ""
     - name: dro_namespace
       type: string
-      default: ""
+      default: "redhat-marketplace"
 
     # Used by UDS & DRO
     - name: uds_contact_email

--- a/tekton/src/tasks/dependencies/uds.yml.j2
+++ b/tekton/src/tasks/dependencies/uds.yml.j2
@@ -45,6 +45,9 @@ spec:
     - name: ibm_entitlement_key
       type: string
       default: ""
+    - name: dro_namespace
+      type: string
+      default: ""
 
     # Used by UDS & DRO
     - name: uds_contact_email
@@ -144,6 +147,8 @@ spec:
           value: $(params.dro_migration)
         - name: DRO_STORAGE_CLASS
           value: $(params.uds_storage_class)
+        - name: DRO_NAMESPACE
+          value: $(params.dro_namespace)
   workspaces:
     - name: configs
       optional: true


### PR DESCRIPTION
https://jsw.ibm.com/browse/MASCORE-2894

DRO namespace is hard coded to rehat-marketplace, remove this hard coded value and make DRO_NAMESPACE user configurable

- add a new env DRO_NAMESPACE
- make dro namespace user configurable, default to redhat-marketplace if a namespace is not supplied
- Add required ClusterRoleBindings for the metric-state containers

related ansible-devops PR: https://github.com/ibm-mas/ansible-devops/pull/1332