### PR TITLE
[patch] Fix COS deprovision action name

### DIFF
--- a/tekton/src/tasks/fvt/fvt-deprovision-cos.yml.j2
+++ b/tekton/src/tasks/fvt/fvt-deprovision-cos.yml.j2
@@ -32,7 +32,7 @@ spec:
               optional: true
 
         - name: COS_ACTION
-          value: "uninstall"
+          value: "deprovision"
 
         # COS Details
         - name: IBMCLOUD_APIKEY


### PR DESCRIPTION
The FVT COS Deprovision task is setting `cos_action=uninstall`, but it needs to be set to `deprovision`.