### PR TITLE
[patch] Add missing github_pat to params

### DIFF
--- a/tekton/src/pipelines/gitops/deprovision-mas-deps.yml.j2
+++ b/tekton/src/pipelines/gitops/deprovision-mas-deps.yml.j2
@@ -40,6 +40,8 @@ spec:
 
     - name: github_url
       type: string
+    - name: github_pat
+      type: string
     - name: rosa_token
       type: string
     - name: account


### PR DESCRIPTION
Fixes regression created by https://github.com/ibm-mas/cli/pull/1149

```
TASK [ibm.mas_fvt.setup_pipeline : Update Devops Tasks (ibm-mas-tekton)] *******
FAILED - RETRYING: [localhost]: Update Devops Tasks (ibm-mas-tekton) (10 retries left).
FAILED - RETRYING: [localhost]: Update Devops Tasks (ibm-mas-tekton) (9 retries left).
FAILED - RETRYING: [localhost]: Update Devops Tasks (ibm-mas-tekton) (8 retries left).
FAILED - RETRYING: [localhost]: Update Devops Tasks (ibm-mas-tekton) (7 retries left).
FAILED - RETRYING: [localhost]: Update Devops Tasks (ibm-mas-tekton) (6 retries left).
FAILED - RETRYING: [localhost]: Update Devops Tasks (ibm-mas-tekton) (5 retries left).
FAILED - RETRYING: [localhost]: Update Devops Tasks (ibm-mas-tekton) (4 retries left).
FAILED - RETRYING: [localhost]: Update Devops Tasks (ibm-mas-tekton) (3 retries left).
FAILED - RETRYING: [localhost]: Update Devops Tasks (ibm-mas-tekton) (2 retries left).
FAILED - RETRYING: [localhost]: Update Devops Tasks (ibm-mas-tekton) (1 retries left).
fatal: [localhost]: FAILED! => {"attempts": 10, "changed": false, "msg": "Failed to create object: b'{\"kind\":\"Status\",\"apiVersion\":\"v1\",\"metadata\":{},\"status\":\"Failure\",\"message\":\"admission webhook \\\\\"validation.webhook.pipeline.tekton.dev\\\\\" denied the request: validation failed: non-existent variable in \\\\\"$(params.github_pat)\\\\\": spec.tasks[3].params[github_pat]\",\"reason\":\"BadRequest\",\"code\":400}\\n'", "reason": "Bad Request"}
```