### PR TITLE
[patch] Fix change of secret type for COS and Kafka in gitops

### DIFF
--- a/image/cli/mascli/functions/gitops_cos
+++ b/image/cli/mascli/functions/gitops_cos
@@ -169,11 +169,11 @@ function gitops_cos() {
   
   # Extract the required details from the generated coscfg/secret.
   export COS_USERNAME
-  COS_USERNAME=$(yq 'select(di == 0) | .stringData.username' $MAS_CONFIG_DIR/cos-ibm-system.yml)
+  COS_USERNAME=$(yq 'select(di == 0) | .data.username' $MAS_CONFIG_DIR/cos-ibm-system.yml | base64 -d)
   rc=$?
   [ $rc -ne 0 ] && exit $rc
   export COS_PASSWORD
-  COS_PASSWORD=$(yq 'select(di == 0) | .stringData.password' $MAS_CONFIG_DIR/cos-ibm-system.yml)
+  COS_PASSWORD=$(yq 'select(di == 0) | .data.password' $MAS_CONFIG_DIR/cos-ibm-system.yml | base64 -d)
   rc=$?
   [ $rc -ne 0 ] && exit $rc
   yq 'select(di == 1) | .spec' $MAS_CONFIG_DIR/cos-ibm-system.yml >> $TEMP_DIR/cos-info.yaml

--- a/image/cli/mascli/functions/gitops_kafka
+++ b/image/cli/mascli/functions/gitops_kafka
@@ -294,8 +294,8 @@ function gitops_kafka() {
     rc=$?
     [ $rc -ne 0 ] && exit $rc
     # Extract the required details from the generated kafkacfg/secret. For msk this is in plain text (stringData)
-    export KAFKA_USERNAME=$(yq 'select(di == 0) | .stringData.username' $TEMP_DIR/${KAFKACFG_FILE_NAME})
-    export KAFKA_PASSWORD=$(yq 'select(di == 0) | .stringData.password' $TEMP_DIR/${KAFKACFG_FILE_NAME})
+    export KAFKA_USERNAME=$(yq 'select(di == 0) | .data.username' $TEMP_DIR/${KAFKACFG_FILE_NAME} | base64 -d)
+    export KAFKA_PASSWORD=$(yq 'select(di == 0) | .data.password' $TEMP_DIR/${KAFKACFG_FILE_NAME} | base64 -d)
     yq 'select(di == 1) | .spec' $TEMP_DIR/${KAFKACFG_FILE_NAME} >> $TEMP_DIR/kafka-info.yaml
     yq -i 'del(.config.credentials)' $TEMP_DIR/kafka-info.yaml
     yq -i 'del(.displayName)' $TEMP_DIR/kafka-info.yaml


### PR DESCRIPTION
The type of secret created in the config file for COS and Kafka was changed from secretData to data in this PR https://github.com/ibm-mas/ansible-devops/pull/1398 which is breaking the gitops helper functions for cos and kafka as this was trying to read them a .stringData and it is now .data and needs to be decoded.