### PR TITLE
[patch] Fix --non-prod in non-interactive install

### DIFF
--- a/python/src/mas/cli/install/app.py
+++ b/python/src/mas/cli/install/app.py
@@ -282,6 +282,7 @@ class InstallApp(BaseApp, InstallSettingsMixin, InstallSummarizerMixin, ConfigGe
         ])
         self.operationalMode = self.promptForInt("Operational Mode", default=1)
 
+    def configAnnotations(self):
         if self.operationalMode == 2:
             self.setParam("mas_annotations", "mas.ibm.com/operationalMode=nonproduction")
 
@@ -1076,6 +1077,9 @@ class InstallApp(BaseApp, InstallSettingsMixin, InstallSummarizerMixin, ConfigGe
             "",
             self.buildCommand()
         ])
+
+        # Based on the parameters set the annotations correctly
+        self.configAnnotations()
 
         self.displayInstallSummary()
 

--- a/python/src/mas/cli/install/app.py
+++ b/python/src/mas/cli/install/app.py
@@ -780,6 +780,7 @@ class InstallApp(BaseApp, InstallSettingsMixin, InstallSummarizerMixin, ConfigGe
                     self.operationalMode = 1
                 else:
                     self.operationalMode = 2
+                    self.setParam("mas_annotations", "mas.ibm.com/operationalMode=nonproduction")
 
             elif key == "additional_configs":
                 self.localConfigDir = value


### PR DESCRIPTION
Moved setting the mas_annotations to after parameters have been processed so common to both interactive and non interactive.

Tested in fyre environment to confirm mas_annotations set correctly when run with:

> mas install --mas-catalog-version v9-master-amd64 --ibm-entitlement-key $IBM_ENTITLEMENT_KEY   --mas-channel 9.1.x-dev --mas-instance-id fvtnonprod --mas-workspace-id masdev --mas-workspace-name "MAS Development" --non-prod   --storage-class-rwo "ocs-storagecluster-ceph-rbd" --storage-class-rwx "ocs-storagecluster-cephfs" --storage-accessmode "ReadWriteMany"   --license-file "/mnt/home/entitlement.lic"   --uds-email "[secure]" --uds-firstname "First" --uds-lastname "Last"   --iot-channel ""   --monitor-channel ""   --accept-license --storage-pipeline "ocs-storagecluster-cephfs"

Fixes #1218 