### PR TITLE
[patch] Fix Assist on 8.x logic

### DIFF
--- a/python/src/mas-install
+++ b/python/src/mas-install
@@ -387,6 +387,8 @@ class App(BaseApp, InstallSettingsMixin, InstallSummarizerMixin, ConfigGenerator
             self.installAssist = self.yesOrNo("Install Assist")
             if self.installAssist:
                 self.configAppChannel("assist")
+        else:
+            self.installAssist = False
 
         self.installOptimizer = self.yesOrNo("Install Optimizer")
         if self.installOptimizer:


### PR DESCRIPTION
We added code to stop presenting the option to install Assist in 8.x, but did not initialise installAssist = False, resulting in the following:

```
Traceback (most recent call last):
  File "/opt/app-root/bin/mas-install", line 964, in <module>
    app.install(args)
  File "/opt/app-root/bin/mas-install", line 881, in install
    self.interactiveMode()
  File "/opt/app-root/bin/mas-install", line 536, in interactiveMode
    self.assistSettings()
  File "/opt/app-root/bin/mas-install", line 497, in assistSettings
    if self.installAssist:
AttributeError: 'App' object has no attribute 'installAssist'
```