### PR TITLE
[patch] Remove set -e from gitops functions

### DIFF
--- a/image/cli/mascli/functions/gitops_cis_compliance
+++ b/image/cli/mascli/functions/gitops_cis_compliance
@@ -125,7 +125,7 @@ function gitops_cis_compliance() {
   fi
 
   # catch errors
-  set -eo pipefail
+  set -o pipefail
   trap 'echo "[ERROR] Error occurred at $BASH_SOURCE, line $LINENO, exited with $?"; exit 1' ERR
 
   mkdir -p ${GITOPS_WORKING_DIR}

--- a/image/cli/mascli/functions/gitops_cluster
+++ b/image/cli/mascli/functions/gitops_cluster
@@ -269,7 +269,7 @@ function gitops_cluster() {
   fi
 
   # catch errors
-  set -eo pipefail
+  set -o pipefail
   trap 'echo "[ERROR] Error occurred at $BASH_SOURCE, line $LINENO, exited with $?"; exit 1' ERR
 
   mkdir -p ${GITOPS_WORKING_DIR}

--- a/image/cli/mascli/functions/gitops_cos
+++ b/image/cli/mascli/functions/gitops_cos
@@ -119,7 +119,7 @@ function gitops_cos() {
   fi
   
   # catch errors
-  set -eo pipefail
+  set -o pipefail
   trap 'echo "[ERROR] Error occurred at $BASH_SOURCE, line $LINENO, exited with $?"; exit 1' ERR
 
   rm -rf $GITOPS_WORKING_DIR

--- a/image/cli/mascli/functions/gitops_cp4d
+++ b/image/cli/mascli/functions/gitops_cp4d
@@ -183,7 +183,7 @@ function gitops_cp4d() {
   fi
 
   # catch errors
-  set -eo pipefail
+  set -o pipefail
   trap 'echo "[ERROR] Error occurred at $BASH_SOURCE, line $LINENO, exited with $?"; exit 1' ERR
 
   mkdir -p ${GITOPS_WORKING_DIR}

--- a/image/cli/mascli/functions/gitops_cp4d_service
+++ b/image/cli/mascli/functions/gitops_cp4d_service
@@ -193,7 +193,7 @@ function gitops_cp4d_service() {
   fi
 
   # catch errors
-  set -eo pipefail
+  set -o pipefail
   trap 'echo "[ERROR] Error occurred at $BASH_SOURCE, line $LINENO, exited with $?"; exit 1' ERR
 
   mkdir -p ${GITOPS_WORKING_DIR}

--- a/image/cli/mascli/functions/gitops_db2u
+++ b/image/cli/mascli/functions/gitops_db2u
@@ -151,7 +151,7 @@ function gitops_db2u() {
   fi
 
   # catch errors
-  set -eo pipefail
+  set -o pipefail
   trap 'echo "[ERROR] Error occurred at $BASH_SOURCE, line $LINENO, exited with $?"; exit 1' ERR
 
   mkdir -p ${GITOPS_WORKING_DIR}

--- a/image/cli/mascli/functions/gitops_db2u_database
+++ b/image/cli/mascli/functions/gitops_db2u_database
@@ -344,7 +344,7 @@ function gitops_db2u_database() {
   fi
 
   # catch errors
-  set -eo pipefail
+  set -o pipefail
   trap 'echo "[ERROR] Error occurred at $BASH_SOURCE, line $LINENO, exited with $?"; exit 1' ERR
 
   mkdir -p ${GITOPS_WORKING_DIR}

--- a/image/cli/mascli/functions/gitops_deprovision_app_config
+++ b/image/cli/mascli/functions/gitops_deprovision_app_config
@@ -152,7 +152,7 @@ function gitops_deprovision_app_config() {
   fi
 
   # catch errors
-  set -eo pipefail
+  set -o pipefail
   trap 'echo "[ERROR] Error occurred at $BASH_SOURCE, line $LINENO, exited with $?"; exit 1' ERR
 
   mkdir -p ${GITOPS_WORKING_DIR}

--- a/image/cli/mascli/functions/gitops_deprovision_app_install
+++ b/image/cli/mascli/functions/gitops_deprovision_app_install
@@ -147,7 +147,7 @@ function gitops_deprovision_app_install() {
   fi
 
   # catch errors
-  set -eo pipefail
+  set -o pipefail
   trap 'echo "[ERROR] Error occurred at $BASH_SOURCE, line $LINENO, exited with $?"; exit 1' ERR
 
   mkdir -p ${GITOPS_WORKING_DIR}

--- a/image/cli/mascli/functions/gitops_deprovision_cluster
+++ b/image/cli/mascli/functions/gitops_deprovision_cluster
@@ -132,7 +132,7 @@ function gitops_deprovision_cluster() {
   fi
 
   # catch errors
-  set -eo pipefail
+  set -o pipefail
   trap 'echo "[ERROR] Error occurred at $BASH_SOURCE, line $LINENO, exited with $?"; exit 1' ERR
 
   mkdir -p ${GITOPS_WORKING_DIR}

--- a/image/cli/mascli/functions/gitops_deprovision_cos
+++ b/image/cli/mascli/functions/gitops_deprovision_cos
@@ -143,7 +143,7 @@ function gitops_deprovision_cos() {
   fi
 
   # catch errors
-  set -eo pipefail
+  set -o pipefail
   trap 'echo "[ERROR] Error occurred at $BASH_SOURCE, line $LINENO, exited with $?"; exit 1' ERR
 
   rm -rf $GITOPS_WORKING_DIR

--- a/image/cli/mascli/functions/gitops_deprovision_db2u
+++ b/image/cli/mascli/functions/gitops_deprovision_db2u
@@ -126,7 +126,7 @@ function gitops_deprovision_db2u() {
   fi
 
   # catch errors
-  set -eo pipefail
+  set -o pipefail
   trap 'echo "[ERROR] Error occurred at $BASH_SOURCE, line $LINENO, exited with $?"; exit 1' ERR
 
   mkdir -p ${GITOPS_WORKING_DIR}

--- a/image/cli/mascli/functions/gitops_deprovision_db2u_database
+++ b/image/cli/mascli/functions/gitops_deprovision_db2u_database
@@ -153,7 +153,7 @@ function gitops_deprovision_db2u_database() {
   fi
 
   # catch errors
-  set -eo pipefail
+  set -o pipefail
   trap 'echo "[ERROR] Error occurred at $BASH_SOURCE, line $LINENO, exited with $?"; exit 1' ERR
 
   mkdir -p ${GITOPS_WORKING_DIR}

--- a/image/cli/mascli/functions/gitops_deprovision_efs
+++ b/image/cli/mascli/functions/gitops_deprovision_efs
@@ -87,7 +87,7 @@ function gitops_deprovision_efs() {
   fi
 
   # catch errors
-  set -eo pipefail
+  set -o pipefail
   trap 'echo "[ERROR] Error occurred at $BASH_SOURCE, line $LINENO, exited with $?"; exit 1' ERR
 
   echo

--- a/image/cli/mascli/functions/gitops_deprovision_kafka
+++ b/image/cli/mascli/functions/gitops_deprovision_kafka
@@ -200,7 +200,7 @@ function gitops_deprovision_kafka() {
   fi
 
   # catch errors
-  set -eo pipefail
+  set -o pipefail
   trap 'echo "[ERROR] Error occurred at $BASH_SOURCE, line $LINENO, exited with $?"; exit 1' ERR
 
   rm -rf $GITOPS_WORKING_DIR

--- a/image/cli/mascli/functions/gitops_deprovision_mongo
+++ b/image/cli/mascli/functions/gitops_deprovision_mongo
@@ -156,7 +156,7 @@ function gitops_deprovision_mongo() {
   fi
 
   # catch errors
-  set -eo pipefail
+  set -o pipefail
   trap 'echo "[ERROR] Error occurred at $BASH_SOURCE, line $LINENO, exited with $?"; exit 1' ERR
 
   echo

--- a/image/cli/mascli/functions/gitops_deprovision_rosa
+++ b/image/cli/mascli/functions/gitops_deprovision_rosa
@@ -53,7 +53,7 @@ function gitops_deprovision_rosa(){
   fi
 
   # catch errors
-  set -eo pipefail
+  set -o pipefail
   trap 'echo "[ERROR] Error occurred at $BASH_SOURCE, line $LINENO, exited with $?"; exit 1' ERR
 
   echo

--- a/image/cli/mascli/functions/gitops_deprovision_suite
+++ b/image/cli/mascli/functions/gitops_deprovision_suite
@@ -170,7 +170,7 @@ function gitops_deprovision_suite() {
   fi
 
   # catch errors
-  set -eo pipefail
+  set -o pipefail
   trap 'echo "[ERROR] Error occurred at $BASH_SOURCE, line $LINENO, exited with $?"; exit 1' ERR
 
   mkdir -p ${GITOPS_WORKING_DIR}

--- a/image/cli/mascli/functions/gitops_deprovision_suite_workspace
+++ b/image/cli/mascli/functions/gitops_deprovision_suite_workspace
@@ -133,7 +133,7 @@ function gitops_deprovision_suite_workspace() {
   fi
   
   # catch errors
-  set -eo pipefail
+  set -o pipefail
   trap 'echo "[ERROR] Error occurred at $BASH_SOURCE, line $LINENO, exited with $?"; exit 1' ERR
 
   mkdir -p ${GITOPS_WORKING_DIR}

--- a/image/cli/mascli/functions/gitops_dro
+++ b/image/cli/mascli/functions/gitops_dro
@@ -168,7 +168,7 @@ function gitops_dro() {
   fi
 
   # catch errors
-  set -eo pipefail
+  set -o pipefail
   trap 'echo "[ERROR] Error occurred at $BASH_SOURCE, line $LINENO, exited with $?"; exit 1' ERR
 
   mkdir -p ${GITOPS_WORKING_DIR}

--- a/image/cli/mascli/functions/gitops_efs
+++ b/image/cli/mascli/functions/gitops_efs
@@ -89,7 +89,7 @@ function gitops_efs() {
   fi
 
   # catch errors
-  set -eo pipefail
+  set -o pipefail
   trap 'echo "[ERROR] Error occurred at $BASH_SOURCE, line $LINENO, exited with $?"; exit 1' ERR
 
   echo

--- a/image/cli/mascli/functions/gitops_kafka
+++ b/image/cli/mascli/functions/gitops_kafka
@@ -199,7 +199,7 @@ function gitops_kafka() {
   fi
 
   # catch errors
-  set -eo pipefail
+  set -o pipefail
   trap 'echo "[ERROR] Error occurred at $BASH_SOURCE, line $LINENO, exited with $?"; exit 1' ERR
 
   rm -rf $GITOPS_WORKING_DIR

--- a/image/cli/mascli/functions/gitops_license
+++ b/image/cli/mascli/functions/gitops_license
@@ -91,7 +91,7 @@ function gitops_license() {
   fi
 
   # catch errors
-  set -eo pipefail
+  set -o pipefail
   trap 'echo "[ERROR] Error occurred at $BASH_SOURCE, line $LINENO, exited with $?"; exit 1' ERR
 
   echo

--- a/image/cli/mascli/functions/gitops_mas_config
+++ b/image/cli/mascli/functions/gitops_mas_config
@@ -427,7 +427,7 @@ function gitops_mas_config() {
   fi
 
   # catch errors
-  set -eo pipefail
+  set -o pipefail
   trap 'echo "[ERROR] Error occurred at $BASH_SOURCE, line $LINENO, exited with $?"; exit 1' ERR
 
   mkdir -p ${GITOPS_WORKING_DIR}

--- a/image/cli/mascli/functions/gitops_mongo
+++ b/image/cli/mascli/functions/gitops_mongo
@@ -185,7 +185,7 @@ function gitops_mongo() {
   fi
 
   # catch errors
-  set -eo pipefail
+  set -o pipefail
   trap 'echo "[ERROR] Error occurred at $BASH_SOURCE, line $LINENO, exited with $?"; exit 1' ERR
 
   echo

--- a/image/cli/mascli/functions/gitops_nvidia_gpu
+++ b/image/cli/mascli/functions/gitops_nvidia_gpu
@@ -166,7 +166,7 @@ function gitops_nvidia_gpu() {
   fi
 
   # catch errors
-  set -eo pipefail
+  set -o pipefail
   trap 'echo "[ERROR] Error occurred at $BASH_SOURCE, line $LINENO, exited with $?"; exit 1' ERR
 
   mkdir -p ${GITOPS_WORKING_DIR}

--- a/image/cli/mascli/functions/gitops_process_mongo_user
+++ b/image/cli/mascli/functions/gitops_process_mongo_user
@@ -194,7 +194,7 @@ function gitops_process_mongo_user() {
   fi
   
   # catch errors
-  set -eo pipefail
+  set -o pipefail
   trap 'echo "[ERROR] Error occurred at $BASH_SOURCE, line $LINENO, exited with $?"; exit 1' ERR
 
   echo

--- a/image/cli/mascli/functions/gitops_rosa
+++ b/image/cli/mascli/functions/gitops_rosa
@@ -64,7 +64,7 @@ function gitops_rosa(){
   fi
 
   # catch errors
-  set -eo pipefail
+  set -o pipefail
   trap 'echo "[ERROR] Error occurred at $BASH_SOURCE, line $LINENO, exited with $?"; exit 1' ERR
 
   echo

--- a/image/cli/mascli/functions/gitops_suite
+++ b/image/cli/mascli/functions/gitops_suite
@@ -346,7 +346,7 @@ function gitops_suite() {
   fi
 
   # catch errors
-  set -eo pipefail
+  set -o pipefail
   trap 'echo "[ERROR] Error occurred at $BASH_SOURCE, line $LINENO, exited with $?"; exit 1' ERR
 
   export DOMAIN=${MAS_DOMAIN}

--- a/image/cli/mascli/functions/gitops_suite_app_config
+++ b/image/cli/mascli/functions/gitops_suite_app_config
@@ -247,7 +247,7 @@ function gitops_suite_app_config() {
   fi
 
   # catch errors
-  set -eo pipefail
+  set -o pipefail
   trap 'echo "[ERROR] Error occurred at $BASH_SOURCE, line $LINENO, exited with $?"; exit 1' ERR
 
   mkdir -p ${GITOPS_WORKING_DIR}

--- a/image/cli/mascli/functions/gitops_suite_app_install
+++ b/image/cli/mascli/functions/gitops_suite_app_install
@@ -221,7 +221,7 @@ function gitops_suite_app_install() {
   fi
 
   # catch errors
-  set -eo pipefail
+  set -o pipefail
   trap 'echo "[ERROR] Error occurred at $BASH_SOURCE, line $LINENO, exited with $?"; exit 1' ERR
 
   mkdir -p ${GITOPS_WORKING_DIR}

--- a/image/cli/mascli/functions/gitops_suite_certs
+++ b/image/cli/mascli/functions/gitops_suite_certs
@@ -135,7 +135,7 @@ function gitops_suite_certs() {
   fi
 
   # catch errors
-  set -eo pipefail
+  set -o pipefail
   trap 'echo "[ERROR] Error occurred at $BASH_SOURCE, line $LINENO, exited with $?"; exit 1' ERR
 
   echo

--- a/image/cli/mascli/functions/gitops_suite_dns
+++ b/image/cli/mascli/functions/gitops_suite_dns
@@ -116,7 +116,7 @@ function gitops_suite_dns() {
   fi
 
   # catch errors
-  set -eo pipefail
+  set -o pipefail
   trap 'echo "[ERROR] Error occurred at $BASH_SOURCE, line $LINENO, exited with $?"; exit 1' ERR
 
   echo

--- a/image/cli/mascli/functions/gitops_suite_workspace
+++ b/image/cli/mascli/functions/gitops_suite_workspace
@@ -139,7 +139,7 @@ function gitops_suite_workspace() {
   fi
 
   # catch errors
-  set -eo pipefail
+  set -o pipefail
   trap 'echo "[ERROR] Error occurred at $BASH_SOURCE, line $LINENO, exited with $?"; exit 1' ERR
   
   mkdir -p ${GITOPS_WORKING_DIR}


### PR DESCRIPTION
We only want to catch the failures in a pipeline rather than all errors as there are cases where a return code other than 0 is expected.