### PR TITLE
[patch] Fix --skip-grafana-install flag & ICD image mirroring

### DIFF
--- a/image/cli/mascli/functions/mirror_images
+++ b/image/cli/mascli/functions/mirror_images
@@ -532,7 +532,7 @@ function mirror_to_registry() {
   export MIRROR_SPARK
   export MIRROR_COGNOS
   export MIRROR_APPCONNECT
-  export MIRROR_MAS_IC
+  export MIRROR_MAS_ICD
   export MIRROR_EVERYTHING
 
   # Authentication

--- a/python/src/mas/cli/install/app.py
+++ b/python/src/mas/cli/install/app.py
@@ -880,6 +880,7 @@ class InstallApp(BaseApp, InstallSettingsMixin, InstallSummarizerMixin, ConfigGe
         self.waitForPVC = not args.no_wait_for_pvc
         self.licenseAccepted = args.accept_license
         self.devMode = args.dev_mode
+        self.skipGrafanaInstall = args.skip_grafana_install
 
         self.approvals = {}
 
@@ -889,9 +890,7 @@ class InstallApp(BaseApp, InstallSettingsMixin, InstallSummarizerMixin, ConfigGe
         # These flags work for setting params in both interactive and non-interactive modes
         if args.skip_pre_check:
             self.setParam("skip_pre_check", "true")
-        if args.skip_grafana_install:
-            self.skipGrafanaInstall = True
-
+        
         self.installOptions = [
             {
                 "#": 1,


### PR DESCRIPTION
## Description:
1. Fix for Initialization failure for skipGrafana
2. mirro-images was not mirroring icd

## Issues:
https://jsw.ibm.com/browse/MASCORE-3552

## Test results:
1. Tested locally with mas install and mas install --skip-grafana
2. Tested with mirroring icd
