### PR TITLE
[patch] need to check for nfs-client now

### DIFF
--- a/image/cli/mascli/functions/internal/install_config_storage_classes
+++ b/image/cli/mascli/functions/internal/install_config_storage_classes
@@ -65,6 +65,18 @@ function install_config_storage_classes() {
     fi
   fi
 
+  if [[ "$STORAGE_CLASS_RWX" == "" ]]; then
+    oc get storageclass nfs-client &>> $LOGFILE
+    if [[ $? == "0" ]]; then
+      echo -e "${COLOR_GREEN}Storage provider auto-detected: OpenShift Container Storage${TEXT_RESET}"
+      echo "${TEXT_DIM}  - Storage class (ReadWriteOnce): nfs-client"
+      echo "${TEXT_DIM}  - Storage class (ReadWriteMany): nfs-client"
+      STORAGE_CLASS_PROVIDER=ocs
+      STORAGE_CLASS_RWO=nfs-client
+      STORAGE_CLASS_RWX=nfs-client
+    fi
+  fi
+
   # 3. Azure
   if [[ "$STORAGE_CLASS_RWX" == "" ]]; then
     oc get storageclass managed-premium &>> $LOGFILE

--- a/python/src/mas/cli/install/app.py
+++ b/python/src/mas/cli/install/app.py
@@ -484,6 +484,14 @@ class InstallApp(BaseApp, InstallSettingsMixin, InstallSummarizerMixin, ConfigGe
             self.storageClassProvider = "ocs"
             self.params["storage_class_rwo"] = "ocs-storagecluster-ceph-rbd"
             self.params["storage_class_rwx"] = "ocs-storagecluster-cephfs"
+        # OCS quick burn uses nfs-client now
+        elif getStorageClass(self.dynamicClient, "nfs-client") is not None:
+            print_formatted_text(HTML("<MediumSeaGreen>Storage provider auto-detected: OpenShift Container Storage</MediumSeaGreen>"))
+            print_formatted_text(HTML("<LightSlateGrey>  - Storage class (ReadWriteOnce): nfs-client</LightSlateGrey>"))
+            print_formatted_text(HTML("<LightSlateGrey>  - Storage class (ReadWriteMany): nfs-client</LightSlateGrey>"))
+            self.storageClassProvider = "ocs"
+            self.params["storage_class_rwo"] = "nfs-client"
+            self.params["storage_class_rwx"] = "nfs-client"
         # 3. Azure
         elif getStorageClass(self.dynamicClient, "managed-premium") is not None:
             print_formatted_text(HTML("<MediumSeaGreen>Storage provider auto-detected: Azure Managed</MediumSeaGreen>"))


### PR DESCRIPTION
No related issue to this but found a bug around the storage class `nfs-client` setup not being defaulted for manage and health as well as not setting it as the cluster primary storage when installing quick burn Fyre clusters. 