### PR TITLE
[patch] Remove installplan from non-gitops pipeline

### DIFF
--- a/tekton/src/pipelines/taskdefs/apps/assist-app.yml.j2
+++ b/tekton/src/pipelines/taskdefs/apps/assist-app.yml.j2
@@ -9,8 +9,7 @@
       value: $(params.mas_instance_id)
     - name: mas_app_id
       value: assist
-    - name: mas_app_install_plan
-      value: $(params.mas_app_install_plan_assist)
+
     - name: artifactory_username
       value: $(params.artifactory_username)
     - name: artifactory_token

--- a/tekton/src/pipelines/taskdefs/apps/iot-app.yml.j2
+++ b/tekton/src/pipelines/taskdefs/apps/iot-app.yml.j2
@@ -16,8 +16,6 @@
       value: iot
     - name: mas_app_channel
       value: "$(params.mas_app_channel_iot)"
-    - name: mas_app_install_plan
-      value: $(params.mas_app_install_plan_iot)
     - name: ibm_entitlement_key
       value: $(params.ibm_entitlement_key)
     - name: custom_labels

--- a/tekton/src/pipelines/taskdefs/apps/manage-app.yml.j2
+++ b/tekton/src/pipelines/taskdefs/apps/manage-app.yml.j2
@@ -15,8 +15,6 @@
       value: $(params.artifactory_token)
     - name: mas_app_channel
       value: "$(params.mas_app_channel_manage)"
-    - name: mas_app_install_plan
-      value: $(params.mas_app_install_plan_manage)
     - name: ibm_entitlement_key
       value: $(params.ibm_entitlement_key)
     - name: custom_labels

--- a/tekton/src/pipelines/taskdefs/apps/monitor-app.yml.j2
+++ b/tekton/src/pipelines/taskdefs/apps/monitor-app.yml.j2
@@ -16,8 +16,6 @@
       value: monitor
     - name: mas_app_channel
       value: "$(params.mas_app_channel_monitor)"
-    - name: mas_app_install_plan
-      value: $(params.mas_app_install_plan_monitor)
     - name: ibm_entitlement_key
       value: $(params.ibm_entitlement_key)
     - name: custom_labels

--- a/tekton/src/pipelines/taskdefs/apps/optimizer-app.yml.j2
+++ b/tekton/src/pipelines/taskdefs/apps/optimizer-app.yml.j2
@@ -15,8 +15,6 @@
       value: $(params.artifactory_token)
     - name: mas_app_channel
       value: "$(params.mas_app_channel_optimizer)"
-    - name: mas_app_install_plan
-      value: $(params.mas_app_install_plan_optimizer)
     - name: mas_app_plan
       value: "$(params.mas_app_plan_optimizer)"
     - name: ibm_entitlement_key

--- a/tekton/src/pipelines/taskdefs/apps/predict-app.yml.j2
+++ b/tekton/src/pipelines/taskdefs/apps/predict-app.yml.j2
@@ -15,8 +15,6 @@
       value: $(params.artifactory_token)
     - name: mas_app_channel
       value: "$(params.mas_app_channel_predict)"
-    - name: mas_app_install_plan
-      value: $(params.mas_app_install_plan_predict)
     - name: ibm_entitlement_key
       value: $(params.ibm_entitlement_key)
     - name: custom_labels

--- a/tekton/src/pipelines/taskdefs/apps/visualinspection-app.yml.j2
+++ b/tekton/src/pipelines/taskdefs/apps/visualinspection-app.yml.j2
@@ -15,8 +15,6 @@
       value: $(params.artifactory_token)
     - name: mas_app_channel
       value: "$(params.mas_app_channel_visualinspection)"
-    - name: mas_app_install_plan
-      value: $(params.mas_app_install_plan_visualinspection)
     - name: mas_app_settings_visualinspection_storage_class
       value: $(params.storage_class_rwx) # use common rwx storage class as user is not prompted to choose this storage class
     - name: ibm_entitlement_key


### PR DESCRIPTION
The installplan vars were incorrectly added to the non-gitops pipelines, which was breaking the tekton install. Removing these and verified it can be installed.