### PR TITLE
[patch] Add statefulsets to list of objects collected by mustgather

### DIFF
--- a/image/cli/mascli/functions/must_gather
+++ b/image/cli/mascli/functions/must_gather
@@ -55,7 +55,7 @@ function genericMustGather() {
   echo
   echo_h4 "Collect Standard Kubernetes Resources"
   ADDITIONAL_RESOURCES=$(echo "$2" | tr "," " ")
-  for RESOURCE in $ADDITIONAL_RESOURCES configmaps services routes deployments jobs pvc operatorconditions clusterserviceversions installplans subscriptions serviceaccounts roles rolebindings certificates
+  for RESOURCE in $ADDITIONAL_RESOURCES configmaps services routes deployments jobs pvc operatorconditions clusterserviceversions installplans subscriptions serviceaccounts roles rolebindings certificates statefulsets
   do
     $MG_SCRIPT_DIR/mg-collect-resources -n $1 -r $RESOURCE -d $OUTPUT_DIR/resources $NO_DETAIL_FLAG
   done


### PR DESCRIPTION
A number of namespaces have statefulsets that we should be collecting (cpd, iot, mongo) so makes sense to add it to the default set we collect.