### PR TITLE
[patch] mobile pytest task performance parameter

### DIFF
--- a/tekton/src/pipelines/taskdefs/fvt-mobile/pytest/phase2-setup.yml.j2
+++ b/tekton/src/pipelines/taskdefs/fvt-mobile/pytest/phase2-setup.yml.j2
@@ -23,6 +23,9 @@
       value: "MobileSetup4MAS.data"
     - name: upload_file
       value: "True"
+    - name: enable_perf_debug
+      value: "True"
+
   when:
     - input: "$(params.mas_app_channel_manage)"
       operator: notin

--- a/tekton/src/pipelines/taskdefs/fvt-mobile/pytest/phase2-setup.yml.j2
+++ b/tekton/src/pipelines/taskdefs/fvt-mobile/pytest/phase2-setup.yml.j2
@@ -23,8 +23,6 @@
       value: "MobileSetup4MAS.data"
     - name: upload_file
       value: "True"
-    - name: enable_perf_debug
-      value: "True"
 
   when:
     - input: "$(params.mas_app_channel_manage)"

--- a/tekton/src/pipelines/taskdefs/fvt-mobile/pytest/phase2-setup.yml.j2
+++ b/tekton/src/pipelines/taskdefs/fvt-mobile/pytest/phase2-setup.yml.j2
@@ -23,7 +23,6 @@
       value: "MobileSetup4MAS.data"
     - name: upload_file
       value: "True"
-
   when:
     - input: "$(params.mas_app_channel_manage)"
       operator: notin

--- a/tekton/src/pipelines/taskdefs/fvt-mobile/pytest/phase3-apps.yml.j2
+++ b/tekton/src/pipelines/taskdefs/fvt-mobile/pytest/phase3-apps.yml.j2
@@ -3,7 +3,10 @@
   params:
     {{ lookup('template', 'taskdefs/fvt-mobile/common/params-pytest.yml.j2') | indent(4) }}
     - name: fvt_test_suite
-      value: mobile-api-sr    
+      value: mobile-api-sr  
+    - name: enable_perf_debug
+      value: "True"
+  
   runAfter:
     - fvt-mobile-pytest-setup
 

--- a/tekton/src/pipelines/taskdefs/fvt-mobile/pytest/phase3-apps.yml.j2
+++ b/tekton/src/pipelines/taskdefs/fvt-mobile/pytest/phase3-apps.yml.j2
@@ -6,7 +6,6 @@
       value: mobile-api-sr  
     - name: enable_perf_debug
       value: "True"
-  
   runAfter:
     - fvt-mobile-pytest-setup
 

--- a/tekton/src/tasks/fvt/fvt-mobile-pytest.yml.j2
+++ b/tekton/src/tasks/fvt/fvt-mobile-pytest.yml.j2
@@ -51,6 +51,10 @@ spec:
 
     # Test-specific Information (all optional)
     # -------------------------------------------------------------------------
+    - name: enable_perf_debug
+      type: string
+      description: Used to determine if response time will be displayed and saved or not
+      default: "False"
     - name: upload_file
       type: string
       description: Used only by fvt-mobile-version step to upload version file to artifactory
@@ -110,7 +114,9 @@ spec:
 
       - name: UPLOAD_FILE
         value: "$(params.upload_file)"
-      
+      - name: ENABLE_PERF_DEBUG
+        value: "$(params.enable_perf_debug)"
+
       - name: WORKSPACE_MANAGEDATA_PATH
         value: "$(params.workspace_managedata_path)"
       - name: INPUT_DATA_FILE


### PR DESCRIPTION
- Adding a new parameter to mobile pytest task that enables request/response elapse time.

Testing evidence of a successful taskrun with this new param
![image](https://github.com/user-attachments/assets/ced7f17c-ad44-4e20-8d7e-c586c90d2cf3)

Successful pipeline run with this cli image version
![image](https://github.com/user-attachments/assets/0b980e24-183e-47b2-9adf-a881c1c67cf4)

