### PR TITLE
[patch] Don't show error when we can't download previous pod logs

### DIFF
--- a/image/cli/mascli/must-gather/mg-collect-pods
+++ b/image/cli/mascli/must-gather/mg-collect-pods
@@ -88,7 +88,7 @@ for POD in ${PODS[@]}; do
       CONTAINERS=$(oc -n "${NAMESPACE}" get "${POD}" -o json -o jsonpath='{range .status.containerStatuses[*]}[{.name}] {end}' | tr -d '[]')
       for CONTAINER in ${CONTAINERS[@]}; do
         oc -n "${NAMESPACE}" logs "${POD}" -c "${CONTAINER}"    &> "${APP_LOG_DIR}/${POD_NAME}_${CONTAINER}.log"      || { echo_warning "  Error fetching current logs for container ${CONTAINER} in pod $POD_NAME"; continue; }
-        oc -n "${NAMESPACE}" logs "${POD}" -c "${CONTAINER}" -p &> "${APP_LOG_DIR}/prev_${POD_NAME}_${CONTAINER}.log" || { echo_warning "  Error fetching previous logs for container ${CONTAINER} in pod $POD_NAME"; continue; }
+        oc -n "${NAMESPACE}" logs "${POD}" -c "${CONTAINER}" -p &> "${APP_LOG_DIR}/${POD_NAME}_${CONTAINER}_prev.log"
       done
     fi
   fi


### PR DESCRIPTION
We can't differentiate between a pod with no previous pod log and an error obtaining a previous pod log that should exist, so don't show an error as it is misleading.

- Fixes #1203 

Also change the `prev_` prefix to a `_prev` suffix so that all logs for a specific pod are grouped when you view them alphabetically (which is the normal way to view a must-gather archive)