### PR TITLE
[patch] install cert manager after catalogs to avoid subscription patch failure

### DIFF
--- a/tekton/src/pipelines/install.yml.j2
+++ b/tekton/src/pipelines/install.yml.j2
@@ -54,7 +54,7 @@ spec:
     # 1.2 Red Hat Certificate Manager
     {{ lookup('template', pipeline_src_dir ~ '/taskdefs/cluster-setup/cert-manager.yml.j2') | indent(4) }}
       runAfter:
-        - pre-install-check
+        - ibm-catalogs
 
     # 1.3 Configure Grafana
     {{ lookup('template', pipeline_src_dir ~ '/taskdefs/cluster-setup/grafana.yml.j2') | indent(4) }}


### PR DESCRIPTION
**Description**
https://jsw.ibm.com/browse/MASCORE-3864 Is caused by an update to catalogs while the cert manager is being installed. To avoid this, the install pipeline has been changed to run the cert-manager role after the ibm-catalogs role.

**Testing**
Tested by running in pfvtpds cluster:
<img width="543" alt="Project mas-pfvtpds-pipelines" src="https://github.com/user-attachments/assets/b51683c0-7fc5-46fd-9c22-a0df2ba36c27">
