### PR TITLE
[patch] mobile-version-finder fix

### DIFF
--- a/image/cli/app-root/src/mobile-version-finder.py
+++ b/image/cli/app-root/src/mobile-version-finder.py
@@ -159,10 +159,13 @@ def get_graphite_versions():
     for app_zip_file in pathlist:
         zip_file_path = f"./{str(app_zip_file)}"
         with zipfile.ZipFile(zip_file_path, "r") as zip_ref:
-            zip_ref.extract("build.json", ".")
+            try:
+                zip_ref.extract("build.json", ".")
+                zip_file_prefix = zip_file_path.split(".zip")
+                os.rename("./build.json", f"{zip_file_prefix[0]}.json")
+            except KeyError as e:
+                print(f"There is no build.json file in {zip_file_path}")
             zip_ref.close()
-        zip_file_prefix = zip_file_path.split(".zip")
-        os.rename("./build.json", f"{zip_file_prefix[0]}.json")
         os.remove(zip_file_path)
 
     # dictionary that will contain all graphite versions for all found zips

--- a/image/cli/app-root/src/mobile-version-finder.py
+++ b/image/cli/app-root/src/mobile-version-finder.py
@@ -20,6 +20,7 @@ artKey = os.getenv("ARTIFACTORY_TOKEN")
 artDir = os.getenv("ARTIFACTORY_UPLOAD_DIR")
 output_filename = "mobile-is-versions.json"
 
+
 class RunCmdResult(object):
     def __init__(self, returnCode, output, error):
         self.rc = returnCode
@@ -31,6 +32,7 @@ class RunCmdResult(object):
 
     def failed(self):
         return self.rc != 0
+
 
 def run_cmd(cmdArray, timeout=630):
     """
@@ -51,7 +53,8 @@ def run_cmd(cmdArray, timeout=630):
             output, error = p.communicate(timeout=timeout)
             return RunCmdResult(p.returncode, output, error)
         except TimeoutExpired as e:
-            return RunCmdResult(127, 'TimeoutExpired', str(e))
+            return RunCmdResult(127, "TimeoutExpired", str(e))
+
 
 def get_graphite_versions():
     # This list will contains all files found in the maxinst pod
@@ -60,7 +63,10 @@ def get_graphite_versions():
     # Downloads all zip files from maxinst container
     try:
         pods = dynClient.resources.get(api_version="v1", kind="Pod")
-        podList = pods.get(namespace=f"mas-{instanceId}-manage", label_selector='mas.ibm.com/appType=maxinstudb')
+        podList = pods.get(
+            namespace=f"mas-{instanceId}-manage",
+            label_selector="mas.ibm.com/appType=maxinstudb",
+        )
 
         if podList is None or podList.items is None or len(podList.items) == 0:
             pass
@@ -68,9 +74,18 @@ def get_graphite_versions():
             podName = podList.items[0].metadata.name
 
             # list all graphite zip packages in maxinst pod
-            ocExecCommand = ["oc", "exec", "-n", f"mas-{instanceId}-manage", podName, "--", "ls", "/opt/IBM/SMP/maximo/tools/maximo/en/graphite/apps"]
+            ocExecCommand = [
+                "oc",
+                "exec",
+                "-n",
+                f"mas-{instanceId}-manage",
+                podName,
+                "--",
+                "ls",
+                "/opt/IBM/SMP/maximo/tools/maximo/en/graphite/apps",
+            ]
             result = run_cmd(ocExecCommand)
-            ls_result = result.out.decode('utf-8')
+            ls_result = result.out.decode("utf-8")
             apps_list = ls_result.split("\n")
             # removes last empty value from the list
             apps_list.pop()
@@ -79,10 +94,13 @@ def get_graphite_versions():
             for a in apps_list:
                 print("Downloading:", a)
                 ocExecCommand = [
-                    "oc", "cp", "-n", f"mas-{instanceId}-manage", 
+                    "oc",
+                    "cp",
+                    "-n",
+                    f"mas-{instanceId}-manage",
                     f"{podName}:/opt/IBM/SMP/maximo/tools/maximo/en/graphite/apps/{a}",
                     f"./{a}",
-                    "--retries=10"
+                    "--retries=10",
                 ]
                 run_cmd(ocExecCommand)
 
@@ -90,11 +108,13 @@ def get_graphite_versions():
         print(f"Unable to download mobile packages from maxinst pod: {e}")
         sys.exit(1)
 
-
     # Downloading navigator from mobileapi pod
     try:
         pods = dynClient.resources.get(api_version="v1", kind="Pod")
-        podList = pods.get(namespace=f"mas-{instanceId}-core", label_selector=f'app={instanceId}-mobileapi')
+        podList = pods.get(
+            namespace=f"mas-{instanceId}-core",
+            label_selector=f"app={instanceId}-mobileapi",
+        )
 
         if podList is None or podList.items is None or len(podList.items) == 0:
             pass
@@ -102,9 +122,18 @@ def get_graphite_versions():
             podName = podList.items[0].metadata.name
 
             # list navigator zip packages in mobileapi pod
-            ocExecCommand = ["oc", "exec", "-n", f"mas-{instanceId}-core", podName, "--", "ls", "/etc/mobile/packages"]
+            ocExecCommand = [
+                "oc",
+                "exec",
+                "-n",
+                f"mas-{instanceId}-core",
+                podName,
+                "--",
+                "ls",
+                "/etc/mobile/packages",
+            ]
             result = run_cmd(ocExecCommand)
-            ls_result = result.out.decode('utf-8')
+            ls_result = result.out.decode("utf-8")
             apps_list = ls_result.split("\n")
             # removes last empty value from the list
             apps_list.pop()
@@ -112,36 +141,38 @@ def get_graphite_versions():
             for a in apps_list:
                 print("Downloading:", a)
                 ocExecCommand = [
-                    "oc", "cp", "-n", f"mas-{instanceId}-core", 
+                    "oc",
+                    "cp",
+                    "-n",
+                    f"mas-{instanceId}-core",
                     f"{podName}:/etc/mobile/packages/{a}",
                     f"./{a}",
-                    "--retries=10"
+                    "--retries=10",
                 ]
                 run_cmd(ocExecCommand)
     except Exception as e:
         print(f"Unable to download mobileapi navigator package from mobileapi pod: {e}")
         sys.exit(1)
 
-
     # Extracting build.json from each file and deleting zip
-    pathlist = Path(".").glob('*.zip')
+    pathlist = Path(".").glob("*.zip")
     for app_zip_file in pathlist:
         zip_file_path = f"./{str(app_zip_file)}"
-        with zipfile.ZipFile(zip_file_path, 'r') as zip_ref:
-            zip_ref.extract('build.json', '.')
+        with zipfile.ZipFile(zip_file_path, "r") as zip_ref:
+            zip_ref.extract("build.json", ".")
             zip_ref.close()
         zip_file_prefix = zip_file_path.split(".zip")
-        os.rename('./build.json', f'{zip_file_prefix[0]}.json')
+        os.rename("./build.json", f"{zip_file_prefix[0]}.json")
         os.remove(zip_file_path)
 
     # dictionary that will contain all graphite versions for all found zips
     graphite_json = {}
 
-    pathlist = Path(".").glob('*.json')
+    pathlist = Path(".").glob("*.json")
     for path in pathlist:
         path_in_str = str(path)
 
-        with open(path_in_str, 'r', encoding="utf-8") as openfile:
+        with open(path_in_str, "r", encoding="utf-8") as openfile:
             json_object = json.load(openfile)
 
         graphite_json.update(
@@ -152,7 +183,7 @@ def get_graphite_versions():
                     "applicationTitle": json_object.get("applicationTitle"),
                     "mobileVersion": json_object.get("mobileVersion"),
                     "buildToolsVersion": json_object.get("buildToolsVersion"),
-                    "appProcessorVersion": json_object.get("appProcessorVersion")
+                    "appProcessorVersion": json_object.get("appProcessorVersion"),
                 }
             }
         )
@@ -173,6 +204,7 @@ def get_graphite_versions():
 
     return graphite_json_sorted
 
+
 def get_mobile_and_is_image_tags():
 
     images_json = {}
@@ -180,7 +212,10 @@ def get_mobile_and_is_image_tags():
     # getting mobileapi image version from entitymgr-suite pod
     try:
         pods = dynClient.resources.get(api_version="v1", kind="Pod")
-        podList = pods.get(namespace=f"mas-{instanceId}-core", label_selector=f'app={instanceId}-entitymgr-suite')
+        podList = pods.get(
+            namespace=f"mas-{instanceId}-core",
+            label_selector=f"app={instanceId}-entitymgr-suite",
+        )
 
         if podList is None or podList.items is None or len(podList.items) == 0:
             pass
@@ -188,11 +223,20 @@ def get_mobile_and_is_image_tags():
             podName = podList.items[0].metadata.name
 
             # list navigator zip packages in mobileapi pod
-            ocExecCommand = ["oc", "exec", "-n", f"mas-{instanceId}-core", podName, "--", "cat", "/opt/ansible/roles/suite/vars/images.yml"]
+            ocExecCommand = [
+                "oc",
+                "exec",
+                "-n",
+                f"mas-{instanceId}-core",
+                podName,
+                "--",
+                "cat",
+                "/opt/ansible/roles/suite/vars/images.yml",
+            ]
             result = run_cmd(ocExecCommand)
-            cat_result = result.out.decode('utf-8')
+            cat_result = result.out.decode("utf-8")
             images = yaml.safe_load(cat_result)
-            images_json.update({"mobileapi": images['defaultTags']['mobileapi']})
+            images_json.update({"mobileapi": images["defaultTags"]["mobileapi"]})
     except Exception as e:
         print(f"Unable to catch images file from entitymgr pod: {e}")
         sys.exit(1)
@@ -200,7 +244,10 @@ def get_mobile_and_is_image_tags():
     # getting industry solutions images version from entitymgr-ws
     try:
         pods = dynClient.resources.get(api_version="v1", kind="Pod")
-        podList = pods.get(namespace=f"mas-{instanceId}-manage", label_selector='mas.ibm.com/appType=entitymgr-ws-operator')
+        podList = pods.get(
+            namespace=f"mas-{instanceId}-manage",
+            label_selector="mas.ibm.com/appType=entitymgr-ws-operator",
+        )
 
         if podList is None or podList.items is None or len(podList.items) == 0:
             pass
@@ -208,11 +255,20 @@ def get_mobile_and_is_image_tags():
             podName = podList.items[0].metadata.name
 
             # list navigator zip packages in mobileapi pod
-            ocExecCommand = ["oc", "exec", "-n", f"mas-{instanceId}-manage", podName, "--", "cat", "/opt/ansible/roles/workspace/vars/images.yml"]
+            ocExecCommand = [
+                "oc",
+                "exec",
+                "-n",
+                f"mas-{instanceId}-manage",
+                podName,
+                "--",
+                "cat",
+                "/opt/ansible/roles/workspace/vars/images.yml",
+            ]
             result = run_cmd(ocExecCommand)
-            cat_result = result.out.decode('utf-8')
+            cat_result = result.out.decode("utf-8")
             images = yaml.safe_load(cat_result)
-            images_json.update(images['defaultTags'])
+            images_json.update(images["defaultTags"])
 
     except Exception as e:
         print(f"Unable to catch images file from entitymgr pod: {e}")
@@ -222,23 +278,21 @@ def get_mobile_and_is_image_tags():
 
     return images_json_sorted
 
+
 def artifactory_upload():
 
-    url = artDir + '/' + output_filename
+    url = artDir + "/" + output_filename
     bearer = f"Bearer {artKey}"
-    headers = {
-        'content-type': 'application/json',
-        'Authorization': bearer
-    }
+    headers = {"content-type": "application/json", "Authorization": bearer}
 
-    with open(output_filename, 'rb') as f:
+    with open(output_filename, "rb") as f:
         r = requests.put(url, data=f, headers=headers, timeout=10)
 
     if r.status_code != 201:
         print("Upload failed.")
     else:
         print("Upload successful")
-        print("Download URL:", r.json()['downloadUri'])
+        print("Download URL:", r.json()["downloadUri"])
 
 
 if __name__ == "__main__":
@@ -265,10 +319,7 @@ if __name__ == "__main__":
     print("Generating output file with versions")
     mobile_is_versions = {}
     mobile_is_versions.update(
-        {
-            "graphite_versions": graphite_versions,
-            "images_versions": img_versions
-        }
+        {"graphite_versions": graphite_versions, "images_versions": img_versions}
     )
 
     with open(output_filename, "w", encoding="utf-8") as outfile:

--- a/tekton/src/pipelines/taskdefs/fvt-mobile/phase1-setup.yml.j2
+++ b/tekton/src/pipelines/taskdefs/fvt-mobile/phase1-setup.yml.j2
@@ -21,6 +21,8 @@
       value: $(params.mas_app_channel_manage)
     - name: output_data_file
       value: "MobileSetup4MAS.data"
+    - name: upload_file
+      value: "True"
   when:
     - input: "$(params.mas_app_channel_manage)"
       operator: notin
@@ -49,8 +51,6 @@
       value: $(params.mas_workspace_id)
     - name: product_channel
       value: $(params.mas_app_channel_manage)
-    - name: upload_file
-      value: "false"
   when:
     - input: "$(params.mas_app_channel_manage)"
       operator: notin

--- a/tekton/src/tasks/fvt/fvt-mobile-pytest.yml.j2
+++ b/tekton/src/tasks/fvt/fvt-mobile-pytest.yml.j2
@@ -54,7 +54,7 @@ spec:
     - name: upload_file
       type: string
       description: Used only by fvt-mobile-version step to upload version file to artifactory
-      default: "true"
+      default: ""
     
     - name: workspace_managedata_path
       type: string


### PR DESCRIPTION
- Fix issue for situation where graphite app zip file does not contain a build.json file.
- fvt-mobile-pytest task env var (UPLOAD_FILE) defaults to "" (None) so file upload is properly skipped.
- Adds instance_name and build_num to file version name
Version file example after these updates:
[ivt811x-1234-mobile-is-versions.json](https://github.com/user-attachments/files/15975543/ivt811x-1234-mobile-is-versions.json)

