### PR TITLE
[patch] Summarizer is not using getParam()

### DIFF
--- a/python/src/mas/cli/install/summarizer.py
+++ b/python/src/mas/cli/install/summarizer.py
@@ -61,19 +61,19 @@ class InstallSummarizerMixin():
             self.printParamSummary("DNS Provider", "dns_provider")
             self.printParamSummary("Certificate Issuer", "mas_cluster_issuer")
 
-            if self.params['dns_provider'] == "cloudflare":
+            if self.getParam('dns_provider') == "cloudflare":
                 self.printParamSummary("CloudFlare e-mail", "cloudflare_email")
                 self.printParamSummary("CloudFlare API token", "cloudflare_apitoken")
                 self.printParamSummary("CloudFlare zone", "cloudflare_zone")
                 self.printParamSummary("CloudFlare subdomain", "cloudflare_subdomain")
-            elif self.params['dns_provider'] == "cis":
+            elif self.getParam('dns_provider') == "cis":
                 pass
-            elif self.params['dns_provider'] == "route53":
+            elif self.getParam('dns_provider') == "route53":
                 pass
-            elif self.params['dns_provider'] == "":
+            elif self.getParam('dns_provider') == "":
                 pass
-        
-        if self.params["mas_manual_cert_mgmt"]:
+
+        if self.getParam("mas_manual_cert_mgmt") != "":
             print()
             self.printParamSummary("Manual Certificates", "mas_manual_cert_dir")
         else:


### PR DESCRIPTION
Direct use of `self.params[]` leaves the code vulnerable to scenarios where a parameter for the pipelinerun has not been initialized depending on the choices made during the install prompts, this is why `self.getParam()` should be used, as it will return `""` if the parameter is undefined.

The majority of the code already uses the latter, but there are a few cases where this isn't happening.