### PR TITLE
[patch] Disable Tekton timeouts

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,7 @@ The tekton defintions can be built locally using `build/bin/build-tekton.sh`:
 
 ```bash
 # Build, and install the MAS Pipeline & Task definitions
-DEV_MODE=true VERSION=9.0.0-pre.majorup build/bin/build-tekton.sh && oc apply -f tekton/target/ibm-mas-tekton-fvt.yaml
+DEV_MODE=true VERSION=10.1.0 build/bin/build-tekton.sh && oc apply -f tekton/target/ibm-mas-tekton-fvt.yaml
 
 # Build, and install the MAS Pipeline & Task definitions 1-by-1
 DEV_MODE=true VERSION=7.8.0-pre.fvtsplit build/bin/build-tekton.sh && tekton/test.sh

--- a/build/bin/build-tekton.sh
+++ b/build/bin/build-tekton.sh
@@ -15,6 +15,7 @@ if [ "$DEV_MODE" != "true" ]; then
   TARGET_FILE=$GITHUB_WORKSPACE/tekton/target/ibm-mas-tekton.yaml
   TARGET_FILE_FVT=$GITHUB_WORKSPACE/tekton/target/ibm-mas-tekton-fvt.yaml
   TARGET_FILE_IN_CLI=$GITHUB_WORKSPACE/image/cli/mascli/templates/ibm-mas-tekton.yaml
+  TARGET_FILE_IN_PY=$GITHUB_WORKSPACE/python/src/mas/cli/templates/ibm-mas-tekton.yaml
 else
   TARGET_DIR=$DIR/../../tekton/target
   VERSION=${VERSION:-100.0.0-pre.localbuild}
@@ -25,6 +26,7 @@ else
   TARGET_FILE=$DIR/../../tekton/target/ibm-mas-tekton.yaml
   TARGET_FILE_FVT=$DIR/../../tekton/target/ibm-mas-tekton-fvt.yaml
   TARGET_FILE_IN_CLI=$DIR/../../image/cli/mascli/templates/ibm-mas-tekton.yaml
+  TARGET_FILE_IN_PY=$DIR/../../python/src/mas/cli/templates/ibm-mas-tekton.yaml
 fi
 
 
@@ -84,6 +86,7 @@ mv $TARGET_FILE.txt $TARGET_FILE
 mv $TARGET_FILE_FVT.txt $TARGET_FILE_FVT
 
 cp $TARGET_FILE $TARGET_FILE_IN_CLI
+cp $TARGET_FILE $TARGET_FILE_IN_PY
 
 # Extra debug for Travis builds
 if [ "$DEV_MODE" != "true" ]; then

--- a/tekton/src/pipelines/fvt-upgrade-post.yml.j2
+++ b/tekton/src/pipelines/fvt-upgrade-post.yml.j2
@@ -93,7 +93,7 @@ spec:
         {{ lookup('template', 'taskdefs/fvt-manage/api/params.yml.j2') | indent(8) }}
         - name: fvt_test_suite
           value: base-api-upgrade-post
-    
+
     # Manage Tests Post Upgrade (UI)
     - name: fvt-manage-base-ui-upgrade-post
       {{ lookup('template', 'taskdefs/fvt-manage/ui/taskref.yml.j2') | indent(6) }}

--- a/tekton/src/pipelines/fvt-upgrade-pre.yml.j2
+++ b/tekton/src/pipelines/fvt-upgrade-pre.yml.j2
@@ -93,7 +93,7 @@ spec:
         {{ lookup('template', 'taskdefs/fvt-manage/api/params.yml.j2') | indent(8) }}
         - name: fvt_test_suite
           value: base-api-setup
-    
+
     # Manage Tests Pre Upgrade (API)
     - name: fvt-manage-base-api-upgrade-pre
       {{ lookup('template', 'taskdefs/fvt-manage/api/taskref.yml.j2') | indent(6) }}
@@ -103,7 +103,7 @@ spec:
           value: base-api-upgrade-pre
       runAfter:
         - fvt-manage-base-api-setup
-    
+
     # Manage Tests Pre Upgrade (UI)
     - name: fvt-manage-base-ui-upgrade-pre
       {{ lookup('template', 'taskdefs/fvt-manage/ui/taskref.yml.j2') | indent(6) }}

--- a/tekton/src/pipelines/install.yml.j2
+++ b/tekton/src/pipelines/install.yml.j2
@@ -355,7 +355,7 @@ spec:
     # Update synchronization configmap
     # -------------------------------------------------------------------------
     - name: sync-install
-      timeout: 0
+      timeout: "0"
       taskRef:
         kind: Task
         name: mas-devops-update-configmap

--- a/tekton/src/pipelines/install.yml.j2
+++ b/tekton/src/pipelines/install.yml.j2
@@ -355,6 +355,7 @@ spec:
     # Update synchronization configmap
     # -------------------------------------------------------------------------
     - name: sync-install
+      timeout: 0
       taskRef:
         kind: Task
         name: mas-devops-update-configmap

--- a/tekton/src/pipelines/rollback.yml.j2
+++ b/tekton/src/pipelines/rollback.yml.j2
@@ -23,7 +23,7 @@ spec:
       type: string
       description: name of the installation pipelinerun that must be tracked til completion
 {% endif %}
-    
+
     # Pipeline config
     - name: skip_pre_check
       type: string
@@ -66,6 +66,7 @@ spec:
     # 0. Wait for the install pipeline to complete
     # -------------------------------------------------------------------------
     - name: wait-for-install
+      timeout: 0
       taskRef:
         kind: Task
         name: mas-devops-wait-for-tekton
@@ -94,6 +95,7 @@ spec:
     # -------------------------------------------------------------------------
     # Suite Rollback
     - name: core-rollback
+      timeout: 0
       taskRef:
         kind: Task
         name: mas-devops-suite-rollback
@@ -119,6 +121,7 @@ spec:
     # -------------------------------------------------------------------------
     # Manage App Rollback
     - name: manage-rollback
+      timeout: 0
       runAfter:
         - core-rollback
       params:
@@ -157,6 +160,7 @@ spec:
     # 5. Verify MAS core version after the rollback complete
     # -------------------------------------------------------------------------
     - name: post-rollback-verify-core-version
+      timeout: 0
       taskRef:
         kind: Task
         name: mas-devops-suite-rollback
@@ -183,6 +187,7 @@ spec:
     # 6. Verify MAS Manage App version after the rollback complete
     # -------------------------------------------------------------------------
     - name: post-rollback-verify-app-version
+      timeout: 0
       taskRef:
         kind: Task
         name: mas-devops-suite-app-rollback
@@ -219,6 +224,7 @@ spec:
     # Finalize the record in the FVT database
     # -------------------------------------------------------------------------
     - name: finalize
+      timeout: 0
       taskRef:
         kind: Task
         name: mas-fvt-finalize

--- a/tekton/src/pipelines/rollback.yml.j2
+++ b/tekton/src/pipelines/rollback.yml.j2
@@ -66,7 +66,7 @@ spec:
     # 0. Wait for the install pipeline to complete
     # -------------------------------------------------------------------------
     - name: wait-for-install
-      timeout: 0
+      timeout: "0"
       taskRef:
         kind: Task
         name: mas-devops-wait-for-tekton
@@ -95,7 +95,7 @@ spec:
     # -------------------------------------------------------------------------
     # Suite Rollback
     - name: core-rollback
-      timeout: 0
+      timeout: "0"
       taskRef:
         kind: Task
         name: mas-devops-suite-rollback
@@ -121,7 +121,7 @@ spec:
     # -------------------------------------------------------------------------
     # Manage App Rollback
     - name: manage-rollback
-      timeout: 0
+      timeout: "0"
       runAfter:
         - core-rollback
       params:
@@ -160,7 +160,7 @@ spec:
     # 5. Verify MAS core version after the rollback complete
     # -------------------------------------------------------------------------
     - name: post-rollback-verify-core-version
-      timeout: 0
+      timeout: "0"
       taskRef:
         kind: Task
         name: mas-devops-suite-rollback
@@ -187,7 +187,7 @@ spec:
     # 6. Verify MAS Manage App version after the rollback complete
     # -------------------------------------------------------------------------
     - name: post-rollback-verify-app-version
-      timeout: 0
+      timeout: "0"
       taskRef:
         kind: Task
         name: mas-devops-suite-app-rollback
@@ -224,7 +224,7 @@ spec:
     # Finalize the record in the FVT database
     # -------------------------------------------------------------------------
     - name: finalize
-      timeout: 0
+      timeout: "0"
       taskRef:
         kind: Task
         name: mas-fvt-finalize

--- a/tekton/src/pipelines/taskdefs/apps/assist-app.yml.j2
+++ b/tekton/src/pipelines/taskdefs/apps/assist-app.yml.j2
@@ -1,5 +1,5 @@
 - name: app-install-assist
-  timeout: 0
+  timeout: "0"
   params:
     {{ lookup('template', 'taskdefs/common/cli-params.yml.j2') | indent(4) }}
     - name: devops_suite_name

--- a/tekton/src/pipelines/taskdefs/apps/assist-app.yml.j2
+++ b/tekton/src/pipelines/taskdefs/apps/assist-app.yml.j2
@@ -1,4 +1,5 @@
 - name: app-install-assist
+  timeout: 0
   params:
     {{ lookup('template', 'taskdefs/common/cli-params.yml.j2') | indent(4) }}
     - name: devops_suite_name

--- a/tekton/src/pipelines/taskdefs/apps/assist-workspace.yml.j2
+++ b/tekton/src/pipelines/taskdefs/apps/assist-workspace.yml.j2
@@ -1,4 +1,5 @@
 - name: app-cfg-assist
+  timeout: 0
   params:
     {{ lookup('template', 'taskdefs/common/cli-params.yml.j2') | indent(4) }}
     - name: devops_suite_name

--- a/tekton/src/pipelines/taskdefs/apps/assist-workspace.yml.j2
+++ b/tekton/src/pipelines/taskdefs/apps/assist-workspace.yml.j2
@@ -1,5 +1,5 @@
 - name: app-cfg-assist
-  timeout: 0
+  timeout: "0"
   params:
     {{ lookup('template', 'taskdefs/common/cli-params.yml.j2') | indent(4) }}
     - name: devops_suite_name

--- a/tekton/src/pipelines/taskdefs/apps/db2-setup-manage.yml.j2
+++ b/tekton/src/pipelines/taskdefs/apps/db2-setup-manage.yml.j2
@@ -1,4 +1,5 @@
 - name: suite-db2-setup-manage
+  timeout: 0
   params:
     {{ lookup('template', 'taskdefs/common/cli-params.yml.j2') | indent(4) }}
     - name: devops_suite_name

--- a/tekton/src/pipelines/taskdefs/apps/db2-setup-manage.yml.j2
+++ b/tekton/src/pipelines/taskdefs/apps/db2-setup-manage.yml.j2
@@ -1,5 +1,5 @@
 - name: suite-db2-setup-manage
-  timeout: 0
+  timeout: "0"
   params:
     {{ lookup('template', 'taskdefs/common/cli-params.yml.j2') | indent(4) }}
     - name: devops_suite_name

--- a/tekton/src/pipelines/taskdefs/apps/db2-setup-system.yml.j2
+++ b/tekton/src/pipelines/taskdefs/apps/db2-setup-system.yml.j2
@@ -1,5 +1,5 @@
 - name: suite-db2-setup-system
-  timeout: 0
+  timeout: "0"
   params:
     {{ lookup('template', 'taskdefs/common/cli-params.yml.j2') | indent(4) }}
     - name: devops_suite_name

--- a/tekton/src/pipelines/taskdefs/apps/db2-setup-system.yml.j2
+++ b/tekton/src/pipelines/taskdefs/apps/db2-setup-system.yml.j2
@@ -1,4 +1,5 @@
 - name: suite-db2-setup-system
+  timeout: 0
   params:
     {{ lookup('template', 'taskdefs/common/cli-params.yml.j2') | indent(4) }}
     - name: devops_suite_name

--- a/tekton/src/pipelines/taskdefs/apps/iot-app.yml.j2
+++ b/tekton/src/pipelines/taskdefs/apps/iot-app.yml.j2
@@ -1,4 +1,5 @@
 - name: app-install-iot
+  timeout: 0
   params:
     {{ lookup('template', 'taskdefs/common/cli-params.yml.j2') | indent(4) }}
     - name: devops_suite_name
@@ -21,7 +22,7 @@
       value: $(params.custom_labels)
     - name: mas_app_settings_iot_deployment_size
       value: $(params.mas_app_settings_iot_deployment_size)
-    - name: mas_app_settings_iot_mqttbroker_pvc_storage_class 
+    - name: mas_app_settings_iot_mqttbroker_pvc_storage_class
       value: $(params.storage_class_rwo) # use common rwo storage class as user is not prompted to choose this storage class
     - name: mas_app_settings_iot_fpl_pvc_storage_class
       value: $(params.storage_class_rwo) # use common rwo storage class as user is not prompted to choose this storage class

--- a/tekton/src/pipelines/taskdefs/apps/iot-app.yml.j2
+++ b/tekton/src/pipelines/taskdefs/apps/iot-app.yml.j2
@@ -1,5 +1,5 @@
 - name: app-install-iot
-  timeout: 0
+  timeout: "0"
   params:
     {{ lookup('template', 'taskdefs/common/cli-params.yml.j2') | indent(4) }}
     - name: devops_suite_name

--- a/tekton/src/pipelines/taskdefs/apps/iot-workspace.yml.j2
+++ b/tekton/src/pipelines/taskdefs/apps/iot-workspace.yml.j2
@@ -1,5 +1,5 @@
 - name: app-cfg-iot
-  timeout: 0
+  timeout: "0"
   params:
     {{ lookup('template', 'taskdefs/common/cli-params.yml.j2') | indent(4) }}
     - name: devops_suite_name

--- a/tekton/src/pipelines/taskdefs/apps/iot-workspace.yml.j2
+++ b/tekton/src/pipelines/taskdefs/apps/iot-workspace.yml.j2
@@ -1,4 +1,5 @@
 - name: app-cfg-iot
+  timeout: 0
   params:
     {{ lookup('template', 'taskdefs/common/cli-params.yml.j2') | indent(4) }}
     - name: devops_suite_name

--- a/tekton/src/pipelines/taskdefs/apps/manage-app.yml.j2
+++ b/tekton/src/pipelines/taskdefs/apps/manage-app.yml.j2
@@ -1,4 +1,5 @@
 - name: app-install-manage
+  timeout: 0
   params:
     {{ lookup('template', 'taskdefs/common/cli-params.yml.j2') | indent(4) }}
     - name: devops_suite_name

--- a/tekton/src/pipelines/taskdefs/apps/manage-app.yml.j2
+++ b/tekton/src/pipelines/taskdefs/apps/manage-app.yml.j2
@@ -1,5 +1,5 @@
 - name: app-install-manage
-  timeout: 0
+  timeout: "0"
   params:
     {{ lookup('template', 'taskdefs/common/cli-params.yml.j2') | indent(4) }}
     - name: devops_suite_name

--- a/tekton/src/pipelines/taskdefs/apps/manage-verify.yml.j2
+++ b/tekton/src/pipelines/taskdefs/apps/manage-verify.yml.j2
@@ -1,5 +1,5 @@
 - name: app-verify-manage
-  timeout: 0
+  timeout: "0"
   params:
     {{ lookup('template', 'taskdefs/common/cli-params.yml.j2') | indent(4) }}
     - name: devops_suite_name

--- a/tekton/src/pipelines/taskdefs/apps/manage-verify.yml.j2
+++ b/tekton/src/pipelines/taskdefs/apps/manage-verify.yml.j2
@@ -1,4 +1,5 @@
 - name: app-verify-manage
+  timeout: 0
   params:
     {{ lookup('template', 'taskdefs/common/cli-params.yml.j2') | indent(4) }}
     - name: devops_suite_name

--- a/tekton/src/pipelines/taskdefs/apps/manage-workspace.yml.j2
+++ b/tekton/src/pipelines/taskdefs/apps/manage-workspace.yml.j2
@@ -1,4 +1,5 @@
 - name: app-cfg-manage
+  timeout: 0
   params:
     {{ lookup('template', 'taskdefs/common/cli-params.yml.j2') | indent(4) }}
     - name: devops_suite_name

--- a/tekton/src/pipelines/taskdefs/apps/manage-workspace.yml.j2
+++ b/tekton/src/pipelines/taskdefs/apps/manage-workspace.yml.j2
@@ -1,5 +1,5 @@
 - name: app-cfg-manage
-  timeout: 0
+  timeout: "0"
   params:
     {{ lookup('template', 'taskdefs/common/cli-params.yml.j2') | indent(4) }}
     - name: devops_suite_name

--- a/tekton/src/pipelines/taskdefs/apps/monitor-app.yml.j2
+++ b/tekton/src/pipelines/taskdefs/apps/monitor-app.yml.j2
@@ -1,5 +1,5 @@
 - name: app-install-monitor
-  timeout: 0
+  timeout: "0"
   params:
     {{ lookup('template', 'taskdefs/common/cli-params.yml.j2') | indent(4) }}
     - name: devops_suite_name

--- a/tekton/src/pipelines/taskdefs/apps/monitor-app.yml.j2
+++ b/tekton/src/pipelines/taskdefs/apps/monitor-app.yml.j2
@@ -1,4 +1,5 @@
 - name: app-install-monitor
+  timeout: 0
   params:
     {{ lookup('template', 'taskdefs/common/cli-params.yml.j2') | indent(4) }}
     - name: devops_suite_name

--- a/tekton/src/pipelines/taskdefs/apps/monitor-workspace.yml.j2
+++ b/tekton/src/pipelines/taskdefs/apps/monitor-workspace.yml.j2
@@ -1,4 +1,5 @@
 - name: app-cfg-monitor
+  timeout: 0
   params:
     {{ lookup('template', 'taskdefs/common/cli-params.yml.j2') | indent(4) }}
     - name: devops_suite_name

--- a/tekton/src/pipelines/taskdefs/apps/monitor-workspace.yml.j2
+++ b/tekton/src/pipelines/taskdefs/apps/monitor-workspace.yml.j2
@@ -1,5 +1,5 @@
 - name: app-cfg-monitor
-  timeout: 0
+  timeout: "0"
   params:
     {{ lookup('template', 'taskdefs/common/cli-params.yml.j2') | indent(4) }}
     - name: devops_suite_name

--- a/tekton/src/pipelines/taskdefs/apps/optimizer-app.yml.j2
+++ b/tekton/src/pipelines/taskdefs/apps/optimizer-app.yml.j2
@@ -1,5 +1,5 @@
 - name: app-install-optimizer
-  timeout: 0
+  timeout: "0"
   params:
     {{ lookup('template', 'taskdefs/common/cli-params.yml.j2') | indent(4) }}
     - name: devops_suite_name

--- a/tekton/src/pipelines/taskdefs/apps/optimizer-app.yml.j2
+++ b/tekton/src/pipelines/taskdefs/apps/optimizer-app.yml.j2
@@ -1,4 +1,5 @@
 - name: app-install-optimizer
+  timeout: 0
   params:
     {{ lookup('template', 'taskdefs/common/cli-params.yml.j2') | indent(4) }}
     - name: devops_suite_name

--- a/tekton/src/pipelines/taskdefs/apps/optimizer-workspace.yml.j2
+++ b/tekton/src/pipelines/taskdefs/apps/optimizer-workspace.yml.j2
@@ -1,4 +1,5 @@
 - name: app-cfg-optimizer
+  timeout: 0
   params:
     {{ lookup('template', 'taskdefs/common/cli-params.yml.j2') | indent(4) }}
     - name: devops_suite_name

--- a/tekton/src/pipelines/taskdefs/apps/optimizer-workspace.yml.j2
+++ b/tekton/src/pipelines/taskdefs/apps/optimizer-workspace.yml.j2
@@ -1,5 +1,5 @@
 - name: app-cfg-optimizer
-  timeout: 0
+  timeout: "0"
   params:
     {{ lookup('template', 'taskdefs/common/cli-params.yml.j2') | indent(4) }}
     - name: devops_suite_name

--- a/tekton/src/pipelines/taskdefs/apps/predict-app.yml.j2
+++ b/tekton/src/pipelines/taskdefs/apps/predict-app.yml.j2
@@ -1,4 +1,5 @@
 - name: app-install-predict
+  timeout: 0
   params:
     {{ lookup('template', 'taskdefs/common/cli-params.yml.j2') | indent(4) }}
     - name: devops_suite_name

--- a/tekton/src/pipelines/taskdefs/apps/predict-app.yml.j2
+++ b/tekton/src/pipelines/taskdefs/apps/predict-app.yml.j2
@@ -1,5 +1,5 @@
 - name: app-install-predict
-  timeout: 0
+  timeout: "0"
   params:
     {{ lookup('template', 'taskdefs/common/cli-params.yml.j2') | indent(4) }}
     - name: devops_suite_name

--- a/tekton/src/pipelines/taskdefs/apps/predict-workspace.yml.j2
+++ b/tekton/src/pipelines/taskdefs/apps/predict-workspace.yml.j2
@@ -1,4 +1,5 @@
 - name: app-cfg-predict
+  timeout: 0
   params:
     {{ lookup('template', 'taskdefs/common/cli-params.yml.j2') | indent(4) }}
     - name: devops_suite_name

--- a/tekton/src/pipelines/taskdefs/apps/predict-workspace.yml.j2
+++ b/tekton/src/pipelines/taskdefs/apps/predict-workspace.yml.j2
@@ -1,5 +1,5 @@
 - name: app-cfg-predict
-  timeout: 0
+  timeout: "0"
   params:
     {{ lookup('template', 'taskdefs/common/cli-params.yml.j2') | indent(4) }}
     - name: devops_suite_name

--- a/tekton/src/pipelines/taskdefs/apps/visualinspection-app.yml.j2
+++ b/tekton/src/pipelines/taskdefs/apps/visualinspection-app.yml.j2
@@ -1,5 +1,5 @@
 - name: app-install-visualinspection
-  timeout: 0
+  timeout: "0"
   params:
     {{ lookup('template', 'taskdefs/common/cli-params.yml.j2') | indent(4) }}
     - name: devops_suite_name

--- a/tekton/src/pipelines/taskdefs/apps/visualinspection-app.yml.j2
+++ b/tekton/src/pipelines/taskdefs/apps/visualinspection-app.yml.j2
@@ -1,4 +1,5 @@
 - name: app-install-visualinspection
+  timeout: 0
   params:
     {{ lookup('template', 'taskdefs/common/cli-params.yml.j2') | indent(4) }}
     - name: devops_suite_name

--- a/tekton/src/pipelines/taskdefs/apps/visualinspection-workspace.yml.j2
+++ b/tekton/src/pipelines/taskdefs/apps/visualinspection-workspace.yml.j2
@@ -1,4 +1,5 @@
 - name: app-cfg-visualinspection
+  timeout: 0
   params:
     {{ lookup('template', 'taskdefs/common/cli-params.yml.j2') | indent(4) }}
     - name: devops_suite_name

--- a/tekton/src/pipelines/taskdefs/apps/visualinspection-workspace.yml.j2
+++ b/tekton/src/pipelines/taskdefs/apps/visualinspection-workspace.yml.j2
@@ -1,5 +1,5 @@
 - name: app-cfg-visualinspection
-  timeout: 0
+  timeout: "0"
   params:
     {{ lookup('template', 'taskdefs/common/cli-params.yml.j2') | indent(4) }}
     - name: devops_suite_name

--- a/tekton/src/pipelines/taskdefs/cluster-setup/cert-manager.yml.j2
+++ b/tekton/src/pipelines/taskdefs/cluster-setup/cert-manager.yml.j2
@@ -1,4 +1,5 @@
 - name: cert-manager
+  timeout: 0
   params:
     {{ lookup('template', 'taskdefs/common/cli-params.yml.j2') | indent(4) }}
     - name: devops_suite_name

--- a/tekton/src/pipelines/taskdefs/cluster-setup/cert-manager.yml.j2
+++ b/tekton/src/pipelines/taskdefs/cluster-setup/cert-manager.yml.j2
@@ -1,5 +1,5 @@
 - name: cert-manager
-  timeout: 0
+  timeout: "0"
   params:
     {{ lookup('template', 'taskdefs/common/cli-params.yml.j2') | indent(4) }}
     - name: devops_suite_name

--- a/tekton/src/pipelines/taskdefs/cluster-setup/common-services.yml.j2
+++ b/tekton/src/pipelines/taskdefs/cluster-setup/common-services.yml.j2
@@ -1,5 +1,5 @@
 - name: common-services
-  timeout: 0
+  timeout: "0"
   taskRef:
     kind: Task
     name: mas-devops-common-services

--- a/tekton/src/pipelines/taskdefs/cluster-setup/common-services.yml.j2
+++ b/tekton/src/pipelines/taskdefs/cluster-setup/common-services.yml.j2
@@ -1,4 +1,5 @@
 - name: common-services
+  timeout: 0
   taskRef:
     kind: Task
     name: mas-devops-common-services

--- a/tekton/src/pipelines/taskdefs/cluster-setup/eck.yml.j2
+++ b/tekton/src/pipelines/taskdefs/cluster-setup/eck.yml.j2
@@ -1,5 +1,5 @@
 - name: eck
-  timeout: 0
+  timeout: "0"
   taskRef:
     kind: Task
     name: mas-devops-eck

--- a/tekton/src/pipelines/taskdefs/cluster-setup/eck.yml.j2
+++ b/tekton/src/pipelines/taskdefs/cluster-setup/eck.yml.j2
@@ -1,4 +1,5 @@
 - name: eck
+  timeout: 0
   taskRef:
     kind: Task
     name: mas-devops-eck

--- a/tekton/src/pipelines/taskdefs/cluster-setup/grafana.yml.j2
+++ b/tekton/src/pipelines/taskdefs/cluster-setup/grafana.yml.j2
@@ -1,5 +1,5 @@
 - name: grafana
-  timeout: 0
+  timeout: "0"
   taskRef:
     kind: Task
     name: mas-devops-grafana

--- a/tekton/src/pipelines/taskdefs/cluster-setup/grafana.yml.j2
+++ b/tekton/src/pipelines/taskdefs/cluster-setup/grafana.yml.j2
@@ -1,4 +1,5 @@
 - name: grafana
+  timeout: 0
   taskRef:
     kind: Task
     name: mas-devops-grafana

--- a/tekton/src/pipelines/taskdefs/cluster-setup/ibm-catalogs.yml.j2
+++ b/tekton/src/pipelines/taskdefs/cluster-setup/ibm-catalogs.yml.j2
@@ -1,4 +1,5 @@
 - name: ibm-catalogs
+  timeout: 0
   params:
     {{ lookup('template', 'taskdefs/common/cli-params.yml.j2') | indent(4) }}
     - name: devops_suite_name

--- a/tekton/src/pipelines/taskdefs/cluster-setup/ibm-catalogs.yml.j2
+++ b/tekton/src/pipelines/taskdefs/cluster-setup/ibm-catalogs.yml.j2
@@ -1,5 +1,5 @@
 - name: ibm-catalogs
-  timeout: 0
+  timeout: "0"
   params:
     {{ lookup('template', 'taskdefs/common/cli-params.yml.j2') | indent(4) }}
     - name: devops_suite_name

--- a/tekton/src/pipelines/taskdefs/cluster-setup/ocp-verify-all.yml.j2
+++ b/tekton/src/pipelines/taskdefs/cluster-setup/ocp-verify-all.yml.j2
@@ -1,4 +1,5 @@
 - name: {{ name | default("ocp-verify") }}
+  timeout: 0
   taskRef:
     kind: Task
     name: mas-devops-ocp-verify-all

--- a/tekton/src/pipelines/taskdefs/cluster-setup/ocp-verify-all.yml.j2
+++ b/tekton/src/pipelines/taskdefs/cluster-setup/ocp-verify-all.yml.j2
@@ -1,5 +1,5 @@
 - name: {{ name | default("ocp-verify") }}
-  timeout: 0
+  timeout: "0"
   taskRef:
     kind: Task
     name: mas-devops-ocp-verify-all

--- a/tekton/src/pipelines/taskdefs/cluster-setup/ocp-verify.yml.j2
+++ b/tekton/src/pipelines/taskdefs/cluster-setup/ocp-verify.yml.j2
@@ -1,5 +1,5 @@
 - name: {{ name | default("ocp-verify") }}
-  timeout: 0
+  timeout: "0"
   taskRef:
     kind: Task
     name: mas-devops-ocp-verify

--- a/tekton/src/pipelines/taskdefs/cluster-setup/ocp-verify.yml.j2
+++ b/tekton/src/pipelines/taskdefs/cluster-setup/ocp-verify.yml.j2
@@ -1,4 +1,5 @@
 - name: {{ name | default("ocp-verify") }}
+  timeout: 0
   taskRef:
     kind: Task
     name: mas-devops-ocp-verify

--- a/tekton/src/pipelines/taskdefs/cluster-setup/turbonomic.yml.j2
+++ b/tekton/src/pipelines/taskdefs/cluster-setup/turbonomic.yml.j2
@@ -1,5 +1,5 @@
 - name: turbonomic
-  timeout: 0
+  timeout: "0"
   params:
     {{ lookup('template', 'taskdefs/common/cli-params.yml.j2') | indent(4) }}
     - name: devops_suite_name

--- a/tekton/src/pipelines/taskdefs/cluster-setup/turbonomic.yml.j2
+++ b/tekton/src/pipelines/taskdefs/cluster-setup/turbonomic.yml.j2
@@ -1,4 +1,5 @@
 - name: turbonomic
+  timeout: 0
   params:
     {{ lookup('template', 'taskdefs/common/cli-params.yml.j2') | indent(4) }}
     - name: devops_suite_name

--- a/tekton/src/pipelines/taskdefs/core/gencfg-workspace.yml.j2
+++ b/tekton/src/pipelines/taskdefs/core/gencfg-workspace.yml.j2
@@ -1,5 +1,5 @@
 - name: gencfg-workspace
-  timeout: 0
+  timeout: "0"
   params:
     {{ lookup('template', 'taskdefs/common/cli-params.yml.j2') | indent(4) }}
     - name: devops_suite_name

--- a/tekton/src/pipelines/taskdefs/core/gencfg-workspace.yml.j2
+++ b/tekton/src/pipelines/taskdefs/core/gencfg-workspace.yml.j2
@@ -1,4 +1,5 @@
 - name: gencfg-workspace
+  timeout: 0
   params:
     {{ lookup('template', 'taskdefs/common/cli-params.yml.j2') | indent(4) }}
     - name: devops_suite_name

--- a/tekton/src/pipelines/taskdefs/core/suite-certs.yml.j2
+++ b/tekton/src/pipelines/taskdefs/core/suite-certs.yml.j2
@@ -1,4 +1,5 @@
 - name: suite-certs
+  timeout: 0
   params:
     {{ lookup('template', 'taskdefs/common/cli-params.yml.j2') | indent(4) }}
     - name: devops_suite_name

--- a/tekton/src/pipelines/taskdefs/core/suite-certs.yml.j2
+++ b/tekton/src/pipelines/taskdefs/core/suite-certs.yml.j2
@@ -1,5 +1,5 @@
 - name: suite-certs
-  timeout: 0
+  timeout: "0"
   params:
     {{ lookup('template', 'taskdefs/common/cli-params.yml.j2') | indent(4) }}
     - name: devops_suite_name

--- a/tekton/src/pipelines/taskdefs/core/suite-config-cos.yml.j2
+++ b/tekton/src/pipelines/taskdefs/core/suite-config-cos.yml.j2
@@ -1,4 +1,5 @@
 - name: suite-config-cos
+  timeout: 0
   params:
     {{ lookup('template', 'taskdefs/common/cli-params.yml.j2') | indent(4) }}
     - name: devops_suite_name

--- a/tekton/src/pipelines/taskdefs/core/suite-config-cos.yml.j2
+++ b/tekton/src/pipelines/taskdefs/core/suite-config-cos.yml.j2
@@ -1,5 +1,5 @@
 - name: suite-config-cos
-  timeout: 0
+  timeout: "0"
   params:
     {{ lookup('template', 'taskdefs/common/cli-params.yml.j2') | indent(4) }}
     - name: devops_suite_name

--- a/tekton/src/pipelines/taskdefs/core/suite-config-db2.yml.j2
+++ b/tekton/src/pipelines/taskdefs/core/suite-config-db2.yml.j2
@@ -1,5 +1,5 @@
 - name: suite-config-db2
-  timeout: 0
+  timeout: "0"
   params:
     {{ lookup('template', 'taskdefs/common/cli-params.yml.j2') | indent(4) }}
     - name: devops_suite_name

--- a/tekton/src/pipelines/taskdefs/core/suite-config-db2.yml.j2
+++ b/tekton/src/pipelines/taskdefs/core/suite-config-db2.yml.j2
@@ -1,4 +1,5 @@
 - name: suite-config-db2
+  timeout: 0
   params:
     {{ lookup('template', 'taskdefs/common/cli-params.yml.j2') | indent(4) }}
     - name: devops_suite_name

--- a/tekton/src/pipelines/taskdefs/core/suite-config-kafka.yml.j2
+++ b/tekton/src/pipelines/taskdefs/core/suite-config-kafka.yml.j2
@@ -1,5 +1,5 @@
 - name: suite-config-kafka
-  timeout: 0
+  timeout: "0"
   params:
     {{ lookup('template', 'taskdefs/common/cli-params.yml.j2') | indent(4) }}
     - name: devops_suite_name

--- a/tekton/src/pipelines/taskdefs/core/suite-config-kafka.yml.j2
+++ b/tekton/src/pipelines/taskdefs/core/suite-config-kafka.yml.j2
@@ -1,4 +1,5 @@
 - name: suite-config-kafka
+  timeout: 0
   params:
     {{ lookup('template', 'taskdefs/common/cli-params.yml.j2') | indent(4) }}
     - name: devops_suite_name

--- a/tekton/src/pipelines/taskdefs/core/suite-config-wsl.yml.j2
+++ b/tekton/src/pipelines/taskdefs/core/suite-config-wsl.yml.j2
@@ -1,5 +1,5 @@
 - name: suite-config-watson-studio
-  timeout: 0
+  timeout: "0"
   params:
     {{ lookup('template', 'taskdefs/common/cli-params.yml.j2') | indent(4) }}
     - name: devops_suite_name

--- a/tekton/src/pipelines/taskdefs/core/suite-config-wsl.yml.j2
+++ b/tekton/src/pipelines/taskdefs/core/suite-config-wsl.yml.j2
@@ -1,4 +1,5 @@
 - name: suite-config-watson-studio
+  timeout: 0
   params:
     {{ lookup('template', 'taskdefs/common/cli-params.yml.j2') | indent(4) }}
     - name: devops_suite_name

--- a/tekton/src/pipelines/taskdefs/core/suite-config.yml.j2
+++ b/tekton/src/pipelines/taskdefs/core/suite-config.yml.j2
@@ -1,4 +1,5 @@
 - name: suite-config
+  timeout: 0
   params:
     {{ lookup('template', 'taskdefs/common/cli-params.yml.j2') | indent(4) }}
     - name: devops_suite_name

--- a/tekton/src/pipelines/taskdefs/core/suite-config.yml.j2
+++ b/tekton/src/pipelines/taskdefs/core/suite-config.yml.j2
@@ -1,5 +1,5 @@
 - name: suite-config
-  timeout: 0
+  timeout: "0"
   params:
     {{ lookup('template', 'taskdefs/common/cli-params.yml.j2') | indent(4) }}
     - name: devops_suite_name

--- a/tekton/src/pipelines/taskdefs/core/suite-dns.yml.j2
+++ b/tekton/src/pipelines/taskdefs/core/suite-dns.yml.j2
@@ -1,5 +1,5 @@
 - name: suite-dns
-  timeout: 0
+  timeout: "0"
   params:
     {{ lookup('template', 'taskdefs/common/cli-params.yml.j2') | indent(4) }}
     - name: devops_suite_name

--- a/tekton/src/pipelines/taskdefs/core/suite-dns.yml.j2
+++ b/tekton/src/pipelines/taskdefs/core/suite-dns.yml.j2
@@ -1,4 +1,5 @@
 - name: suite-dns
+  timeout: 0
   params:
     {{ lookup('template', 'taskdefs/common/cli-params.yml.j2') | indent(4) }}
     - name: devops_suite_name

--- a/tekton/src/pipelines/taskdefs/core/suite-install.yml.j2
+++ b/tekton/src/pipelines/taskdefs/core/suite-install.yml.j2
@@ -1,5 +1,5 @@
 - name: suite-install
-  timeout: 0
+  timeout: "0"
   params:
     {{ lookup('template', 'taskdefs/common/cli-params.yml.j2') | indent(4) }}
     - name: devops_suite_name

--- a/tekton/src/pipelines/taskdefs/core/suite-install.yml.j2
+++ b/tekton/src/pipelines/taskdefs/core/suite-install.yml.j2
@@ -1,4 +1,5 @@
 - name: suite-install
+  timeout: 0
   params:
     {{ lookup('template', 'taskdefs/common/cli-params.yml.j2') | indent(4) }}
     - name: devops_suite_name

--- a/tekton/src/pipelines/taskdefs/core/suite-verify.yml.j2
+++ b/tekton/src/pipelines/taskdefs/core/suite-verify.yml.j2
@@ -1,4 +1,5 @@
 - name: suite-verify
+  timeout: 0
   params:
     {{ lookup('template', 'taskdefs/common/cli-params.yml.j2') | indent(4) }}
     - name: devops_suite_name

--- a/tekton/src/pipelines/taskdefs/core/suite-verify.yml.j2
+++ b/tekton/src/pipelines/taskdefs/core/suite-verify.yml.j2
@@ -1,5 +1,5 @@
 - name: suite-verify
-  timeout: 0
+  timeout: "0"
   params:
     {{ lookup('template', 'taskdefs/common/cli-params.yml.j2') | indent(4) }}
     - name: devops_suite_name

--- a/tekton/src/pipelines/taskdefs/cp4d/cp4d-aiopenscale-update.yml.j2
+++ b/tekton/src/pipelines/taskdefs/cp4d/cp4d-aiopenscale-update.yml.j2
@@ -1,4 +1,5 @@
 - name: update-aiopenscale
+  timeout: 0
   params:
     # Controls the image pull policy for the ibmmas/cli image
     - name: image_pull_policy

--- a/tekton/src/pipelines/taskdefs/cp4d/cp4d-aiopenscale-update.yml.j2
+++ b/tekton/src/pipelines/taskdefs/cp4d/cp4d-aiopenscale-update.yml.j2
@@ -1,5 +1,5 @@
 - name: update-aiopenscale
-  timeout: 0
+  timeout: "0"
   params:
     # Controls the image pull policy for the ibmmas/cli image
     - name: image_pull_policy

--- a/tekton/src/pipelines/taskdefs/cp4d/cp4d-aiopenscale.yml.j2
+++ b/tekton/src/pipelines/taskdefs/cp4d/cp4d-aiopenscale.yml.j2
@@ -1,4 +1,5 @@
 - name: aiopenscale
+  timeout: 0
   params:
     {{ lookup('template', 'taskdefs/common/cli-params.yml.j2') | indent(4) }}
     - name: devops_suite_name

--- a/tekton/src/pipelines/taskdefs/cp4d/cp4d-aiopenscale.yml.j2
+++ b/tekton/src/pipelines/taskdefs/cp4d/cp4d-aiopenscale.yml.j2
@@ -1,5 +1,5 @@
 - name: aiopenscale
-  timeout: 0
+  timeout: "0"
   params:
     {{ lookup('template', 'taskdefs/common/cli-params.yml.j2') | indent(4) }}
     - name: devops_suite_name

--- a/tekton/src/pipelines/taskdefs/cp4d/cp4d-cognos-update.yml.j2
+++ b/tekton/src/pipelines/taskdefs/cp4d/cp4d-cognos-update.yml.j2
@@ -1,5 +1,5 @@
 - name: update-cognos
-  timeout: 0
+  timeout: "0"
   params:
     # Controls the image pull policy for the ibmmas/cli image
     - name: image_pull_policy

--- a/tekton/src/pipelines/taskdefs/cp4d/cp4d-cognos-update.yml.j2
+++ b/tekton/src/pipelines/taskdefs/cp4d/cp4d-cognos-update.yml.j2
@@ -1,4 +1,5 @@
 - name: update-cognos
+  timeout: 0
   params:
     # Controls the image pull policy for the ibmmas/cli image
     - name: image_pull_policy

--- a/tekton/src/pipelines/taskdefs/cp4d/cp4d-cognos.yml.j2
+++ b/tekton/src/pipelines/taskdefs/cp4d/cp4d-cognos.yml.j2
@@ -1,4 +1,5 @@
 - name: cognos
+  timeout: 0
   params:
     {{ lookup('template', 'taskdefs/common/cli-params.yml.j2') | indent(4) }}
     - name: devops_suite_name

--- a/tekton/src/pipelines/taskdefs/cp4d/cp4d-cognos.yml.j2
+++ b/tekton/src/pipelines/taskdefs/cp4d/cp4d-cognos.yml.j2
@@ -1,5 +1,5 @@
 - name: cognos
-  timeout: 0
+  timeout: "0"
   params:
     {{ lookup('template', 'taskdefs/common/cli-params.yml.j2') | indent(4) }}
     - name: devops_suite_name

--- a/tekton/src/pipelines/taskdefs/cp4d/cp4d-platform-update.yml.j2
+++ b/tekton/src/pipelines/taskdefs/cp4d/cp4d-platform-update.yml.j2
@@ -1,5 +1,5 @@
 - name: update-cp4d
-  timeout: 0
+  timeout: "0"
   params:
     {{ lookup('template', 'taskdefs/common/cli-params.yml.j2') | indent(4) }}
     - name: devops_suite_name

--- a/tekton/src/pipelines/taskdefs/cp4d/cp4d-platform-update.yml.j2
+++ b/tekton/src/pipelines/taskdefs/cp4d/cp4d-platform-update.yml.j2
@@ -1,4 +1,5 @@
 - name: update-cp4d
+  timeout: 0
   params:
     {{ lookup('template', 'taskdefs/common/cli-params.yml.j2') | indent(4) }}
     - name: devops_suite_name

--- a/tekton/src/pipelines/taskdefs/cp4d/cp4d-platform.yml.j2
+++ b/tekton/src/pipelines/taskdefs/cp4d/cp4d-platform.yml.j2
@@ -1,4 +1,5 @@
 - name: cp4d
+  timeout: 0
   params:
     {{ lookup('template', 'taskdefs/common/cli-params.yml.j2') | indent(4) }}
     - name: devops_suite_name

--- a/tekton/src/pipelines/taskdefs/cp4d/cp4d-platform.yml.j2
+++ b/tekton/src/pipelines/taskdefs/cp4d/cp4d-platform.yml.j2
@@ -1,5 +1,5 @@
 - name: cp4d
-  timeout: 0
+  timeout: "0"
   params:
     {{ lookup('template', 'taskdefs/common/cli-params.yml.j2') | indent(4) }}
     - name: devops_suite_name

--- a/tekton/src/pipelines/taskdefs/cp4d/cp4d-spark-update.yml.j2
+++ b/tekton/src/pipelines/taskdefs/cp4d/cp4d-spark-update.yml.j2
@@ -1,4 +1,5 @@
 - name: update-analytics-engine
+  timeout: 0
   params:
     # Controls the image pull policy for the ibmmas/cli image
     - name: image_pull_policy

--- a/tekton/src/pipelines/taskdefs/cp4d/cp4d-spark-update.yml.j2
+++ b/tekton/src/pipelines/taskdefs/cp4d/cp4d-spark-update.yml.j2
@@ -1,5 +1,5 @@
 - name: update-analytics-engine
-  timeout: 0
+  timeout: "0"
   params:
     # Controls the image pull policy for the ibmmas/cli image
     - name: image_pull_policy

--- a/tekton/src/pipelines/taskdefs/cp4d/cp4d-spark.yml.j2
+++ b/tekton/src/pipelines/taskdefs/cp4d/cp4d-spark.yml.j2
@@ -1,4 +1,5 @@
 - name: analytics-service
+  timeout: 0
   params:
     {{ lookup('template', 'taskdefs/common/cli-params.yml.j2') | indent(4) }}
     - name: devops_suite_name

--- a/tekton/src/pipelines/taskdefs/cp4d/cp4d-spark.yml.j2
+++ b/tekton/src/pipelines/taskdefs/cp4d/cp4d-spark.yml.j2
@@ -1,5 +1,5 @@
 - name: analytics-service
-  timeout: 0
+  timeout: "0"
   params:
     {{ lookup('template', 'taskdefs/common/cli-params.yml.j2') | indent(4) }}
     - name: devops_suite_name

--- a/tekton/src/pipelines/taskdefs/cp4d/cp4d-spss-update.yml.j2
+++ b/tekton/src/pipelines/taskdefs/cp4d/cp4d-spss-update.yml.j2
@@ -1,4 +1,5 @@
 - name: update-spss
+  timeout: 0
   params:
     # Controls the image pull policy for the ibmmas/cli image
     - name: image_pull_policy

--- a/tekton/src/pipelines/taskdefs/cp4d/cp4d-spss-update.yml.j2
+++ b/tekton/src/pipelines/taskdefs/cp4d/cp4d-spss-update.yml.j2
@@ -1,5 +1,5 @@
 - name: update-spss
-  timeout: 0
+  timeout: "0"
   params:
     # Controls the image pull policy for the ibmmas/cli image
     - name: image_pull_policy

--- a/tekton/src/pipelines/taskdefs/cp4d/cp4d-spss.yml.j2
+++ b/tekton/src/pipelines/taskdefs/cp4d/cp4d-spss.yml.j2
@@ -1,4 +1,5 @@
 - name: spss
+  timeout: 0
   params:
     {{ lookup('template', 'taskdefs/common/cli-params.yml.j2') | indent(4) }}
     - name: devops_suite_name

--- a/tekton/src/pipelines/taskdefs/cp4d/cp4d-spss.yml.j2
+++ b/tekton/src/pipelines/taskdefs/cp4d/cp4d-spss.yml.j2
@@ -1,5 +1,5 @@
 - name: spss
-  timeout: 0
+  timeout: "0"
   params:
     {{ lookup('template', 'taskdefs/common/cli-params.yml.j2') | indent(4) }}
     - name: devops_suite_name

--- a/tekton/src/pipelines/taskdefs/cp4d/cp4d-wml-update.yml.j2
+++ b/tekton/src/pipelines/taskdefs/cp4d/cp4d-wml-update.yml.j2
@@ -1,4 +1,5 @@
 - name: update-watson-machine-learning
+  timeout: 0
   params:
     # Controls the image pull policy for the ibmmas/cli image
     - name: image_pull_policy

--- a/tekton/src/pipelines/taskdefs/cp4d/cp4d-wml-update.yml.j2
+++ b/tekton/src/pipelines/taskdefs/cp4d/cp4d-wml-update.yml.j2
@@ -1,5 +1,5 @@
 - name: update-watson-machine-learning
-  timeout: 0
+  timeout: "0"
   params:
     # Controls the image pull policy for the ibmmas/cli image
     - name: image_pull_policy

--- a/tekton/src/pipelines/taskdefs/cp4d/cp4d-wml.yml.j2
+++ b/tekton/src/pipelines/taskdefs/cp4d/cp4d-wml.yml.j2
@@ -1,5 +1,5 @@
 - name: watson-machine-learning
-  timeout: 0
+  timeout: "0"
   params:
     {{ lookup('template', 'taskdefs/common/cli-params.yml.j2') | indent(4) }}
     - name: devops_suite_name

--- a/tekton/src/pipelines/taskdefs/cp4d/cp4d-wml.yml.j2
+++ b/tekton/src/pipelines/taskdefs/cp4d/cp4d-wml.yml.j2
@@ -1,4 +1,5 @@
 - name: watson-machine-learning
+  timeout: 0
   params:
     {{ lookup('template', 'taskdefs/common/cli-params.yml.j2') | indent(4) }}
     - name: devops_suite_name

--- a/tekton/src/pipelines/taskdefs/cp4d/cp4d-wsl-update.yml.j2
+++ b/tekton/src/pipelines/taskdefs/cp4d/cp4d-wsl-update.yml.j2
@@ -1,5 +1,5 @@
 - name: update-watson-studio
-  timeout: 0
+  timeout: "0"
   params:
     # Controls the image pull policy for the ibmmas/cli image
     - name: image_pull_policy

--- a/tekton/src/pipelines/taskdefs/cp4d/cp4d-wsl-update.yml.j2
+++ b/tekton/src/pipelines/taskdefs/cp4d/cp4d-wsl-update.yml.j2
@@ -1,4 +1,5 @@
 - name: update-watson-studio
+  timeout: 0
   params:
     # Controls the image pull policy for the ibmmas/cli image
     - name: image_pull_policy

--- a/tekton/src/pipelines/taskdefs/cp4d/cp4d-wsl.yml.j2
+++ b/tekton/src/pipelines/taskdefs/cp4d/cp4d-wsl.yml.j2
@@ -1,5 +1,5 @@
 - name: watson-studio
-  timeout: 0
+  timeout: "0"
   params:
     {{ lookup('template', 'taskdefs/common/cli-params.yml.j2') | indent(4) }}
     - name: devops_suite_name

--- a/tekton/src/pipelines/taskdefs/cp4d/cp4d-wsl.yml.j2
+++ b/tekton/src/pipelines/taskdefs/cp4d/cp4d-wsl.yml.j2
@@ -1,4 +1,5 @@
 - name: watson-studio
+  timeout: 0
   params:
     {{ lookup('template', 'taskdefs/common/cli-params.yml.j2') | indent(4) }}
     - name: devops_suite_name

--- a/tekton/src/pipelines/taskdefs/dependencies/arcgis.yml.j2
+++ b/tekton/src/pipelines/taskdefs/dependencies/arcgis.yml.j2
@@ -1,5 +1,5 @@
 - name: arcgis
-  timeout: 0
+  timeout: "0"
   params:
     {{ lookup('template', 'taskdefs/common/cli-params.yml.j2') | indent(4) }}
     - name: devops_suite_name

--- a/tekton/src/pipelines/taskdefs/dependencies/arcgis.yml.j2
+++ b/tekton/src/pipelines/taskdefs/dependencies/arcgis.yml.j2
@@ -1,4 +1,5 @@
 - name: arcgis
+  timeout: 0
   params:
     {{ lookup('template', 'taskdefs/common/cli-params.yml.j2') | indent(4) }}
     - name: devops_suite_name

--- a/tekton/src/pipelines/taskdefs/dependencies/cos-deprovision.yml.j2
+++ b/tekton/src/pipelines/taskdefs/dependencies/cos-deprovision.yml.j2
@@ -1,5 +1,5 @@
 - name: cos-deprovision
-  timeout: 0
+  timeout: "0"
   params:
     {{ lookup('template', 'taskdefs/common/cli-params.yml.j2') | indent(4) }}
     - name: devops_suite_name

--- a/tekton/src/pipelines/taskdefs/dependencies/cos-deprovision.yml.j2
+++ b/tekton/src/pipelines/taskdefs/dependencies/cos-deprovision.yml.j2
@@ -1,4 +1,5 @@
 - name: cos-deprovision
+  timeout: 0
   params:
     {{ lookup('template', 'taskdefs/common/cli-params.yml.j2') | indent(4) }}
     - name: devops_suite_name

--- a/tekton/src/pipelines/taskdefs/dependencies/cos.yml.j2
+++ b/tekton/src/pipelines/taskdefs/dependencies/cos.yml.j2
@@ -1,5 +1,5 @@
 - name: cos
-  timeout: 0
+  timeout: "0"
   params:
     {{ lookup('template', 'taskdefs/common/cli-params.yml.j2') | indent(4) }}
     - name: devops_suite_name

--- a/tekton/src/pipelines/taskdefs/dependencies/cos.yml.j2
+++ b/tekton/src/pipelines/taskdefs/dependencies/cos.yml.j2
@@ -1,4 +1,5 @@
 - name: cos
+  timeout: 0
   params:
     {{ lookup('template', 'taskdefs/common/cli-params.yml.j2') | indent(4) }}
     - name: devops_suite_name
@@ -17,13 +18,13 @@
       value: $(params.ibmcloud_apikey)
     - name: cos_resourcegroup
       value: $(params.cos_resourcegroup)
-  
+
     - name: custom_labels
       value: $(params.custom_labels)
   taskRef:
     kind: Task
     name: mas-devops-cos
-  
+
   # Only install COS if Assist or Manage applications are being installed
   when:
     - input: "$(params.cos_type)"

--- a/tekton/src/pipelines/taskdefs/dependencies/db2.yml.j2
+++ b/tekton/src/pipelines/taskdefs/dependencies/db2.yml.j2
@@ -1,4 +1,5 @@
 - name: db2-{{ suffix }}
+  timeout: 0
   params:
     {{ lookup('template', 'taskdefs/common/cli-params.yml.j2') | indent(4) }}
     - name: devops_suite_name

--- a/tekton/src/pipelines/taskdefs/dependencies/db2.yml.j2
+++ b/tekton/src/pipelines/taskdefs/dependencies/db2.yml.j2
@@ -1,5 +1,5 @@
 - name: db2-{{ suffix }}
-  timeout: 0
+  timeout: "0"
   params:
     {{ lookup('template', 'taskdefs/common/cli-params.yml.j2') | indent(4) }}
     - name: devops_suite_name

--- a/tekton/src/pipelines/taskdefs/dependencies/kafka-deprovision.yml.j2
+++ b/tekton/src/pipelines/taskdefs/dependencies/kafka-deprovision.yml.j2
@@ -1,4 +1,5 @@
 - name: kafka-deprovision
+  timeout: 0
   params:
     {{ lookup('template', 'taskdefs/common/cli-params.yml.j2') | indent(4) }}
     - name: devops_suite_name

--- a/tekton/src/pipelines/taskdefs/dependencies/kafka-deprovision.yml.j2
+++ b/tekton/src/pipelines/taskdefs/dependencies/kafka-deprovision.yml.j2
@@ -1,5 +1,5 @@
 - name: kafka-deprovision
-  timeout: 0
+  timeout: "0"
   params:
     {{ lookup('template', 'taskdefs/common/cli-params.yml.j2') | indent(4) }}
     - name: devops_suite_name

--- a/tekton/src/pipelines/taskdefs/dependencies/kafka.yml.j2
+++ b/tekton/src/pipelines/taskdefs/dependencies/kafka.yml.j2
@@ -1,5 +1,5 @@
 - name: kafka
-  timeout: 0
+  timeout: "0"
   params:
     {{ lookup('template', 'taskdefs/common/cli-params.yml.j2') | indent(4) }}
     - name: devops_suite_name

--- a/tekton/src/pipelines/taskdefs/dependencies/kafka.yml.j2
+++ b/tekton/src/pipelines/taskdefs/dependencies/kafka.yml.j2
@@ -1,4 +1,5 @@
 - name: kafka
+  timeout: 0
   params:
     {{ lookup('template', 'taskdefs/common/cli-params.yml.j2') | indent(4) }}
     - name: devops_suite_name

--- a/tekton/src/pipelines/taskdefs/dependencies/mongo.yml.j2
+++ b/tekton/src/pipelines/taskdefs/dependencies/mongo.yml.j2
@@ -1,4 +1,5 @@
 - name: mongodb
+  timeout: 0
   params:
     {{ lookup('template', 'taskdefs/common/cli-params.yml.j2') | indent(4) }}
     - name: devops_suite_name

--- a/tekton/src/pipelines/taskdefs/dependencies/mongo.yml.j2
+++ b/tekton/src/pipelines/taskdefs/dependencies/mongo.yml.j2
@@ -1,5 +1,5 @@
 - name: mongodb
-  timeout: 0
+  timeout: "0"
   params:
     {{ lookup('template', 'taskdefs/common/cli-params.yml.j2') | indent(4) }}
     - name: devops_suite_name

--- a/tekton/src/pipelines/taskdefs/dependencies/nvidia.yml.j2
+++ b/tekton/src/pipelines/taskdefs/dependencies/nvidia.yml.j2
@@ -1,4 +1,5 @@
 - name: nvidia-gpu
+  timeout: 0
   params:
     {{ lookup('template', 'taskdefs/common/cli-params.yml.j2') | indent(4) }}
     - name: devops_suite_name

--- a/tekton/src/pipelines/taskdefs/dependencies/nvidia.yml.j2
+++ b/tekton/src/pipelines/taskdefs/dependencies/nvidia.yml.j2
@@ -1,5 +1,5 @@
 - name: nvidia-gpu
-  timeout: 0
+  timeout: "0"
   params:
     {{ lookup('template', 'taskdefs/common/cli-params.yml.j2') | indent(4) }}
     - name: devops_suite_name

--- a/tekton/src/pipelines/taskdefs/dependencies/sls.yml.j2
+++ b/tekton/src/pipelines/taskdefs/dependencies/sls.yml.j2
@@ -1,5 +1,5 @@
 - name: sls
-  timeout: 0
+  timeout: "0"
   params:
     {{ lookup('template', 'taskdefs/common/cli-params.yml.j2') | indent(4) }}
     - name: devops_suite_name

--- a/tekton/src/pipelines/taskdefs/dependencies/sls.yml.j2
+++ b/tekton/src/pipelines/taskdefs/dependencies/sls.yml.j2
@@ -1,4 +1,5 @@
 - name: sls
+  timeout: 0
   params:
     {{ lookup('template', 'taskdefs/common/cli-params.yml.j2') | indent(4) }}
     - name: devops_suite_name

--- a/tekton/src/pipelines/taskdefs/dependencies/uds.yml.j2
+++ b/tekton/src/pipelines/taskdefs/dependencies/uds.yml.j2
@@ -1,5 +1,5 @@
 - name: uds
-  timeout: 0
+  timeout: "0"
   params:
     {{ lookup('template', 'taskdefs/common/cli-params.yml.j2') | indent(4) }}
     - name: uds_action

--- a/tekton/src/pipelines/taskdefs/dependencies/uds.yml.j2
+++ b/tekton/src/pipelines/taskdefs/dependencies/uds.yml.j2
@@ -1,4 +1,5 @@
 - name: uds
+  timeout: 0
   params:
     {{ lookup('template', 'taskdefs/common/cli-params.yml.j2') | indent(4) }}
     - name: uds_action

--- a/tekton/src/pipelines/uninstall.yml.j2
+++ b/tekton/src/pipelines/uninstall.yml.j2
@@ -90,7 +90,7 @@ spec:
     # 0. Wait for the install pipeline to complete
     # -------------------------------------------------------------------------
     - name: wait-for-install
-      timeout: 0
+      timeout: "0"
       taskRef:
         kind: Task
         name: mas-devops-wait-for-tekton
@@ -113,7 +113,7 @@ spec:
 
     # 1.1 Uninstall Visual Inspection
     - name: app-uninstall-visualinspection
-      timeout: 0
+      timeout: "0"
 {% if wait_for_install == true %}
       runAfter:
         - wait-for-install
@@ -131,7 +131,7 @@ spec:
 
     # 1.2 Uninstall Assist
     - name: app-uninstall-assist
-      timeout: 0
+      timeout: "0"
 {% if wait_for_install == true %}
       runAfter:
         - wait-for-install
@@ -149,7 +149,7 @@ spec:
 
     # 1.3 Uninstall Optimizer
     - name: app-uninstall-optimizer
-      timeout: 0
+      timeout: "0"
 {% if wait_for_install == true %}
       runAfter:
         - wait-for-install
@@ -167,7 +167,7 @@ spec:
 
     # 1.4 Uninstall Predict
     - name: app-uninstall-predict
-      timeout: 0
+      timeout: "0"
 {% if wait_for_install == true %}
       runAfter:
         - wait-for-install
@@ -185,7 +185,7 @@ spec:
 
     # 1.5 Uninstall Manage
     - name: app-uninstall-manage
-      timeout: 0
+      timeout: "0"
       runAfter:
         - app-uninstall-predict
       taskRef:
@@ -201,7 +201,7 @@ spec:
 
     # 1.6 Uninstall Monitor
     - name: app-uninstall-monitor
-      timeout: 0
+      timeout: "0"
       runAfter:
         - app-uninstall-predict
       taskRef:
@@ -217,7 +217,7 @@ spec:
 
     # 1.7 Uninstall IoT
     - name: app-uninstall-iot
-      timeout: 0
+      timeout: "0"
       runAfter:
         - app-uninstall-monitor
       taskRef:
@@ -234,7 +234,7 @@ spec:
     # 2. Uninstall IBM Maximo Application Suite
     # -------------------------------------------------------------------------
     - name: uninstall-suite
-      timeout: 0
+      timeout: "0"
       runAfter:
         - app-uninstall-iot
         - app-uninstall-visualinspection
@@ -258,7 +258,7 @@ spec:
     # 3. Uninstall IBM Suite Licensing Service
     # -------------------------------------------------------------------------
     - name: uninstall-sls
-      timeout: 0
+      timeout: "0"
       params:
         - name: image_pull_policy
           value: $(params.image_pull_policy)
@@ -280,7 +280,7 @@ spec:
     # 4. Uninstall MongoDB
     # -------------------------------------------------------------------------
     - name: uninstall-mongodb
-      timeout: 0
+      timeout: "0"
       params:
         - name: image_pull_policy
           value: $(params.image_pull_policy)
@@ -302,7 +302,7 @@ spec:
     # 5. Uninstall IBM User Data Services (or DRO)
     # -------------------------------------------------------------------------
     - name: uninstall-uds
-      timeout: 0
+      timeout: "0"
       params:
         - name: image_pull_policy
           value: $(params.image_pull_policy)
@@ -323,7 +323,7 @@ spec:
     # 6. Uninstall IBM Cert Manager
     # -------------------------------------------------------------------------
     - name: uninstall-cert-manager
-      timeout: 0
+      timeout: "0"
       params:
         - name: image_pull_policy
           value: $(params.image_pull_policy)
@@ -347,7 +347,7 @@ spec:
     # 7. Uninstall IBM Common Services
     # -------------------------------------------------------------------------
     - name: uninstall-common-services
-      timeout: 0
+      timeout: "0"
       params:
         - name: image_pull_policy
           value: $(params.image_pull_policy)
@@ -369,7 +369,7 @@ spec:
     # 8. Uninstall IBM Catalogs
     # -------------------------------------------------------------------------
     - name: uninstall-ibm-catalogs
-      timeout: 0
+      timeout: "0"
       params:
         - name: image_pull_policy
           value: $(params.image_pull_policy)
@@ -391,7 +391,7 @@ spec:
     # 9. Uninstall Grafana
     # -------------------------------------------------------------------------
     - name: uninstall-grafana
-      timeout: 0
+      timeout: "0"
       params:
         - name: image_pull_policy
           value: $(params.image_pull_policy)
@@ -421,7 +421,7 @@ spec:
     # Finalize the record in the FVT database
     # -------------------------------------------------------------------------
     - name: finalize
-      timeout: 0
+      timeout: "0"
       taskRef:
         kind: Task
         name: mas-fvt-finalize

--- a/tekton/src/pipelines/uninstall.yml.j2
+++ b/tekton/src/pipelines/uninstall.yml.j2
@@ -90,6 +90,7 @@ spec:
     # 0. Wait for the install pipeline to complete
     # -------------------------------------------------------------------------
     - name: wait-for-install
+      timeout: 0
       taskRef:
         kind: Task
         name: mas-devops-wait-for-tekton
@@ -112,6 +113,7 @@ spec:
 
     # 1.1 Uninstall Visual Inspection
     - name: app-uninstall-visualinspection
+      timeout: 0
 {% if wait_for_install == true %}
       runAfter:
         - wait-for-install
@@ -129,6 +131,7 @@ spec:
 
     # 1.2 Uninstall Assist
     - name: app-uninstall-assist
+      timeout: 0
 {% if wait_for_install == true %}
       runAfter:
         - wait-for-install
@@ -146,6 +149,7 @@ spec:
 
     # 1.3 Uninstall Optimizer
     - name: app-uninstall-optimizer
+      timeout: 0
 {% if wait_for_install == true %}
       runAfter:
         - wait-for-install
@@ -163,6 +167,7 @@ spec:
 
     # 1.4 Uninstall Predict
     - name: app-uninstall-predict
+      timeout: 0
 {% if wait_for_install == true %}
       runAfter:
         - wait-for-install
@@ -180,6 +185,7 @@ spec:
 
     # 1.5 Uninstall Manage
     - name: app-uninstall-manage
+      timeout: 0
       runAfter:
         - app-uninstall-predict
       taskRef:
@@ -195,6 +201,7 @@ spec:
 
     # 1.6 Uninstall Monitor
     - name: app-uninstall-monitor
+      timeout: 0
       runAfter:
         - app-uninstall-predict
       taskRef:
@@ -210,6 +217,7 @@ spec:
 
     # 1.7 Uninstall IoT
     - name: app-uninstall-iot
+      timeout: 0
       runAfter:
         - app-uninstall-monitor
       taskRef:
@@ -226,6 +234,7 @@ spec:
     # 2. Uninstall IBM Maximo Application Suite
     # -------------------------------------------------------------------------
     - name: uninstall-suite
+      timeout: 0
       runAfter:
         - app-uninstall-iot
         - app-uninstall-visualinspection
@@ -249,6 +258,7 @@ spec:
     # 3. Uninstall IBM Suite Licensing Service
     # -------------------------------------------------------------------------
     - name: uninstall-sls
+      timeout: 0
       params:
         - name: image_pull_policy
           value: $(params.image_pull_policy)
@@ -270,6 +280,7 @@ spec:
     # 4. Uninstall MongoDB
     # -------------------------------------------------------------------------
     - name: uninstall-mongodb
+      timeout: 0
       params:
         - name: image_pull_policy
           value: $(params.image_pull_policy)
@@ -291,6 +302,7 @@ spec:
     # 5. Uninstall IBM User Data Services (or DRO)
     # -------------------------------------------------------------------------
     - name: uninstall-uds
+      timeout: 0
       params:
         - name: image_pull_policy
           value: $(params.image_pull_policy)
@@ -311,6 +323,7 @@ spec:
     # 6. Uninstall IBM Cert Manager
     # -------------------------------------------------------------------------
     - name: uninstall-cert-manager
+      timeout: 0
       params:
         - name: image_pull_policy
           value: $(params.image_pull_policy)
@@ -334,6 +347,7 @@ spec:
     # 7. Uninstall IBM Common Services
     # -------------------------------------------------------------------------
     - name: uninstall-common-services
+      timeout: 0
       params:
         - name: image_pull_policy
           value: $(params.image_pull_policy)
@@ -355,6 +369,7 @@ spec:
     # 8. Uninstall IBM Catalogs
     # -------------------------------------------------------------------------
     - name: uninstall-ibm-catalogs
+      timeout: 0
       params:
         - name: image_pull_policy
           value: $(params.image_pull_policy)
@@ -376,6 +391,7 @@ spec:
     # 9. Uninstall Grafana
     # -------------------------------------------------------------------------
     - name: uninstall-grafana
+      timeout: 0
       params:
         - name: image_pull_policy
           value: $(params.image_pull_policy)
@@ -405,6 +421,7 @@ spec:
     # Finalize the record in the FVT database
     # -------------------------------------------------------------------------
     - name: finalize
+      timeout: 0
       taskRef:
         kind: Task
         name: mas-fvt-finalize

--- a/tekton/src/pipelines/update.yml.j2
+++ b/tekton/src/pipelines/update.yml.j2
@@ -201,6 +201,7 @@ spec:
     # 0. Wait for the install pipeline to complete
     # -------------------------------------------------------------------------
     - name: wait-for-install
+      timeout: 0
       taskRef:
         kind: Task
         name: mas-devops-wait-for-tekton
@@ -232,6 +233,7 @@ spec:
     # 2. Pre-Upgrade pipeline call - test scripts to run before update
     # -------------------------------------------------------------------------
     - name: launchfvt-upgrade-pre
+      timeout: 0
       params:
         - name: image_pull_policy
           value: $(params.image_pull_policy)
@@ -251,6 +253,7 @@ spec:
     # 3. Run the catalog update
     # -------------------------------------------------------------------------
     - name: update-catalog
+      timeout: 0
       taskRef:
         kind: Task
         name: mas-devops-ibm-catalogs
@@ -285,6 +288,7 @@ spec:
     # 5. Update Dependencies
     # ---------------------------------------------------------------------------
     - name: update-ocs
+      timeout: 0
       taskRef:
         kind: Task
         name: mas-devops-ocs
@@ -297,6 +301,7 @@ spec:
           value: $(params.ocs_action)
 
     - name: update-common-services
+      timeout: 0
       taskRef:
         kind: Task
         name: mas-devops-common-services
@@ -314,6 +319,7 @@ spec:
 
     # Only migrate to Red Hat Certificate Manager if identified that IBM Cloud Pak Foundational Services Certificate Manager is running
     - name: update-cert-manager
+      timeout: 0
       taskRef:
         kind: Task
         name: mas-devops-cert-manager
@@ -335,6 +341,7 @@ spec:
           values: ["redhat"]
 
     - name: update-grafana
+      timeout: 0
       taskRef:
         kind: Task
         name: mas-devops-grafana
@@ -351,6 +358,7 @@ spec:
         - update-common-services
 
     - name: update-db2
+      timeout: 0
       taskRef:
         kind: Task
         name: mas-devops-db2
@@ -365,6 +373,7 @@ spec:
           value: $(params.db2_namespace)
 
     - name: update-mongodb
+      timeout: 0
       taskRef:
         kind: Task
         name: mas-devops-mongodb
@@ -387,6 +396,7 @@ spec:
           value: $(params.mongodb_replicas)
 
     - name: update-kafka
+      timeout: 0
       taskRef:
         kind: Task
         name: mas-devops-kafka
@@ -404,6 +414,7 @@ spec:
 
     # UDS/DRO Migration
     - name: update-uds
+      timeout: 0
       taskRef:
         kind: Task
         name: mas-devops-uds
@@ -490,6 +501,7 @@ spec:
     # 7. Post-Upgrade pipeline call - test scripts to run before upgrade
     # -------------------------------------------------------------------------
     - name: launchfvt-upgrade-post
+      timeout: 0
       params:
         - name: image_pull_policy
           value: $(params.image_pull_policy)
@@ -517,6 +529,7 @@ spec:
     # Finalize the record in the FVT database
     # -------------------------------------------------------------------------
     - name: finalize
+      timeout: 0
       taskRef:
         kind: Task
         name: mas-fvt-finalize

--- a/tekton/src/pipelines/update.yml.j2
+++ b/tekton/src/pipelines/update.yml.j2
@@ -201,7 +201,7 @@ spec:
     # 0. Wait for the install pipeline to complete
     # -------------------------------------------------------------------------
     - name: wait-for-install
-      timeout: 0
+      timeout: "0"
       taskRef:
         kind: Task
         name: mas-devops-wait-for-tekton
@@ -233,7 +233,7 @@ spec:
     # 2. Pre-Upgrade pipeline call - test scripts to run before update
     # -------------------------------------------------------------------------
     - name: launchfvt-upgrade-pre
-      timeout: 0
+      timeout: "0"
       params:
         - name: image_pull_policy
           value: $(params.image_pull_policy)
@@ -253,7 +253,7 @@ spec:
     # 3. Run the catalog update
     # -------------------------------------------------------------------------
     - name: update-catalog
-      timeout: 0
+      timeout: "0"
       taskRef:
         kind: Task
         name: mas-devops-ibm-catalogs
@@ -288,7 +288,7 @@ spec:
     # 5. Update Dependencies
     # ---------------------------------------------------------------------------
     - name: update-ocs
-      timeout: 0
+      timeout: "0"
       taskRef:
         kind: Task
         name: mas-devops-ocs
@@ -301,7 +301,7 @@ spec:
           value: $(params.ocs_action)
 
     - name: update-common-services
-      timeout: 0
+      timeout: "0"
       taskRef:
         kind: Task
         name: mas-devops-common-services
@@ -319,7 +319,7 @@ spec:
 
     # Only migrate to Red Hat Certificate Manager if identified that IBM Cloud Pak Foundational Services Certificate Manager is running
     - name: update-cert-manager
-      timeout: 0
+      timeout: "0"
       taskRef:
         kind: Task
         name: mas-devops-cert-manager
@@ -341,7 +341,7 @@ spec:
           values: ["redhat"]
 
     - name: update-grafana
-      timeout: 0
+      timeout: "0"
       taskRef:
         kind: Task
         name: mas-devops-grafana
@@ -358,7 +358,7 @@ spec:
         - update-common-services
 
     - name: update-db2
-      timeout: 0
+      timeout: "0"
       taskRef:
         kind: Task
         name: mas-devops-db2
@@ -373,7 +373,7 @@ spec:
           value: $(params.db2_namespace)
 
     - name: update-mongodb
-      timeout: 0
+      timeout: "0"
       taskRef:
         kind: Task
         name: mas-devops-mongodb
@@ -396,7 +396,7 @@ spec:
           value: $(params.mongodb_replicas)
 
     - name: update-kafka
-      timeout: 0
+      timeout: "0"
       taskRef:
         kind: Task
         name: mas-devops-kafka
@@ -414,7 +414,7 @@ spec:
 
     # UDS/DRO Migration
     - name: update-uds
-      timeout: 0
+      timeout: "0"
       taskRef:
         kind: Task
         name: mas-devops-uds
@@ -501,7 +501,7 @@ spec:
     # 7. Post-Upgrade pipeline call - test scripts to run before upgrade
     # -------------------------------------------------------------------------
     - name: launchfvt-upgrade-post
-      timeout: 0
+      timeout: "0"
       params:
         - name: image_pull_policy
           value: $(params.image_pull_policy)
@@ -529,7 +529,7 @@ spec:
     # Finalize the record in the FVT database
     # -------------------------------------------------------------------------
     - name: finalize
-      timeout: 0
+      timeout: "0"
       taskRef:
         kind: Task
         name: mas-fvt-finalize

--- a/tekton/src/pipelines/upgrade.yml.j2
+++ b/tekton/src/pipelines/upgrade.yml.j2
@@ -48,7 +48,7 @@ spec:
     # 0. Wait for the install pipeline to complete
     # -------------------------------------------------------------------------
     - name: wait-for-install
-      timeout: 0
+      timeout: "0"
       taskRef:
         kind: Task
         name: mas-devops-wait-for-tekton
@@ -80,7 +80,7 @@ spec:
     # 2. Pre-Upgrade pipeline call - test scripts to run before upgrade
     # -------------------------------------------------------------------------
     - name: launchfvt-upgrade-pre
-      timeout: 0
+      timeout: "0"
       params:
         - name: image_pull_policy
           value: $(params.image_pull_policy)
@@ -100,7 +100,7 @@ spec:
     # 3. Suite Upgrade (Phase 1)
     # -------------------------------------------------------------------------
     - name: core-upgrade
-      timeout: 0
+      timeout: "0"
       taskRef:
         kind: Task
         name: mas-devops-suite-upgrade
@@ -121,7 +121,7 @@ spec:
           value: core-upgrade
 
     - name: core-verify
-      timeout: 0
+      timeout: "0"
       params:
         - name: mas_instance_id
           value: $(params.mas_instance_id)
@@ -141,7 +141,7 @@ spec:
     # 4. IoT Upgrade (Phase 2)
     # -------------------------------------------------------------------------
     - name: iot-upgrade
-      timeout: 0
+      timeout: "0"
       params:
         - name: mas_instance_id
           value: $(params.mas_instance_id)
@@ -163,7 +163,7 @@ spec:
     # 5. Manage Upgrade (Phase 2)
     # -------------------------------------------------------------------------
     - name: manage-upgrade
-      timeout: 0
+      timeout: "0"
       params:
         - name: mas_instance_id
           value: $(params.mas_instance_id)
@@ -185,7 +185,7 @@ spec:
     # 6. Visual Inspection Upgrade (Phase 2)
     # -------------------------------------------------------------------------
     - name: visualinspection-upgrade
-      timeout: 0
+      timeout: "0"
       params:
         - name: mas_instance_id
           value: $(params.mas_instance_id)
@@ -207,7 +207,7 @@ spec:
     # 7. Assist Upgrade (Phase 2)
     # -------------------------------------------------------------------------
     - name: assist-upgrade
-      timeout: 0
+      timeout: "0"
       params:
         - name: mas_instance_id
           value: $(params.mas_instance_id)
@@ -229,7 +229,7 @@ spec:
     # 8. Optimizer Upgrade (Phase 2)
     # -------------------------------------------------------------------------
     - name: optimizer-upgrade
-      timeout: 0
+      timeout: "0"
       params:
         - name: mas_instance_id
           value: $(params.mas_instance_id)
@@ -251,7 +251,7 @@ spec:
     # 9. Monitor Upgrade (Phase 3 - after IoT)
     # -------------------------------------------------------------------------
     - name: monitor-upgrade
-      timeout: 0
+      timeout: "0"
       params:
         - name: mas_instance_id
           value: $(params.mas_instance_id)
@@ -273,7 +273,7 @@ spec:
     # 10. Predict Upgrade (Phase 3 - after Manage)
     # -------------------------------------------------------------------------
     - name: predict-upgrade
-      timeout: 0
+      timeout: "0"
       params:
         - name: mas_instance_id
           value: $(params.mas_instance_id)
@@ -310,7 +310,7 @@ spec:
     # 12. Post-Upgrade pipeline call - test scripts to run before upgrade
     # -------------------------------------------------------------------------
     - name: launchfvt-upgrade-post
-      timeout: 0
+      timeout: "0"
       params:
         - name: image_pull_policy
           value: $(params.image_pull_policy)
@@ -338,7 +338,7 @@ spec:
     # Finalize the record in the FVT database
     # -------------------------------------------------------------------------
     - name: finalize
-      timeout: 0
+      timeout: "0"
       taskRef:
         kind: Task
         name: mas-fvt-finalize

--- a/tekton/src/pipelines/upgrade.yml.j2
+++ b/tekton/src/pipelines/upgrade.yml.j2
@@ -48,6 +48,7 @@ spec:
     # 0. Wait for the install pipeline to complete
     # -------------------------------------------------------------------------
     - name: wait-for-install
+      timeout: 0
       taskRef:
         kind: Task
         name: mas-devops-wait-for-tekton
@@ -79,6 +80,7 @@ spec:
     # 2. Pre-Upgrade pipeline call - test scripts to run before upgrade
     # -------------------------------------------------------------------------
     - name: launchfvt-upgrade-pre
+      timeout: 0
       params:
         - name: image_pull_policy
           value: $(params.image_pull_policy)
@@ -98,6 +100,7 @@ spec:
     # 3. Suite Upgrade (Phase 1)
     # -------------------------------------------------------------------------
     - name: core-upgrade
+      timeout: 0
       taskRef:
         kind: Task
         name: mas-devops-suite-upgrade
@@ -118,6 +121,7 @@ spec:
           value: core-upgrade
 
     - name: core-verify
+      timeout: 0
       params:
         - name: mas_instance_id
           value: $(params.mas_instance_id)
@@ -137,6 +141,7 @@ spec:
     # 4. IoT Upgrade (Phase 2)
     # -------------------------------------------------------------------------
     - name: iot-upgrade
+      timeout: 0
       params:
         - name: mas_instance_id
           value: $(params.mas_instance_id)
@@ -158,6 +163,7 @@ spec:
     # 5. Manage Upgrade (Phase 2)
     # -------------------------------------------------------------------------
     - name: manage-upgrade
+      timeout: 0
       params:
         - name: mas_instance_id
           value: $(params.mas_instance_id)
@@ -179,6 +185,7 @@ spec:
     # 6. Visual Inspection Upgrade (Phase 2)
     # -------------------------------------------------------------------------
     - name: visualinspection-upgrade
+      timeout: 0
       params:
         - name: mas_instance_id
           value: $(params.mas_instance_id)
@@ -200,6 +207,7 @@ spec:
     # 7. Assist Upgrade (Phase 2)
     # -------------------------------------------------------------------------
     - name: assist-upgrade
+      timeout: 0
       params:
         - name: mas_instance_id
           value: $(params.mas_instance_id)
@@ -221,6 +229,7 @@ spec:
     # 8. Optimizer Upgrade (Phase 2)
     # -------------------------------------------------------------------------
     - name: optimizer-upgrade
+      timeout: 0
       params:
         - name: mas_instance_id
           value: $(params.mas_instance_id)
@@ -242,6 +251,7 @@ spec:
     # 9. Monitor Upgrade (Phase 3 - after IoT)
     # -------------------------------------------------------------------------
     - name: monitor-upgrade
+      timeout: 0
       params:
         - name: mas_instance_id
           value: $(params.mas_instance_id)
@@ -263,6 +273,7 @@ spec:
     # 10. Predict Upgrade (Phase 3 - after Manage)
     # -------------------------------------------------------------------------
     - name: predict-upgrade
+      timeout: 0
       params:
         - name: mas_instance_id
           value: $(params.mas_instance_id)
@@ -299,6 +310,7 @@ spec:
     # 12. Post-Upgrade pipeline call - test scripts to run before upgrade
     # -------------------------------------------------------------------------
     - name: launchfvt-upgrade-post
+      timeout: 0
       params:
         - name: image_pull_policy
           value: $(params.image_pull_policy)
@@ -326,6 +338,7 @@ spec:
     # Finalize the record in the FVT database
     # -------------------------------------------------------------------------
     - name: finalize
+      timeout: 0
       taskRef:
         kind: Task
         name: mas-fvt-finalize


### PR DESCRIPTION
We already have timeouts implemented inside the Ansible roles that are running, and the layer of tekton timeouts on top have always been problematic, even more so now that we are not hijacking the global tekton configuration in the cluster to set the global timeout to 10 hours.