### PR TITLE
[patch] Update name of finally task and set max_retries correctly

### DIFF
--- a/image/cli/app-root/src/wait-for-tekton.sh
+++ b/image/cli/app-root/src/wait-for-tekton.sh
@@ -85,7 +85,10 @@ done
 
 echo "Completion Time = $COMPLETION_TIME"
 echo "Retries Used    = $RETRIES_USED"
-RESULT=$(oc -n ${NAMESPACE} get ${TYPE}/$NAME -o jsonpath='{.status.conditions[0].status}')
+RESULT=""
+while [[ "$RESULT" == "" ]]; do
+  RESULT=$(oc -n ${NAMESPACE} get ${TYPE}/$NAME -o jsonpath='{.status.conditions[0].status}')
+done
 
 if [[ "$RESULT" == "True" ]]; then
   echo "Result          = ${TYPE} completed successfully"

--- a/image/cli/mascli/functions/gitops_mas_fvt_preparer
+++ b/image/cli/mascli/functions/gitops_mas_fvt_preparer
@@ -82,8 +82,11 @@ function gitops_mas_fvt_preparer() {
   export SYNC_WITH_INSTALL=false
   #If this is the FVT Core run then don't call finalize at the end of this run
   if [[ "$LAUNCHER_ID" == "core" ]]; then
-    export RUN_FINALIZE=false
+    export FINALIZE=false
+    export SET_FINISHED=false
   fi
+  export DEPROVISION=false
+  
   #FVT pipeline to run
   export PIPELINE_NAME=$FVT_PIPELINE_NAME
   ansible-playbook ibm.mas_fvt.setup_pipeline

--- a/image/cli/masfvt/finally.yml
+++ b/image/cli/masfvt/finally.yml
@@ -9,7 +9,7 @@
 
     # Pipeline Run Info
     devops_build_number: "{{ lookup('env', 'DEVOPS_BUILD_NUMBER') | default('0', True) }}"
-    pipelinerun_name: "{{ lookup('env', 'PIPELINERUN_NAME') | default('mas-fvt-finally', True) }}-{{ devops_build_number }}"
+    pipelinerun_name: "{{ lookup('env', 'PIPELINERUN_NAME') | default('mas-fvt-finally-' ~ devops_build_number, True) }}"
     mas_instance_id: "{{ lookup('env', 'MAS_INSTANCE_ID') }}"
     pipelinerun_namespace: "{{ lookup('env', 'PIPELINERUN_NAMESPACE') | default('mas-' ~ mas_instance_id ~ '-pipelines', True) }}"
   tasks:

--- a/tekton/src/pipelines/fvt-deprovision-after.yml.j2
+++ b/tekton/src/pipelines/fvt-deprovision-after.yml.j2
@@ -88,7 +88,7 @@ spec:
           value: $(params.pipelinerun_name)
         - name: delay
           value: 1200  # 20 minutes between checking the status of the pipelinerun
-        - name: retries
+        - name: max_retries
           value: 60  # attempts before giving up (approximately 20 hours)
         - name: ignore_failure
           value: $(params.ignore_failure)

--- a/tekton/src/pipelines/fvt-launcher.yml.j2
+++ b/tekton/src/pipelines/fvt-launcher.yml.j2
@@ -98,6 +98,10 @@ spec:
       type: string
       default: "true"
       description: "Set this to 'false' to stop the finalize task from running for this launcher"
+    - name: set_finished
+      type: string
+      default: "true"
+      description: "Set this to 'false' to stop the the fvt test being marked as complete"
 
     # Deprovision Resources
     # -------------------------------------------------------------------------
@@ -936,6 +940,8 @@ spec:
           value: "$(params.deprovision)"
         - name: finalize
           value: "$(params.finalize)"
+        - name: set_finished
+          value: "$(params.set_finished)"
         - name: image_pull_policy
           value: $(params.image_pull_policy)
         - name: pipelinerun_name

--- a/tekton/src/pipelines/fvt-launcher.yml.j2
+++ b/tekton/src/pipelines/fvt-launcher.yml.j2
@@ -939,7 +939,7 @@ spec:
         - name: image_pull_policy
           value: $(params.image_pull_policy)
         - name: pipelinerun_name
-          value: "$(params.mas_instance_id)-fvt-finally"
+          value: "$(context.pipelineRun.name)-fvt-finally"
 
   workspaces:
     # The generated configuration files

--- a/tekton/src/pipelines/gitops/deprovision-cluster.yml.j2
+++ b/tekton/src/pipelines/gitops/deprovision-cluster.yml.j2
@@ -59,7 +59,7 @@ spec:
           value: $(params.pipelinerun_name)
         - name: delay
           value: 120  # seconds between checking the status of the pipelinerun
-        - name: retries
+        - name: max_retries
           value: 120  # attempts before giving up
         - name: ignore_failure
           value: $(params.ignore_failure)  # fails and exit once the first failure is detected

--- a/tekton/src/pipelines/gitops/deprovision-cluster.yml.j2
+++ b/tekton/src/pipelines/gitops/deprovision-cluster.yml.j2
@@ -60,7 +60,7 @@ spec:
         - name: delay
           value: 120  # seconds between checking the status of the pipelinerun
         - name: retries
-          value: 50  # attempts before giving up
+          value: 120  # attempts before giving up
         - name: ignore_failure
           value: $(params.ignore_failure)  # fails and exit once the first failure is detected
 {% endif %}

--- a/tekton/src/pipelines/gitops/deprovision-mas-deps.yml.j2
+++ b/tekton/src/pipelines/gitops/deprovision-mas-deps.yml.j2
@@ -104,7 +104,7 @@ spec:
           value: $(params.pipelinerun_name)
         - name: delay
           value: 120  # seconds between checking the status of the pipelinerun
-        - name: retries
+        - name: max_retries
           value: 120  # attempts before giving up
         - name: ignore_failure
           value: $(params.ignore_failure)  # fails and exit once the first failure is detected

--- a/tekton/src/pipelines/gitops/deprovision-mas-deps.yml.j2
+++ b/tekton/src/pipelines/gitops/deprovision-mas-deps.yml.j2
@@ -105,7 +105,7 @@ spec:
         - name: delay
           value: 120  # seconds between checking the status of the pipelinerun
         - name: retries
-          value: 50  # attempts before giving up
+          value: 120  # attempts before giving up
         - name: ignore_failure
           value: $(params.ignore_failure)  # fails and exit once the first failure is detected
 {% endif %}

--- a/tekton/src/pipelines/gitops/gitops-mas-deps.yml.j2
+++ b/tekton/src/pipelines/gitops/gitops-mas-deps.yml.j2
@@ -111,7 +111,7 @@ spec:
         - name: delay
           value: 120  # seconds between checking the status of the pipelinerun
         - name: retries
-          value: 50  # attempts before giving up
+          value: 120  # attempts before giving up
         - name: ignore_failure
           value: $(params.ignore_failure)  # fails and exit once the first failure is detected
 {% endif %}

--- a/tekton/src/pipelines/gitops/gitops-mas-deps.yml.j2
+++ b/tekton/src/pipelines/gitops/gitops-mas-deps.yml.j2
@@ -110,7 +110,7 @@ spec:
           value: $(params.pipelinerun_name)
         - name: delay
           value: 120  # seconds between checking the status of the pipelinerun
-        - name: retries
+        - name: max_retries
           value: 120  # attempts before giving up
         - name: ignore_failure
           value: $(params.ignore_failure)  # fails and exit once the first failure is detected

--- a/tekton/src/pipelines/gitops/gitops-mas-fvt-preparer-pipeline.yml.j2
+++ b/tekton/src/pipelines/gitops/gitops-mas-fvt-preparer-pipeline.yml.j2
@@ -81,6 +81,8 @@ spec:
 
     - name: mas_workspace_id
       type: string
+    - name: mas_channel
+      type: string
 
     - name: launchfvt_core
       type: string
@@ -229,6 +231,8 @@ spec:
 
         - name: mas_workspace_id
           value: $(params.mas_workspace_id)
+        - name: mas_channel
+          value: $(params.mas_channel)
 
         - name: launchfvt_core
           value: $(params.launchfvt_core)

--- a/tekton/src/pipelines/gitops/gitops-mas-initiator.yml.j2
+++ b/tekton/src/pipelines/gitops/gitops-mas-initiator.yml.j2
@@ -125,7 +125,7 @@ spec:
           value: $(params.pipelinerun_name)
         - name: delay
           value: 120  # seconds between checking the status of the pipelinerun
-        - name: retries
+        - name: max_retries
           value: 120  # attempts before giving up
         - name: ignore_failure
           value: $(params.ignore_failure)  # fails and exit once the first failure is detected

--- a/tekton/src/pipelines/gitops/gitops-mas-initiator.yml.j2
+++ b/tekton/src/pipelines/gitops/gitops-mas-initiator.yml.j2
@@ -126,7 +126,7 @@ spec:
         - name: delay
           value: 120  # seconds between checking the status of the pipelinerun
         - name: retries
-          value: 50  # attempts before giving up
+          value: 120  # attempts before giving up
         - name: ignore_failure
           value: $(params.ignore_failure)  # fails and exit once the first failure is detected
 {% endif %}

--- a/tekton/src/pipelines/gitops/provision-bootstrap-cluster.yml.j2
+++ b/tekton/src/pipelines/gitops/provision-bootstrap-cluster.yml.j2
@@ -76,7 +76,7 @@ spec:
         - name: delay
           value: 120  # seconds between checking the status of the pipelinerun
         - name: retries
-          value: 50  # attempts before giving up
+          value: 120  # attempts before giving up
         - name: ignore_failure
           value: $(params.ignore_failure)  # fails and exit once the first failure is detected
 {% endif %}

--- a/tekton/src/pipelines/gitops/provision-bootstrap-cluster.yml.j2
+++ b/tekton/src/pipelines/gitops/provision-bootstrap-cluster.yml.j2
@@ -75,7 +75,7 @@ spec:
           value: $(params.pipelinerun_name)
         - name: delay
           value: 120  # seconds between checking the status of the pipelinerun
-        - name: retries
+        - name: max_retries
           value: 120  # attempts before giving up
         - name: ignore_failure
           value: $(params.ignore_failure)  # fails and exit once the first failure is detected

--- a/tekton/src/pipelines/rollback.yml.j2
+++ b/tekton/src/pipelines/rollback.yml.j2
@@ -77,7 +77,7 @@ spec:
           value: $(params.pipelinerun_name)
         - name: delay
           value: 600  # seconds between checking the status of the pipelinerun
-        - name: retries
+        - name: max_retries
           value: 50  # attempts before giving up
         - name: ignore_failure
           value: "False"  # fails and exit once the first failure is detected

--- a/tekton/src/pipelines/update.yml.j2
+++ b/tekton/src/pipelines/update.yml.j2
@@ -228,7 +228,7 @@ spec:
           value: $(params.pipelinerun_name)
         - name: delay
           value: 600  # seconds between checking the status of the pipelinerun
-        - name: retries
+        - name: max_retries
           value: 50  # attempts before giving up
         - name: ignore_failure
           value: "False"  # fails and exit once the first failure is detected

--- a/tekton/src/pipelines/upgrade.yml.j2
+++ b/tekton/src/pipelines/upgrade.yml.j2
@@ -59,7 +59,7 @@ spec:
           value: $(params.pipelinerun_name)
         - name: delay
           value: 600  # seconds between checking the status of the pipelinerun
-        - name: retries
+        - name: max_retries
           value: 50  # attempts before giving up
         - name: ignore_failure
           value: "False"  # fails and exit once the first failure is detected


### PR DESCRIPTION
A few changes/fixes:
- updates the name of the finally pipelinerun so we can have mulitple finally pipelineruns per build. See screenshot for it working:
![image- 2024-09-16 at 08 17 38](https://github.com/user-attachments/assets/63a9f7c8-8752-4e8a-9b1f-8f305b1f152e)
- Adds a retry loop in the wait-for-tekton to cope with bad connections to the cluster causing failures
- For gitops call the fvt launcher for core with the finailize and set_finished as false
- For gitops the `mas_channel` was not be set correctly on the fvt_preparer
- The retries on the wait-for-tetkton should be max_retries as it was not getting picked up.

Tested in fvtsaas as per screenshot above.