### PR TITLE
[patch] collect the storageCluster as part of must-gather

### DIFF
--- a/image/cli/mascli/functions/must_gather
+++ b/image/cli/mascli/functions/must_gather
@@ -277,6 +277,13 @@ function mustgather() {
       echo_highlight "Unable to find cert-manager namespace"
     fi
 
+    NAMESPACE_LOOKUP=$(oc get namespace openshift-storage --ignore-not-found)
+    if [[ "$NAMESPACE_LOOKUP" != "" ]]; then
+      genericMustGather openshift-storage StorageCluster
+    else
+      echo_highlight "Unable to find openshift-storage namespace"
+    fi
+
     echo_h3 "Kafka"
     KAFKA_NAMESPACES=$(oc get Kafka -A --ignore-not-found -o jsonpath='{.items[*].metadata.namespace}')
     for KAFKA_NAMESPACE in $KAFKA_NAMESPACES


### PR DESCRIPTION
Added a section to must-gather to pull in resources from openshift-storage including the storageCluster

Tested by running against a cluster (took nearly 2 hours but I don't think this caused that, the openshift-storage section idn't drag on too long) verified that the openshift-storage namespace had collected resources including the storageCluster