### PR TITLE
[patch] Step timeout to 6.40hrs as imagescan wait for 6.30hrs

### DIFF
--- a/tekton/src/tasks/ivt/ivt-core.yml.j2
+++ b/tekton/src/tasks/ivt/ivt-core.yml.j2
@@ -108,7 +108,7 @@ spec:
   steps:
     - image: '$(params.fvt_image_registry)/mas-devops/ivt-core@$(params.fvt_image_digest)'
       imagePullPolicy: $(params.image_pull_policy)
-      timeout: 4h0m0s # SPS Multi-Scan can take over three hours to run for IoT
+      timeout: 6h40m0s # SPS Multi-Scan can take over three hours to run for IoT
       onError: continue # Ensure bad FVTs don't break the pipeline
       resources: {}
       workingDir: /opt/ibm/test/src


### PR DESCRIPTION
Increased imagescan wait time to 6.30 hours in this PR https://github.ibm.com/maximoappsuite/ivt-ibm-mas/pull/118 as Some instance of IOT image scan takes > 4 hours to scan 100 images

Added corresponding change in this PR to increase the step timeout to 6.40 hrs

---

Task: https://jsw.ibm.com/browse/IBMIOT-575?filter=-1
