### PR TITLE
[patch] Fix default value for --manage-components

### DIFF
--- a/python/src/mas/cli/install/argParser.py
+++ b/python/src/mas/cli/install/argParser.py
@@ -333,7 +333,7 @@ manageArgGroup.add_argument(
     dest="mas_appws_components",
     required=False,
     help="",
-    default="base=latest;health=latest"
+    default="base=latest,health=latest"
 )
 
 manageArgGroup.add_argument(


### PR DESCRIPTION
The default value for `--manage-components` is set to `base=latest;health=latest` rather than `base=latest,health=latest`.  This will manifest in an install failure if the user installs using the non-interactive mode and accepts the default:

```
TASK [ibm.mas_devops.suite_app_config : Configure application in workspace] ****
fatal: [localhost]: FAILED! => changed=false
error: 400
msg: 'ManageWorkspace djptest-ws1: Failed to create object: b''{"kind":"Status","apiVersion":"v1","metadata":{},"status":"Failure","message":"admission webhook \\"vmanage.ibm.com\\" denied the request: Maximo Manage version latest;health is not compatible with Manage version latest;health. Select a version that is compatible with Manage version latest;health. To learn more, review the Manage application compatibility report.","code":400}\n'''
reason: Bad Request
status: 400
```