### PR TITLE
[patch] remove optimizer-manage-setup test

### DIFF
--- a/tekton/src/pipelines/fvt-optimizer.yml.j2
+++ b/tekton/src/pipelines/fvt-optimizer.yml.j2
@@ -124,53 +124,7 @@ spec:
         - name: configs
           workspace: shared-configs
 
-
-    # 3. Run "optimizer-manage-setup"  (Optimizer)
-    # -----------------------------------------------------------------------------
-    - name: fvt-optimizer-manage-connection-setup
-      taskRef:
-        kind: Task
-        name: mas-fvt-manage
-      params:
-        - name: mas_instance_id
-          value: $(params.mas_instance_id)
-        - name: mas_workspace_id
-          value: $(params.mas_workspace_id)
-        - name: fvt_image_registry
-          value: $(params.fvt_image_registry)
-        - name: fvt_image_namespace
-          value: fvt-optimizer
-        - name: fvt_image_name
-          value: fvt-optimizer-manage-setup
-        - name: fvt_image_digest
-          value: $(params.fvt_digest_optimizer)
-        - name: product_channel
-          value: $(params.mas_app_channel_manage)
-        - name: product_id
-          value: ibm-mas-optimizer
-        - name: artifactory_token
-          value: $(params.fvt_artifactory_token)
-        - name: fvt_test_suite
-          value: optimizer-manage-setup
-        - name: fvt_mas_appws_component
-          value: optimizer
-        - name: fvt_test_driver
-          value: tpae
-      when:
-        - input: "$(params.fvt_digest_optimizer)"
-          operator: notin
-          values: [""]
-        - input: "$(params.mas_app_channel_manage)"
-          operator: notin
-          values: [""]
-      workspaces:
-        - name: configs
-          workspace: shared-configs
-      runAfter:
-        - fvt-optimizer
-
-
-    # 4. Run "optimizer-gs-resource-leveling" (Optimizer)
+    # 3. Run "optimizer-gs-resource-leveling" (Optimizer)
     # -----------------------------------------------------------------------------
     - name: fvt-optimizer-manage-connection
       taskRef:
@@ -212,7 +166,7 @@ spec:
         - name: configs
           workspace: shared-configs
       runAfter:
-        - fvt-optimizer-manage-connection-setup
+        - fvt-optimizer
 
   finally:
     # 1. Run CV


### PR DESCRIPTION
Removing a test step from fvt in optimizer that has been moved to `[ibm-mas-manage/base-api-setup](https://dashboard.masdev.wiotp.sl.hursley.ibm.com/tests/fvtstable/testsuite/ibm-mas-manage/base-api-setup)`

<img width="666" alt="image" src="https://github.com/ibm-mas/cli/assets/31037381/339aaf7b-c225-493b-a670-5b37a3b95528">
