### PR TITLE
[patch] Add optional --db2-timezone parameter

### DIFF
--- a/image/cli/mascli/functions/gitops_db2u_database
+++ b/image/cli/mascli/functions/gitops_db2u_database
@@ -308,6 +308,7 @@ function gitops_db2u_database_noninteractive() {
   [[ -z "$SM_AWS_ACCESS_KEY_ID" ]] &&  gitops_db2u_database_help "SM_AWS_ACCESS_KEY_ID is not set"
   [[ -z "$SM_AWS_SECRET_ACCESS_KEY" ]] && gitops_db2u_database_help "SM_AWS_SECRET_ACCESS_KEY is not set"
   [[ -z "$SM_AWS_REGION" ]] && gitops_db2u_database_help "SM_AWS_REGION is not set"
+  [[ -z "$SECRETS_PATH" ]] && gitops_db2u_database_help "SECRETS_PATH is not set"
 
   [[ -z "$GITOPS_WORKING_DIR" ]] && gitops_db2u_database_help "GITOPS_WORKING_DIR is not set"
   [[ -z "$ACCOUNT_ID" ]] && gitops_db2u_database_help "ACCOUNT_ID is not set"
@@ -315,14 +316,14 @@ function gitops_db2u_database_noninteractive() {
   [[ -z "$CLUSTER_ID" ]] && gitops_db2u_database_help "CLUSTER_ID is not set"
   
   #db2u
-  [[ -z "$DB2_VERSION" ]] && gitops_db2u_help "DB2_VERSION is not set"
-  [[ -z "$DB2_META_STORAGE_CLASS" ]] && gitops_db2u_help "DB2_META_STORAGE_CLASS is not set"
-  [[ -z "$DB2_DATA_STORAGE_CLASS" ]] && gitops_db2u_help "DB2_DATA_STORAGE_CLASS is not set"
-  [[ -z "$DB2_BACKUP_STORAGE_CLASS" ]] && gitops_db2u_help "DB2_BACKUP_STORAGE_CLASS is not set"
-  [[ -z "$DB2_ARCHIVELOGS_STORAGE_CLASS" ]] && gitops_db2u_help "DB2_ARCHIVELOGS_STORAGE_CLASS is not set"
-  [[ -z "$DB2_LOGS_STORAGE_CLASS" ]] && gitops_db2u_help "DB2_LOGS_STORAGE_CLASS is not set"
-  [[ -z "$MAS_INSTANCE_ID" ]] && gitops_db2u_help "MAS_INSTANCE_ID is not set"
-  [[ -z "$MAS_APP_ID" ]] && gitops_db2u_help "MAS_APP_ID is not set"
+  [[ -z "$DB2_VERSION" ]] && gitops_db2u_database_help "DB2_VERSION is not set"
+  [[ -z "$DB2_META_STORAGE_CLASS" ]] && gitops_db2u_database_help "DB2_META_STORAGE_CLASS is not set"
+  [[ -z "$DB2_DATA_STORAGE_CLASS" ]] && gitops_db2u_database_help "DB2_DATA_STORAGE_CLASS is not set"
+  [[ -z "$DB2_BACKUP_STORAGE_CLASS" ]] && gitops_db2u_database_help "DB2_BACKUP_STORAGE_CLASS is not set"
+  [[ -z "$DB2_ARCHIVELOGS_STORAGE_CLASS" ]] && gitops_db2u_database_help "DB2_ARCHIVELOGS_STORAGE_CLASS is not set"
+  [[ -z "$DB2_LOGS_STORAGE_CLASS" ]] && gitops_db2u_database_help "DB2_LOGS_STORAGE_CLASS is not set"
+  [[ -z "$MAS_INSTANCE_ID" ]] && gitops_db2u_database_help "MAS_INSTANCE_ID is not set"
+  [[ -z "$MAS_APP_ID" ]] && gitops_db2u_database_help "MAS_APP_ID is not set"
   
   #MAS
   [[ -z "$MAS_INSTANCE_ID" ]] && gitops_db2u_database_help "MAS_INSTANCE_ID is not set"

--- a/image/cli/mascli/functions/gitops_db2u_database
+++ b/image/cli/mascli/functions/gitops_db2u_database
@@ -58,6 +58,7 @@ IBM DB2U:
       --db2-instance-dbm-config-yaml ${COLOR_YELLOW}DB2_INSTANCE_DBM_CONFIG_YAML${TEXT_RESET}                 Yaml file containing the db2ucluster instance dbm config section.
       --db2-database-db-config-yaml ${COLOR_YELLOW}DB2_DATABASE_DB_CONFIG_YAML${TEXT_RESET}                   Yaml file containing the db2ucluster database db config section.
       --db2-addons-audit-config-yaml ${COLOR_YELLOW}DB2_ADDONS_AUDIT_CONFIG_YAML${TEXT_RESET}                 Yaml file containing the db2ucluster addons audit config section.
+      --db2-timezone ${COLOR_YELLOW}DB2_TIMEZONE${TEXT_RESET}                                                 DB2 DB Timezone (optional, DB2 default of "UTC" will be used if not specified)
 
 Secrets Manager:
       --secrets-path ${COLOR_YELLOW}SECRETS_PATH${TEXT_RESET}                     Secrets Manager path
@@ -263,6 +264,10 @@ function gitops_db2u_database_noninteractive() {
       --db2-tolerate-effect)
         export DB2_TOLERATE_EFFECT=$1 && shift
         ;;
+      --db2-timezone)
+        export DB2_TIMEZONE=$1 && shift
+        ;;
+
 
       # Automatic GitHub Push
       -P|--github-push)
@@ -534,6 +539,7 @@ DB2_WORKLOAD: '${DB2_WORKLOAD}'"
   echo_reset_dim "db2-tolerate-key .............................. ${COLOR_MAGENTA}${DB2_TOLERATE_KEY}"
   echo_reset_dim "db2-tolerate-value ............................ ${COLOR_MAGENTA}${DB2_TOLERATE_VALUE}"
   echo_reset_dim "db2-tolerate-effect ........................... ${COLOR_MAGENTA}${DB2_TOLERATE_EFFECT}"
+  echo_reset_dim "db2-timezone .................................. ${COLOR_MAGENTA}${DB2_TIMEZONE}"
   reset_colors
 
   AVP_TYPE=aws  # Support for IBM will be added later

--- a/image/cli/mascli/templates/gitops/appset-configs/cluster/instance/db2-databases/ibm-db2u-database.yaml.j2
+++ b/image/cli/mascli/templates/gitops/appset-configs/cluster/instance/db2-databases/ibm-db2u-database.yaml.j2
@@ -60,4 +60,4 @@ db2_tolerate_value: {{DB2_TOLERATE_VALUE}}
 db2_tolerate_effect: {{DB2_TOLERATE_EFFECT}}
 cluster_domain: <path:{{ SECRETS_PATH }}:{{ SECRET_KEY_CLUSTER_DOMAIN }}>
 mas_application_id: {{MAS_APP_ID}}
-
+db2_timezone: {{DB2_TIMEZONE}}

--- a/tekton/src/pipelines/gitops/gitops-mas-apps.yml.j2
+++ b/tekton/src/pipelines/gitops/gitops-mas-apps.yml.j2
@@ -200,6 +200,9 @@ spec:
     - name: db2_tolerate_effect
       type: string
       default: ""
+    - name: db2_timezone
+      type: string
+      default: ""
 
     - name: custom_labels
       type: string
@@ -573,6 +576,8 @@ spec:
           value: $(params.db2_tolerate_value)
         - name: db2_tolerate_effect
           value: $(params.db2_tolerate_effect)
+        - name: db2_timezone
+          value: $(params.db2_timezone)
 
       workspaces:
         - name: configs
@@ -728,6 +733,8 @@ spec:
           value: $(params.db2_tolerate_value)
         - name: db2_tolerate_effect
           value: $(params.db2_tolerate_effect)
+        - name: db2_timezone
+          value: $(params.db2_timezone)
         
       workspaces:
         - name: configs

--- a/tekton/src/tasks/gitops/gitops-db2u-database.yml.j2
+++ b/tekton/src/tasks/gitops/gitops-db2u-database.yml.j2
@@ -100,6 +100,8 @@ spec:
       type: string
     - name: db2_tolerate_effect
       type: string
+    - name: db2_timezone
+      type: string
     - name: mas_instance_id
       type: string
     - name: mas_app_id
@@ -203,6 +205,8 @@ spec:
         value: $(params.db2_tolerate_value)
       - name: DB2_TOLERATE_EFFECT
         value: $(params.db2_tolerate_effect)
+      - name: DB2_TIMEZONE
+        value: $(params.db2_timezone)
       - name: MAS_APP_ID
         value: $(params.mas_app_id)
     envFrom:


### PR DESCRIPTION
https://jsw.ibm.com/browse/MASCORE-3382

gitops_db2u_database function and tekton changes verified in this run of [gitops-mas-apps](https://cloud.ibm.com/devops/pipelines/tekton/8bb11078-2a03-43b2-9d30-df3ea17af143/runs/c32f86f1-62ae-4921-be9e-4b5e17217b33/gitops-db2u-database-manage/gitops-db2u-database?env_id=ibm:yp:us-south)

### Associated PRs:
https://github.com/ibm-mas/gitops/pull/179
https://github.ibm.com/maximoappsuite/saas-tekton/pull/55
https://github.ibm.com/maximoappsuite/saas-deploy-py/pull/70
https://github.ibm.com/maximoappsuite/saas-envs/pull/144