### PR TITLE
[patch] include default for set_finished parameter

### DIFF
--- a/tekton/src/tasks/fvt/fvt-finalize.yml.j2
+++ b/tekton/src/tasks/fvt/fvt-finalize.yml.j2
@@ -9,6 +9,8 @@ spec:
     
     - name: set_finished
       type: string
+      default: "true"
+      description: "Set this to 'false' to stop the the fvt test being marked as complete"
 
   steps:
     - name: finalize


### PR DESCRIPTION
See https://jsw.ibm.com/browse/MASCORE-3994, addition of set_finished parameter to the fvt-finalize task with no default breaks the update pipeline (and presumably others too)

Testing - I just successfully started an update pipeline in pfvtcpd48 with this change (it failed before)