### PR TITLE
[patch] Update sls to 90 mins wait time in gitops fvt-preparer

### DIFF
--- a/tekton/src/tasks/gitops/gitops-mas-fvt-preparer.yml.j2
+++ b/tekton/src/tasks/gitops/gitops-mas-fvt-preparer.yml.j2
@@ -370,7 +370,7 @@ spec:
           SUITE_APP_NAME="suite.${CLUSTER_NAME}.${MAS_INSTANCE_ID}"
           WORKSPACE_APP="${MAS_WORKSPACE_ID}.suite.${CLUSTER_NAME}.${MAS_INSTANCE_ID}"
 
-          check_argo_app_healthy "${SLS_APP_NAME}" 60 #30 minutes
+          check_argo_app_healthy "${SLS_APP_NAME}" 180 #90 minutes
           check_argo_app_healthy "${MONGO_CONFIG_APP}" 30 #15 minutes
           check_argo_app_healthy "${SLS_CONFIG_APP}" 30
           check_argo_app_healthy "${BAS_CONFIG_APP}" 30


### PR DESCRIPTION
Add an hour to the first check which is SLS to cater for delays in ArgoCD rolling out changes. Once SLS it healthy then the following apps should be fine.