### PR TITLE
[patch] Set ignore_failure = true in waitfor-installation

### DIFF
--- a/rbac/install/README.md
+++ b/rbac/install/README.md
@@ -22,6 +22,33 @@ If using these minimal permissions then the `pipelines` service account must hav
 ```bash
 export MAS_INSTANCE_ID=dev1
 
+oc new-project eck
+oc new-project grafana5
+oc new-project ibm-common-services
+oc new-project redhat-marketplace
+
 oc apply -f pipeline/serviceaccount.yaml -n mas-${MAS_INSTANCE_ID}-pipelines
 
+oc apply -f pipeline/cluster.yaml
+
+oc apply -f pipeline/eck.yaml
+oc apply -f pipeline/grafana5.yaml
+oc apply -f pipeline/ibm-common-services.yaml
+oc apply -f pipeline/openshift-config.yaml
+oc apply -f pipeline/openshift-ingress-operator.yaml
+oc apply -f pipeline/openshift-ingress.yaml
+oc apply -f pipeline/openshift-marketplace.yaml
+oc apply -f pipeline/openshift-monitoring.yaml
+oc apply -f pipeline/openshift-operators.yaml
+oc apply -f pipeline/openshift-user-workload-monitoring.yaml
+oc apply -f pipeline/redhat-marketplace.yaml
+```
+
+Note that to use these you will need to modify `subjects[0].namespace` in each of the bindings.
+
+
+## Useful Commands
+To get the service account token
+```bash
+oc -n kube-system describe secret $(oc -n kube-system get secret | grep masinstall-sa | awk '{print $1}')
 ```

--- a/rbac/install/pipeline/cluster.yaml
+++ b/rbac/install/pipeline/cluster.yaml
@@ -1,0 +1,129 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: masinstall-pipeline-clusterrole
+rules:
+  # ocp_verify will lookup the clusterversion to determine health of the cluster, and obtain the cluster ingres cert from the proxy/ingress
+  - apiGroups:
+      - config.openshift.io
+    resources:
+      - clusterversions
+      - proxies
+      - ingresses
+    verbs:
+      - get
+  # ocp_verify will query all installed catalogsources, and subscriptions
+  - apiGroups:
+      - operators.coreos.com
+    resources:
+      - catalogsources
+      - subscriptions
+    verbs:
+      - get
+      - list
+  # ocp_verify will query all deployments and statefulsets to check health of the cluster
+  - apiGroups:
+      - apps
+    resources:
+      - deployments
+      - statefulsets
+    verbs:
+      - get
+      - list
+  # Used to detect whether the install is a disconnected install in various places
+  - apiGroups:
+      - operator.openshift.io
+    resources:
+      - imagecontentsourcepolicies
+    verbs:
+      - get
+  # Monitor the progress of operator installations
+  - apiGroups:
+      - apiextensions.k8s.io
+    resources:
+      - customresourcedefinitions
+    verbs:
+      - get
+  # Creation of RBAC (e.g. for Grafana)
+  - apiGroups:
+      - rbac.authorization.k8s.io
+    resources:
+      - clusterroles
+      - clusterrolebindings
+      - roles
+      - rolebindings
+    verbs:
+      - get
+      - create
+      - patch
+  # DRO install will search all namespaces for a BASCfg
+  - apiGroups:
+      - config.mas.ibm.com
+    resources:
+      - bascfgs
+    verbs:
+      - list
+  # DRO install will attempt to get the IBM entitlement key from any namespace where it finds a BASCfg
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - get
+
+  # We need all the same permissions that the Grafana ClusterRole needs, to be able to create that ClusterRole
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - delete
+      - update
+      - patch
+  - apiGroups:
+      - integreatly.org
+    resources:
+      - grafanadashboards
+      - grafanadatasources
+      - grafanadatasources/status
+    verbs:
+      - get
+      - list
+      - create
+      - update
+      - delete
+      - deletecollection
+      - watch
+  - apiGroups:
+      - grafana.integreatly.org
+    resources:
+      - grafanadashboards
+      - grafanadatasources
+      - grafanadatasources/status
+    verbs:
+      - get
+      - list
+      - create
+      - update
+      - delete
+      - deletecollection
+      - watch
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: masinstall-pipeline-crb
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: masinstall-pipeline-clusterrole
+subjects:
+  - kind: ServiceAccount
+    name: pipeline
+    namespace: mas-djptest-pipelines

--- a/rbac/install/pipeline/eck.yaml
+++ b/rbac/install/pipeline/eck.yaml
@@ -1,0 +1,39 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: masinstall-pipeline-role
+  namespace: eck
+rules:
+  # User workload monitoring will be enabled during the install of Grafana (enableUserWorkload)
+  - apiGroups:
+      - ""
+    resources:
+      - namespaces
+    verbs:
+      - get
+      - patch
+  # Work with the ECK resources
+  - apiGroups:
+      - elasticsearch.k8s.elastic.co
+    resources:
+      - elasticsearches
+    verbs:
+      - get
+      - list
+      - patch
+      - create
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: masinstall-pipeline-rb
+  namespace: eck
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: masinstall-pipeline-role
+subjects:
+  - kind: ServiceAccount
+    name: pipeline
+    namespace: mas-djptest-pipelines

--- a/rbac/install/pipeline/grafana5.yaml
+++ b/rbac/install/pipeline/grafana5.yaml
@@ -1,0 +1,50 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: masinstall-pipeline-role
+  namespace: grafana5
+rules:
+  # Grafana subscripton will be created in this namespace
+  # Detect presence of existing operator group before creating a new one
+  - apiGroups:
+      - ""
+    resources:
+      - namespaces
+    verbs:
+      - get
+      - patch
+  - apiGroups:
+      - operators.coreos.com
+    resources:
+      - installplans
+      - operatorgroups
+      - subscriptions
+    verbs:
+      - get
+      - list
+      - create
+      - patch
+  # Create the Grafana instance
+  - apiGroups:
+      - grafana.integreatly.org
+    resources:
+      - grafanas
+    verbs:
+      - get
+      - create
+      - patch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: masinstall-pipeline-rb
+  namespace: grafana5
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: masinstall-pipeline-role
+subjects:
+  - kind: ServiceAccount
+    name: pipeline
+    namespace: mas-djptest-pipelines

--- a/rbac/install/pipeline/ibm-common-services.yaml
+++ b/rbac/install/pipeline/ibm-common-services.yaml
@@ -1,0 +1,64 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: masinstall-pipeline-role
+  namespace: ibm-common-services
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - namespaces
+    verbs:
+      - get
+      - patch
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+      - configmaps
+    verbs:
+      - get
+  # Detect presence of existing operator group before creating a new one
+  - apiGroups:
+      - operators.coreos.com
+    resources:
+      - installplans
+      - subscriptions
+      - operatorgroups
+    verbs:
+      - get
+      - list
+      - create
+      - patch
+  # Pipeline will query available packages
+  - apiGroups:
+      - packages.operators.coreos.com
+    resources:
+      - packagemanifests
+    verbs:
+      - get
+  # IBM ODLM
+  - apiGroups:
+      - operator.ibm.com
+    resources:
+      - operandrequests
+    verbs:
+      - get
+      - list
+      - create
+      - patch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: masinstall-pipeline-rb
+  namespace: ibm-common-services
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: masinstall-pipeline-role
+subjects:
+  - kind: ServiceAccount
+    name: pipeline
+    namespace: mas-djptest-pipelines

--- a/rbac/install/pipeline/openshift-config.yaml
+++ b/rbac/install/pipeline/openshift-config.yaml
@@ -1,0 +1,28 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: masinstall-pipeline-role
+  namespace: openshift-config
+rules:
+  # MAS install will create subscription for OpenShift Pipelines Operator
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+    verbs:
+      - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: masinstall-pipeline-rb
+  namespace: openshift-config
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: masinstall-pipeline-role
+subjects:
+  - kind: ServiceAccount
+    name: pipeline
+    namespace: mas-djptest-pipelines

--- a/rbac/install/pipeline/openshift-ingress-operator.yaml
+++ b/rbac/install/pipeline/openshift-ingress-operator.yaml
@@ -1,0 +1,28 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: masinstall-pipeline-role
+  namespace: openshift-ingress-operator
+rules:
+  # Required to lookup the default ingress TLS certificate
+  - apiGroups:
+      - operator.openshift.io
+    resources:
+      - ingresscontrollers
+    verbs:
+      - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: masinstall-pipeline-rb
+  namespace: openshift-ingress-operator
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: masinstall-pipeline-role
+subjects:
+  - kind: ServiceAccount
+    name: pipeline
+    namespace: mas-djptest-pipelines

--- a/rbac/install/pipeline/openshift-ingress.yaml
+++ b/rbac/install/pipeline/openshift-ingress.yaml
@@ -1,0 +1,28 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: masinstall-pipeline-role
+  namespace: openshift-ingress
+rules:
+  # Required to lookup the default ingress TLS certificate
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: masinstall-pipeline-rb
+  namespace: openshift-ingress
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: masinstall-pipeline-role
+subjects:
+  - kind: ServiceAccount
+    name: pipeline
+    namespace: mas-djptest-pipelines

--- a/rbac/install/pipeline/openshift-marketplace.yaml
+++ b/rbac/install/pipeline/openshift-marketplace.yaml
@@ -1,0 +1,37 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: masinstall-pipeline-role
+  namespace: openshift-marketplace
+rules:
+  # Pipeline will get and create catalog sources
+  - apiGroups:
+      - operators.coreos.com
+    resources:
+      - catalogsources
+    verbs:
+      - get
+      - create
+      - patch
+  # Pipeline will query available packages
+  - apiGroups:
+      - packages.operators.coreos.com
+    resources:
+      - packagemanifests
+    verbs:
+      - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: masinstall-pipeline-rb
+  namespace: openshift-marketplace
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: masinstall-pipeline-role
+subjects:
+  - kind: ServiceAccount
+    name: pipeline
+    namespace: mas-djptest-pipelines

--- a/rbac/install/pipeline/openshift-monitoring.yaml
+++ b/rbac/install/pipeline/openshift-monitoring.yaml
@@ -1,0 +1,38 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: masinstall-pipeline-role
+  namespace: openshift-monitoring
+rules:
+  # User workload monitoring will be enabled during the install of Grafana (enableUserWorkload)
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+    verbs:
+      - get
+      - create
+      - patch
+  # When setting up grafana we need to lookup the thanos-querier route
+  - apiGroups:
+      - route.openshift.io
+    resources:
+      - routes
+    verbs:
+      - get
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: masinstall-pipeline-rb
+  namespace: openshift-monitoring
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: masinstall-pipeline-role
+subjects:
+  - kind: ServiceAccount
+    name: pipeline
+    namespace: mas-djptest-pipelines

--- a/rbac/install/pipeline/openshift-operators.yaml
+++ b/rbac/install/pipeline/openshift-operators.yaml
@@ -1,0 +1,29 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: masinstall-pipeline-role
+  namespace: openshift-operators
+rules:
+  # The ECK operator subscription is created in openshift-operators
+  - apiGroups:
+      - operators.coreos.com
+    resources:
+      - subscriptions
+    verbs:
+      - get
+      - create
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: masinstall-pipeline-rb
+  namespace: openshift-operators
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: masinstall-pipeline-role
+subjects:
+  - kind: ServiceAccount
+    name: pipeline
+    namespace: mas-djptest-pipelines

--- a/rbac/install/pipeline/openshift-user-workload-monitoring.yaml
+++ b/rbac/install/pipeline/openshift-user-workload-monitoring.yaml
@@ -1,0 +1,29 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: masinstall-pipeline-role
+  namespace: openshift-user-workload-monitoring
+rules:
+  # Used to obtain the user workload monitoring token (for grafana install)
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - get
+      - list
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: masinstall-pipeline-rb
+  namespace: openshift-user-workload-monitoring
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: masinstall-pipeline-role
+subjects:
+  - kind: ServiceAccount
+    name: pipeline
+    namespace: mas-djptest-pipelines

--- a/rbac/install/pipeline/redhat-marketplace.yaml
+++ b/rbac/install/pipeline/redhat-marketplace.yaml
@@ -1,0 +1,46 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: masinstall-pipeline-role
+  namespace: redhat-marketplace
+rules:
+  # DRO installs in this namespace (for some reason)
+  - apiGroups:
+      - ""
+    resources:
+      - namespaces
+    verbs:
+      - get
+      - patch
+  - apiGroups:
+      - operators.coreos.com
+    resources:
+      - installplans
+      - operatorgroups
+      - subscriptions
+    verbs:
+      - get
+      - list
+      - create
+      - patch
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: masinstall-pipeline-rb
+  namespace: redhat-marketplace
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: masinstall-pipeline-role
+subjects:
+  - kind: ServiceAccount
+    name: pipeline
+    namespace: mas-djptest-pipelines

--- a/rbac/install/user/mas-x-pipelines.yaml
+++ b/rbac/install/user/mas-x-pipelines.yaml
@@ -22,6 +22,17 @@ rules:
       - get
       - create
       - delete
+  # MAS install creates Pipelines, Tasks, and PipelineRuns
+  - apiGroups:
+      - tekton.dev
+    resources:
+      - pipelines
+      - pipelineruns
+      - tasks
+    verbs:
+      - get
+      - create
+
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/tekton/src/pipelines/fvt-launcher.yml.j2
+++ b/tekton/src/pipelines/fvt-launcher.yml.j2
@@ -892,7 +892,7 @@ spec:
     # same time install's post-verify starts. It means its timeout must be higher than
     # post-verify + sync-install, which will set the flag needed to finalize this fvt-launcher
     # - Escape Route: INSTALL_STATUS != "" (i.e. FAILED)
-    # - Ignore Failures: False
+    # - Ignore Failures: True
     # -------------------------------------------------------------------------
     - name: waitfor-installation
       timeout: "0"
@@ -921,7 +921,7 @@ spec:
         - name: max_retries
           value: "25"
         - name: ignore_failure
-          value: "False"
+          value: "True"
       when:
         - input: $(params.sync_with_install)
           operator: in


### PR DESCRIPTION
Prevent the FVT Launcher pipeline from failing to run it's cleanup when there are install problems in the build under test.