### PR TITLE
[patch] Fix a number of places in gitops that failed due to set -o pipefail

### DIFF
--- a/image/cli/mascli/functions/gitops_suite
+++ b/image/cli/mascli/functions/gitops_suite
@@ -518,8 +518,6 @@ function gitops_suite() {
   # ---------------------------------------------------------------------------
   # Note that these instance-level secrets are set up by gitops-license
   export SECRET_KEY_LICENSE_FILE=${ACCOUNT_ID}${SECRETS_KEY_SEPERATOR}${CLUSTER_ID}${SECRETS_KEY_SEPERATOR}${MAS_INSTANCE_ID}${SECRETS_KEY_SEPERATOR}license#license_file
-  export LICENSE_FILE=$TEMP_DIR/license.lic
-  sm_get_secret_file $SECRET_KEY_LICENSE_FILE $LICENSE_FILE
 
   # Instance-level secrets to create
   # ---------------------------------------------------------------------------

--- a/image/cli/mascli/functions/gitops_utils
+++ b/image/cli/mascli/functions/gitops_utils
@@ -22,12 +22,14 @@ function sm_list_cluster_secrets() {
   CLUSTER_ID=$2
 
   if [[ "$AVP_TYPE" == "aws" ]]; then
+    set +o pipefail
     LIST_SECRETS_OUTPUT="$(aws secretsmanager list-secrets --output yaml --no-cli-pager --filters Key=name,Values=${ACCOUNT}${DELIMIITER}${CLUSTER_ID}${DELIMIITER})"
     return_code=$?
     if [ $return_code -ne 0 ]; then
       echo "aws: secretmanager list-secrets failed with error: $return_code"
       exit $return_code
     fi
+    set -o pipefail
 
     echo "$LIST_SECRETS_OUTPUT" | yq -r '.SecretList[].Name'
   elif [[ "$AVP_TYPE" == "ibm" ]]; then
@@ -48,6 +50,7 @@ function sm_update_secret(){
     # exists and is already set to what we want to use.
 
     # Get the current value
+    set +o pipefail
     CURRENT_SECRET_VALUE=$(aws secretsmanager get-secret-value --secret-id ${SECRET_NAME} --output json 2> /dev/null | jq -r .SecretString)
 
     if [[ "$CURRENT_SECRET_VALUE" == "" ]]; then
@@ -62,6 +65,7 @@ function sm_update_secret(){
       # No change
       echo "- Secret $SECRET_NAME unchanged"
     fi
+    set -o pipefail
   elif [[ "$AVP_TYPE" == "ibm" ]]; then
     echo "IBM SecretsManager not yet supported"
     exit 1
@@ -73,7 +77,9 @@ function sm_delete_secret(){
   if [[ "$AVP_TYPE" == "aws" ]]; then
 
     # Delete the secret
+    set +o pipefail
     aws secretsmanager delete-secret --force-delete-without-recovery --secret-id ${SECRET_NAME} --output json 2> /dev/null || exit 1
+    set -o pipefail
 
   elif [[ "$AVP_TYPE" == "ibm" ]]; then
     echo "IBM SecretsManager not yet supported"
@@ -88,7 +94,9 @@ function sm_get_secret(){
     # Get the current value and set it to the provided env var
     # echo "- Getting Secret $SECRET_NAME to set in env var $SECRET_ENV_VAR"
     # export $SECRET_ENV_VAR=$(aws secretsmanager get-secret-value --secret-id ${SECRET_NAME} --output json 2> /dev/null | jq -r .SecretString)
+    set +o pipefail
     aws secretsmanager get-secret-value --secret-id ${SECRET_NAME} --output json 2> /dev/null | jq -r .SecretString
+    set -o pipefail
 
   elif [[ "$AVP_TYPE" == "ibm" ]]; then
     # echo "IBM SecretsManager not yet supported"
@@ -101,7 +109,10 @@ function sm_get_secret_value(){
   SECRET_NAME=$1
   SECRET_KEY=$2
   if [[ "$AVP_TYPE" == "aws" ]]; then
+    set +o pipefail
     aws secretsmanager get-secret-value --secret-id ${SECRET_NAME} --output json 2> /dev/null | jq -r .SecretString | jq -r .${SECRET_KEY}
+    set -o pipefail
+
   elif [[ "$AVP_TYPE" == "ibm" ]]; then
     # echo "IBM SecretsManager not yet supported"
     echo ""
@@ -115,7 +126,9 @@ function sm_get_secret_file(){
   if [[ "$AVP_TYPE" == "aws" ]]; then
     # Get the current value and send it to the file passed in
     echo "- Getting Secret $SECRET_NAME to set in file $SECRET_FILE"
+    set +o pipefail
     aws secretsmanager get-secret-value --secret-id ${SECRET_NAME} --output json 2> /dev/null | jq -r .SecretString > $SECRET_FILE
+    set -o pipefail
 
   elif [[ "$AVP_TYPE" == "ibm" ]]; then
     echo "IBM SecretsManager not yet supported"
@@ -169,7 +182,9 @@ function sm_get_cluster_secret() {
 #   echo "${SECRET_NAME_IBM_ENTITLEMENT} ARN: ${SECRET_ARN_IBM_ENTITLEMENT}"
 function sm_get_secret_arn() {
   local _SECRET_NAME="$1"
+  set +o pipefail
   local _SECRET_ARN=$(aws secretsmanager describe-secret --secret-id "${_SECRET_NAME}" --output json | jq -r .ARN)
+  set -o pipefail
 
   # can't check RC of the call inside $(), so we'll have to make do with checking for empty output instead
    if [ -z "${_SECRET_ARN}" ]; then

--- a/tekton/src/tasks/gitops/gitops-suite-objectstorage-config.yml.j2
+++ b/tekton/src/tasks/gitops/gitops-suite-objectstorage-config.yml.j2
@@ -59,7 +59,6 @@ spec:
   steps:
     - args:
       - |-
-        set -e -o pipefail
 
         mkdir -p /tmp/init-suite-objectstorage-config
         mkdir -p /tmp/suite-objectstorage-config-dir


### PR DESCRIPTION
A number of calls in the gitops functions failed when the `set -o pipefail` was added. These were all around the calls to the aws secretsmanager as the aws cli calls are not expected to get the secret each time. It is valid for the secret to not exist but the aws cli will return a 254 anyway. Turning off the -o pipefail aroiund these calls allows them to work and the caller can check the response.

Also removed an invalid call for licensefile that wasn't actually needed. Tested the functions in the pipeline