### PR TITLE
[patch] Default of "None" is eval'd as null/not set by Ansible

### DIFF
--- a/tekton/src/params/install-eck.yml.j2
+++ b/tekton/src/params/install-eck.yml.j2
@@ -1,6 +1,6 @@
 - name: eck_action
   type: string
-  default: "none"
+  default: "no-action"
 
 - name: eck_enable_elasticsearch
   type: string


### PR DESCRIPTION
Setting `eck_action` to `none` did not have the intended effect as it effectively is treated the same as empty string/null, so we are going to set this to `no-action` instead.