### PR TITLE
[patch] Fix reset of mas_appws_components to default

### DIFF
--- a/python/src/mas/cli/displayMixins.py
+++ b/python/src/mas/cli/displayMixins.py
@@ -108,7 +108,9 @@ class PromptMixin():
         # List indices are 0 origin, so we need to subtract 1 from the selection made to arrive at the correct value
         self.setParam(param, options[selection-1])
 
-    def promptForFile(self, message: str, mustExist: bool=True, default: str="") -> None:
+    def promptForFile(self, message: str, mustExist: bool=True, default: str="", envVar: str="") -> None:
+        if default == "" and envVar != "":
+            default = getenv(envVar, "")
         if mustExist:
             return prompt(masPromptValue(message), validator=FileExistsValidator(), validate_while_typing=False, default=default)
         else:

--- a/python/src/mas/cli/install/app.py
+++ b/python/src/mas/cli/install/app.py
@@ -150,7 +150,7 @@ class InstallApp(BaseApp, InstallSettingsMixin, InstallSummarizerMixin, ConfigGe
 
     def configSLS(self) -> None:
         self.printH1("Configure Product License")
-        self.slsLicenseFileLocal = self.promptForFile("License file", mustExist=True)
+        self.slsLicenseFileLocal = self.promptForFile("License file", mustExist=True, envVar="SLS_LICENSE_FILE_LOCAL")
         self.promptForString("Contact e-mail address", "uds_contact_email")
         self.promptForString("Contact first name", "uds_contact_firstname")
         self.promptForString("Contact last name", "uds_contact_lastname")

--- a/python/src/mas/cli/install/settings/manageSettings.py
+++ b/python/src/mas/cli/install/settings/manageSettings.py
@@ -8,6 +8,9 @@
 #
 # *****************************************************************************
 
+import logging
+logger = logging.getLogger(__name__)
+
 class ManageSettingsMixin():
 
     def arcgisSettings(self) -> None:
@@ -82,6 +85,7 @@ class ManageSettingsMixin():
             if self.yesOrNo(" - Tririga"): self.params["mas_appws_components"] += ",tririga=latest"
             if self.yesOrNo(" - Utilities"): self.params["mas_appws_components"] += ",utilities=latest"
             if self.yesOrNo(" - Workday Applications"): self.params["mas_appws_components"] += ",workday=latest"
+            logger.debug(f"Generated mas_appws_components = {self.params['mas_appws_components']}")
 
             if ",icd=" in self.params["mas_appws_components"]:
                 self.printH2("Maximo IT License Terms")
@@ -97,7 +101,6 @@ class ManageSettingsMixin():
         self.printH2("Maximo Manage Settings - Database")
         self.printDescription(["Customise the schema, tablespace, indexspace, and encryption settings used by Manage"])
 
-        self.params["mas_appws_components"] = "base=latest,health=latest"
         if self.yesOrNo("Customize database settings"):
             self.promptForString("Schema", "mas_app_settings_db2_schema", default="maximo")
             self.promptForString("Tablespace", "mas_app_settings_db2_tablespace", default="MAXDATA")


### PR DESCRIPTION
Investigation showed a rogue reset of the users choice for mas_appws_components  being performed by `manageSettingsDatabase()` ... this has been removed in addition to some extra debug logging and restoring support for the `SLS_LICENSE_FILE_LOCAL` environment variable (which is unrelated to this problem, but something wanted to fix for a while)

- #1139