### PR TITLE
[patch] Add missing support for COS in non-interactive install

### DIFF
--- a/docs/commands/install.md
+++ b/docs/commands/install.md
@@ -41,14 +41,15 @@ mas install [-c MAS_CATALOG_VERSION] [--mas-catalog-digest MAS_CATALOG_DIGEST] [
             [--msk-instance-nodes AWS_MSK_INSTANCE_NUMBER] [--msk-instance-volume-size AWS_MSK_VOLUME_SIZE] [--msk-cidr-az1 AWS_MSK_CIDR_AZ1]
             [--msk-cidr-az2 AWS_MSK_CIDR_AZ2] [--msk-cidr-az3 AWS_MSK_CIDR_AZ3] [--msk-cidr-egress AWS_MSK_EGRESS_CIDR]
             [--msk-cidr-ingress AWS_MSK_INGRESS_CIDR] [--eventstreams-resource-group EVENTSTREAMS_RESOURCE_GROUP]
-            [--eventstreams-instance-name EVENTSTREAMS_INSTANCE_NAME] [--eventstreams-instance-location EVENTSTREAMS_INSTANCE_LOCATION]
-            [--turbonomic-name TURBONOMIC_TARGET_NAME] [--turbonomic-url TURBONOMIC_SERVER_URL] [--turbonomic-version TURBONOMIC_SERVER_VERSION]
-            [--turbonomic-username TURBONOMIC_USERNAME] [--turbonomic-password TURBONOMIC_PASSWORD] [--ibmcloud-apikey IBMCLOUD_APIKEY]
-            [--aws-region AWS_REGION] [--aws-access-key-id AWS_ACCESS_KEY_ID] [--secret-access-key SECRET_ACCESS_KEY] [--aws-vpc-id AWS_VPC_ID]
-            [--artifactory-username ARTIFACTORY_USERNAME] [--artifactory-token ARTIFACTORY_TOKEN] [--approval-core APPROVAL_CORE]
-            [--approval-assist APPROVAL_ASSIST] [--approval-iot APPROVAL_IOT] [--approval-manage APPROVAL_MANAGE] [--approval-monitor APPROVAL_MONITOR]
-            [--approval-optimizer APPROVAL_OPTIMIZER] [--approval-predict APPROVAL_PREDICT] [--approval-visualinspection APPROVAL_VISUALINSPECTION]
-            [--accept-license] [--dev-mode] [--no-wait-for-pvc] [--skip-pre-check] [--skip-grafana-install] [--no-confirm] [-h]
+            [--eventstreams-instance-name EVENTSTREAMS_INSTANCE_NAME] [--eventstreams-instance-location EVENTSTREAMS_INSTANCE_LOCATION] [--cos {ibm,ocs}]
+            [--cos-resourcegroup COS_RESOURCEGROUP] [--turbonomic-name TURBONOMIC_TARGET_NAME] [--turbonomic-url TURBONOMIC_SERVER_URL]
+            [--turbonomic-version TURBONOMIC_SERVER_VERSION] [--turbonomic-username TURBONOMIC_USERNAME] [--turbonomic-password TURBONOMIC_PASSWORD]
+            [--ibmcloud-apikey IBMCLOUD_APIKEY] [--aws-region AWS_REGION] [--aws-access-key-id AWS_ACCESS_KEY_ID] [--secret-access-key SECRET_ACCESS_KEY]
+            [--aws-vpc-id AWS_VPC_ID] [--artifactory-username ARTIFACTORY_USERNAME] [--artifactory-token ARTIFACTORY_TOKEN]
+            [--approval-core APPROVAL_CORE] [--approval-assist APPROVAL_ASSIST] [--approval-iot APPROVAL_IOT] [--approval-manage APPROVAL_MANAGE]
+            [--approval-monitor APPROVAL_MONITOR] [--approval-optimizer APPROVAL_OPTIMIZER] [--approval-predict APPROVAL_PREDICT]
+            [--approval-visualinspection APPROVAL_VISUALINSPECTION] [--accept-license] [--dev-mode] [--no-wait-for-pvc] [--skip-pre-check]
+            [--skip-grafana-install] [--no-confirm] [-h]
 ```
 
 

--- a/python/src/mas/cli/install/app.py
+++ b/python/src/mas/cli/install/app.py
@@ -717,6 +717,9 @@ class InstallApp(BaseApp, InstallSettingsMixin, InstallSummarizerMixin, ConfigGe
             "eventstreams_resource_group",
             "eventstreams_instance_name",
             "eventstreams_instance_location",
+            # COS
+            "cos_type",
+            "cos_resourcegroup",
             # ECK
             "eck_action",
             "eck_enable_logstash",

--- a/python/src/mas/cli/install/argBuilder.py
+++ b/python/src/mas/cli/install/argBuilder.py
@@ -299,6 +299,14 @@ class installArgBuilderMixin():
                     command += f" --eventstreams-instance-name \"{self.getParam('eventstreams_instance_name')}\""
                     command += f" --eventstreams-instance-location \"{self.getParam('eventstreams_instance_location')}\"{newline}"
 
+            # COS
+            # -----------------------------------------------------------------------------
+            if self.getParam('cos_type') != "":
+                command += f"  --cos \"{self.getParam('cos_type')}\""
+                if self.getParam('cos_resourcegroup') != "":
+                    command += f" --cos-resourcegroup \"{self.getParam('cos_resourcegroup')}\""
+                command += newline
+
             # Turbonomic Integration
             # -----------------------------------------------------------------------------
             if self.getParam('turbonomic_target_name') != "":

--- a/python/src/mas/cli/install/argParser.py
+++ b/python/src/mas/cli/install/argParser.py
@@ -600,7 +600,6 @@ db2ArgGroup.add_argument(
     help="Customize Db2 storage capacity"
 )
 
-
 # Kafka - Common
 # -----------------------------------------------------------------------------
 kafkaCommonArgGroup = installArgParser.add_argument_group("Kafka - Common")
@@ -704,6 +703,22 @@ eventstreamsArgGroup.add_argument(
     "--eventstreams-instance-location",
     required=False,
     help="Set IBM Event Streams instance location"
+)
+
+# COS
+# -----------------------------------------------------------------------------
+cosArgGroup = installArgParser.add_argument_group("Cloud Object Storage")
+cosArgGroup.add_argument(
+    "--cos",
+    dest="cos_type",
+    required=False,
+    help="Set cloud object storage provider.  Supported options are `ibm` and `ocs`",
+    choices=["ibm", "ocs"]
+)
+cosArgGroup.add_argument(
+    "--cos-resourcegroup",
+    required=False,
+    help="When using IBM COS, set the resource group where the instance will run"
 )
 
 # Turbonomic Integration

--- a/python/src/mas/cli/install/summarizer.py
+++ b/python/src/mas/cli/install/summarizer.py
@@ -249,6 +249,15 @@ class InstallSummarizerMixin():
         self.printSummary("License File", self.slsLicenseFileLocal)
         self.printParamSummary("IBM Open Registry", "sls_icr_cpopen")
 
+    def cosSummary(self) -> None:
+        self.printH2("Cloud Object Storage")
+        if self.getParam("cos_type") != "":
+            self.printParamSummary("Type", "cos_type")
+            if self.getParam("cos_resourcegroup") != "":
+                self.printParamSummary("Resource Group", "cos_resourcegroup")
+        else:
+            self.printSummary("Type", "None")
+
     def eckSummary(self) -> None:
         self.printH2("Elastic Cloud on Kubernetes")
         if self.getParam("eck_action") == "install":
@@ -336,6 +345,7 @@ class InstallSummarizerMixin():
         # Application Dependencies
         self.mongoSummary()
         self.db2Summary()
+        self.cosSummary()
         self.kafkaSummary()
         self.cp4dSummary()
         self.grafanaSummary()


### PR DESCRIPTION
Updating FVT to directly use the CLI has highlighted a gap in the non-interactive install mode regarding the COS support; specifically that it's completely absent.