### PR TITLE
[patch] Post-install verify should run after arcgis

### DIFF
--- a/tekton/src/pipelines/install.yml.j2
+++ b/tekton/src/pipelines/install.yml.j2
@@ -349,6 +349,7 @@ spec:
         - app-cfg-predict # infers Manage completed
         - app-cfg-monitor # infers IoT completed
         - app-cfg-visualinspection
+        - arcgis
         - eck
         - turbonomic
         - cognos


### PR DESCRIPTION
When `arcgis` was added to the pipeline, the `when` criteria for `post-install-verify` was not updated to include the new stage in the pipeline.