### PR TITLE
[patch] Align base language variable names

### DIFF
--- a/tekton/src/params/install.yml.j2
+++ b/tekton/src/params/install.yml.j2
@@ -516,11 +516,11 @@
   type: string
   description: Flag indicating if manage demodata should be loaded or not
   default: ""
-- name: mas_app_settings_base_language
+- name: mas_app_settings_base_lang
   type: string
   description: Defines Manage application base language
   default: "EN"
-- name: mas_app_settings_secondary_languages
+- name: mas_app_settings_secondary_langs
   type: string
   description: Defines Manage application list of secondary languages
   default: ""

--- a/tekton/src/pipelines/taskdefs/apps/manage-workspace.yml.j2
+++ b/tekton/src/pipelines/taskdefs/apps/manage-workspace.yml.j2
@@ -24,10 +24,10 @@
       value: $(params.mas_app_settings_aio_flag)
     - name: mas_app_settings_demodata
       value: $(params.mas_app_settings_demodata)
-    - name: mas_app_settings_base_language
-      value: $(params.mas_app_settings_base_language)
-    - name: mas_app_settings_secondary_languages
-      value: $(params.mas_app_settings_secondary_languages)
+    - name: mas_app_settings_base_lang
+      value: $(params.mas_app_settings_base_lang)
+    - name: mas_app_settings_secondary_langs
+      value: $(params.mas_app_settings_secondary_langs)
     - name: mas_app_settings_server_timezone
       value: $(params.mas_app_settings_server_timezone)
     - name: mas_app_settings_persistent_volumes_flag

--- a/tekton/src/tasks/suite-app-config.yml.j2
+++ b/tekton/src/tasks/suite-app-config.yml.j2
@@ -49,11 +49,11 @@ spec:
       type: string
       description: Flag indicating if manage demodata should be loaded or not
       default: ""
-    - name: mas_app_settings_base_language
+    - name: mas_app_settings_base_lang
       type: string
       description: Defines Manage application base language
       default: "EN"
-    - name: mas_app_settings_secondary_languages
+    - name: mas_app_settings_secondary_langs
       type: string
       description: Defines Manage application list of secondary languages
       default: ""
@@ -240,9 +240,9 @@ spec:
       - name: MAS_APP_SETTINGS_DEMODATA
         value: $(params.mas_app_settings_demodata)
       - name: MAS_APP_SETTINGS_BASE_LANG
-        value: $(params.mas_app_settings_base_language)
+        value: $(params.mas_app_settings_base_langs)
       - name: MAS_APP_SETTINGS_SECONDARY_LANGS
-        value: $(params.mas_app_settings_secondary_languages)
+        value: $(params.mas_app_settings_secondary_langs)
       - name: MAS_APP_SETTINGS_SERVER_TIMEZONE
         value: $(params.mas_app_settings_server_timezone)
       - name: MAS_APP_SETTINGS_PERSISTENT_VOLUMES_FLAG

--- a/tekton/src/tasks/suite-app-config.yml.j2
+++ b/tekton/src/tasks/suite-app-config.yml.j2
@@ -240,7 +240,7 @@ spec:
       - name: MAS_APP_SETTINGS_DEMODATA
         value: $(params.mas_app_settings_demodata)
       - name: MAS_APP_SETTINGS_BASE_LANG
-        value: $(params.mas_app_settings_base_langs)
+        value: $(params.mas_app_settings_base_lang)
       - name: MAS_APP_SETTINGS_SECONDARY_LANGS
         value: $(params.mas_app_settings_secondary_langs)
       - name: MAS_APP_SETTINGS_SERVER_TIMEZONE


### PR DESCRIPTION
For ibm-mas/cli#1216

Corresponding issues:
- https://github.com/ibm-mas/ansible-devops/pull/1439
- https://github.com/ibm-mas/python-devops/pull/22

Aligning variable name usage across our devops tools:
- Any instance of `mas_app_settings_base_language` has been changed to `mas_app_settings_base_lang`
- Any instance of `mas_app_settings_secondary_languages` has been changed to `mas_app_settings_secondary_langs`