### PR TITLE
[patch] Disable warnings on OCP with self-signed cert

### DIFF
--- a/python/src/mas-install
+++ b/python/src/mas-install
@@ -82,10 +82,11 @@ class App(BaseApp, InstallSettingsMixin, InstallSummarizerMixin, ConfigGenerator
             serviceAPI.get(name="image-registry", namespace="openshift-image-registry")
         except NotFoundError:
             self.fatalError(
-                "\n".join[
+                "\n".join([
                     "Unable to proceed with installation of Maximo Manage.  Could not detect the required \"image-registry\" service in the openshift-image-registry namespace",
                     "For more information refer to <u>https://www.ibm.com/docs/en/masv-and-l/continuous-delivery?topic=installing-enabling-openshift-internal-image-registry</u>"
                 ])
+            )
 
     def licensePrompt(self):
         licenses = {

--- a/python/src/mas/cli/cli.py
+++ b/python/src/mas/cli/cli.py
@@ -8,6 +8,9 @@
 #
 # *****************************************************************************
 
+import logging
+import urllib3
+
 from argparse import RawTextHelpFormatter
 from shutil import which
 from os import path
@@ -20,15 +23,17 @@ from kubernetes.client import api_client
 
 from prompt_toolkit import prompt, print_formatted_text, HTML
 
-from .validators import YesNoValidator
-
-from . import __version__ as packageVersion
-from .displayMixins import PrintMixin, PromptMixin
 from mas.devops.ocp import connect, isSNO
 
-import logging
+from . import __version__ as packageVersion
+from .validators import YesNoValidator
+from .displayMixins import PrintMixin, PromptMixin
+
+# Configure the logger
 logger = logging.getLogger(__name__)
 
+# Disable warnings when users are connecting to OCP clusters with self-signed certificates
+urllib3.disable_warnings()
 
 def getHelpFormatter(formatter=RawTextHelpFormatter, w=160, h=50):
     """


### PR DESCRIPTION
This avoids the following being spammed to stdout:

```
/opt/app-root/lib64/python3.9/site-packages/urllib3/connectionpool.py:1061: InsecureRequestWarning: Unverified HTTPS request is being made to host 'api.ocp-uat1.tarshid.com.sa'. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/1.26.x/advanced-usage.html#ssl-warnings
```

Also fixes an error in the error handling when the OCP internal image registry is not present:

```
During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/opt/app-root/bin/mas-install", line 966, in <module>
    app.install(args)
  File "/opt/app-root/bin/mas-install", line 883, in install
    self.interactiveMode()
  File "/opt/app-root/bin/mas-install", line 533, in interactiveMode
    self.validateInternalRegistryAvailable()
  File "/opt/app-root/bin/mas-install", line 85, in validateInternalRegistryAvailable
    "\n".join[
TypeError: 'builtin_function_or_method' object is not subscriptable
```