### PR TITLE
[patch] run grafana role after catalog install

### DIFF
--- a/tekton/src/pipelines/install.yml.j2
+++ b/tekton/src/pipelines/install.yml.j2
@@ -63,7 +63,7 @@ spec:
           operator: in
           values: ["install"]
       runAfter:
-        - pre-install-check
+        - ibm-catalogs
 
     # 1.4 Configure ECK
     {{ lookup('template', pipeline_src_dir ~ '/taskdefs/cluster-setup/eck.yml.j2') | indent(4) }}


### PR DESCRIPTION
**Description**
Similar to https://github.com/ibm-mas/cli/pull/1249, while investigating https://jsw.ibm.com/browse/MASCORE-3864, the same error is seen with the grafana operator subscription (See FVTcore run #3754
https://na.artifactory.swg-devops.com/artifactory/wiotp-generic-logs/mas-fvt/fvtcore/3754/must-gather-20240821-165003.tgz). 
 To avoid this, the install pipeline has been changed to run the grafana role after the ibm-catalogs role.

**Testing**
Tested by running in pfvtpds cluster:
<img width="494" alt="image" src="https://github.com/user-attachments/assets/9cae45b8-d77e-4a94-9ae1-a45b3ccc7252">

