### PR TITLE
[patch] update gitops pipelines to use wait-for-tekton task

### DIFF
--- a/tekton/src/pipelines/gitops/deprovision-cluster.yml.j2
+++ b/tekton/src/pipelines/gitops/deprovision-cluster.yml.j2
@@ -48,14 +48,21 @@ spec:
     # 0. Wait for the deprovsion mas pipeline to complete
     # -------------------------------------------------------------------------
     - name: wait-for-deprovision
-      params:
-        - name: pipelinerun_name
-          value: $(params.pipelinerun_name)
-        - name: ignore_failure
-          value: $(params.ignore_failure)
+      timeout: "0"
       taskRef:
         kind: Task
-        name: mas-fvt-wait-for-pipelinerun
+        name: mas-devops-wait-for-tekton
+      params:
+        - name: type
+          value: pipelinerun
+        - name: name
+          value: $(params.pipelinerun_name)
+        - name: delay
+          value: 120  # seconds between checking the status of the pipelinerun
+        - name: retries
+          value: 50  # attempts before giving up
+        - name: ignore_failure
+          value: $(params.ignore_failure)  # fails and exit once the first failure is detected
 {% endif %}
 
     - name: gitops-deprovision-rosa

--- a/tekton/src/pipelines/gitops/deprovision-mas-deps.yml.j2
+++ b/tekton/src/pipelines/gitops/deprovision-mas-deps.yml.j2
@@ -93,14 +93,21 @@ spec:
     # 0. Wait for the deprovsion mas pipeline to complete
     # -------------------------------------------------------------------------
     - name: wait-for-deprovision
-      params:
-        - name: pipelinerun_name
-          value: $(params.pipelinerun_name)
-        - name: ignore_failure
-          value: $(params.ignore_failure)
+      timeout: "0"
       taskRef:
         kind: Task
-        name: mas-fvt-wait-for-pipelinerun
+        name: mas-devops-wait-for-tekton
+      params:
+        - name: type
+          value: pipelinerun
+        - name: name
+          value: $(params.pipelinerun_name)
+        - name: delay
+          value: 120  # seconds between checking the status of the pipelinerun
+        - name: retries
+          value: 50  # attempts before giving up
+        - name: ignore_failure
+          value: $(params.ignore_failure)  # fails and exit once the first failure is detected
 {% endif %}
     - name: gitops-deprovision-mongo
 {% if wait_for_deprovision == true %}

--- a/tekton/src/pipelines/gitops/gitops-mas-deps.yml.j2
+++ b/tekton/src/pipelines/gitops/gitops-mas-deps.yml.j2
@@ -99,14 +99,21 @@ spec:
     # 0. Wait for the provsion pipeline to complete
     # -------------------------------------------------------------------------
     - name: wait-for-provision
-      params:
-        - name: pipelinerun_name
-          value: $(params.pipelinerun_name)
-        - name: ignore_failure
-          value: $(params.ignore_failure)
+      timeout: "0"
       taskRef:
         kind: Task
-        name: mas-fvt-wait-for-pipelinerun
+        name: mas-devops-wait-for-tekton
+      params:
+        - name: type
+          value: pipelinerun
+        - name: name
+          value: $(params.pipelinerun_name)
+        - name: delay
+          value: 120  # seconds between checking the status of the pipelinerun
+        - name: retries
+          value: 50  # attempts before giving up
+        - name: ignore_failure
+          value: $(params.ignore_failure)  # fails and exit once the first failure is detected
 {% endif %}
     - name: gitops-mongo
 {% if wait_for_provision == true %}

--- a/tekton/src/pipelines/gitops/gitops-mas-initiator.yml.j2
+++ b/tekton/src/pipelines/gitops/gitops-mas-initiator.yml.j2
@@ -114,14 +114,21 @@ spec:
     # 0. Wait for the provsion pipeline to complete
     # -------------------------------------------------------------------------
     - name: wait-for-provision
-      params:
-        - name: pipelinerun_name
-          value: $(params.pipelinerun_name)
-        - name: ignore_failure
-          value: $(params.ignore_failure)
+      timeout: "0"
       taskRef:
         kind: Task
-        name: mas-fvt-wait-for-pipelinerun
+        name: mas-devops-wait-for-tekton
+      params:
+        - name: type
+          value: pipelinerun
+        - name: name
+          value: $(params.pipelinerun_name)
+        - name: delay
+          value: 120  # seconds between checking the status of the pipelinerun
+        - name: retries
+          value: 50  # attempts before giving up
+        - name: ignore_failure
+          value: $(params.ignore_failure)  # fails and exit once the first failure is detected
 {% endif %}
     - name: gitops-mas-initiator
 {% if wait_for_provision == true %}

--- a/tekton/src/pipelines/gitops/provision-bootstrap-cluster.yml.j2
+++ b/tekton/src/pipelines/gitops/provision-bootstrap-cluster.yml.j2
@@ -64,14 +64,21 @@ spec:
     # 0. Wait for the deprovsion pipeline to complete
     # -------------------------------------------------------------------------
     - name: wait-for-deprovision
-      params:
-        - name: pipelinerun_name
-          value: $(params.pipelinerun_name)
-        - name: ignore_failure
-          value: $(params.ignore_failure)
+      timeout: "0"
       taskRef:
         kind: Task
-        name: mas-fvt-wait-for-pipelinerun
+        name: mas-devops-wait-for-tekton
+      params:
+        - name: type
+          value: pipelinerun
+        - name: name
+          value: $(params.pipelinerun_name)
+        - name: delay
+          value: 120  # seconds between checking the status of the pipelinerun
+        - name: retries
+          value: 50  # attempts before giving up
+        - name: ignore_failure
+          value: $(params.ignore_failure)  # fails and exit once the first failure is detected
 {% endif %}
     - name: gitops-rosa
 {% if wait_for_deprovision == true %}


### PR DESCRIPTION
A number of gitops based pipelines were using an old task that no longer exists for waiting for another pipelinerun to complete. This changes moves to using the expected wait-for-tekton task. Tested in FVT cluster:

```
step-wait
Waiting for pipelinerun/gitops-mas-deps-fvtsaas-3943 in mas-fvtsaas-pipelines to complete ...

Status of pipelinerun
------------------------------------------------------------------
NAME                           SUCCEEDED   REASON      STARTTIME   COMPLETIONTIME
gitops-mas-deps-fvtsaas-3943   True        Completed   3h8m        172m

Waiting for pipelinerun/gitops-mas-deps-fvtsaas-3943 to complete
------------------------------------------------------------------
Completion Time = 2024-09-13T06:47:25Z
Retries Used    = 0
Result          = pipelinerun completed successfully
```