### PR TITLE
[patch] Don't fail FVT pipeline if we can't post to Slack

### DIFF
--- a/image/cli/app-root/src/finalizer.py
+++ b/image/cli/app-root/src/finalizer.py
@@ -559,8 +559,11 @@ if __name__ == "__main__":
 
     messageBlocks.append(buildSection(f"Download Must Gather from <https://na.artifactory.swg-devops.com/ui/repos/tree/General/wiotp-generic-logs/mas-fvt/{instanceId}/{build}|Artifactory> (may not be available yet), see thread for more information ..."))
     response = postMessage(FVT_SLACK_CHANNEL, messageBlocks)
-    threadId = response["ts"]
-
+    if response["ok"]:
+        threadId = response["ts"]
+    else:
+        print(f"Unable to post FVT summary to Slack: {response['error']}")
+        sys.exit(0)
 
     # Generate threaded messages with failure details
     # -------------------------------------------------------------------------


### PR DESCRIPTION
Avoid a pipeline failure just because we can't post to Slack (for any reason):

```
Posting 8 block message to mas-fvtreports-corenew in Slack
{'ok': False, 'error': 'channel_not_found',  ... }
Failed to call Slack API
Traceback (most recent call last):
  File "/opt/app-root/src/finalizer.py", line 562, in <module>
    threadId = response["ts"]
KeyError: 'ts'
```

![image](https://github.com/user-attachments/assets/40fd116d-8b5c-4745-a468-4164bf3e3159)
