### PR TITLE
[patch] fix SM tag gitops issue and gitops_cos function 

### DIFF
--- a/image/cli/mascli/functions/gitops_cos
+++ b/image/cli/mascli/functions/gitops_cos
@@ -100,7 +100,9 @@ function gitops_cos_noninteractive() {
 
   [[ -z "$CLUSTER_ID" ]] && gitops_cos_help "CLUSTER_ID is not set"
   [[ -z "$COS_TYPE" ]] && gitops_cos_help "COS_TYPE is not set"
-  [[ -z "$IBMCLOUD_APIKEY" ]] && gitops_cos_help "IBMCLOUD_APIKEY is not set"
+  if [[ "${COS_TYPE}" == "ibm" ]]; then
+    [[ -z "$IBMCLOUD_APIKEY" ]] && gitops_cos_help "IBMCLOUD_APIKEY is not set"
+  fi
   [[ -z "$ACCOUNT_ID" ]] && gitops_cos_help "ACCOUNT_ID is not set"
   [[ -z "$MAS_INSTANCE_ID" ]] && gitops_cos_help "MAS_INSTANCE_ID is not set"
   [[ -z "$MAS_CONFIG_DIR" ]] && gitops_cp4d_service_help "MAS_CONFIG_DIR is not set"
@@ -147,9 +149,11 @@ function gitops_cos() {
   echo_h2 "COS" "    "
   echo_reset_dim "COS action  ........................... ${COLOR_MAGENTA}${COS_ACTION}"
   echo_reset_dim "COS type  ............................. ${COLOR_MAGENTA}${COS_TYPE}"
-  echo_reset_dim "IBMCLOUD Resource Group  .............. ${COLOR_MAGENTA}${IBMCLOUD_RESOURCEGROUP}"
-  echo_reset_dim "IBMCLOUD ApiKey ....................... ${COLOR_MAGENTA}${IBMCLOUD_APIKEY:0:8}<snip>"
-
+  if [[ "${COS_TYPE}" == "ibm" ]]; then
+    echo_reset_dim "IBMCLOUD Resource Group  .............. ${COLOR_MAGENTA}${IBMCLOUD_RESOURCEGROUP}"
+    echo_reset_dim "IBMCLOUD ApiKey ....................... ${COLOR_MAGENTA}${IBMCLOUD_APIKEY:0:8}<snip>"
+  fi
+  
   echo "${TEXT_DIM}"
   echo_h2 "IBM Maximo Application Suite" "    "
   echo_reset_dim "Instance ID ............................. ${COLOR_MAGENTA}${MAS_INSTANCE_ID}"

--- a/image/cli/mascli/functions/gitops_utils
+++ b/image/cli/mascli/functions/gitops_utils
@@ -56,12 +56,15 @@ function sm_update_secret(){
 
     if [[ "$CURRENT_SECRET_VALUE" == "" ]]; then
       # Create the secret
+      echo "- Secret $SECRET_NAME creating"
       aws secretsmanager create-secret --name ${SECRET_NAME} --secret-string "${SECRET_VALUE}" --tags "${SECRET_TAGS}" || exit 1
       echo "- Secret $SECRET_NAME created"
     elif [[ "$SECRET_VALUE" != "$CURRENT_SECRET_VALUE" ]]; then
       # Update the secret
+      echo "- Secret $SECRET_NAME updating"
+      aws secretsmanager update-secret --secret-id ${SECRET_NAME} --secret-string "${SECRET_VALUE}" || exit 1
+      aws secretsmanager tag-resource --secret-id ${SECRET_NAME} --tags "${SECRET_TAGS}"
       echo "- Secret $SECRET_NAME updated"
-      aws secretsmanager update-secret --secret-id ${SECRET_NAME} --secret-string "${SECRET_VALUE}" --tags "${SECRET_TAGS}" || exit 1
     else
       # No change
       echo "- Secret $SECRET_NAME unchanged"


### PR DESCRIPTION
Fixes the gitops_cos function so that it only checks for IBMCLOUD_APIKEY if cos type is ibm.

Also fixes the AWS SM tagging as you can't pass the --tags on the update-secret call. Instead the tag-resource will be called if we are updating the secret.