### PR TITLE
[patch] Add fvt predict to gitops

### DIFF
--- a/tekton/src/pipelines/gitops/gitops-mas-fvt-preparer-pipeline.yml.j2
+++ b/tekton/src/pipelines/gitops/gitops-mas-fvt-preparer-pipeline.yml.j2
@@ -49,6 +49,8 @@ spec:
       type: string
     - name: fvt_version_ctf
       type: string
+    - name: fvt_version_predict
+      type: string
     - name: fvt_version_assist
       type: string
     - name: fvt_version_iot
@@ -201,6 +203,8 @@ spec:
           value: $(params.ivt_version_core)
         - name: fvt_version_ctf
           value: $(params.fvt_version_ctf)
+        - name: fvt_version_predict
+          value: $(params.fvt_version_predict)
         - name: fvt_version_assist
           value: $(params.fvt_version_assist)
         - name: fvt_version_iot

--- a/tekton/src/tasks/gitops/gitops-mas-fvt-preparer.yml.j2
+++ b/tekton/src/tasks/gitops/gitops-mas-fvt-preparer.yml.j2
@@ -35,6 +35,8 @@ spec:
       type: string
     - name: fvt_version_ctf
       type: string
+    - name: fvt_version_predict
+      type: string
     - name: fvt_version_assist
       type: string
     - name: fvt_version_iot
@@ -212,6 +214,8 @@ spec:
         value: $(params.ivt_version_core)
       - name: FVT_VERSION_CTF
         value: $(params.fvt_version_ctf)
+      - name: FVT_VERSION_PREDICT
+        value: $(params.fvt_version_predict)
       - name: FVT_VERSION_ASSIST
         value: $(params.fvt_version_assist)
       - name: FVT_VERSION_IOT


### PR DESCRIPTION
On the back of changes in https://github.com/ibm-mas/cli/pull/1297 we need to add this to the gitops fvt preparer