### PR TITLE
[patch] Check for no status on subscription - gitops

### DIFF
--- a/image/cli/mascli/templates/gitops/bootstrap/argocd.yaml
+++ b/image/cli/mascli/templates/gitops/bootstrap/argocd.yaml
@@ -940,8 +940,10 @@ spec:
           end
           hs.status = "Progressing"
           hs.message = "Unknown"
-          if obj.status.state ~= nil then
-            hs.message = obj.status.state
+          if obj.status ~= nil then
+            if obj.status.state ~= nil then
+              hs.message = obj.status.state
+            end
           end
           return hs
 


### PR DESCRIPTION
Updates the lua healthy check used in gitops/argocd so that if the Subscription has no status yet then we don't try to get the state. Failure to have this check results in the error:

```
error setting app health: failed to get resource health for "Subscription" with name "nfd-operator" in namespace "openshift-nfd": <string>:17: attempt to index a non-table object(nil) with key 'state' stack traceback: <string>:17: in main chunk [G]: ?
```

I have set this in our FVT Argo and it works