### PR TITLE
[patch] Extend custom Application healthcheck to detect Helm chart rendering failures

### DIFF
--- a/image/cli/mascli/templates/gitops/bootstrap/argocd.yaml
+++ b/image/cli/mascli/templates/gitops/bootstrap/argocd.yaml
@@ -1055,6 +1055,21 @@ spec:
           hs.status = "Progressing"
           hs.message = ""
           if obj.status ~= nil then
+
+            if obj.status.conditions ~= nil then
+              for i, condition in ipairs(obj.status.conditions) do
+                if condition.type == "ComparisonError" and condition.status ~= "False" then
+                    hs.status = "Degraded"
+                    if condition.message ~= nil then
+                      hs.message = condition.message
+                    else
+                      hs.message = "ComparisonError"
+                    end
+                    return hs
+                end
+              end
+            end
+
             if obj.status.health ~= nil then
               hs.status = obj.status.health.status
               if obj.status.health.message ~= nil then


### PR DESCRIPTION
By default, an Application's health status will not be affected if ArgoCD fails to render its Helm template (e.g. due to a bad secret reference causing AVP to error). 

For example, in the following screenshot the application in syncwave 1 is showing as **synced** and **healthy** even though its Helm chart rendering failed. Wave 2 was allowed to proceed even though the resources in wave 1 were not deployed. This would cause problems if the application in wave 2 depended on a resource being configured in wave 1 first:
![image](https://github.com/user-attachments/assets/a9c57ef8-dd8c-445d-9c44-8bd4dfe2d870)

If we look inside the application in wave 1, we can see that it is in an error state and no resources were deployed:
![image](https://github.com/user-attachments/assets/b4d5d826-726e-4d4f-b98b-7b6a9e4a2122)

ArgoCD is working as intended here; the Application in wave 1 is showing as **synced**, since this is the sync status of the Application CR itself (which synced just fine). It is showing as **healthy** since the health of a resource in ArgoCD is determined solely by the health of its direct children (and the application in wave 1 has no children since it failed to deploy any resources). The problem is that the intended behaviour means we cannot rely on syncwaves to control deployment ordering when Helm template rendering fails. 

There are a number of issues already open against ArgoCD relating to this, but none have come to any sort of conclusion about what should be changed. The most relevant one I have found is this: https://github.com/argoproj/argo-cd/issues/10088.
That includes the idea of adding logic to the custom Application healthcheck to check for the "ComparisonError" condition seen when the helm chart fails to render. This at least prevents ArgoCD from allowing sibling applications in later waves from syncing.

This PR extends the custom Application healthcheck established by `gitops-bootstrap` to set Application health to degraded when this ComparisonError condition is present. I've verified that this works as expected and (crucially) blocks sibling applications in later syncwaves from progressing:
![image](https://github.com/user-attachments/assets/8710860b-ce25-4713-bff7-1ff2bf06ae30)

https://jsw.ibm.com/browse/MASCORE-3669