### PR TITLE
[patch] Fix rogue output in catalog validation

### DIFF
--- a/python/src/mas/cli/install/app.py
+++ b/python/src/mas/cli/install/app.py
@@ -59,7 +59,6 @@ class InstallApp(BaseApp, InstallSettingsMixin, InstallSummarizerMixin, ConfigGe
             catalogDisplayName = catalog.spec.displayName
 
             m = re.match(r".+(?P<catalogId>v[89]-(?P<catalogVersion>[0-9]+)-amd64)", catalogDisplayName)
-            print(f"m: {m}")
             if m:
                 # catalogId = v8-yymmdd-amd64
                 # catalogVersion = yymmdd


### PR DESCRIPTION
Removes the rogue output seen here: `m: <re.Match object; span=(0, 37), match='IBM Maximo Operators (v9-240625-amd64'>`

![image](https://github.com/user-attachments/assets/5066adfb-75dd-4e0d-9dfc-49ff5c75d04a)
