### PR TITLE
[patch] Fix handling of advanced Manage configuration

### DIFF
--- a/python/src/mas/cli/install/settings/db2Settings.py
+++ b/python/src/mas/cli/install/settings/db2Settings.py
@@ -104,7 +104,7 @@ class Db2SettingsMixin():
                         "  1. DB2 Warehouse (Default option)",
                         "  2. DB2 Online Transactional Processing (OLTP)"
                     ])
-                    self.promptForListSelect(message="Select the Manage dedicated DB2 instance type", options=["db2wh", "db2oltp"], param="db2oltp", default="db2wh")
+                    self.promptForListSelect(message="Select the Manage dedicated DB2 instance type", options=["db2wh", "db2oltp"], param="db2_type", default="1")
                 else:
                     workspaceId = self.getParam("mas_workspace_id")
                     self.setParam("db2_action_manage", "byo")

--- a/python/src/mas/cli/install/settings/manageSettings.py
+++ b/python/src/mas/cli/install/settings/manageSettings.py
@@ -104,10 +104,10 @@ class ManageSettingsMixin():
             self.promptForString("Indexspace", "mas_app_settings_db2_indexspace", default="MAXINDEX")
 
             if self.yesOrNo("Customize database encryption settings"):
-                self.promptForString("MXE_SECURITY_CRYPTO_KEY", "mxe_security_crypto_key")
-                self.promptForString("MXE_SECURITY_CRYPTOX_KEY", "mxe_security_cryptox_key")
-                self.promptForString("MXE_SECURITY_OLD_CRYPTO_KEY", "mxe_security_old_crypto_key")
-                self.promptForString("MXE_SECURITY_OLD_CRYPTOX_KEY", "mxe_security_old_cryptox_key")
+                self.promptForString("MXE_SECURITY_CRYPTO_KEY", "mas_app_settings_crypto_key")
+                self.promptForString("MXE_SECURITY_CRYPTOX_KEY", "mas_app_settings_cryptox_key")
+                self.promptForString("MXE_SECURITY_OLD_CRYPTO_KEY", "mas_app_settings_old_crypto_key")
+                self.promptForString("MXE_SECURITY_OLD_CRYPTOX_KEY", "mas_app_settings_old_cryptox_key")
                 self.yesOrNo("Override database encryption secrets with provided keys", "mas_app_settings_override_encryption_secrets_flag")
 
     def manageSettingsServerBundleConfig(self) -> None:
@@ -166,7 +166,7 @@ class ManageSettingsMixin():
                 self.promptForString("Password", "mas_app_settings_customization_archive_password", isPassword=True)
 
     def manageSettingsDemodata(self) -> None:
-        self.yesOrNo("Create demo data", "masp_app_settings_demodata")
+        self.yesOrNo("Create demo data", "mas_app_settings_demodata")
 
     def manageSettingsTimezone(self) -> None:
         self.promptForString("Manage server timezone", "mas_app_settings_server_timezone", default="GMT")


### PR DESCRIPTION
There were a couple of errors with Manage database advanced settings:
- `mxe_security_crypto_xxx` params should have been `mas_app_settings_crypto_xxx`
- `mas_app_settings_demodata` was being passed as `masp_app_settings_demodata`

After these fixes, we can see the expected data in the pipelinerun template now:
```yaml
    # Manage Application
    # -------------------------------------------------------------------------
    - name: mas_app_channel_manage
      value: "9.0.x"
    - name: mas_appws_components
      value: "base=latest,health=latest"
    - name: mas_app_settings_demodata
      value: "true"
    - name: mas_appws_bindings_jdbc_manage
      value: "workspace-application"
    - name: mas_app_settings_jms_queue_pvc_storage_class
      value: "ibmc-file-gold-gid"
    - name: mas_app_settings_jms_queue_pvc_accessmode
      value: "ReadWriteMany"
    - name: mas_app_settings_bim_pvc_storage_class
      value: "ibmc-file-gold-gid"
    - name: mas_app_settings_bim_pvc_accessmode
      value: "ReadWriteMany"
    - name: mas_app_settings_doclinks_pvc_storage_class
      value: "ibmc-file-gold-gid"
    - name: mas_app_settings_doclinks_pvc_accessmode
      value: "ReadWriteMany"
    - name: mas_app_settings_server_bundles_size
      value: "dev"
    - name: mas_app_settings_server_timezone
      value: "GMT"
    - name: mas_app_settings_crypto_key
      value: "1"
    - name: mas_app_settings_cryptox_key
      value: "2"
    - name: mas_app_settings_old_crypto_key
      value: "3"
    - name: mas_app_settings_old_cryptox_key
      value: "4"
    - name: mas_app_settings_override_encryption_secrets_flag
      value: "true"
```