### PR TITLE
[patch] [mascore-2980] manual certs validation correction

### DIFF
--- a/tekton/src/tasks/gitops/gitops-mas-initiator.yml.j2
+++ b/tekton/src/tasks/gitops/gitops-mas-initiator.yml.j2
@@ -228,6 +228,11 @@ spec:
           rm -rf $TARGET_LOCAL_DIR/manual-certs
         fi
 
+        if [[ "${MANUAL_CERTS_CONTROL_FLAG}" != "True" ]]; then
+          yq -iY 'del(.dns.manual_certs)' gitops/$ACCOUNT/$REGION/$CLUSTER_NAME/fvtsaas/mas-instance-params.yaml
+          echo "gitops-mas-initiator: removed .dns.manual_certs node"
+        fi
+
         cd $TARGET_LOCAL_DIR/$TARGET_GITHUB_REPO
 
         # Update the domain name in the mas-instance-params.yaml. Assume fvtsaas here


### PR DESCRIPTION
PR - https://jsw.ibm.com/browse/MASCORE-2980 

This PR has changes related to manual certs validation logic
The .dns.manual_certs node will be removed from mas-instance-params.yaml in case if MANUAL_CERTS_CONTROL_FLAG is not true