### PR TITLE
[patch] Restore support for --skip-grafana-install

### DIFF
--- a/docs/commands/install.md
+++ b/docs/commands/install.md
@@ -247,6 +247,7 @@ More:
   --dev-mode                                      Configure installation for development mode
   --no-wait-for-pvc                               Disable the wait for pipeline PVC to bind before starting the pipeline
   --skip-pre-check                                Disable the 'pre-install-check' at the start of the install pipeline
+  --skip-grafana-install                          Skips Grafana install action
   --no-confirm                                    Launch the upgrade without prompting for confirmation
   -h, --help                                      Show this help message and exit
 ```

--- a/docs/commands/install.md
+++ b/docs/commands/install.md
@@ -45,7 +45,7 @@ usage: mas install [-c MAS_CATALOG_VERSION] [--ibm-entitlement-key IBM_ENTITLEME
                    [--artifactory-username ARTIFACTORY_USERNAME] [--artifactory-token ARTIFACTORY_TOKEN] [--approval-core APPROVAL_CORE]
                    [--approval-assist APPROVAL_ASSIST] [--approval-iot APPROVAL_IOT] [--approval-manage APPROVAL_MANAGE] [--approval-monitor APPROVAL_MONITOR]
                    [--approval-optimizer APPROVAL_OPTIMIZER] [--approval-predict APPROVAL_PREDICT] [--approval-visualinspection APPROVAL_VISUALINSPECTION]
-                   [--accept-license] [--dev-mode] [--no-wait-for-pvc] [--skip-pre-check] [--no-confirm] [-h]
+                   [--accept-license] [--dev-mode] [--no-wait-for-pvc] [--skip-pre-check] [--skip-grafana-install] [--no-confirm] [-h]
 
 IBM Maximo Application Suite Admin CLI v100.0.0
 Install MAS by configuring and launching the MAS Uninstall Tekton Pipeline.

--- a/python/src/mas/cli/install/app.py
+++ b/python/src/mas/cli/install/app.py
@@ -165,7 +165,10 @@ class InstallApp(BaseApp, InstallSettingsMixin, InstallSummarizerMixin, ConfigGe
         try:
             packagemanifestAPI = self.dynamicClient.resources.get(api_version="packages.operators.coreos.com/v1", kind="PackageManifest")
             packagemanifestAPI.get(name="grafana-operator", namespace="openshift-marketplace")
-            self.setParam("grafana_action", "install")
+            if self.skipGrafanaInstall:
+                self.setParam("grafana_action", "none")
+            else:
+                self.setParam("grafana_action", "install")
         except NotFoundError:
             self.setParam("grafana_action", "none")
 
@@ -842,7 +845,7 @@ class InstallApp(BaseApp, InstallSettingsMixin, InstallSummarizerMixin, ConfigGe
                             self.fatalError(f"Unsupported format for {key} ({value}).  Expected string:int:int:boolean")
 
             # Arguments that we don't need to do anything with
-            elif key in ["accept_license", "dev_mode", "skip_pre_check", "no_confirm", "no_wait_for_pvc", "help"]:
+            elif key in ["accept_license", "dev_mode", "skip_pre_check", "skip_grafana_install", "no_confirm", "no_wait_for_pvc", "help"]:
                 pass
 
             elif key == "manual_certificates":
@@ -886,6 +889,8 @@ class InstallApp(BaseApp, InstallSettingsMixin, InstallSummarizerMixin, ConfigGe
         # These flags work for setting params in both interactive and non-interactive modes
         if args.skip_pre_check:
             self.setParam("skip_pre_check", "true")
+        if args.skip_grafana_install:
+            self.skipGrafanaInstall = True
 
         self.installOptions = [
             {

--- a/python/src/mas/cli/install/argParser.py
+++ b/python/src/mas/cli/install/argParser.py
@@ -844,6 +844,12 @@ otherArgGroup.add_argument(
     help="Disable the 'pre-install-check' at the start of the install pipeline"
 )
 otherArgGroup.add_argument(
+    "--skip-grafana-install",
+    required=False,
+    action="store_true",
+    help="Skips Grafana install action"
+)
+otherArgGroup.add_argument(
     "--no-confirm",
     required=False,
     action="store_true",

--- a/python/src/mas/cli/install/summarizer.py
+++ b/python/src/mas/cli/install/summarizer.py
@@ -32,6 +32,7 @@ class InstallSummarizerMixin():
             self.printSummary("Single Node OpenShift", "No")
 
         self.printSummary("Skip Pre-Install Healthcheck", "Yes" if self.getParam('skip_pre_check') == "true" else "No")
+        self.printSummary("Skip Grafana-Install", "Yes" if self.getParam('grafana_action') == "none" else "No")
 
     def icrSummary(self) -> None:
         self.printH2("IBM Container Registry Credentials")


### PR DESCRIPTION
## Description:
Add `--skip-grafana-install` parameter to support disable install grafana

## Issue:
https://jsw.ibm.com/browse/MASCORE-3481

## Test:
```
20.8) Grafana
  Install Grafana ......................... Do Not Install
```