### PR TITLE
[patch] Temporay workaround to fix image push action

### DIFF
--- a/.github/workflows/build-cli.yml
+++ b/.github/workflows/build-cli.yml
@@ -79,6 +79,7 @@ jobs:
 
       # https://github.com/marketplace/actions/push-to-registry
       - name: Push the docker image
+        id: push_to_quay
         run: |
           docker images
           docker login --username "${{ secrets.QUAYIO_USERNAME }}" --password "${{ secrets.QUAYIO_PASSWORD }}" quay.io

--- a/.github/workflows/build-cli.yml
+++ b/.github/workflows/build-cli.yml
@@ -79,12 +79,16 @@ jobs:
 
       # https://github.com/marketplace/actions/push-to-registry
       - name: Push the docker image
-        id: push_to_quay
-        uses: redhat-actions/push-to-registry@v2
-        with:
-          tags: quay.io/ibmmas/cli:${{ env.DOCKER_TAG }}
-          username: ${{ secrets.QUAYIO_USERNAME }}
-          password: ${{ secrets.QUAYIO_PASSWORD }}
+        run: |
+          docker images
+          docker login --username "${{ secrets.QUAYIO_USERNAME }}" --password "${{ secrets.QUAYIO_PASSWORD }}" quay.io
+          docker push quay.io/ibmmas/cli:${{ env.DOCKER_TAG }}
+        # Old version ...
+        # uses: redhat-actions/push-to-registry@v2
+        # with:
+        #   tags: quay.io/ibmmas/cli:${{ env.DOCKER_TAG }}
+        #   username: ${{ secrets.QUAYIO_USERNAME }}
+        #   password: ${{ secrets.QUAYIO_PASSWORD }}
 
       # 5. OWASP Dependency Check
       # -------------------------------------------------------------------------------------------


### PR DESCRIPTION
This is a temporary workaround to docker incompatibility issue caused by redhat actions to push the image.

![image (9)](https://github.com/ibm-mas/cli/assets/728940/5b5185c3-ea94-4474-9075-c4d5dd3ec702)
