### PR TITLE
[patch] Provide approvals even if FVT doesn't run

### DIFF
--- a/tekton/src/pipelines/fvt-launcher.yml.j2
+++ b/tekton/src/pipelines/fvt-launcher.yml.j2
@@ -288,9 +288,6 @@ spec:
         - name: configmap_value
           value: approved
       when:
-        - input: $(params.launchfvt_assist)
-          operator: in
-          values: ["true", "True"]
         - input: $(params.sync_with_install)
           operator: in
           values: ["true", "True"]
@@ -371,9 +368,6 @@ spec:
         - name: configmap_value
           value: approved
       when:
-        - input: "$(params.launchfvt_iot)$(params.launchfvt_monitor)"
-          operator: in
-          values: ["true", "True", "truetrue", "TrueTrue", "falsetrue", "FalseTrue", "truefalse","TrueFalse" ]
         - input: $(params.sync_with_install)
           operator: in
           values: ["true", "True"]
@@ -505,10 +499,6 @@ spec:
         - name: configmap_value
           value: approved
       when:
-        # Same criteria used in waitfor-manage task
-        - input: $(params.launchfvt_manage)$(params.launchfvt_mobile)$(params.launchfvt_manage_is)$(params.launchfvt_optimizer)$(params.launchfvt_predict)$(params.launchivt_manage)
-          operator: notin
-          values: ["falsefalsefalsefalsefalsefalse"] # case sensitive to simplify (here is how launchfvt flags are in fvt template repos)
         - input: $(params.sync_with_install)
           operator: in
           values: ["true", "True"]
@@ -617,9 +607,6 @@ spec:
         - name: configmap_value
           value: approved
       when:
-        - input: $(params.launchfvt_monitor)
-          operator: in
-          values: ["true", "True"]
         - input: $(params.sync_with_install)
           operator: in
           values: ["true", "True"]
@@ -699,9 +686,6 @@ spec:
         - name: configmap_value
           value: approved
       when:
-        - input: $(params.launchfvt_optimizer)
-          operator: in
-          values: ["true", "True"]
         - input: $(params.sync_with_install)
           operator: in
           values: ["true", "True"]
@@ -787,9 +771,6 @@ spec:
         - name: configmap_value
           value: approved
       when:
-        - input: $(params.launchfvt_predict)
-          operator: in
-          values: ["true", "True"]
         - input: $(params.sync_with_install)
           operator: in
           values: ["true", "True"]
@@ -869,9 +850,6 @@ spec:
         - name: configmap_value
           value: approved
       when:
-        - input: $(params.launchfvt_visualinspection)
-          operator: in
-          values: ["true", "True"]
         - input: $(params.sync_with_install)
           operator: in
           values: ["true", "True"]


### PR DESCRIPTION
The FVT launcher pipeline must provide the required approvals even when we are not running the FVT, otherwise when we try to run the launcher pipeline in sync with an install and we don't test everything that is installed we will see the installation pipeline hanging waiting for the approval configmap to be set to approved.

Additionally, this accounts for the ability to pre-approve a checkpoint in the pipeline.  Before this update if we approved an approval record before the install pipeline reached the point where it started to wait for that approval then install pipeline would reset the approval back to pending.