### PR TITLE
[patch] Updating 90x license links

### DIFF
--- a/image/cli/mascli/functions/internal/utils
+++ b/image/cli/mascli/functions/internal/utils
@@ -354,6 +354,9 @@ function build_license_link_by_mas_version() {
 
 function license_prompt() {
   case $MAS_CHANNEL in
+    9.0.x)
+      MAS_LICENSE_LINK=$( build_license_link_by_mas_version "90" )
+      ;;
     8.11.x)
       MAS_LICENSE_LINK=$( build_license_link_by_mas_version "811" )
       ;;
@@ -371,9 +374,17 @@ function license_prompt() {
   else
     echo
     echo_h2 "License Terms"
-    echo -e "To continue with the installation, you must accept the license terms:"
+    echo -e "To continue with the installation, you must accept the license terms:"    
     echo -e "   ${COLOR_CYAN}${TEXT_UNDERLINE}${MAS_LICENSE_LINK}${TEXT_RESET}"
-    echo -e "   ${COLOR_CYAN}${TEXT_UNDERLINE}https://ibm.biz/MAXIT81-License"
+    # In MAS 9.0.x we have added the license for ArcGIS and a new license for MaximoIT
+    # In MAS 8.11.x we only need MaximoIT license and no additional license links are needed
+    # for versions previous 8.11.x
+    if [[ "$MAS_CHANNEL" == "9.0.x" ]]; then
+      echo -e "   ${COLOR_CYAN}${TEXT_UNDERLINE}https://ibm.biz/MaximoIT90-license"
+      echo -e "   ${COLOR_CYAN}${TEXT_UNDERLINE}https://ibm.biz/MAXArcGIS90-License"
+    elif [[ "$MAS_CHANNEL" == "8.11.x" ]]; then
+      echo -e "   ${COLOR_CYAN}${TEXT_UNDERLINE}https://ibm.biz/MAXIT81-License"
+    fi
     echo
     reset_colors
     if [[ "$NO_CONFIRM" == "true" ]]; then


### PR DESCRIPTION
We need to show the new license files during MAS installation process.
Besides MAS license we also need to include MaximoIT and ArcGIS licenses.

**9.0.x:**
<img width="1696" alt="image" src="https://github.com/ibm-mas/cli/assets/26097641/fe8c2a27-0948-41d5-8c4c-eef772053e95">

**8.11.x:**
<img width="1700" alt="image" src="https://github.com/ibm-mas/cli/assets/26097641/7892085f-6cc6-48a0-893a-bf6237ef2638">

**8.10.x:**
<img width="1704" alt="image" src="https://github.com/ibm-mas/cli/assets/26097641/c02e5c4b-1aa7-4e34-8bff-9cea101f8b17">

**8.11.x dynamic catalog:**
<img width="1701" alt="image" src="https://github.com/ibm-mas/cli/assets/26097641/560eaa6d-98d8-4ee0-90d7-3b0b28404f5b">

**8.10.x dynamic catalog:**
<img width="1693" alt="image" src="https://github.com/ibm-mas/cli/assets/26097641/a6e41f9e-3ed8-49b5-b1b0-67742e0eccb9">
