### PR TITLE
[patch] Don't remove ldap or smtp secrets in gitops

### DIFF
--- a/image/cli/mascli/functions/gitops_mas_config
+++ b/image/cli/mascli/functions/gitops_mas_config
@@ -833,22 +833,10 @@ function gitops_mas_config() {
       sm_delete_secret $SECRET_NAME_MAS_SEGMENT_KEY
     fi
 
-    if [ "${MAS_CONFIG_TYPE}" == "ldap-default" ]; then
-      sm_login
-      SECRET_NAME_LDAP=${ACCOUNT_ID}${SECRETS_KEY_SEPERATOR}${CLUSTER_ID}${SECRETS_KEY_SEPERATOR}${MAS_INSTANCE_ID}${SECRETS_KEY_SEPERATOR}ldap
-      sm_delete_secret $SECRET_NAME_LDAP
-    fi
-
     if [ "${MAS_CONFIG_TYPE}" == "jdbc" ]; then
       sm_login
       export JDBC_CREDENTIALS_SECRET_ID=${ACCOUNT_ID}${SECRETS_KEY_SEPERATOR}${CLUSTER_ID}${SECRETS_KEY_SEPERATOR}${MAS_INSTANCE_ID}${SECRETS_KEY_SEPERATOR}jdbc${SECRETS_KEY_SEPERATOR}${JDBC_INSTANCE_NAME}${SECRETS_KEY_SEPERATOR}credentials
       sm_delete_secret $JDBC_CREDENTIALS_SECRET_ID
-    fi
-
-    if [ "${MAS_CONFIG_TYPE}" == "smtp" ]; then
-      sm_login
-      SECRET_NAME_SMTP=${ACCOUNT_ID}${SECRETS_KEY_SEPERATOR}${CLUSTER_ID}${SECRETS_KEY_SEPERATOR}${MAS_INSTANCE_ID}${SECRETS_KEY_SEPERATOR}smtp
-      sm_delete_secret $SECRET_NAME_SMTP
     fi
 
     # If the file doesn't exist, nothing to remove, so no-op
@@ -863,7 +851,6 @@ function gitops_mas_config() {
       fi
     fi
 
-    
 
   fi
 


### PR DESCRIPTION
Don't remove the secrets that were provided outside of the automation in gitops mas-config for SMTP and LDAP configurations.