### PR TITLE
[patch] workaround for pushing image action in release

### DIFF
--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -68,11 +68,16 @@ jobs:
       # https://github.com/marketplace/actions/push-to-registry
       - name: Push the docker image
         id: push_to_quay
-        uses: redhat-actions/push-to-registry@v2
-        with:
-          tags: quay.io/ibmmas/cli:${{ env.DOCKER_TAG }} quay.io/ibmmas/cli:latest
-          username: ${{ secrets.QUAYIO_USERNAME }}
-          password: ${{ secrets.QUAYIO_PASSWORD }}
+        run: |
+          docker images
+          docker login --username "${{ secrets.QUAYIO_USERNAME }}" --password "${{ secrets.QUAYIO_PASSWORD }}" quay.io
+          docker push quay.io/ibmmas/cli:${{ env.DOCKER_TAG }}
+        # Old version ...
+        # uses: redhat-actions/push-to-registry@v2
+        # with:
+        #   tags: quay.io/ibmmas/cli:${{ env.DOCKER_TAG }}
+        #   username: ${{ secrets.QUAYIO_USERNAME }}
+        #   password: ${{ secrets.QUAYIO_PASSWORD }}
 
       # 4. OWASP Dependency Check
       # -------------------------------------------------------------------------------------------


### PR DESCRIPTION
This workaround will push images to quay.io without using the broken redhat-actions