### PR TITLE
[patch] eck_action param not being passed from pipeline to task

### DIFF
--- a/examples/mirror_db2.md
+++ b/examples/mirror_db2.md
@@ -1,0 +1,26 @@
+Mirror IBM Db2 Content
+===============================================================================
+
+This example shows how to mirror jsut the IBM Db2u content associated with a specific release of the **IBM Maximo Operator Catalog**
+
+```bash
+#!/bin/bash
+
+# Destination registry
+export REGISTRY_PRIVATE_HOST=airgap-registry-lb.airgap-registry.svc
+export REGISTRY_PRIVATE_PORT=5000
+export REGISTRY_USERNAME=x
+export REGISTRY_PASSWORD=x
+
+# Source registry
+export IBM_ENTITLEMENT_KEY=x
+
+# Catalog
+export CATALOG=v9-240730-amd64
+
+mas mirror-images -m to-filesystem -d /pvc/mirror/$CATALOG --no-confirm \
+  -H $REGISTRY_PRIVATE_HOST -P $REGISTRY_PRIVATE_PORT -u $REGISTRY_USERNAME -p $REGISTRY_PASSWORD \
+  --ibm-entitlement $IBM_ENTITLEMENT_KEY \
+  -c $CATALOG -C 9.0.x \
+  --mirror-db2
+```

--- a/tekton/src/tasks/dependencies/eck.yml.j2
+++ b/tekton/src/tasks/dependencies/eck.yml.j2
@@ -7,6 +7,10 @@ spec:
   params:
     {{ lookup('template', task_src_dir ~ '/common/cli-params.yml.j2') | indent(4) }}
 
+    - name: eck_action
+      type: string
+      default: ""
+
     # Internal Stack
     - name: eck_enable_elasticsearch
       type: string
@@ -38,6 +42,9 @@ spec:
   stepTemplate:
     env:
       {{ lookup('template', task_src_dir ~ '/common/cli-env.yml.j2') | indent(6) }}
+
+      - name: ECK_ACTION
+        value: $(params.eck_action)
 
       # Internal Stack
       - name: ECK_ENABLE_ELASTICSEARCH


### PR DESCRIPTION
Although the pipeline supports `eck_action`, the task does not have this param, so we were left with a task that always defaulted to the `install` action.