### PR TITLE
Add manage logging and attachment secrets

### DIFF
--- a/image/cli/mascli/functions/gitops_suite_app_config
+++ b/image/cli/mascli/functions/gitops_suite_app_config
@@ -452,6 +452,10 @@ function gitops_suite_app_config() {
     echo_h2 "Using application spec provided for $MAS_APP_ID at $MAS_APPWS_SPEC_YAML"
     export MAS_APPWS_SPEC=$(cat ${MAS_APPWS_SPEC_YAML} | yq '.' --output-format yaml)
     yq eval '.mas_appws_spec.settings.customizationList  | to_entries | .[].value.customizationArchiveCredentials.secretName | [] + .' ${MAS_APPWS_SPEC_YAML} | yq '{"CUSTOMIZATION_ARCHIVE_SECRET_NAMES": [] + .}'  > $ADDITIONAL_JINJA_PARAMS_FILE
+    export MANAGE_ATTACHMENTS_SECRET_NAME=$(yq eval '.mas_appws_spec.settings.db.attachmentProvider.providerCredentials.secretName // ""' ${MAS_APPWS_SPEC_YAML})
+    export MANAGE_LOGGING_SECRET_NAME=$(yq eval '.mas_appws_spec.settings.deployment.loggingS3Destination.secretKey.secretName // ""' ${MAS_APPWS_SPEC_YAML})
+    export MANAGE_ATTACHMENTS_SECRET=${ACCOUNT_ID}${SECRETS_KEY_SEPERATOR}${CLUSTER_ID}${SECRETS_KEY_SEPERATOR}${MAS_INSTANCE_ID}${SECRETS_KEY_SEPERATOR}manage_logging${SECRETS_KEY_SEPERATOR}
+    export MANAGE_LOGGING_SECRET=${ACCOUNT_ID}${SECRETS_KEY_SEPERATOR}${CLUSTER_ID}${SECRETS_KEY_SEPERATOR}${MAS_INSTANCE_ID}${SECRETS_KEY_SEPERATOR}manage_attachments${SECRETS_KEY_SEPERATOR}
   else
     echo
     echo_h2 "Using default application spec for $MAS_APP_ID"

--- a/image/cli/mascli/templates/gitops/appset-configs/cluster/instance/masapp/ibm-mas-masapp-config.yaml.j2
+++ b/image/cli/mascli/templates/gitops/appset-configs/cluster/instance/masapp/ibm-mas-masapp-config.yaml.j2
@@ -18,6 +18,16 @@ customization_archive_secret_names:
 {%- endfor %}
 {%- endif %}
 
+{%- if MANAGE_LOGGING_SECRET_NAME is defined and MANAGE_LOGGING_SECRET_NAME !='' %}
+manage_logging_secret_name: {{ MANAGE_LOGGING_SECRET_NAME }}
+manage_logging_access_secret_key: <path:{{ SECRETS_PATH }}:{{ MANAGE_LOGGING_SECRET }}{{ manage_logging_secret_name }}#access_secret_key>
+{%- endif %}
+
+{%- if MANAGE_ATTACHMENTS_SECRET_NAME is defined and MANAGE_ATTACHMENTS_SECRET_NAME !='' %}
+manage_attachments_secret_name: {{ MANAGE_ATTACHMENTS_SECRET_NAME }}
+manage_attachments_access_secret_key: <path:{{ SECRETS_PATH }}:{{ MANAGE_ATTACHMENTS_SECRET }}{{ manage_attachments_secret_name }}#access_secret_key>
+{%- endif %}
+
 {{ MAS_APPWS_SPEC | indent(2) }}
 
 {% if MAS_MANUAL_CERT_MGMT == 'True' %}


### PR DESCRIPTION
Adds the manage logging and attachement secrets when the mas appws spec contains those values.

Goes with PR https://github.com/ibm-mas/gitops/pull/168