### PR TITLE
[patch] Add missing namespace when backing up Manage certificates

### DIFF
--- a/image/cli/mascli/backup-restore/manage-backup-restore.sh
+++ b/image/cli/mascli/backup-restore/manage-backup-restore.sh
@@ -58,7 +58,7 @@ function checkForManualCertMgmt {
     if [ "$hasCertMgmt" == "true" ]; then
         hasCertMgmtValue=`(echo "$suiteYaml" | yq .spec.settings.manualCertMgmt)`
         if [ "$hasCertMgmtValue" == "true" ]; then
-            backupSingleResource Secret $MAS_INSTANCE_ID-$MAS_WORKSPACE_ID-cert-public-81
+            backupSingleResource Secret $MAS_INSTANCE_ID-$MAS_WORKSPACE_ID-cert-public-81 $MAS_MANAGE_NAMESPACE
         fi
     fi
 


### PR DESCRIPTION
This pull request fixes issue #1120 

The only change is to add missing `$MAS_MANAGE_NAMESPACE` reference when backing up manually managed certificate.