### PR TITLE
[patch] Fix catalog validation in dev mode

### DIFF
--- a/python/src/mas-install
+++ b/python/src/mas-install
@@ -11,7 +11,6 @@
 
 import logging
 import logging.handlers
-import os
 from sys import exit
 from os import path
 import re

--- a/python/src/mas-install
+++ b/python/src/mas-install
@@ -110,7 +110,7 @@ class App(BaseApp, InstallSettingsMixin, InstallSummarizerMixin, ConfigGenerator
                     exit(1)
 
     def configICR(self):
-        if self.args.dev_mode:
+        if self.devMode:
             self.setParam("mas_icr_cp", "docker-na-public.artifactory.swg-devops.com/wiotp-docker-local")
             self.setParam("mas_icr_cpopen", "docker-na-public.artifactory.swg-devops.com/wiotp-docker-local/cpopen")
             self.setParam("sls_icr_cpopen", "docker-na-public.artifactory.swg-devops.com/wiotp-docker-local/cpopen")
@@ -122,7 +122,7 @@ class App(BaseApp, InstallSettingsMixin, InstallSummarizerMixin, ConfigGenerator
     def configICRCredentials(self):
         self.printH1("Configure IBM Container Registry")
         self.promptForString("IBM entitlement key", "ibm_entitlement_key", isPassword=True)
-        if self.args.dev_mode:
+        if self.devMode:
             self.promptForString("Artifactory username", "artifactory_username", isPassword=True)
             self.promptForString("Artifactory token", "artifactory_token", isPassword=True)
 
@@ -133,7 +133,7 @@ class App(BaseApp, InstallSettingsMixin, InstallSummarizerMixin, ConfigGenerator
 
     def configCatalog(self):
         self.printH1("IBM Maximo Operator Catalog Selection")
-        if self.args.dev_mode:
+        if self.devMode:
             self.promptForString("Select catalog source", "mas_catalog_version", default="v9-master-amd64")
             self.promptForString("Select channel", "mas_channel", default="9.0.x-dev")
         else:
@@ -511,11 +511,10 @@ class App(BaseApp, InstallSettingsMixin, InstallSummarizerMixin, ConfigGenerator
     def interactiveMode(self) -> None:
         # Interactive mode
         self.interactiveMode = True
-        self.devMode = os.environ.get('DEV_MODE')
 
         # Catalog
         self.configCatalog()
-        if self.devMode is None or self.devMode.lower() not in ['true', '1', 'yes', 'on']:
+        if self.devMode:
             self.validateCatalogSource()
         self.licensePrompt()
 
@@ -554,7 +553,6 @@ class App(BaseApp, InstallSettingsMixin, InstallSummarizerMixin, ConfigGenerator
     def nonInteractiveMode(self) -> None:
         # Non-interactive mode
         self.interactiveMode = False
-        self.devMode = self.args.dev_mode
 
         # Set defaults
         self.storageClassProvider="custom"
@@ -784,12 +782,20 @@ class App(BaseApp, InstallSettingsMixin, InstallSummarizerMixin, ConfigGenerator
         """
         Install MAS instance
         """
+        # We use the presence of --mas-instance-id to determine whether
+        # the CLI is being started in interactive mode or not
         instanceId = args.mas_instance_id
+
+        # Properties for arguments that control the behavior of the CLI
         self.noConfirm = args.no_confirm
         self.waitForPVC = not args.no_wait_for_pvc
         self.licenseAccepted = args.accept_license
+        self.devMode = args.dev_mode
 
+        # Store all args
         self.args = args
+
+        # Initialize the dictionary that will hold the parameters we pass to the PipelineRun
         self.params = dict()
 
         # These flags work for setting params in both interactive and non-interactive modes

--- a/python/src/mas-install
+++ b/python/src/mas-install
@@ -776,7 +776,7 @@ class App(BaseApp, InstallSettingsMixin, InstallSummarizerMixin, ConfigGenerator
                 self.fatalError(f"Unknown option: {key} {value}")
 
         # Once we've processed the inputs, we should validate the catalog source & prompt to accept the license terms
-        if self.devMode is None or self.devMode.lower() not in ['true', '1', 'yes', 'on']:
+        if not self.devMode:
             self.validateCatalogSource()
         self.licensePrompt()
 

--- a/python/src/mas-install
+++ b/python/src/mas-install
@@ -199,7 +199,7 @@ class App(BaseApp, InstallSettingsMixin, InstallSummarizerMixin, ConfigGenerator
             " - Must start with a lowercase letter",
             " - Must end with a lowercase letter or a number"
         ])
-        self.promptForString("Instance ID", "mas_instance_id", validator=InstanceIDFormatValidator(), default="dev1")
+        self.promptForString("Instance ID", "mas_instance_id", validator=InstanceIDFormatValidator())
         self.printDescription([
             "",
             "Workspace ID restrictions:",
@@ -207,13 +207,13 @@ class App(BaseApp, InstallSettingsMixin, InstallSummarizerMixin, ConfigGenerator
             " - Must only use lowercase letters and numbers",
             " - Must start with a lowercase letter"
         ])
-        self.promptForString("Workspace ID", "mas_workspace_id", validator=WorkspaceIDFormatValidator(), default="ws1")
+        self.promptForString("Workspace ID", "mas_workspace_id", validator=WorkspaceIDFormatValidator())
         self.printDescription([
             "",
             "Workspace display name restrictions:",
             " - Must be 3-300 characters long"
         ])
-        self.promptForString("Workspace name", "mas_workspace_name", validator=WorkspaceNameFormatValidator(), default="My Workspace")
+        self.promptForString("Workspace name", "mas_workspace_name", validator=WorkspaceNameFormatValidator())
 
         self.configOperationMode()
         self.configCATrust()

--- a/python/src/mas-install
+++ b/python/src/mas-install
@@ -515,7 +515,7 @@ class App(BaseApp, InstallSettingsMixin, InstallSummarizerMixin, ConfigGenerator
         self.configCatalog()
         if not self.devMode:
             self.validateCatalogSource()
-        self.licensePrompt()
+            self.licensePrompt()
 
         # SNO & Storage Classes
         self.configSNO()
@@ -775,7 +775,7 @@ class App(BaseApp, InstallSettingsMixin, InstallSummarizerMixin, ConfigGenerator
         # Once we've processed the inputs, we should validate the catalog source & prompt to accept the license terms
         if not self.devMode:
             self.validateCatalogSource()
-        self.licensePrompt()
+            self.licensePrompt()
 
     def install(self, args):
         """

--- a/python/src/mas-install
+++ b/python/src/mas-install
@@ -514,7 +514,7 @@ class App(BaseApp, InstallSettingsMixin, InstallSummarizerMixin, ConfigGenerator
 
         # Catalog
         self.configCatalog()
-        if self.devMode:
+        if not self.devMode:
             self.validateCatalogSource()
         self.licensePrompt()
 

--- a/python/src/mas-install
+++ b/python/src/mas-install
@@ -46,23 +46,23 @@ from mas.devops.tekton import installOpenShiftPipelines, updateTektonDefinitions
 
 logger = logging.getLogger(__name__)
 
+
 class App(BaseApp, InstallSettingsMixin, InstallSummarizerMixin, ConfigGeneratorMixin):
     def validateCatalogSource(self):
         catalogsAPI = self.dynamicClient.resources.get(api_version="operators.coreos.com/v1alpha1", kind="CatalogSource")
         try:
             catalog = catalogsAPI.get(name="ibm-operator-catalog", namespace="openshift-marketplace")
             catalogDisplayName = catalog.spec.displayName
-            catalogImage = catalog.spec.image
 
             m = re.match(r".+(?P<catalogId>v[89]-(?P<catalogVersion>[0-9]+)-amd64)", catalogDisplayName)
             if m:
                 # catalogId = v8-yymmdd-amd64
                 # catalogVersion = yymmdd
                 catalogId = m.group("catalogId")
-                catalogVersion = m.group("catalogVersion")
             elif re.match(r".+v8-amd64", catalogDisplayName):
                 catalogId = "v8-amd64"
-                catalogVersion = "v8-amd64"
+            else:
+                self.fatalError(f"IBM Maximo Operator Catalog is already installed on this cluster. However, it is not possible to identify its version. If you wish to install a new MAS instance using the {self.getParam('mas_catalog_version')} catalog please first run 'mas update' to switch to this catalog, this will ensure the appropriate actions are performed as part of the catalog update")
 
             if catalogId != self.getParam("mas_catalog_version"):
                 self.fatalError(f"IBM Maximo Operator Catalog {catalogId} is already installed on this cluster, if you wish to install a new MAS instance using the {self.getParam('mas_catalog_version')} catalog please first run 'mas update' to switch to this catalog, this will ensure the appropriate actions are performed as part of the catalog update")
@@ -513,7 +513,8 @@ class App(BaseApp, InstallSettingsMixin, InstallSummarizerMixin, ConfigGenerator
 
         # Catalog
         self.configCatalog()
-        self.validateCatalogSource()
+        if not self.args.dev_mode:
+            self.validateCatalogSource()
         self.licensePrompt()
 
         # SNO & Storage Classes
@@ -772,7 +773,8 @@ class App(BaseApp, InstallSettingsMixin, InstallSummarizerMixin, ConfigGenerator
                 self.fatalError(f"Unknown option: {key} {value}")
 
         # Once we've processed the inputs, we should validate the catalog source & prompt to accept the license terms
-        self.validateCatalogSource()
+        if not self.args.dev_mode:
+            self.validateCatalogSource()
         self.licensePrompt()
 
     def install(self, args):

--- a/python/src/mas-install
+++ b/python/src/mas-install
@@ -11,6 +11,7 @@
 
 import logging
 import logging.handlers
+import os
 from sys import exit
 from os import path
 import re
@@ -510,10 +511,11 @@ class App(BaseApp, InstallSettingsMixin, InstallSummarizerMixin, ConfigGenerator
     def interactiveMode(self) -> None:
         # Interactive mode
         self.interactiveMode = True
+        self.devMode = os.environ.get('DEV_MODE')
 
         # Catalog
         self.configCatalog()
-        if not self.args.dev_mode:
+        if self.devMode is None or self.devMode.lower() not in ['true', '1', 'yes', 'on']:
             self.validateCatalogSource()
         self.licensePrompt()
 
@@ -552,6 +554,7 @@ class App(BaseApp, InstallSettingsMixin, InstallSummarizerMixin, ConfigGenerator
     def nonInteractiveMode(self) -> None:
         # Non-interactive mode
         self.interactiveMode = False
+        self.devMode = self.args.dev_mode
 
         # Set defaults
         self.storageClassProvider="custom"
@@ -773,7 +776,7 @@ class App(BaseApp, InstallSettingsMixin, InstallSummarizerMixin, ConfigGenerator
                 self.fatalError(f"Unknown option: {key} {value}")
 
         # Once we've processed the inputs, we should validate the catalog source & prompt to accept the license terms
-        if not self.args.dev_mode:
+        if self.devMode is None or self.devMode.lower() not in ['true', '1', 'yes', 'on']:
             self.validateCatalogSource()
         self.licensePrompt()
 

--- a/python/src/mas/cli/install/settings/additionalConfigs.py
+++ b/python/src/mas/cli/install/settings/additionalConfigs.py
@@ -67,8 +67,7 @@ class AdditionalConfigsMixin():
             self.printDescription([
                 "The CLI supports two pod template profiles out of the box that allow you to reconfigure MAS for either a guaranteed or best effort QoS level",
                 "For more information about the Kubernetes quality of service (QoS) levels, see https://kubernetes.io/docs/concepts/workloads/pods/pod-qos/",
-                "You may also choose to use your own customized pod template definitions",
-                ""
+                "You may also choose to use your own customized pod template definitions"
             ])
 
             if not self.yesOrNo("Use pod templates"):
@@ -79,8 +78,7 @@ class AdditionalConfigsMixin():
                 "",
                 "1. Guaranteed QoS",
                 "2. Best Effort QoS",
-                "3. Custom",
-                ""
+                "3. Custom"
             ])
 
             podTemplateChoice = self.promptForInt("Select pod templates profile")

--- a/python/src/mas/cli/install/settings/kafkaSettings.py
+++ b/python/src/mas/cli/install/settings/kafkaSettings.py
@@ -18,8 +18,7 @@ class KafkaSettingsMixin():
             self.printDescription([
                 "Maximo IoT requires a shared system-scope Kafka instance",
                 "Supported Kafka providers: Strimzi, Red Hat AMQ Streams, IBM Cloud Event Streams and AWS MSK",
-                "You may also choose to configure MAS to use an existing Kafka instance by providing a pre-existing configuration file",
-                ""
+                "You may also choose to configure MAS to use an existing Kafka instance by providing a pre-existing configuration file"
             ])
             if self.yesOrNo("Create system Kafka instance using one of the supported providers"):
                 self.setParam("kafka_action_system", "install")
@@ -30,8 +29,7 @@ class KafkaSettingsMixin():
                     "  1. Strimzi (opensource)",
                     "  2. Red Hat AMQ Streams (requires a separate license)",
                     "  3. IBM Cloud Event Streams (paid IBM Cloud service)",
-                    "  4. AWS MSK (paid AWS service)",
-                    ""
+                    "  4. AWS MSK (paid AWS service)"
                 ])
                 self.promptForListSelect("Select Kafka provider", ["strimzi", "redhat", "ibm", "aws"], "kafka_provider")
 
@@ -41,8 +39,7 @@ class KafkaSettingsMixin():
                         "Strimzi: Cluster Version",
                         "The version of the Strimzi operator available on your cluster will determine the supported versions of Kafka that can be deployed.",
                         " - If you are using the latest available operator catalog then the default version below can be accepted",
-                        " - If you are using older operator catalogs (e.g. in a disconnected install) you should confirm the supported versions in your OperatorHub",
-                        ""
+                        " - If you are using older operator catalogs (e.g. in a disconnected install) you should confirm the supported versions in your OperatorHub"
                     ])
                     self.promptForString("Install namespace", "kafka_namespace", default="strimzi")
                     self.promptForString("Kafka version", "kafka_version", default="3.7.0")
@@ -53,8 +50,7 @@ class KafkaSettingsMixin():
                         "Red Hat AMQ Streams: Cluster Version",
                         "The version of the Red Hat AMQ Streams operator available on your cluster will determine the supported versions of Kafka that can be deployed.",
                         " - If you are using the latest available operator catalog then the default version below can be accepted",
-                        " - If you are using older operator catalogs (e.g. in a disconnected install) you should confirm the supported versions in your OperatorHub",
-                        ""
+                        " - If you are using older operator catalogs (e.g. in a disconnected install) you should confirm the supported versions in your OperatorHub"
                     ])
                     self.promptForString("Install namespace", "kafka_namespace", default="amq-streams")
                     self.promptForString("Kafka version", "kafka_version", default="3.5.0")
@@ -72,8 +68,7 @@ class KafkaSettingsMixin():
                         "While provisioning the AWS MSK instance, you will be required to provide the AWS Virtual Private Cloud ID and subnet details",
                         "where your instance will be deployed to properly configure inbound and outbound connectivity.",
                         "You should be able to find these information inside your VPC and subnet configurations in the target AWS account.",
-                        "For more details about AWS subnet/CIDR configuration, refer: https://docs.aws.amazon.com/vpc/latest/userguide/subnet-sizing.html",
-                        ""
+                        "For more details about AWS subnet/CIDR configuration, refer: https://docs.aws.amazon.com/vpc/latest/userguide/subnet-sizing.html"
                     ])
                     self.promptForString("AWS Access Key ID", "aws_access_key_id", isPassword=True)
                     self.promptForString("AWS Secret Access Key" "aws_secret_access_key", isPassword=True)

--- a/python/src/mas/cli/install/summarizer.py
+++ b/python/src/mas/cli/install/summarizer.py
@@ -36,7 +36,7 @@ class InstallSummarizerMixin():
     def icrSummary(self) -> None:
         self.printH2("IBM Container Registry Credentials")
         self.printSummary("IBM Entitlement Key", f"{self.params['ibm_entitlement_key'][0:8]}&lt;snip&gt;")
-        if self.args.dev_mode:
+        if self.devMode:
             self.printSummary("Artifactory Username", self.params['artifactory_username'])
             self.printSummary("Artifactory Token", f"{self.params['artifactory_token'][0:8]}&lt;snip&gt;")
 


### PR DESCRIPTION
* Removing catalogVersion and catalogImage vars as they were not being used.

* Catalog validation in based on the assumption the displayName will follow a given pattern.
We have two different scenarios we want to cover:
1- When dev mode is set, we need to skip this validation;
1.1- Interactive mode:
DEV_MODE comes from env var (string)

1.2- Non interactive mode:
DEV_MODE comes from args (boolean)

2- When the displayName does not match what is expected, we abort the installation and ask the admin to update the catalog first.


When dev mode is not set and catalog displayName is wrong:
<img width="1701" alt="image" src="https://github.com/ibm-mas/cli/assets/26097641/ce56caa1-600b-4fa0-aba5-d57e3b68c7bc">

When dev mode is set or catalog displayName is correct:
<img width="1473" alt="image" src="https://github.com/ibm-mas/cli/assets/26097641/adcf046d-d8f1-4bc7-99d0-2c026563426d">
