### PR TITLE
[minor] Add tags to secrets created by gitops functions

### DIFF
--- a/image/cli/mascli/functions/gitops_cluster
+++ b/image/cli/mascli/functions/gitops_cluster
@@ -405,13 +405,13 @@ function gitops_cluster() {
   export IBM_ENTITLEMENT_PULL_SECRET_B64=$(echo -n $IBM_ENTITLEMENT_WITH_ARTIFACTORY | base64 -w 0)
   export IBM_ENTITLEMENT_B64=$(echo -n $ICR_PASSWORD | base64 -w 0)
 
-  TAGS="[{\"Key\" \"source\", \"Value\": \"gitops_cluster\"}, {\"Key\": \"account\", \"Value\": \"${ACCOUNT_ID}\"}, {\"Key\": cluster\", \"Value\": \"${CLUSTER_ID}\"}]"
+  TAGS="[{\"Key\": \"source\", \"Value\": \"gitops_cluster\"}, {\"Key\": \"account\", \"Value\": \"${ACCOUNT_ID}\"}, {\"Key\": \"cluster\", \"Value\": \"${CLUSTER_ID}\"}]"
   sm_update_secret $SECRET_NAME_IBM_ENTITLEMENT "{\"image_pull_secret_b64\": \"${IBM_ENTITLEMENT_PULL_SECRET_B64}\", \"entitlement_key\": \"${IBM_ENTITLEMENT_B64}\"}" "${TAGS}"
 
   if [[ "$CLUSTER_PROMOTION" == "true" ]]; then
     export SECRET_NAME_GITHUB_PAT=${ACCOUNT_ID}${SM_DELIM}${CLUSTER_ID}${SM_DELIM}github_pat
     export SECRET_KEY_GITHUB_PAT=${SECRET_NAME_GITHUB_PAT}#github_pat
-    TAGS="[{\"Key\" \"source\", \"Value\": \"gitops_cluster\"}, {\"Key\": \"account\", \"Value\": \"${ACCOUNT_ID}\"}, {\"Key\": cluster\", \"Value\": \"${CLUSTER_ID}\"}]"
+    TAGS="[{\"Key\": \"source\", \"Value\": \"gitops_cluster\"}, {\"Key\": \"account\", \"Value\": \"${ACCOUNT_ID}\"}, {\"Key\": \"cluster\", \"Value\": \"${CLUSTER_ID}\"}]"
     sm_update_secret $SECRET_NAME_GITHUB_PAT "{\"github_pat\": \"${CLUSTER_PROMOTION_TARGET_GITHUB_PAT}\"}" "${TAGS}"
   fi
 
@@ -421,7 +421,7 @@ function gitops_cluster() {
   echo "- Generate AWS secret"
   # This is used by some of the ArgoCD sync hooks to make updates to AWS SM from within the cluster
   export SECRET_NAME_AWS=${ACCOUNT_ID}${SM_DELIM}${CLUSTER_ID}${SM_DELIM}aws
-  TAGS="[{\"Key\" \"source\", \"Value\": \"gitops_cluster\"}, {\"Key\": \"account\", \"Value\": \"${ACCOUNT_ID}\"}, {\"Key\": cluster\", \"Value\": \"${CLUSTER_ID}\"}]
+  TAGS="[{\"Key\": \"source\", \"Value\": \"gitops_cluster\"}, {\"Key\": \"account\", \"Value\": \"${ACCOUNT_ID}\"}, {\"Key\": \"cluster\", \"Value\": \"${CLUSTER_ID}\"}]
   sm_update_secret $SECRET_NAME_AWS "{\"sm_aws_access_key_id\": \"${SM_AWS_ACCESS_KEY_ID}\", \"sm_aws_secret_access_key\": \"${SM_AWS_SECRET_ACCESS_KEY}\"}" "${TAGS}"
 
 

--- a/image/cli/mascli/functions/gitops_cluster
+++ b/image/cli/mascli/functions/gitops_cluster
@@ -405,13 +405,13 @@ function gitops_cluster() {
   export IBM_ENTITLEMENT_PULL_SECRET_B64=$(echo -n $IBM_ENTITLEMENT_WITH_ARTIFACTORY | base64 -w 0)
   export IBM_ENTITLEMENT_B64=$(echo -n $ICR_PASSWORD | base64 -w 0)
 
-  TAGS="[{Key=source,Value=gitops_cluster}, {Key=account,Value=\"${ACCOUNT_ID}\"}, {Key=cluster,Value=\"${CLUSTER_ID}\"}]"
+  TAGS="[{\"Key\" \"source\", \"Value\": \"gitops_cluster\"}, {\"Key\": \"account\", \"Value\": \"${ACCOUNT_ID}\"}, {\"Key\": cluster\", \"Value\": \"${CLUSTER_ID}\"}]"
   sm_update_secret $SECRET_NAME_IBM_ENTITLEMENT "{\"image_pull_secret_b64\": \"${IBM_ENTITLEMENT_PULL_SECRET_B64}\", \"entitlement_key\": \"${IBM_ENTITLEMENT_B64}\"}" "${TAGS}"
 
   if [[ "$CLUSTER_PROMOTION" == "true" ]]; then
     export SECRET_NAME_GITHUB_PAT=${ACCOUNT_ID}${SM_DELIM}${CLUSTER_ID}${SM_DELIM}github_pat
     export SECRET_KEY_GITHUB_PAT=${SECRET_NAME_GITHUB_PAT}#github_pat
-    TAGS="[{Key=source,Value=gitops_cluster}, {Key=account,Value=\"${ACCOUNT_ID}\"}, {Key=cluster,Value=\"${CLUSTER_ID}\"}]"
+    TAGS="[{\"Key\" \"source\", \"Value\": \"gitops_cluster\"}, {\"Key\": \"account\", \"Value\": \"${ACCOUNT_ID}\"}, {\"Key\": cluster\", \"Value\": \"${CLUSTER_ID}\"}]"
     sm_update_secret $SECRET_NAME_GITHUB_PAT "{\"github_pat\": \"${CLUSTER_PROMOTION_TARGET_GITHUB_PAT}\"}" "${TAGS}"
   fi
 
@@ -421,7 +421,7 @@ function gitops_cluster() {
   echo "- Generate AWS secret"
   # This is used by some of the ArgoCD sync hooks to make updates to AWS SM from within the cluster
   export SECRET_NAME_AWS=${ACCOUNT_ID}${SM_DELIM}${CLUSTER_ID}${SM_DELIM}aws
-  TAGS="[{Key=source,Value=gitops_cluster}, {Key=account,Value=\"${ACCOUNT_ID}\"}, {Key=cluster,Value=\"${CLUSTER_ID}\"}]"
+  TAGS="[{\"Key\" \"source\", \"Value\": \"gitops_cluster\"}, {\"Key\": \"account\", \"Value\": \"${ACCOUNT_ID}\"}, {\"Key\": cluster\", \"Value\": \"${CLUSTER_ID}\"}]
   sm_update_secret $SECRET_NAME_AWS "{\"sm_aws_access_key_id\": \"${SM_AWS_ACCESS_KEY_ID}\", \"sm_aws_secret_access_key\": \"${SM_AWS_SECRET_ACCESS_KEY}\"}" "${TAGS}"
 
 

--- a/image/cli/mascli/functions/gitops_cluster
+++ b/image/cli/mascli/functions/gitops_cluster
@@ -421,7 +421,7 @@ function gitops_cluster() {
   echo "- Generate AWS secret"
   # This is used by some of the ArgoCD sync hooks to make updates to AWS SM from within the cluster
   export SECRET_NAME_AWS=${ACCOUNT_ID}${SM_DELIM}${CLUSTER_ID}${SM_DELIM}aws
-  TAGS="[{\"Key\": \"source\", \"Value\": \"gitops_cluster\"}, {\"Key\": \"account\", \"Value\": \"${ACCOUNT_ID}\"}, {\"Key\": \"cluster\", \"Value\": \"${CLUSTER_ID}\"}]
+  TAGS="[{\"Key\": \"source\", \"Value\": \"gitops_cluster\"}, {\"Key\": \"account\", \"Value\": \"${ACCOUNT_ID}\"}, {\"Key\": \"cluster\", \"Value\": \"${CLUSTER_ID}\"}]"
   sm_update_secret $SECRET_NAME_AWS "{\"sm_aws_access_key_id\": \"${SM_AWS_ACCESS_KEY_ID}\", \"sm_aws_secret_access_key\": \"${SM_AWS_SECRET_ACCESS_KEY}\"}" "${TAGS}"
 
 

--- a/image/cli/mascli/functions/gitops_cluster
+++ b/image/cli/mascli/functions/gitops_cluster
@@ -405,12 +405,14 @@ function gitops_cluster() {
   export IBM_ENTITLEMENT_PULL_SECRET_B64=$(echo -n $IBM_ENTITLEMENT_WITH_ARTIFACTORY | base64 -w 0)
   export IBM_ENTITLEMENT_B64=$(echo -n $ICR_PASSWORD | base64 -w 0)
 
-  sm_update_secret $SECRET_NAME_IBM_ENTITLEMENT "{\"image_pull_secret_b64\": \"${IBM_ENTITLEMENT_PULL_SECRET_B64}\", \"entitlement_key\": \"${IBM_ENTITLEMENT_B64}\"}"
+  TAGS="[{Key=source,Value=gitops_cluster}, {Key=account,Value=\"${ACCOUNT_ID}\", {Key=cluster,Value=\"${CLUSTER_ID}\"}]"
+  sm_update_secret $SECRET_NAME_IBM_ENTITLEMENT "{\"image_pull_secret_b64\": \"${IBM_ENTITLEMENT_PULL_SECRET_B64}\", \"entitlement_key\": \"${IBM_ENTITLEMENT_B64}\"}" "${TAGS}"
 
   if [[ "$CLUSTER_PROMOTION" == "true" ]]; then
     export SECRET_NAME_GITHUB_PAT=${ACCOUNT_ID}${SM_DELIM}${CLUSTER_ID}${SM_DELIM}github_pat
     export SECRET_KEY_GITHUB_PAT=${SECRET_NAME_GITHUB_PAT}#github_pat
-    sm_update_secret $SECRET_NAME_GITHUB_PAT "{\"github_pat\": \"${CLUSTER_PROMOTION_TARGET_GITHUB_PAT}\"}"
+    TAGS="[{Key=source,Value=gitops_cluster}, {Key=account,Value=\"${ACCOUNT_ID}\", {Key=cluster,Value=\"${CLUSTER_ID}\"}]"
+    sm_update_secret $SECRET_NAME_GITHUB_PAT "{\"github_pat\": \"${CLUSTER_PROMOTION_TARGET_GITHUB_PAT}\"}" "${TAGS}"
   fi
 
   rm -rf ${GITOPS_CLUSTER_DIR}/ibm-entitlement-with-artifactory.json
@@ -419,7 +421,8 @@ function gitops_cluster() {
   echo "- Generate AWS secret"
   # This is used by some of the ArgoCD sync hooks to make updates to AWS SM from within the cluster
   export SECRET_NAME_AWS=${ACCOUNT_ID}${SM_DELIM}${CLUSTER_ID}${SM_DELIM}aws
-  sm_update_secret $SECRET_NAME_AWS "{\"sm_aws_access_key_id\": \"${SM_AWS_ACCESS_KEY_ID}\", \"sm_aws_secret_access_key\": \"${SM_AWS_SECRET_ACCESS_KEY}\"}"
+  TAGS="[{Key=source,Value=gitops_cluster}, {Key=account,Value=\"${ACCOUNT_ID}\", {Key=cluster,Value=\"${CLUSTER_ID}\"}]"
+  sm_update_secret $SECRET_NAME_AWS "{\"sm_aws_access_key_id\": \"${SM_AWS_ACCESS_KEY_ID}\", \"sm_aws_secret_access_key\": \"${SM_AWS_SECRET_ACCESS_KEY}\"}" "${TAGS}"
 
 
   # Generate ArgoApps

--- a/image/cli/mascli/functions/gitops_cluster
+++ b/image/cli/mascli/functions/gitops_cluster
@@ -405,13 +405,13 @@ function gitops_cluster() {
   export IBM_ENTITLEMENT_PULL_SECRET_B64=$(echo -n $IBM_ENTITLEMENT_WITH_ARTIFACTORY | base64 -w 0)
   export IBM_ENTITLEMENT_B64=$(echo -n $ICR_PASSWORD | base64 -w 0)
 
-  TAGS="[{Key=source,Value=gitops_cluster}, {Key=account,Value=\"${ACCOUNT_ID}\", {Key=cluster,Value=\"${CLUSTER_ID}\"}]"
+  TAGS="[{Key=source,Value=gitops_cluster}, {Key=account,Value=\"${ACCOUNT_ID}\"}, {Key=cluster,Value=\"${CLUSTER_ID}\"}]"
   sm_update_secret $SECRET_NAME_IBM_ENTITLEMENT "{\"image_pull_secret_b64\": \"${IBM_ENTITLEMENT_PULL_SECRET_B64}\", \"entitlement_key\": \"${IBM_ENTITLEMENT_B64}\"}" "${TAGS}"
 
   if [[ "$CLUSTER_PROMOTION" == "true" ]]; then
     export SECRET_NAME_GITHUB_PAT=${ACCOUNT_ID}${SM_DELIM}${CLUSTER_ID}${SM_DELIM}github_pat
     export SECRET_KEY_GITHUB_PAT=${SECRET_NAME_GITHUB_PAT}#github_pat
-    TAGS="[{Key=source,Value=gitops_cluster}, {Key=account,Value=\"${ACCOUNT_ID}\", {Key=cluster,Value=\"${CLUSTER_ID}\"}]"
+    TAGS="[{Key=source,Value=gitops_cluster}, {Key=account,Value=\"${ACCOUNT_ID}\"}, {Key=cluster,Value=\"${CLUSTER_ID}\"}]"
     sm_update_secret $SECRET_NAME_GITHUB_PAT "{\"github_pat\": \"${CLUSTER_PROMOTION_TARGET_GITHUB_PAT}\"}" "${TAGS}"
   fi
 
@@ -421,7 +421,7 @@ function gitops_cluster() {
   echo "- Generate AWS secret"
   # This is used by some of the ArgoCD sync hooks to make updates to AWS SM from within the cluster
   export SECRET_NAME_AWS=${ACCOUNT_ID}${SM_DELIM}${CLUSTER_ID}${SM_DELIM}aws
-  TAGS="[{Key=source,Value=gitops_cluster}, {Key=account,Value=\"${ACCOUNT_ID}\", {Key=cluster,Value=\"${CLUSTER_ID}\"}]"
+  TAGS="[{Key=source,Value=gitops_cluster}, {Key=account,Value=\"${ACCOUNT_ID}\"}, {Key=cluster,Value=\"${CLUSTER_ID}\"}]"
   sm_update_secret $SECRET_NAME_AWS "{\"sm_aws_access_key_id\": \"${SM_AWS_ACCESS_KEY_ID}\", \"sm_aws_secret_access_key\": \"${SM_AWS_SECRET_ACCESS_KEY}\"}" "${TAGS}"
 
 

--- a/image/cli/mascli/functions/gitops_cos
+++ b/image/cli/mascli/functions/gitops_cos
@@ -184,7 +184,7 @@ function gitops_cos() {
   ESCAPED_INFO=${UNESCAPED_INFO//\"/\\\"}
   ESCAPED_INFO=${ESCAPED_INFO//$'\n'/\\n}
 
-  TAGS="[{\"Key\" \"source\", \"Value\": \"gitops_cos\"}, {\"Key\": \"account\", \"Value\": \"${ACCOUNT_ID}\"}, {\"Key\": cluster\", \"Value\": \"${CLUSTER_ID}\"}]"
+  TAGS="[{\"Key\": \"source\", \"Value\": \"gitops_cos\"}, {\"Key\": \"account\", \"Value\": \"${ACCOUNT_ID}\"}, {\"Key\": \"cluster\", \"Value\": \"${CLUSTER_ID}\"}]"
   sm_update_secret $COS_SECRET "{\"username\": \"$COS_USERNAME\", \"password\": \"$COS_PASSWORD\", \"info\": \"$ESCAPED_INFO\"}" "${TAGS}"
 
   rc=$?

--- a/image/cli/mascli/functions/gitops_cos
+++ b/image/cli/mascli/functions/gitops_cos
@@ -184,7 +184,8 @@ function gitops_cos() {
   ESCAPED_INFO=${UNESCAPED_INFO//\"/\\\"}
   ESCAPED_INFO=${ESCAPED_INFO//$'\n'/\\n}
 
-  sm_update_secret $COS_SECRET "{\"username\": \"$COS_USERNAME\", \"password\": \"$COS_PASSWORD\", \"info\": \"$ESCAPED_INFO\"}"
+  TAGS="[{Key=source,Value=gitops_cos, {Key=account,Value=\"${ACCOUNT_ID}\", {Key=cluster,Value=\"${CLUSTER_ID}\"}]"
+  sm_update_secret $COS_SECRET "{\"username\": \"$COS_USERNAME\", \"password\": \"$COS_PASSWORD\", \"info\": \"$ESCAPED_INFO\"}" "${TAGS}"
 
   rc=$?
   [ $rc -ne 0 ] && exit $rc

--- a/image/cli/mascli/functions/gitops_cos
+++ b/image/cli/mascli/functions/gitops_cos
@@ -184,7 +184,7 @@ function gitops_cos() {
   ESCAPED_INFO=${UNESCAPED_INFO//\"/\\\"}
   ESCAPED_INFO=${ESCAPED_INFO//$'\n'/\\n}
 
-  TAGS="[{Key=source,Value=gitops_cos, {Key=account,Value=\"${ACCOUNT_ID}\"}, {Key=cluster,Value=\"${CLUSTER_ID}\"}]"
+  TAGS="[{\"Key\" \"source\", \"Value\": \"gitops_cos\"}, {\"Key\": \"account\", \"Value\": \"${ACCOUNT_ID}\"}, {\"Key\": cluster\", \"Value\": \"${CLUSTER_ID}\"}]"
   sm_update_secret $COS_SECRET "{\"username\": \"$COS_USERNAME\", \"password\": \"$COS_PASSWORD\", \"info\": \"$ESCAPED_INFO\"}" "${TAGS}"
 
   rc=$?

--- a/image/cli/mascli/functions/gitops_cos
+++ b/image/cli/mascli/functions/gitops_cos
@@ -184,7 +184,7 @@ function gitops_cos() {
   ESCAPED_INFO=${UNESCAPED_INFO//\"/\\\"}
   ESCAPED_INFO=${ESCAPED_INFO//$'\n'/\\n}
 
-  TAGS="[{Key=source,Value=gitops_cos, {Key=account,Value=\"${ACCOUNT_ID}\", {Key=cluster,Value=\"${CLUSTER_ID}\"}]"
+  TAGS="[{Key=source,Value=gitops_cos, {Key=account,Value=\"${ACCOUNT_ID}\"}, {Key=cluster,Value=\"${CLUSTER_ID}\"}]"
   sm_update_secret $COS_SECRET "{\"username\": \"$COS_USERNAME\", \"password\": \"$COS_PASSWORD\", \"info\": \"$ESCAPED_INFO\"}" "${TAGS}"
 
   rc=$?

--- a/image/cli/mascli/functions/gitops_dro
+++ b/image/cli/mascli/functions/gitops_dro
@@ -239,7 +239,7 @@ function gitops_dro() {
   if [ "$DRO_CMM_SETUP" == "true" ]; then
     export SECRET_KEY_DRO_CMM_AUTH_APIKEY=${ACCOUNT_ID}${SECRETS_KEY_SEPERATOR}${CLUSTER_ID}${SECRETS_KEY_SEPERATOR}dro_cmm_auth#api_key
     export SECRET_NAME_DRO_CMM_AUTH=${ACCOUNT_ID}${SECRETS_KEY_SEPERATOR}${CLUSTER_ID}${SECRETS_KEY_SEPERATOR}dro_cmm_auth
-    TAGS="[{Key=source,Value=gitops_dro}, {Key=account,Value=\"${ACCOUNT_ID}\", {Key=cluster,Value=\"${CLUSTER_ID}\"}]"
+    TAGS="[{Key=source,Value=gitops_dro}, {Key=account,Value=\"${ACCOUNT_ID}\"}, {Key=cluster,Value=\"${CLUSTER_ID}\"}]"
     sm_update_secret $SECRET_NAME_DRO_CMM_AUTH "{\"api_key\": \"$DRO_CMM_AUTH_APIKEY\"}" "${TAGS}"
   fi
 

--- a/image/cli/mascli/functions/gitops_dro
+++ b/image/cli/mascli/functions/gitops_dro
@@ -239,7 +239,7 @@ function gitops_dro() {
   if [ "$DRO_CMM_SETUP" == "true" ]; then
     export SECRET_KEY_DRO_CMM_AUTH_APIKEY=${ACCOUNT_ID}${SECRETS_KEY_SEPERATOR}${CLUSTER_ID}${SECRETS_KEY_SEPERATOR}dro_cmm_auth#api_key
     export SECRET_NAME_DRO_CMM_AUTH=${ACCOUNT_ID}${SECRETS_KEY_SEPERATOR}${CLUSTER_ID}${SECRETS_KEY_SEPERATOR}dro_cmm_auth
-    TAGS="[{\"Key\" \"source\", \"Value\": \"gitops_dro\"}, {\"Key\": \"account\", \"Value\": \"${ACCOUNT_ID}\"}, {\"Key\": cluster\", \"Value\": \"${CLUSTER_ID}\"}]"
+    TAGS="[{\"Key\": \"source\", \"Value\": \"gitops_dro\"}, {\"Key\": \"account\", \"Value\": \"${ACCOUNT_ID}\"}, {\"Key\": \"cluster\", \"Value\": \"${CLUSTER_ID}\"}]"
     sm_update_secret $SECRET_NAME_DRO_CMM_AUTH "{\"api_key\": \"$DRO_CMM_AUTH_APIKEY\"}" "${TAGS}"
   fi
 

--- a/image/cli/mascli/functions/gitops_dro
+++ b/image/cli/mascli/functions/gitops_dro
@@ -239,7 +239,7 @@ function gitops_dro() {
   if [ "$DRO_CMM_SETUP" == "true" ]; then
     export SECRET_KEY_DRO_CMM_AUTH_APIKEY=${ACCOUNT_ID}${SECRETS_KEY_SEPERATOR}${CLUSTER_ID}${SECRETS_KEY_SEPERATOR}dro_cmm_auth#api_key
     export SECRET_NAME_DRO_CMM_AUTH=${ACCOUNT_ID}${SECRETS_KEY_SEPERATOR}${CLUSTER_ID}${SECRETS_KEY_SEPERATOR}dro_cmm_auth
-    TAGS="[{Key=source,Value=gitops_dro}, {Key=account,Value=\"${ACCOUNT_ID}\"}, {Key=cluster,Value=\"${CLUSTER_ID}\"}]"
+    TAGS="[{\"Key\" \"source\", \"Value\": \"gitops_dro\"}, {\"Key\": \"account\", \"Value\": \"${ACCOUNT_ID}\"}, {\"Key\": cluster\", \"Value\": \"${CLUSTER_ID}\"}]"
     sm_update_secret $SECRET_NAME_DRO_CMM_AUTH "{\"api_key\": \"$DRO_CMM_AUTH_APIKEY\"}" "${TAGS}"
   fi
 

--- a/image/cli/mascli/functions/gitops_dro
+++ b/image/cli/mascli/functions/gitops_dro
@@ -239,7 +239,8 @@ function gitops_dro() {
   if [ "$DRO_CMM_SETUP" == "true" ]; then
     export SECRET_KEY_DRO_CMM_AUTH_APIKEY=${ACCOUNT_ID}${SECRETS_KEY_SEPERATOR}${CLUSTER_ID}${SECRETS_KEY_SEPERATOR}dro_cmm_auth#api_key
     export SECRET_NAME_DRO_CMM_AUTH=${ACCOUNT_ID}${SECRETS_KEY_SEPERATOR}${CLUSTER_ID}${SECRETS_KEY_SEPERATOR}dro_cmm_auth
-    sm_update_secret $SECRET_NAME_DRO_CMM_AUTH "{\"api_key\": \"$DRO_CMM_AUTH_APIKEY\"}"
+    TAGS="[{Key=source,Value=gitops_dro}, {Key=account,Value=\"${ACCOUNT_ID}\", {Key=cluster,Value=\"${CLUSTER_ID}\"}]"
+    sm_update_secret $SECRET_NAME_DRO_CMM_AUTH "{\"api_key\": \"$DRO_CMM_AUTH_APIKEY\"}" "${TAGS}"
   fi
 
   if [ -z $GIT_SSH ]; then

--- a/image/cli/mascli/functions/gitops_kafka
+++ b/image/cli/mascli/functions/gitops_kafka
@@ -305,7 +305,7 @@ function gitops_kafka() {
     
     ESCAPED_INFO=${UNESCAPED_INFO//\"/\\\"}
     ESCAPED_INFO=${ESCAPED_INFO//$'\n'/\\n}
-    TAGS="[{Key=source,Value=gitops_kafka}, {Key=account,Value=\"${ACCOUNT_ID}\", {Key=cluster,Value=\"${CLUSTER_ID}\"}]"
+    TAGS="[{Key=source,Value=gitops_kafka}, {Key=account,Value=\"${ACCOUNT_ID}\"}, {Key=cluster,Value=\"${CLUSTER_ID}\"}]"
     sm_update_secret $AWS_MSK_SECRET "{\"info\": \"$ESCAPED_INFO\", \"username\": \"$KAFKA_USERNAME\", \"password\": \"$KAFKA_PASSWORD\"}" "${TAGS}"
 
     rm -rf $TEMP_DIR

--- a/image/cli/mascli/functions/gitops_kafka
+++ b/image/cli/mascli/functions/gitops_kafka
@@ -305,7 +305,7 @@ function gitops_kafka() {
     
     ESCAPED_INFO=${UNESCAPED_INFO//\"/\\\"}
     ESCAPED_INFO=${ESCAPED_INFO//$'\n'/\\n}
-    TAGS="[{\"Key\" \"source\", \"Value\": \"gitops_kafka\"}, {\"Key\": \"account\", \"Value\": \"${ACCOUNT_ID}\"}, {\"Key\": cluster\", \"Value\": \"${CLUSTER_ID}\"}]"
+    TAGS="[{\"Key\": \"source\", \"Value\": \"gitops_kafka\"}, {\"Key\": \"account\", \"Value\": \"${ACCOUNT_ID}\"}, {\"Key\": \"cluster\", \"Value\": \"${CLUSTER_ID}\"}]"
     sm_update_secret $AWS_MSK_SECRET "{\"info\": \"$ESCAPED_INFO\", \"username\": \"$KAFKA_USERNAME\", \"password\": \"$KAFKA_PASSWORD\"}" "${TAGS}"
 
     rm -rf $TEMP_DIR

--- a/image/cli/mascli/functions/gitops_kafka
+++ b/image/cli/mascli/functions/gitops_kafka
@@ -305,7 +305,7 @@ function gitops_kafka() {
     
     ESCAPED_INFO=${UNESCAPED_INFO//\"/\\\"}
     ESCAPED_INFO=${ESCAPED_INFO//$'\n'/\\n}
-    TAGS="[{Key=source,Value=gitops_kafka}, {Key=account,Value=\"${ACCOUNT_ID}\"}, {Key=cluster,Value=\"${CLUSTER_ID}\"}]"
+    TAGS="[{\"Key\" \"source\", \"Value\": \"gitops_kafka\"}, {\"Key\": \"account\", \"Value\": \"${ACCOUNT_ID}\"}, {\"Key\": cluster\", \"Value\": \"${CLUSTER_ID}\"}]"
     sm_update_secret $AWS_MSK_SECRET "{\"info\": \"$ESCAPED_INFO\", \"username\": \"$KAFKA_USERNAME\", \"password\": \"$KAFKA_PASSWORD\"}" "${TAGS}"
 
     rm -rf $TEMP_DIR

--- a/image/cli/mascli/functions/gitops_kafka
+++ b/image/cli/mascli/functions/gitops_kafka
@@ -305,7 +305,8 @@ function gitops_kafka() {
     
     ESCAPED_INFO=${UNESCAPED_INFO//\"/\\\"}
     ESCAPED_INFO=${ESCAPED_INFO//$'\n'/\\n}
-    sm_update_secret $AWS_MSK_SECRET "{\"info\": \"$ESCAPED_INFO\", \"username\": \"$KAFKA_USERNAME\", \"password\": \"$KAFKA_PASSWORD\"}"
+    TAGS="[{Key=source,Value=gitops_kafka}, {Key=account,Value=\"${ACCOUNT_ID}\", {Key=cluster,Value=\"${CLUSTER_ID}\"}]"
+    sm_update_secret $AWS_MSK_SECRET "{\"info\": \"$ESCAPED_INFO\", \"username\": \"$KAFKA_USERNAME\", \"password\": \"$KAFKA_PASSWORD\"}" "${TAGS}"
 
     rm -rf $TEMP_DIR
   fi

--- a/image/cli/mascli/functions/gitops_license
+++ b/image/cli/mascli/functions/gitops_license
@@ -129,7 +129,7 @@ function gitops_license() {
   ESCAPED_LICENSE=${ESCAPED_LICENSE//$'\t'/\\t}
   ESCAPED_LICENSE=${ESCAPED_LICENSE//$'\r'/''}
 
-  TAGS="[{\"Key\" \"source\", \"Value\": \"gitops_license\"}, {\"Key\": \"account\", \"Value\": \"${ACCOUNT_ID}\"}, {\"Key\": cluster\", \"Value\": \"${CLUSTER_ID}\"}]"
+  TAGS="[{\"Key\": \"source\", \"Value\": \"gitops_license\"}, {\"Key\": \"account\", \"Value\": \"${ACCOUNT_ID}\"}, {\"Key\": \"cluster\", \"Value\": \"${CLUSTER_ID}\"}]"
   sm_update_secret $SECRET_NAME_LICENSE_FILE "{\"license_file\": \"$ESCAPED_LICENSE\"}" "${TAGS}"
 
 }

--- a/image/cli/mascli/functions/gitops_license
+++ b/image/cli/mascli/functions/gitops_license
@@ -129,7 +129,7 @@ function gitops_license() {
   ESCAPED_LICENSE=${ESCAPED_LICENSE//$'\t'/\\t}
   ESCAPED_LICENSE=${ESCAPED_LICENSE//$'\r'/''}
 
-  TAGS="[{Key=source,Value=gitops_license}, {Key=account,Value=\"${ACCOUNT_ID}\"}, {Key=cluster,Value=\"${CLUSTER_ID}\"}]"
+  TAGS="[{\"Key\" \"source\", \"Value\": \"gitops_license\"}, {\"Key\": \"account\", \"Value\": \"${ACCOUNT_ID}\"}, {\"Key\": cluster\", \"Value\": \"${CLUSTER_ID}\"}]"
   sm_update_secret $SECRET_NAME_LICENSE_FILE "{\"license_file\": \"$ESCAPED_LICENSE\"}" "${TAGS}"
 
 }

--- a/image/cli/mascli/functions/gitops_license
+++ b/image/cli/mascli/functions/gitops_license
@@ -129,7 +129,7 @@ function gitops_license() {
   ESCAPED_LICENSE=${ESCAPED_LICENSE//$'\t'/\\t}
   ESCAPED_LICENSE=${ESCAPED_LICENSE//$'\r'/''}
 
-  TAGS="[{Key=source,Value=gitops_license}, {Key=account,Value=\"${ACCOUNT_ID}\", {Key=cluster,Value=\"${CLUSTER_ID}\"}]"
+  TAGS="[{Key=source,Value=gitops_license}, {Key=account,Value=\"${ACCOUNT_ID}\"}, {Key=cluster,Value=\"${CLUSTER_ID}\"}]"
   sm_update_secret $SECRET_NAME_LICENSE_FILE "{\"license_file\": \"$ESCAPED_LICENSE\"}" "${TAGS}"
 
 }

--- a/image/cli/mascli/functions/gitops_license
+++ b/image/cli/mascli/functions/gitops_license
@@ -129,6 +129,7 @@ function gitops_license() {
   ESCAPED_LICENSE=${ESCAPED_LICENSE//$'\t'/\\t}
   ESCAPED_LICENSE=${ESCAPED_LICENSE//$'\r'/''}
 
-  sm_update_secret $SECRET_NAME_LICENSE_FILE "{\"license_file\": \"$ESCAPED_LICENSE\"}"
+  TAGS="[{Key=source,Value=gitops_license}, {Key=account,Value=\"${ACCOUNT_ID}\", {Key=cluster,Value=\"${CLUSTER_ID}\"}]"
+  sm_update_secret $SECRET_NAME_LICENSE_FILE "{\"license_file\": \"$ESCAPED_LICENSE\"}" "${TAGS}"
 
 }

--- a/image/cli/mascli/functions/gitops_mas_config
+++ b/image/cli/mascli/functions/gitops_mas_config
@@ -648,7 +648,8 @@ function gitops_mas_config() {
       
       if [[ -n "${MAS_SEGMENT_KEY}" ]]; then
         sm_login
-        sm_update_secret $SECRET_NAME_MAS_SEGMENT_KEY "{\"mas_segment_key\": \"$MAS_SEGMENT_KEY\"}"
+        TAGS="[{Key=source,Value=gitops_mas_config}, {Key=account,Value=\"${ACCOUNT_ID}\", {Key=cluster,Value=\"${CLUSTER_ID}\"}]"
+        sm_update_secret $SECRET_NAME_MAS_SEGMENT_KEY "{\"mas_segment_key\": \"$MAS_SEGMENT_KEY\"}" "${TAGS}"
       fi
     fi
 
@@ -671,7 +672,7 @@ function gitops_mas_config() {
       sm_get_secret_file ${SECRET_PREFIX}${ACCOUNT_ID}${SECRETS_KEY_SEPERATOR}${CLUSTER_ID}${SECRETS_KEY_SEPERATOR}${MAS_INSTANCE_ID}${SECRETS_KEY_SEPERATOR}kafka $KAFKA_SECRET_FILE
       jq -r .info $KAFKA_SECRET_FILE > $ADDITIONAL_JINJA_PARAMS_FILE
       export AWS_MSK_SECRET=${SECRET_PREFIX}${ACCOUNT_ID}${SECRETS_KEY_SEPERATOR}${CLUSTER_ID}${SECRETS_KEY_SEPERATOR}${MAS_INSTANCE_ID}${SECRETS_KEY_SEPERATOR}kafka
-      export SECRET_KEY_KAFKA_USERNAME=${AWS_MSK_SECRET}#username
+      export ECRET_KEY_KAFKA_USERNAME=${AWS_MSK_SECRET}#username
       export SECRET_KEY_KAFKA_PASSWORD=${AWS_MSK_SECRET}#password
     fi
 
@@ -683,7 +684,8 @@ function gitops_mas_config() {
       if [ -z "${LDAP_BIND_DN}" ] || [ -z "${LDAP_BIND_PASSWORD}" ]; then
         sm_verify_secret_exists $SECRET_NAME_LDAP
       else
-        sm_update_secret $SECRET_NAME_LDAP "{\"bindDN\": \"$LDAP_BIND_DN\", \"bindPassword\": \"$LDAP_BIND_PASSWORD\"}"
+        TAGS="[{Key=source,Value=gitops_mas_config}, {Key=account,Value=\"${ACCOUNT_ID}\", {Key=cluster,Value=\"${CLUSTER_ID}\"}]"
+        sm_update_secret $SECRET_NAME_LDAP "{\"bindDN\": \"$LDAP_BIND_DN\", \"bindPassword\": \"$LDAP_BIND_PASSWORD\"}" "${TAGS}"
       fi
       export SECRET_KEY_LDAP_BIND_DN=${SECRET_NAME_LDAP}#bindDN
       export SECRET_KEY_LDAP_BIND_PASSWORD=${SECRET_NAME_LDAP}#bindPassword
@@ -730,7 +732,8 @@ function gitops_mas_config() {
           echo_reset_dim "JDBC_PASSWORD ........................... ${COLOR_MAGENTA}${JDBC_PASSWORD:0:8}<snip> is available in the secret, using that value"
         fi
         echo_reset_dim "JDBC_PASSWORD ............................. ${COLOR_MAGENTA}${JDBC_PASSWORD:0:8}<snip>"
-        sm_update_secret $JDBC_CREDENTIALS_SECRET_ID "{ \"username\": \"$JDBC_USERNAME\", \"password\": \"$JDBC_PASSWORD\"}"
+        TAGS="[{Key=source,Value=gitops_mas_config}, {Key=account,Value=\"${ACCOUNT_ID}\", {Key=cluster,Value=\"${CLUSTER_ID}\"}]"
+        sm_update_secret $JDBC_CREDENTIALS_SECRET_ID "{ \"username\": \"$JDBC_USERNAME\", \"password\": \"$JDBC_PASSWORD\"}" "${TAGS}"
       fi
 
       export SECRET_KEY_JDBC_USERNAME=${JDBC_CREDENTIALS_SECRET_ID}#username
@@ -745,7 +748,8 @@ function gitops_mas_config() {
         # This secret we are creating here
         export JDBC_CONFIG_SECRET_ID=${ACCOUNT_ID}${SECRETS_KEY_SEPERATOR}${CLUSTER_ID}${SECRETS_KEY_SEPERATOR}${MAS_INSTANCE_ID}${SECRETS_KEY_SEPERATOR}jdbc${SECRETS_KEY_SEPERATOR}${JDBC_INSTANCE_NAME}${SECRETS_KEY_SEPERATOR}config
         export JDBC_CERTIFICATE_CONTENT_B64=$(cat $JDBC_CERTIFICATE_FILE | base64 -w0)
-        sm_update_secret $JDBC_CONFIG_SECRET_ID "{ \"jdbc_connection_url\": \"${JDBC_CONNECTION_URL}\", \"jdbc_instance_name\": \"${JDBC_INSTANCE_NAME}\", \"ca_b64\": \"${JDBC_CERTIFICATE_CONTENT_B64}\" }"
+        TAGS="[{Key=source,Value=gitops_mas_config}, {Key=account,Value=\"${ACCOUNT_ID}\", {Key=cluster,Value=\"${CLUSTER_ID}\"}]"
+        sm_update_secret $JDBC_CONFIG_SECRET_ID "{ \"jdbc_connection_url\": \"${JDBC_CONNECTION_URL}\", \"jdbc_instance_name\": \"${JDBC_INSTANCE_NAME}\", \"ca_b64\": \"${JDBC_CERTIFICATE_CONTENT_B64}\" }" "${TAGS}"
         echo_reset_dim "JDBC_INSTANCE_NAME ........................ ${COLOR_MAGENTA}$JDBC_INSTANCE_NAME"
         echo_reset_dim "JDBC_CONNECTION_URL ....................... ${COLOR_MAGENTA}${JDBC_CONNECTION_URL}"
       fi
@@ -763,7 +767,8 @@ function gitops_mas_config() {
       if [ -z "${SMTP_USERNAME}" ] || [ -z "${SMTP_PASSWORD}" ]; then
         sm_verify_secret_exists $SECRET_NAME_SMTP
       else
-        sm_update_secret $SECRET_NAME_SMTP "{\"username\": \"$SMTP_USERNAME\", \"password\": \"$SMTP_PASSWORD\"}"
+        TAGS="[{Key=source,Value=gitops_mas_config}, {Key=account,Value=\"${ACCOUNT_ID}\", {Key=cluster,Value=\"${CLUSTER_ID}\"}]"
+        sm_update_secret $SECRET_NAME_SMTP "{\"username\": \"$SMTP_USERNAME\", \"password\": \"$SMTP_PASSWORD\"}" "${TAGS}"
       fi
 
       export SECRET_KEY_SMTP_USERNAME=${SECRET_NAME_SMTP}#username

--- a/image/cli/mascli/functions/gitops_mas_config
+++ b/image/cli/mascli/functions/gitops_mas_config
@@ -648,7 +648,7 @@ function gitops_mas_config() {
       
       if [[ -n "${MAS_SEGMENT_KEY}" ]]; then
         sm_login
-        TAGS="[{\"Key\" \"source\", \"Value\": \"gitops_mas_config\"}, {\"Key\": \"account\", \"Value\": \"${ACCOUNT_ID}\"}, {\"Key\": cluster\", \"Value\": \"${CLUSTER_ID}\"}]"
+        TAGS="[{\"Key\": \"source\", \"Value\": \"gitops_mas_config\"}, {\"Key\": \"account\", \"Value\": \"${ACCOUNT_ID}\"}, {\"Key\": \"cluster\", \"Value\": \"${CLUSTER_ID}\"}]"
         sm_update_secret $SECRET_NAME_MAS_SEGMENT_KEY "{\"mas_segment_key\": \"$MAS_SEGMENT_KEY\"}" "${TAGS}"
       fi
     fi
@@ -684,7 +684,7 @@ function gitops_mas_config() {
       if [ -z "${LDAP_BIND_DN}" ] || [ -z "${LDAP_BIND_PASSWORD}" ]; then
         sm_verify_secret_exists $SECRET_NAME_LDAP
       else
-        TAGS="[{\"Key\" \"source\", \"Value\": \"gitops_mas_config\"}, {\"Key\": \"account\", \"Value\": \"${ACCOUNT_ID}\"}, {\"Key\": cluster\", \"Value\": \"${CLUSTER_ID}\"}]"
+        TAGS="[{\"Key\": \"source\", \"Value\": \"gitops_mas_config\"}, {\"Key\": \"account\", \"Value\": \"${ACCOUNT_ID}\"}, {\"Key\": \"cluster\", \"Value\": \"${CLUSTER_ID}\"}]"
         sm_update_secret $SECRET_NAME_LDAP "{\"bindDN\": \"$LDAP_BIND_DN\", \"bindPassword\": \"$LDAP_BIND_PASSWORD\"}" "${TAGS}"
       fi
       export SECRET_KEY_LDAP_BIND_DN=${SECRET_NAME_LDAP}#bindDN
@@ -732,7 +732,7 @@ function gitops_mas_config() {
           echo_reset_dim "JDBC_PASSWORD ........................... ${COLOR_MAGENTA}${JDBC_PASSWORD:0:8}<snip> is available in the secret, using that value"
         fi
         echo_reset_dim "JDBC_PASSWORD ............................. ${COLOR_MAGENTA}${JDBC_PASSWORD:0:8}<snip>"
-        TAGS="[{\"Key\" \"source\", \"Value\": \"gitops_mas_config\"}, {\"Key\": \"account\", \"Value\": \"${ACCOUNT_ID}\"}, {\"Key\": cluster\", \"Value\": \"${CLUSTER_ID}\"}]"
+        TAGS="[{\"Key\": \"source\", \"Value\": \"gitops_mas_config\"}, {\"Key\": \"account\", \"Value\": \"${ACCOUNT_ID}\"}, {\"Key\": \"cluster\", \"Value\": \"${CLUSTER_ID}\"}]"
         sm_update_secret $JDBC_CREDENTIALS_SECRET_ID "{ \"username\": \"$JDBC_USERNAME\", \"password\": \"$JDBC_PASSWORD\"}" "${TAGS}"
       fi
 
@@ -748,7 +748,7 @@ function gitops_mas_config() {
         # This secret we are creating here
         export JDBC_CONFIG_SECRET_ID=${ACCOUNT_ID}${SECRETS_KEY_SEPERATOR}${CLUSTER_ID}${SECRETS_KEY_SEPERATOR}${MAS_INSTANCE_ID}${SECRETS_KEY_SEPERATOR}jdbc${SECRETS_KEY_SEPERATOR}${JDBC_INSTANCE_NAME}${SECRETS_KEY_SEPERATOR}config
         export JDBC_CERTIFICATE_CONTENT_B64=$(cat $JDBC_CERTIFICATE_FILE | base64 -w0)
-        TAGS="[{\"Key\" \"source\", \"Value\": \"gitops_mas_config\"}, {\"Key\": \"account\", \"Value\": \"${ACCOUNT_ID}\"}, {\"Key\": cluster\", \"Value\": \"${CLUSTER_ID}\"}]"
+        TAGS="[{\"Key\": \"source\", \"Value\": \"gitops_mas_config\"}, {\"Key\": \"account\", \"Value\": \"${ACCOUNT_ID}\"}, {\"Key\": \"cluster\", \"Value\": \"${CLUSTER_ID}\"}]"
         sm_update_secret $JDBC_CONFIG_SECRET_ID "{ \"jdbc_connection_url\": \"${JDBC_CONNECTION_URL}\", \"jdbc_instance_name\": \"${JDBC_INSTANCE_NAME}\", \"ca_b64\": \"${JDBC_CERTIFICATE_CONTENT_B64}\" }" "${TAGS}"
         echo_reset_dim "JDBC_INSTANCE_NAME ........................ ${COLOR_MAGENTA}$JDBC_INSTANCE_NAME"
         echo_reset_dim "JDBC_CONNECTION_URL ....................... ${COLOR_MAGENTA}${JDBC_CONNECTION_URL}"
@@ -767,7 +767,7 @@ function gitops_mas_config() {
       if [ -z "${SMTP_USERNAME}" ] || [ -z "${SMTP_PASSWORD}" ]; then
         sm_verify_secret_exists $SECRET_NAME_SMTP
       else
-        TAGS="[{\"Key\" \"source\", \"Value\": \"gitops_mas_config\"}, {\"Key\": \"account\", \"Value\": \"${ACCOUNT_ID}\"}, {\"Key\": cluster\", \"Value\": \"${CLUSTER_ID}\"}]"
+        TAGS="[{\"Key\": \"source\", \"Value\": \"gitops_mas_config\"}, {\"Key\": \"account\", \"Value\": \"${ACCOUNT_ID}\"}, {\"Key\": \"cluster\", \"Value\": \"${CLUSTER_ID}\"}]"
         sm_update_secret $SECRET_NAME_SMTP "{\"username\": \"$SMTP_USERNAME\", \"password\": \"$SMTP_PASSWORD\"}" "${TAGS}"
       fi
 

--- a/image/cli/mascli/functions/gitops_mas_config
+++ b/image/cli/mascli/functions/gitops_mas_config
@@ -648,7 +648,7 @@ function gitops_mas_config() {
       
       if [[ -n "${MAS_SEGMENT_KEY}" ]]; then
         sm_login
-        TAGS="[{Key=source,Value=gitops_mas_config}, {Key=account,Value=\"${ACCOUNT_ID}\"}, {Key=cluster,Value=\"${CLUSTER_ID}\"}]"
+        TAGS="[{\"Key\" \"source\", \"Value\": \"gitops_mas_config\"}, {\"Key\": \"account\", \"Value\": \"${ACCOUNT_ID}\"}, {\"Key\": cluster\", \"Value\": \"${CLUSTER_ID}\"}]"
         sm_update_secret $SECRET_NAME_MAS_SEGMENT_KEY "{\"mas_segment_key\": \"$MAS_SEGMENT_KEY\"}" "${TAGS}"
       fi
     fi
@@ -684,7 +684,7 @@ function gitops_mas_config() {
       if [ -z "${LDAP_BIND_DN}" ] || [ -z "${LDAP_BIND_PASSWORD}" ]; then
         sm_verify_secret_exists $SECRET_NAME_LDAP
       else
-        TAGS="[{Key=source,Value=gitops_mas_config}, {Key=account,Value=\"${ACCOUNT_ID}\"}, {Key=cluster,Value=\"${CLUSTER_ID}\"}]"
+        TAGS="[{\"Key\" \"source\", \"Value\": \"gitops_mas_config\"}, {\"Key\": \"account\", \"Value\": \"${ACCOUNT_ID}\"}, {\"Key\": cluster\", \"Value\": \"${CLUSTER_ID}\"}]"
         sm_update_secret $SECRET_NAME_LDAP "{\"bindDN\": \"$LDAP_BIND_DN\", \"bindPassword\": \"$LDAP_BIND_PASSWORD\"}" "${TAGS}"
       fi
       export SECRET_KEY_LDAP_BIND_DN=${SECRET_NAME_LDAP}#bindDN
@@ -732,7 +732,7 @@ function gitops_mas_config() {
           echo_reset_dim "JDBC_PASSWORD ........................... ${COLOR_MAGENTA}${JDBC_PASSWORD:0:8}<snip> is available in the secret, using that value"
         fi
         echo_reset_dim "JDBC_PASSWORD ............................. ${COLOR_MAGENTA}${JDBC_PASSWORD:0:8}<snip>"
-        TAGS="[{Key=source,Value=gitops_mas_config}, {Key=account,Value=\"${ACCOUNT_ID}\"}, {Key=cluster,Value=\"${CLUSTER_ID}\"}]"
+        TAGS="[{\"Key\" \"source\", \"Value\": \"gitops_mas_config\"}, {\"Key\": \"account\", \"Value\": \"${ACCOUNT_ID}\"}, {\"Key\": cluster\", \"Value\": \"${CLUSTER_ID}\"}]"
         sm_update_secret $JDBC_CREDENTIALS_SECRET_ID "{ \"username\": \"$JDBC_USERNAME\", \"password\": \"$JDBC_PASSWORD\"}" "${TAGS}"
       fi
 
@@ -748,7 +748,7 @@ function gitops_mas_config() {
         # This secret we are creating here
         export JDBC_CONFIG_SECRET_ID=${ACCOUNT_ID}${SECRETS_KEY_SEPERATOR}${CLUSTER_ID}${SECRETS_KEY_SEPERATOR}${MAS_INSTANCE_ID}${SECRETS_KEY_SEPERATOR}jdbc${SECRETS_KEY_SEPERATOR}${JDBC_INSTANCE_NAME}${SECRETS_KEY_SEPERATOR}config
         export JDBC_CERTIFICATE_CONTENT_B64=$(cat $JDBC_CERTIFICATE_FILE | base64 -w0)
-        TAGS="[{Key=source,Value=gitops_mas_config}, {Key=account,Value=\"${ACCOUNT_ID}\"}, {Key=cluster,Value=\"${CLUSTER_ID}\"}]"
+        TAGS="[{\"Key\" \"source\", \"Value\": \"gitops_mas_config\"}, {\"Key\": \"account\", \"Value\": \"${ACCOUNT_ID}\"}, {\"Key\": cluster\", \"Value\": \"${CLUSTER_ID}\"}]"
         sm_update_secret $JDBC_CONFIG_SECRET_ID "{ \"jdbc_connection_url\": \"${JDBC_CONNECTION_URL}\", \"jdbc_instance_name\": \"${JDBC_INSTANCE_NAME}\", \"ca_b64\": \"${JDBC_CERTIFICATE_CONTENT_B64}\" }" "${TAGS}"
         echo_reset_dim "JDBC_INSTANCE_NAME ........................ ${COLOR_MAGENTA}$JDBC_INSTANCE_NAME"
         echo_reset_dim "JDBC_CONNECTION_URL ....................... ${COLOR_MAGENTA}${JDBC_CONNECTION_URL}"
@@ -767,7 +767,7 @@ function gitops_mas_config() {
       if [ -z "${SMTP_USERNAME}" ] || [ -z "${SMTP_PASSWORD}" ]; then
         sm_verify_secret_exists $SECRET_NAME_SMTP
       else
-        TAGS="[{Key=source,Value=gitops_mas_config}, {Key=account,Value=\"${ACCOUNT_ID}\"}, {Key=cluster,Value=\"${CLUSTER_ID}\"}]"
+        TAGS="[{\"Key\" \"source\", \"Value\": \"gitops_mas_config\"}, {\"Key\": \"account\", \"Value\": \"${ACCOUNT_ID}\"}, {\"Key\": cluster\", \"Value\": \"${CLUSTER_ID}\"}]"
         sm_update_secret $SECRET_NAME_SMTP "{\"username\": \"$SMTP_USERNAME\", \"password\": \"$SMTP_PASSWORD\"}" "${TAGS}"
       fi
 

--- a/image/cli/mascli/functions/gitops_mas_config
+++ b/image/cli/mascli/functions/gitops_mas_config
@@ -648,7 +648,7 @@ function gitops_mas_config() {
       
       if [[ -n "${MAS_SEGMENT_KEY}" ]]; then
         sm_login
-        TAGS="[{Key=source,Value=gitops_mas_config}, {Key=account,Value=\"${ACCOUNT_ID}\", {Key=cluster,Value=\"${CLUSTER_ID}\"}]"
+        TAGS="[{Key=source,Value=gitops_mas_config}, {Key=account,Value=\"${ACCOUNT_ID}\"}, {Key=cluster,Value=\"${CLUSTER_ID}\"}]"
         sm_update_secret $SECRET_NAME_MAS_SEGMENT_KEY "{\"mas_segment_key\": \"$MAS_SEGMENT_KEY\"}" "${TAGS}"
       fi
     fi
@@ -684,7 +684,7 @@ function gitops_mas_config() {
       if [ -z "${LDAP_BIND_DN}" ] || [ -z "${LDAP_BIND_PASSWORD}" ]; then
         sm_verify_secret_exists $SECRET_NAME_LDAP
       else
-        TAGS="[{Key=source,Value=gitops_mas_config}, {Key=account,Value=\"${ACCOUNT_ID}\", {Key=cluster,Value=\"${CLUSTER_ID}\"}]"
+        TAGS="[{Key=source,Value=gitops_mas_config}, {Key=account,Value=\"${ACCOUNT_ID}\"}, {Key=cluster,Value=\"${CLUSTER_ID}\"}]"
         sm_update_secret $SECRET_NAME_LDAP "{\"bindDN\": \"$LDAP_BIND_DN\", \"bindPassword\": \"$LDAP_BIND_PASSWORD\"}" "${TAGS}"
       fi
       export SECRET_KEY_LDAP_BIND_DN=${SECRET_NAME_LDAP}#bindDN
@@ -732,7 +732,7 @@ function gitops_mas_config() {
           echo_reset_dim "JDBC_PASSWORD ........................... ${COLOR_MAGENTA}${JDBC_PASSWORD:0:8}<snip> is available in the secret, using that value"
         fi
         echo_reset_dim "JDBC_PASSWORD ............................. ${COLOR_MAGENTA}${JDBC_PASSWORD:0:8}<snip>"
-        TAGS="[{Key=source,Value=gitops_mas_config}, {Key=account,Value=\"${ACCOUNT_ID}\", {Key=cluster,Value=\"${CLUSTER_ID}\"}]"
+        TAGS="[{Key=source,Value=gitops_mas_config}, {Key=account,Value=\"${ACCOUNT_ID}\"}, {Key=cluster,Value=\"${CLUSTER_ID}\"}]"
         sm_update_secret $JDBC_CREDENTIALS_SECRET_ID "{ \"username\": \"$JDBC_USERNAME\", \"password\": \"$JDBC_PASSWORD\"}" "${TAGS}"
       fi
 
@@ -748,7 +748,7 @@ function gitops_mas_config() {
         # This secret we are creating here
         export JDBC_CONFIG_SECRET_ID=${ACCOUNT_ID}${SECRETS_KEY_SEPERATOR}${CLUSTER_ID}${SECRETS_KEY_SEPERATOR}${MAS_INSTANCE_ID}${SECRETS_KEY_SEPERATOR}jdbc${SECRETS_KEY_SEPERATOR}${JDBC_INSTANCE_NAME}${SECRETS_KEY_SEPERATOR}config
         export JDBC_CERTIFICATE_CONTENT_B64=$(cat $JDBC_CERTIFICATE_FILE | base64 -w0)
-        TAGS="[{Key=source,Value=gitops_mas_config}, {Key=account,Value=\"${ACCOUNT_ID}\", {Key=cluster,Value=\"${CLUSTER_ID}\"}]"
+        TAGS="[{Key=source,Value=gitops_mas_config}, {Key=account,Value=\"${ACCOUNT_ID}\"}, {Key=cluster,Value=\"${CLUSTER_ID}\"}]"
         sm_update_secret $JDBC_CONFIG_SECRET_ID "{ \"jdbc_connection_url\": \"${JDBC_CONNECTION_URL}\", \"jdbc_instance_name\": \"${JDBC_INSTANCE_NAME}\", \"ca_b64\": \"${JDBC_CERTIFICATE_CONTENT_B64}\" }" "${TAGS}"
         echo_reset_dim "JDBC_INSTANCE_NAME ........................ ${COLOR_MAGENTA}$JDBC_INSTANCE_NAME"
         echo_reset_dim "JDBC_CONNECTION_URL ....................... ${COLOR_MAGENTA}${JDBC_CONNECTION_URL}"
@@ -767,7 +767,7 @@ function gitops_mas_config() {
       if [ -z "${SMTP_USERNAME}" ] || [ -z "${SMTP_PASSWORD}" ]; then
         sm_verify_secret_exists $SECRET_NAME_SMTP
       else
-        TAGS="[{Key=source,Value=gitops_mas_config}, {Key=account,Value=\"${ACCOUNT_ID}\", {Key=cluster,Value=\"${CLUSTER_ID}\"}]"
+        TAGS="[{Key=source,Value=gitops_mas_config}, {Key=account,Value=\"${ACCOUNT_ID}\"}, {Key=cluster,Value=\"${CLUSTER_ID}\"}]"
         sm_update_secret $SECRET_NAME_SMTP "{\"username\": \"$SMTP_USERNAME\", \"password\": \"$SMTP_PASSWORD\"}" "${TAGS}"
       fi
 

--- a/image/cli/mascli/functions/gitops_mongo
+++ b/image/cli/mascli/functions/gitops_mongo
@@ -271,14 +271,16 @@ function gitops_mongo() {
     ESCAPED_INFO=${ESCAPED_INFO//$'\n'/\\n}
 
     echo -e "init_mongo : DOCDB_HOST=$DOCDB_HOST \t DOCDB_PORT=$DOCDB_PORT \t DOCDB_MASTER_USERNAME=$MONGO_USERNAME \t DOCDB_MASTER_PASSWORD=$MONGO_PASSWORD"
-    sm_update_secret $SECRET_NAME_MONGO "{\"info\": \"$ESCAPED_INFO\", \"username\": \"$MONGO_USERNAME\", \"password\": \"$MONGO_PASSWORD\", \"docdb_host\": \"$DOCDB_HOST\", \"docdb_port\": \"$DOCDB_PORT\" }"
+    TAGS="[{Key=source,Value=gitops_mongo}, {Key=account,Value=\"${ACCOUNT_ID}\", {Key=cluster,Value=\"${CLUSTER_ID}\"}]"
+    sm_update_secret $SECRET_NAME_MONGO "{\"info\": \"$ESCAPED_INFO\", \"username\": \"$MONGO_USERNAME\", \"password\": \"$MONGO_PASSWORD\", \"docdb_host\": \"$DOCDB_HOST\", \"docdb_port\": \"$DOCDB_PORT\" }" "${TAGS}"
     rm -rf $TEMP_DIR
 
   elif [ $MONGODB_PROVIDER == 'yaml' ]; then
     UNESCAPED_INFO="$(cat $MONGO_YAML_FILE)"
     ESCAPED_INFO=${UNESCAPED_INFO//\"/\\\"}
     ESCAPED_INFO=${ESCAPED_INFO//$'\n'/\\n}
-    sm_update_secret $SECRET_NAME_MONGO "{\"info\": \"$ESCAPED_INFO\", \"username\": \"$MONGO_USERNAME\", \"password\": \"$MONGO_PASSWORD\"}"
+    TAGS="[{Key=source,Value=gitops_mas_config}, {Key=account,Value=\"${ACCOUNT_ID}\", {Key=cluster,Value=\"${CLUSTER_ID}\"}]"
+    sm_update_secret $SECRET_NAME_MONGO "{\"info\": \"$ESCAPED_INFO\", \"username\": \"$MONGO_USERNAME\", \"password\": \"$MONGO_PASSWORD\"}" "${TAGS}"
   fi
 
   exit 0

--- a/image/cli/mascli/functions/gitops_mongo
+++ b/image/cli/mascli/functions/gitops_mongo
@@ -271,7 +271,7 @@ function gitops_mongo() {
     ESCAPED_INFO=${ESCAPED_INFO//$'\n'/\\n}
 
     echo -e "init_mongo : DOCDB_HOST=$DOCDB_HOST \t DOCDB_PORT=$DOCDB_PORT \t DOCDB_MASTER_USERNAME=$MONGO_USERNAME \t DOCDB_MASTER_PASSWORD=$MONGO_PASSWORD"
-    TAGS="[{Key=source,Value=gitops_mongo}, {Key=account,Value=\"${ACCOUNT_ID}\", {Key=cluster,Value=\"${CLUSTER_ID}\"}]"
+    TAGS="[{Key=source,Value=gitops_mongo}, {Key=account,Value=\"${ACCOUNT_ID}\"}, {Key=cluster,Value=\"${CLUSTER_ID}\"}]"
     sm_update_secret $SECRET_NAME_MONGO "{\"info\": \"$ESCAPED_INFO\", \"username\": \"$MONGO_USERNAME\", \"password\": \"$MONGO_PASSWORD\", \"docdb_host\": \"$DOCDB_HOST\", \"docdb_port\": \"$DOCDB_PORT\" }" "${TAGS}"
     rm -rf $TEMP_DIR
 
@@ -279,7 +279,7 @@ function gitops_mongo() {
     UNESCAPED_INFO="$(cat $MONGO_YAML_FILE)"
     ESCAPED_INFO=${UNESCAPED_INFO//\"/\\\"}
     ESCAPED_INFO=${ESCAPED_INFO//$'\n'/\\n}
-    TAGS="[{Key=source,Value=gitops_mas_config}, {Key=account,Value=\"${ACCOUNT_ID}\", {Key=cluster,Value=\"${CLUSTER_ID}\"}]"
+    TAGS="[{Key=source,Value=gitops_mas_config}, {Key=account,Value=\"${ACCOUNT_ID}\"}, {Key=cluster,Value=\"${CLUSTER_ID}\"}]"
     sm_update_secret $SECRET_NAME_MONGO "{\"info\": \"$ESCAPED_INFO\", \"username\": \"$MONGO_USERNAME\", \"password\": \"$MONGO_PASSWORD\"}" "${TAGS}"
   fi
 

--- a/image/cli/mascli/functions/gitops_mongo
+++ b/image/cli/mascli/functions/gitops_mongo
@@ -271,7 +271,7 @@ function gitops_mongo() {
     ESCAPED_INFO=${ESCAPED_INFO//$'\n'/\\n}
 
     echo -e "init_mongo : DOCDB_HOST=$DOCDB_HOST \t DOCDB_PORT=$DOCDB_PORT \t DOCDB_MASTER_USERNAME=$MONGO_USERNAME \t DOCDB_MASTER_PASSWORD=$MONGO_PASSWORD"
-    TAGS="[{Key=source,Value=gitops_mongo}, {Key=account,Value=\"${ACCOUNT_ID}\"}, {Key=cluster,Value=\"${CLUSTER_ID}\"}]"
+    TAGS="[{\"Key\" \"source\", \"Value\": \"gitops_mongo\"}, {\"Key\": \"account\", \"Value\": \"${ACCOUNT_ID}\"}, {\"Key\": cluster\", \"Value\": \"${CLUSTER_ID}\"}]"
     sm_update_secret $SECRET_NAME_MONGO "{\"info\": \"$ESCAPED_INFO\", \"username\": \"$MONGO_USERNAME\", \"password\": \"$MONGO_PASSWORD\", \"docdb_host\": \"$DOCDB_HOST\", \"docdb_port\": \"$DOCDB_PORT\" }" "${TAGS}"
     rm -rf $TEMP_DIR
 
@@ -279,7 +279,7 @@ function gitops_mongo() {
     UNESCAPED_INFO="$(cat $MONGO_YAML_FILE)"
     ESCAPED_INFO=${UNESCAPED_INFO//\"/\\\"}
     ESCAPED_INFO=${ESCAPED_INFO//$'\n'/\\n}
-    TAGS="[{Key=source,Value=gitops_mas_config}, {Key=account,Value=\"${ACCOUNT_ID}\"}, {Key=cluster,Value=\"${CLUSTER_ID}\"}]"
+    TAGS="[{\"Key\" \"source\", \"Value\": \"gitops_mongo\"}, {\"Key\": \"account\", \"Value\": \"${ACCOUNT_ID}\"}, {\"Key\": cluster\", \"Value\": \"${CLUSTER_ID}\"}]"
     sm_update_secret $SECRET_NAME_MONGO "{\"info\": \"$ESCAPED_INFO\", \"username\": \"$MONGO_USERNAME\", \"password\": \"$MONGO_PASSWORD\"}" "${TAGS}"
   fi
 

--- a/image/cli/mascli/functions/gitops_mongo
+++ b/image/cli/mascli/functions/gitops_mongo
@@ -271,7 +271,7 @@ function gitops_mongo() {
     ESCAPED_INFO=${ESCAPED_INFO//$'\n'/\\n}
 
     echo -e "init_mongo : DOCDB_HOST=$DOCDB_HOST \t DOCDB_PORT=$DOCDB_PORT \t DOCDB_MASTER_USERNAME=$MONGO_USERNAME \t DOCDB_MASTER_PASSWORD=$MONGO_PASSWORD"
-    TAGS="[{\"Key\" \"source\", \"Value\": \"gitops_mongo\"}, {\"Key\": \"account\", \"Value\": \"${ACCOUNT_ID}\"}, {\"Key\": cluster\", \"Value\": \"${CLUSTER_ID}\"}]"
+    TAGS="[{\"Key\": \"source\", \"Value\": \"gitops_mongo\"}, {\"Key\": \"account\", \"Value\": \"${ACCOUNT_ID}\"}, {\"Key\": \"cluster\", \"Value\": \"${CLUSTER_ID}\"}]"
     sm_update_secret $SECRET_NAME_MONGO "{\"info\": \"$ESCAPED_INFO\", \"username\": \"$MONGO_USERNAME\", \"password\": \"$MONGO_PASSWORD\", \"docdb_host\": \"$DOCDB_HOST\", \"docdb_port\": \"$DOCDB_PORT\" }" "${TAGS}"
     rm -rf $TEMP_DIR
 
@@ -279,7 +279,7 @@ function gitops_mongo() {
     UNESCAPED_INFO="$(cat $MONGO_YAML_FILE)"
     ESCAPED_INFO=${UNESCAPED_INFO//\"/\\\"}
     ESCAPED_INFO=${ESCAPED_INFO//$'\n'/\\n}
-    TAGS="[{\"Key\" \"source\", \"Value\": \"gitops_mongo\"}, {\"Key\": \"account\", \"Value\": \"${ACCOUNT_ID}\"}, {\"Key\": cluster\", \"Value\": \"${CLUSTER_ID}\"}]"
+    TAGS="[{\"Key\": \"source\", \"Value\": \"gitops_mongo\"}, {\"Key\": \"account\", \"Value\": \"${ACCOUNT_ID}\"}, {\"Key\": \"cluster\", \"Value\": \"${CLUSTER_ID}\"}]"
     sm_update_secret $SECRET_NAME_MONGO "{\"info\": \"$ESCAPED_INFO\", \"username\": \"$MONGO_USERNAME\", \"password\": \"$MONGO_PASSWORD\"}" "${TAGS}"
   fi
 

--- a/image/cli/mascli/functions/gitops_suite
+++ b/image/cli/mascli/functions/gitops_suite
@@ -555,7 +555,7 @@ function gitops_suite() {
 
   ESCAPED_INFO=${UNESCAPED_MONGO_INFO//\"/\\\"}
   ESCAPED_INFO=${ESCAPED_INFO//$'\n'/\\n}
-  TAGS="[{\"Key\" \"source\", \"Value\": \"gitops_suite\"}, {\"Key\": \"account\", \"Value\": \"${ACCOUNT_ID}\"}, {\"Key\": cluster\", \"Value\": \"${CLUSTER_ID}\"}]"
+  TAGS="[{\"Key\": \"source\", \"Value\": \"gitops_suite\"}, {\"Key\": \"account\", \"Value\": \"${ACCOUNT_ID}\"}, {\"Key\": \"cluster\", \"Value\": \"${CLUSTER_ID}\"}]"
   sm_update_secret $SECRET_NAME_MONGO "{\"info\": \"$ESCAPED_INFO\", \"username\": \"$INSTANCE_MONGO_USERNAME\", \"password\": \"$INSTANCE_MONGO_PASSWORD\"}" "${TAGS}"
   
 

--- a/image/cli/mascli/functions/gitops_suite
+++ b/image/cli/mascli/functions/gitops_suite
@@ -555,7 +555,7 @@ function gitops_suite() {
 
   ESCAPED_INFO=${UNESCAPED_MONGO_INFO//\"/\\\"}
   ESCAPED_INFO=${ESCAPED_INFO//$'\n'/\\n}
-  TAGS="[{Key=source,Value=gitops_suite}, {Key=account,Value=\"${ACCOUNT_ID}\", {Key=cluster,Value=\"${CLUSTER_ID}\"}]"
+  TAGS="[{Key=source,Value=gitops_suite}, {Key=account,Value=\"${ACCOUNT_ID}\"}, {Key=cluster,Value=\"${CLUSTER_ID}\"}]"
   sm_update_secret $SECRET_NAME_MONGO "{\"info\": \"$ESCAPED_INFO\", \"username\": \"$INSTANCE_MONGO_USERNAME\", \"password\": \"$INSTANCE_MONGO_PASSWORD\"}" "${TAGS}"
   
 

--- a/image/cli/mascli/functions/gitops_suite
+++ b/image/cli/mascli/functions/gitops_suite
@@ -555,7 +555,7 @@ function gitops_suite() {
 
   ESCAPED_INFO=${UNESCAPED_MONGO_INFO//\"/\\\"}
   ESCAPED_INFO=${ESCAPED_INFO//$'\n'/\\n}
-  TAGS="[{Key=source,Value=gitops_suite}, {Key=account,Value=\"${ACCOUNT_ID}\"}, {Key=cluster,Value=\"${CLUSTER_ID}\"}]"
+  TAGS="[{\"Key\" \"source\", \"Value\": \"gitops_suite\"}, {\"Key\": \"account\", \"Value\": \"${ACCOUNT_ID}\"}, {\"Key\": cluster\", \"Value\": \"${CLUSTER_ID}\"}]"
   sm_update_secret $SECRET_NAME_MONGO "{\"info\": \"$ESCAPED_INFO\", \"username\": \"$INSTANCE_MONGO_USERNAME\", \"password\": \"$INSTANCE_MONGO_PASSWORD\"}" "${TAGS}"
   
 

--- a/image/cli/mascli/functions/gitops_suite
+++ b/image/cli/mascli/functions/gitops_suite
@@ -555,7 +555,8 @@ function gitops_suite() {
 
   ESCAPED_INFO=${UNESCAPED_MONGO_INFO//\"/\\\"}
   ESCAPED_INFO=${ESCAPED_INFO//$'\n'/\\n}
-  sm_update_secret $SECRET_NAME_MONGO "{\"info\": \"$ESCAPED_INFO\", \"username\": \"$INSTANCE_MONGO_USERNAME\", \"password\": \"$INSTANCE_MONGO_PASSWORD\"}"
+  TAGS="[{Key=source,Value=gitops_suite}, {Key=account,Value=\"${ACCOUNT_ID}\", {Key=cluster,Value=\"${CLUSTER_ID}\"}]"
+  sm_update_secret $SECRET_NAME_MONGO "{\"info\": \"$ESCAPED_INFO\", \"username\": \"$INSTANCE_MONGO_USERNAME\", \"password\": \"$INSTANCE_MONGO_PASSWORD\"}" "${TAGS}"
   
 
   if [ -z $GIT_SSH ]; then

--- a/image/cli/mascli/functions/gitops_suite_certs
+++ b/image/cli/mascli/functions/gitops_suite_certs
@@ -215,7 +215,7 @@ function gitops_suite_certs() {
           PUBLIC_TLS_KEY=${PUBLIC_TLS_KEY//\"/\\\"}
           PUBLIC_TLS_KEY=${PUBLIC_TLS_KEY//$'\n'/\\n}
         fi    
-        TAGS="[{Key=source,Value=gitops_suite_certs}, {Key=account,Value=\"${ACCOUNT_ID}\", {Key=cluster,Value=\"${CLUSTER_ID}\"}]"
+        TAGS="[{Key=source,Value=gitops_suite_certs}, {Key=account,Value=\"${ACCOUNT_ID}\"}, {Key=cluster,Value=\"${CLUSTER_ID}\"}]"
         sm_update_secret $PUBLIC_CERT_SECRET_NAME "{\"cert_ca\": \"$PUBLIC_CERT_CA\", \"cert_tls\": \"$PUBLIC_CERT_TLS\", \"tls_key\": \"$PUBLIC_TLS_KEY\"}" "${TAGS}"
 
       done  

--- a/image/cli/mascli/functions/gitops_suite_certs
+++ b/image/cli/mascli/functions/gitops_suite_certs
@@ -215,7 +215,7 @@ function gitops_suite_certs() {
           PUBLIC_TLS_KEY=${PUBLIC_TLS_KEY//\"/\\\"}
           PUBLIC_TLS_KEY=${PUBLIC_TLS_KEY//$'\n'/\\n}
         fi
-        TAGS="[{\"Key\" \"source\", \"Value\": \"gitops_suite_certs\"}, {\"Key\": \"account\", \"Value\": \"${ACCOUNT_ID}\"}, {\"Key\": cluster\", \"Value\": \"${CLUSTER_ID}\"}]"
+        TAGS="[{\"Key\": \"source\", \"Value\": \"gitops_suite_certs\"}, {\"Key\": \"account\", \"Value\": \"${ACCOUNT_ID}\"}, {\"Key\": \"cluster\", \"Value\": \"${CLUSTER_ID}\"}]"
         sm_update_secret $PUBLIC_CERT_SECRET_NAME "{\"cert_ca\": \"$PUBLIC_CERT_CA\", \"cert_tls\": \"$PUBLIC_CERT_TLS\", \"tls_key\": \"$PUBLIC_TLS_KEY\"}" "${TAGS}"
 
       done  

--- a/image/cli/mascli/functions/gitops_suite_certs
+++ b/image/cli/mascli/functions/gitops_suite_certs
@@ -214,8 +214,8 @@ function gitops_suite_certs() {
           PUBLIC_TLS_KEY=$(cat $PUBLIC_TLS_KEY_FILE_PATH)
           PUBLIC_TLS_KEY=${PUBLIC_TLS_KEY//\"/\\\"}
           PUBLIC_TLS_KEY=${PUBLIC_TLS_KEY//$'\n'/\\n}
-        fi    
-        TAGS="[{Key=source,Value=gitops_suite_certs}, {Key=account,Value=\"${ACCOUNT_ID}\"}, {Key=cluster,Value=\"${CLUSTER_ID}\"}]"
+        fi
+        TAGS="[{\"Key\" \"source\", \"Value\": \"gitops_suite_certs\"}, {\"Key\": \"account\", \"Value\": \"${ACCOUNT_ID}\"}, {\"Key\": cluster\", \"Value\": \"${CLUSTER_ID}\"}]"
         sm_update_secret $PUBLIC_CERT_SECRET_NAME "{\"cert_ca\": \"$PUBLIC_CERT_CA\", \"cert_tls\": \"$PUBLIC_CERT_TLS\", \"tls_key\": \"$PUBLIC_TLS_KEY\"}" "${TAGS}"
 
       done  

--- a/image/cli/mascli/functions/gitops_suite_certs
+++ b/image/cli/mascli/functions/gitops_suite_certs
@@ -214,8 +214,9 @@ function gitops_suite_certs() {
           PUBLIC_TLS_KEY=$(cat $PUBLIC_TLS_KEY_FILE_PATH)
           PUBLIC_TLS_KEY=${PUBLIC_TLS_KEY//\"/\\\"}
           PUBLIC_TLS_KEY=${PUBLIC_TLS_KEY//$'\n'/\\n}
-        fi
-        sm_update_secret $PUBLIC_CERT_SECRET_NAME "{\"cert_ca\": \"$PUBLIC_CERT_CA\", \"cert_tls\": \"$PUBLIC_CERT_TLS\", \"tls_key\": \"$PUBLIC_TLS_KEY\"}"
+        fi    
+        TAGS="[{Key=source,Value=gitops_suite_certs}, {Key=account,Value=\"${ACCOUNT_ID}\", {Key=cluster,Value=\"${CLUSTER_ID}\"}]"
+        sm_update_secret $PUBLIC_CERT_SECRET_NAME "{\"cert_ca\": \"$PUBLIC_CERT_CA\", \"cert_tls\": \"$PUBLIC_CERT_TLS\", \"tls_key\": \"$PUBLIC_TLS_KEY\"}" "${TAGS}"
 
       done  
     fi

--- a/image/cli/mascli/functions/gitops_utils
+++ b/image/cli/mascli/functions/gitops_utils
@@ -41,8 +41,9 @@ function sm_list_cluster_secrets() {
 function sm_update_secret(){
   SECRET_NAME=$1
   SECRET_VALUE=$2
+  SECRET_TAGS=$3
 
-  echo "Secret Manager: Updating $SECRET_NAME"
+  echo "Secret Manager: Updating $SECRET_NAME with tags $SECRET_TAGS"
   if [[ "$AVP_TYPE" == "aws" ]]; then
     # There's a different command to run depending on whether we are creating or updating a secret
     # It's annoying there isn't an upsert/idemopotent command as we don't really care either way, but
@@ -55,12 +56,12 @@ function sm_update_secret(){
 
     if [[ "$CURRENT_SECRET_VALUE" == "" ]]; then
       # Create the secret
-      aws secretsmanager create-secret --name ${SECRET_NAME} --secret-string "${SECRET_VALUE}" || exit 1
+      aws secretsmanager create-secret --name ${SECRET_NAME} --secret-string "${SECRET_VALUE}" --tags "${SECRET_TAGS}" || exit 1
       echo "- Secret $SECRET_NAME created"
     elif [[ "$SECRET_VALUE" != "$CURRENT_SECRET_VALUE" ]]; then
       # Update the secret
       echo "- Secret $SECRET_NAME updated"
-      aws secretsmanager update-secret --secret-id ${SECRET_NAME} --secret-string "${SECRET_VALUE}" || exit 1
+      aws secretsmanager update-secret --secret-id ${SECRET_NAME} --secret-string "${SECRET_VALUE}" --tags "${SECRET_TAGS}" || exit 1
     else
       # No change
       echo "- Secret $SECRET_NAME unchanged"
@@ -158,8 +159,9 @@ function sm_update_account_secret() {
   ACCOUNT=$1
   SECRET_NAME=$2
   SECRET_VALUE=$3
+  SECRET_TAGS=$4
 
-  sm_update_secret ${ACCOUNT}${DELIMIITER}${SECRET_NAME} "${SECRET_VALUE}"
+  sm_update_secret ${ACCOUNT}${DELIMIITER}${SECRET_NAME} "${SECRET_VALUE}" "${TAGS}"
 }
 
 function sm_update_cluster_secret() {
@@ -167,8 +169,9 @@ function sm_update_cluster_secret() {
   CLUSTER_ID=$2
   SECRET_NAME=$3
   SECRET_VALUE=$4
+  SECRET_TAGS=$5
 
-  sm_update_secret ${ACCOUNT}${DELIMIITER}${CLUSTER_ID}${DELIMIITER}${SECRET_NAME} "${SECRET_VALUE}"
+  sm_update_secret ${ACCOUNT}${DELIMIITER}${CLUSTER_ID}${DELIMIITER}${SECRET_NAME} "${SECRET_VALUE}" "${TAGS}"
 }
 
 function sm_update_mas_secret() {
@@ -177,8 +180,9 @@ function sm_update_mas_secret() {
   MAS_INSTANCE_ID=$3
   SECRET_NAME=$4
   SECRET_VALUE=$5
+  SECRET_TAGS=$6
 
-  sm_update_secret ${ACCOUNT}${DELIMIITER}${CLUSTER_ID}${DELIMIITER}${MAS_INSTANCE_ID}${DELIMIITER}${SECRET_NAME} "${SECRET_VALUE}"
+  sm_update_secret ${ACCOUNT}${DELIMIITER}${CLUSTER_ID}${DELIMIITER}${MAS_INSTANCE_ID}${DELIMIITER}${SECRET_NAME} "${SECRET_VALUE}" "${TAGS}"
 }
 
 function sm_get_cluster_secret() {


### PR DESCRIPTION
For all secretmanager secrets created by the gitops function this will add tags to those secrets.

The tags created are:
- cluster
- account
- source
- 
![image- 2024-08-13 at 14 14 09](https://github.com/user-attachments/assets/ee62c807-298f-4f81-8edc-0fbef8de6bf8)

Tested in dev cluster