### PR TITLE
[patch] Fix double "github_pat" param

### DIFF
--- a/tekton/src/pipelines/gitops/deprovision-mas-deps.yml.j2
+++ b/tekton/src/pipelines/gitops/deprovision-mas-deps.yml.j2
@@ -40,8 +40,6 @@ spec:
 
     - name: github_url
       type: string
-    - name: github_pat
-      type: string
     - name: rosa_token
       type: string
     - name: account


### PR DESCRIPTION
```
 - Adding Pipeline: /mnt/c/Users/097891866/Documents/GitHub/ibm-mas/installer/tekton/target/pipelines/deprovision-mas-deps-after-deprovision.yaml
Error from server (BadRequest): error when creating "/mnt/c/Users/097891866/Documents/GitHub/ibm-mas/installer/tekton/target/pipelines/deprovision-mas-deps-after-deprovision.yaml": admission webhook "validation.webhook.pipeline.tekton.dev" denied the request: validation failed: parameter appears more than once: spec.finally.params[github_pat], spec.tasks.params[github_pat]
```

Back to the drawing board with the fix for this issue.