### PR TITLE
[patch] Add sleep for gitops fvt-preparer

### DIFF
--- a/tekton/src/tasks/gitops/gitops-mas-fvt-preparer.yml.j2
+++ b/tekton/src/tasks/gitops/gitops-mas-fvt-preparer.yml.j2
@@ -450,6 +450,9 @@ spec:
 
         fi
 
+        echo "Sleeping for 60 seconds to give postsync job a chance to run before creating sync window"
+        sleep 60
+
         echo "argo:argocd proj windows add mas --kind deny --schedule * * * * * --duration 4h --applications *"  
         argocd proj windows add mas --kind deny --schedule "* * * * *" --duration 4h --applications "*.$MAS_INSTANCE_ID"
 


### PR DESCRIPTION
Adds a simple sleep between the argo apps being synched and the sync window in argo being set to deny. This is to let the post-sync jobs of the last app to be able to run as this is what is setting the reporting of the job. It is a simple job and should be complete within 20 seconds or so.