### PR TITLE
[minor] Add simple/advanced install modes

### DIFF
--- a/python/src/mas/cli/install/app.py
+++ b/python/src/mas/cli/install/app.py
@@ -642,6 +642,7 @@ class InstallApp(BaseApp, InstallSettingsMixin, InstallSummarizerMixin, ConfigGe
             " - Enable optional Maximo Predict integration with SPSS and Watson OpenScale",
             " - Enable optional IBM Turbonomic integration",
             " - Customize Db2 node affinity and tolerations, memory, cpu, and storage settings (when using the IBM Db2 Universal Operator)",
+            " - Choose alternative Apache Kafka providers (default to Strimzi)",
             " - Customize Grafana storage settings"
         ])
         self.showAdvancedOptions = self.yesOrNo("Show advanced installation options")

--- a/python/src/mas/cli/install/app.py
+++ b/python/src/mas/cli/install/app.py
@@ -174,9 +174,9 @@ class InstallApp(BaseApp, InstallSettingsMixin, InstallSummarizerMixin, ConfigGe
         self.promptForString("Contact first name", "uds_contact_firstname")
         self.promptForString("Contact last name", "uds_contact_lastname")
 
-        self.promptForString("Namespace", "sls_namespace")
-
-        self.promptForString("IBM Data Reporter Operator (DRO) Namespace", "dro_namespace", default="redhat-marketplace")
+        if self.showAdvancedOptions:
+            self.promptForString("IBM Suite License Services (SLS) Namespace", "sls_namespace", default="ibm-sls")
+            self.promptForString("IBM Data Reporter Operator (DRO) Namespace", "dro_namespace", default="redhat-marketplace")
 
     @logMethodCall
     def selectLocalConfigDir(self) -> None:
@@ -196,7 +196,7 @@ class InstallApp(BaseApp, InstallSettingsMixin, InstallSummarizerMixin, ConfigGe
         except NotFoundError:
             self.setParam("grafana_action", "none")
 
-        if self.interactiveMode:
+        if self.interactiveMode and self.showAdvancedOptions:
             self.printH1("Configure Grafana")
             if self.getParam("grafana_action") == "none":
                 print_formatted_text("The Grafana operator package is not available in any catalogs on the target cluster, the installation of Grafana will be disabled")
@@ -206,11 +206,12 @@ class InstallApp(BaseApp, InstallSettingsMixin, InstallSummarizerMixin, ConfigGe
 
     @logMethodCall
     def configSpecialCharacters(self):
-        self.printH1("Configure special characters for userID and username")
-        self.printDescription([
-            "By default Maximo Application Suite will not allow special characters in usernames and userIDs, and this is the recommended setting.  However, legacy Maximo products allowed this, so for maximum compatibilty when migrating from EAM 7 you can choose to enable this support."
-        ])
-        self.yesOrNo("Allow special characters for user IDs and usernames", "mas_special_characters")
+        if self.showAdvancedOptions:
+            self.printH1("Configure special characters for userID and username")
+            self.printDescription([
+                "By default Maximo Application Suite will not allow special characters in usernames and userIDs, and this is the recommended setting.  However, legacy Maximo products allowed this, so for maximum compatibilty when migrating from EAM 7 you can choose to enable this support."
+            ])
+            self.yesOrNo("Allow special characters for user IDs and usernames", "mas_special_characters")
 
     @logMethodCall
     def configCP4D(self):
@@ -231,36 +232,38 @@ class InstallApp(BaseApp, InstallSettingsMixin, InstallSummarizerMixin, ConfigGe
 
     @logMethodCall
     def configSSOProperties(self):
-        self.printH1("Single Sign-On (SSO)")
-        self.printDescription([
-            "Many aspects of Maximo Application Suite's Single Sign-On (SSO) can be customized:",
-            " - Idle session automatic logout timer",
-            " - Session, access token, and refresh token timeouts",
-            " - Default identity provider (IDP), and seamless login",
-            " - Brower cookie properties"
-        ])
-        if self.yesOrNo("Configure SSO properties"):
-            self.promptForInt("Idle session logout timer (seconds)", "idle_timeout")
-            self.promptForString("Session timeout (e.g. '12h' for 12 hours)", "idp_session_timeout", validator=TimeoutFormatValidator())
-            self.promptForString("Access token timeout (e.g. '30m' for 30 minutes)", "access_token_timeout", validator=TimeoutFormatValidator())
-            self.promptForString("Refresh token timeout (e.g. '12h' for 12 hours)", "refresh_token_timeout", validator=TimeoutFormatValidator())
-            self.promptForString("Default Identity Provider", "default_idp")
+        if self.showAdvancedOptions:
+            self.printH1("Single Sign-On (SSO)")
+            self.printDescription([
+                "Many aspects of Maximo Application Suite's Single Sign-On (SSO) can be customized:",
+                " - Idle session automatic logout timer",
+                " - Session, access token, and refresh token timeouts",
+                " - Default identity provider (IDP), and seamless login",
+                " - Brower cookie properties"
+            ])
+            if self.yesOrNo("Configure SSO properties"):
+                self.promptForInt("Idle session logout timer (seconds)", "idle_timeout")
+                self.promptForString("Session timeout (e.g. '12h' for 12 hours)", "idp_session_timeout", validator=TimeoutFormatValidator())
+                self.promptForString("Access token timeout (e.g. '30m' for 30 minutes)", "access_token_timeout", validator=TimeoutFormatValidator())
+                self.promptForString("Refresh token timeout (e.g. '12h' for 12 hours)", "refresh_token_timeout", validator=TimeoutFormatValidator())
+                self.promptForString("Default Identity Provider", "default_idp")
 
-            self.promptForString("SSO cookie name", "sso_cookie_name")
-            self.yesOrNo("Enable seamless login", "seamless_login")
-            self.yesOrNo("Allow default SSO cookie name", "allow_default_sso_cookie_name")
-            self.yesOrNo("Use only custom cookie name", "use_only_custom_cookie_name")
-            self.yesOrNo("Disable LDAP cookie", "disable_ldap_cookie")
-            self.yesOrNo("Allow custom cache key", "allow_custom_cache_key")
+                self.promptForString("SSO cookie name", "sso_cookie_name")
+                self.yesOrNo("Enable seamless login", "seamless_login")
+                self.yesOrNo("Allow default SSO cookie name", "allow_default_sso_cookie_name")
+                self.yesOrNo("Use only custom cookie name", "use_only_custom_cookie_name")
+                self.yesOrNo("Disable LDAP cookie", "disable_ldap_cookie")
+                self.yesOrNo("Allow custom cache key", "allow_custom_cache_key")
 
     @logMethodCall
     def configGuidedTour(self):
-        self.printH1("Enable Guided Tour")
-        self.printDescription([
-            "By default, Maximo Application Suite is configured with guided tour, you can disable this if it not required"
-        ])
-        if not self.yesOrNo("Enable Guided Tour"):
-            self.setParam("mas_enable_walkme", "false")
+        if self.showAdvancedOptions:
+            self.printH1("Enable Guided Tour")
+            self.printDescription([
+                "By default, Maximo Application Suite is configured with guided tour, you can disable this if it not required"
+            ])
+            if not self.yesOrNo("Enable Guided Tour"):
+                self.setParam("mas_enable_walkme", "false")
 
     @logMethodCall
     def configMAS(self):
@@ -297,11 +300,14 @@ class InstallApp(BaseApp, InstallSettingsMixin, InstallSummarizerMixin, ConfigGe
 
     @logMethodCall
     def configCATrust(self) -> None:
-        self.printH1("Certificate Authority Trust")
-        self.printDescription([
-            "By default, Maximo Application Suite is configured to trust well-known certificate authoritories, you can disable this so that it will only trust the CAs that you explicitly define"
-        ])
-        self.yesOrNo("Trust default CAs", "mas_trust_default_cas")
+        if self.showAdvancedOptions:
+            self.printH1("Certificate Authority Trust")
+            self.printDescription([
+                "By default, Maximo Application Suite is configured to trust well-known certificate authoritories, you can disable this so that it will only trust the CAs that you explicitly define"
+            ])
+            self.yesOrNo("Trust default CAs", "mas_trust_default_cas")
+        else:
+            self.setParam("mas_trust_default_cas", True)
 
     @logMethodCall
     def configOperationMode(self):
@@ -330,51 +336,52 @@ class InstallApp(BaseApp, InstallSettingsMixin, InstallSummarizerMixin, ConfigGe
 
     @logMethodCall
     def configDNSAndCerts(self):
-        self.printH1("Cluster Ingress Secret Override")
-        self.printDescription([
-            "In most OpenShift clusters the installation is able to automatically locate the default ingress certificate, however in some configurations it is necessary to manually configure the name of the secret",
-            "Unless you see an error during the ocp-verify stage indicating that the secret can not be determined you do not need to set this and can leave the response empty"
-        ])
-        self.promptForString("Cluster ingress certificate secret name", "ocp_ingress_tls_secret_name", default="")
+        if self.showAdvancedOptions:
+            self.printH1("Cluster Ingress Secret Override")
+            self.printDescription([
+                "In most OpenShift clusters the installation is able to automatically locate the default ingress certificate, however in some configurations it is necessary to manually configure the name of the secret",
+                "Unless you see an error during the ocp-verify stage indicating that the secret can not be determined you do not need to set this and can leave the response empty"
+            ])
+            self.promptForString("Cluster ingress certificate secret name", "ocp_ingress_tls_secret_name", default="")
 
-        self.printH1("Configure Domain & Certificate Management")
-        configureDomainAndCertMgmt = self.yesOrNo('Configure domain & certificate management')
-        if configureDomainAndCertMgmt:
-            configureDomain = self.yesOrNo('Configure custom domain')
-            if configureDomain:
-                self.promptForString("MAS top-level domain", "mas_domain")
-                self.printDescription([
-                    "",
-                    "DNS Integrations:",
-                    "  1. Cloudflare",
-                    "  2. IBM Cloud Internet Services",
-                    "  3. AWS Route 53",
-                    "  4. None (I will set up DNS myself)"
-                ])
+            self.printH1("Configure Domain & Certificate Management")
+            configureDomainAndCertMgmt = self.yesOrNo('Configure domain & certificate management')
+            if configureDomainAndCertMgmt:
+                configureDomain = self.yesOrNo('Configure custom domain')
+                if configureDomain:
+                    self.promptForString("MAS top-level domain", "mas_domain")
+                    self.printDescription([
+                        "",
+                        "DNS Integrations:",
+                        "  1. Cloudflare",
+                        "  2. IBM Cloud Internet Services",
+                        "  3. AWS Route 53",
+                        "  4. None (I will set up DNS myself)"
+                    ])
 
-                dnsProvider = self.promptForInt("DNS Provider")
+                    dnsProvider = self.promptForInt("DNS Provider")
 
-                if dnsProvider == 1:
-                    self.configDNSAndCertsCloudflare()
-                elif dnsProvider == 2:
-                    self.configDNSAndCertsCIS()
-                elif dnsProvider == 3:
-                    self.configDNSAndCertsRoute53()
-                elif dnsProvider == 4:
-                    # Use MAS default self-signed cluster issuer with a custom domain
+                    if dnsProvider == 1:
+                        self.configDNSAndCertsCloudflare()
+                    elif dnsProvider == 2:
+                        self.configDNSAndCertsCIS()
+                    elif dnsProvider == 3:
+                        self.configDNSAndCertsRoute53()
+                    elif dnsProvider == 4:
+                        # Use MAS default self-signed cluster issuer with a custom domain
+                        self.setParam("dns_provider", "")
+                        self.setParam("mas_cluster_issuer", "")
+                else:
+                    # Use MAS default self-signed cluster issuer with the default domain
                     self.setParam("dns_provider", "")
+                    self.setParam("mas_domain", "")
                     self.setParam("mas_cluster_issuer", "")
-            else:
-                # Use MAS default self-signed cluster issuer with the default domain
-                self.setParam("dns_provider", "")
-                self.setParam("mas_domain", "")
-                self.setParam("mas_cluster_issuer", "")
-            self.manualCerts = self.yesOrNo("Configure manual certificates")
-            self.setParam("mas_manual_cert_mgmt", self.manualCerts)
-            if self.getParam("mas_manual_cert_mgmt"):
-                self.manualCertsDir = self.promptForDir("Enter the path containing the manual certificates", mustExist=True)
-            else:
-                self.manualCertsDir = None
+                self.manualCerts = self.yesOrNo("Configure manual certificates")
+                self.setParam("mas_manual_cert_mgmt", self.manualCerts)
+                if self.getParam("mas_manual_cert_mgmt"):
+                    self.manualCertsDir = self.promptForDir("Enter the path containing the manual certificates", mustExist=True)
+                else:
+                    self.manualCertsDir = None
 
     @logMethodCall
     def configDNSAndCertsCloudflare(self):
@@ -594,7 +601,7 @@ class InstallApp(BaseApp, InstallSettingsMixin, InstallSummarizerMixin, ConfigGe
 
     @logMethodCall
     def predictSettings(self) -> None:
-        if self.installPredict:
+        if self.showAdvancedOptions and self.installPredict:
             self.printH1("Configure Maximo Predict")
             self.printDescription([
                 "Predict application supports integration with IBM SPSS and Watson Openscale which are optional services installed on top of IBM Cloud Pak for Data",
@@ -618,9 +625,38 @@ class InstallApp(BaseApp, InstallSettingsMixin, InstallSummarizerMixin, ConfigGe
                 self.promptForString("IBM Cloud Resource Group", "ibmcos_resourcegroup")
 
     @logMethodCall
-    def interactiveMode(self) -> None:
+    def chooseInstallFlavour(self) -> None:
+        self.printH1("Choose Install Mode")
+        self.printDescription([
+            "There are two flavours of the interactive install to choose from: <u>Simplified</u> and <u>Advanced</u>.  The simplified option will present fewer dialogs, but you lose the ability to configure the following aspects of the installation:",
+            " - Configure installation namespaces",
+            " - Provide pod templates",
+            " - Configure Single Sign-On (SSO) settings"
+            " - Configure whether to trust well-known certificate authorities by default (defaults to enabled)",
+            " - Configure whether the Guided Tour feature is enabled (defaults to enabled)",
+            " - Configure whether special characters are allowed in usernames and userids (defaults to disabled)",
+            " - Configure a custom domain, DNS integrations, and manual certificates",
+            " - Customize Maximo Manage database settings (schema, tablespace, indexspace)",
+            " - Customize Maximo Manage server bundle configuration (defaults to \"all\" configuration)",
+            " - Enable optional Maximo Manage integration Cognos Analytics and Watson Studio Local",
+            " - Enable optional Maximo Predict integration with SPSS and Watson OpenScale",
+            " - Enable optional IBM Turbonomic integration",
+            " - Customize Db2 node affinity and tolerations, memory, cpu, and storage settings (when using the IBM Db2 Universal Operator)",
+            " - Customize Grafana storage settings"
+        ])
+        self.showAdvancedOptions = self.yesOrNo("Show advanced installation options")
+
+    @logMethodCall
+    def interactiveMode(self, simplified: bool, advanced: bool) -> None:
         # Interactive mode
         self.interactiveMode = True
+
+        if simplified:
+            self.showAdvancedOptions = False
+        elif advanced:
+            self.showAdvancedOptions = True
+        else:
+            self.chooseInstallFlavour()
 
         # Catalog
         self.configCatalog()
@@ -823,7 +859,7 @@ class InstallApp(BaseApp, InstallSettingsMixin, InstallSummarizerMixin, ConfigGe
                             self.fatalError(f"Unsupported format for {key} ({value}).  Expected string:int:int:boolean")
 
             # Arguments that we don't need to do anything with
-            elif key in ["accept_license", "dev_mode", "skip_pre_check", "skip_grafana_install", "no_confirm", "no_wait_for_pvc", "help"]:
+            elif key in ["accept_license", "dev_mode", "skip_pre_check", "skip_grafana_install", "no_confirm", "no_wait_for_pvc", "help", "advanced", "simplified"]:
                 pass
 
             elif key == "manual_certificates":
@@ -896,7 +932,7 @@ class InstallApp(BaseApp, InstallSettingsMixin, InstallSummarizerMixin, ConfigGe
 
         # User must either provide the configuration via numerous command line arguments, or the interactive prompts
         if instanceId is None:
-            self.interactiveMode()
+            self.interactiveMode(simplified=args.simplified, advanced=args.advanced)
         else:
             self.nonInteractiveMode()
 

--- a/python/src/mas/cli/install/argParser.py
+++ b/python/src/mas/cli/install/argParser.py
@@ -1048,6 +1048,19 @@ approvalsGroup.add_argument(
 # -----------------------------------------------------------------------------
 otherArgGroup = installArgParser.add_argument_group("More")
 otherArgGroup.add_argument(
+    "--advanced",
+    action="store_true",
+    default=False,
+    help="Show advanced install options (in interactve mode)"
+)
+otherArgGroup.add_argument(
+    "--simplified",
+    action="store_true",
+    default=False,
+    help="Don't show advanced install options (in interactve mode)"
+)
+
+otherArgGroup.add_argument(
     "--accept-license",
     action="store_true",
     default=False,

--- a/python/src/mas/cli/install/settings/additionalConfigs.py
+++ b/python/src/mas/cli/install/settings/additionalConfigs.py
@@ -63,7 +63,7 @@ class AdditionalConfigsMixin():
             self.additionalConfigsSecret = additionalConfigsSecret
 
     def podTemplates(self) -> None:
-        if self.interactiveMode:
+        if self.interactiveMode and self.showAdvancedOptions:
             self.printH1("Configure Pod Templates")
             self.printDescription([
                 "The CLI supports two pod template profiles out of the box that allow you to reconfigure MAS for either a guaranteed or best effort QoS level",

--- a/python/src/mas/cli/install/settings/db2Settings.py
+++ b/python/src/mas/cli/install/settings/db2Settings.py
@@ -153,48 +153,51 @@ class Db2SettingsMixin():
 
         # Do we need to configure Db2u?
         if self.getParam("db2_action_system") == "install" or self.getParam("db2_action_manage") == "install":
-            self.printH2("Installation Namespace")
-            self.promptForString("Install namespace", "db2_namespace", default="db2u")
+            if self.showAdvancedOptions:
+                self.printH2("Installation Namespace")
+                self.promptForString("Install namespace", "db2_namespace", default="db2u")
 
-            # Node Affinity & Tolerations
-            # -------------------------------------------------------------------------
-            self.printH2("Node Affinity and Tolerations")
-            self.printDescription([
-                "Note that the same settings are applied to both the IoT and Manage Db2 instances",
-                "Use existing node labels and taints to control scheduling of the Db2 workload in your cluster",
-                "For more information refer to the Red Hat documentation:",
-                " - <u>https://docs.openshift.com/container-platform/4.12/nodes/scheduling/nodes-scheduler-node-affinity.html</u>",
-                " - <u>https://docs.openshift.com/container-platform/4.12/nodes/scheduling/nodes-scheduler-taints-tolerations.html</u>"
-            ])
+                # Node Affinity & Tolerations
+                # -------------------------------------------------------------------------
+                self.printH2("Node Affinity and Tolerations")
+                self.printDescription([
+                    "Note that the same settings are applied to both the IoT and Manage Db2 instances",
+                    "Use existing node labels and taints to control scheduling of the Db2 workload in your cluster",
+                    "For more information refer to the Red Hat documentation:",
+                    " - <u>https://docs.openshift.com/container-platform/4.12/nodes/scheduling/nodes-scheduler-node-affinity.html</u>",
+                    " - <u>https://docs.openshift.com/container-platform/4.12/nodes/scheduling/nodes-scheduler-taints-tolerations.html</u>"
+                ])
 
-            if self.yesOrNo("Configure node affinity"):
-                self.promptForString(" + Key", "db2_affinity_key")
-                self.promptForString(" + Value", "db2_affinity_value")
+                if self.yesOrNo("Configure node affinity"):
+                    self.promptForString(" + Key", "db2_affinity_key")
+                    self.promptForString(" + Value", "db2_affinity_value")
 
-            if self.yesOrNo("Configure node tolerations"):
-                self.promptForString(" + Key", "db2_tolerate_key")
-                self.promptForString(" + Value", "db2_tolerate_value")
-                self.promptForString(" + Effect", "db2_tolerate_effect")
+                if self.yesOrNo("Configure node tolerations"):
+                    self.promptForString(" + Key", "db2_tolerate_key")
+                    self.promptForString(" + Value", "db2_tolerate_value")
+                    self.promptForString(" + Effect", "db2_tolerate_effect")
 
-            self.printH2("Database CPU & Memory")
-            self.printDescription([
-                "Note that the same settings are applied to both the IoT and Manage Db2 instances"
-            ])
+                self.printH2("Database CPU & Memory")
+                self.printDescription([
+                    "Note that the same settings are applied to both the IoT and Manage Db2 instances"
+                ])
 
-            if self.yesOrNo("Customize CPU and memory request/limit"):
-                self.promptForString(" + CPU Request", "db2_cpu_requests", default=self.getParam("db2_cpu_requests"))
-                self.promptForString(" + CPU Limit", "db2_cpu_limits", default=self.getParam("db2_cpu_limits"))
-                self.promptForString(" + Memory Request", "db2_memory_requests", default=self.getParam("db2_memory_requests"))
-                self.promptForString(" + Memory Limit", "db2_memory_limits", default=self.getParam("db2_memory_limits"))
+                if self.yesOrNo("Customize CPU and memory request/limit"):
+                    self.promptForString(" + CPU Request", "db2_cpu_requests", default=self.getParam("db2_cpu_requests"))
+                    self.promptForString(" + CPU Limit", "db2_cpu_limits", default=self.getParam("db2_cpu_limits"))
+                    self.promptForString(" + Memory Request", "db2_memory_requests", default=self.getParam("db2_memory_requests"))
+                    self.promptForString(" + Memory Limit", "db2_memory_limits", default=self.getParam("db2_memory_limits"))
 
-            self.printH2("Database Storage Capacity")
-            self.printDescription([
-                "Note that the same settings are applied to both the IoT and Manage Db2 instances"
-            ])
+                self.printH2("Database Storage Capacity")
+                self.printDescription([
+                    "Note that the same settings are applied to both the IoT and Manage Db2 instances"
+                ])
 
-            if self.yesOrNo("Customize storage capacity"):
-                self.promptForString(" + Data Volume", "db2_data_storage_size", default=self.getParam("db2_data_storage_size"))
-                self.promptForString(" + Temporary Volume", "db2_temp_storage_size", default=self.getParam("db2_temp_storage_size"))
-                self.promptForString(" + Metadata Volume", "db2_meta_storage_size", default=self.getParam("db2_meta_storage_size"))
-                self.promptForString(" + Transaction Logs Volume", "db2_logs_storage_size", default=self.getParam("db2_logs_storage_size"))
-                self.promptForString(" + Backup Volume", "db2_backup_storage_size", default=self.getParam("db2_backup_storage_size"))
+                if self.yesOrNo("Customize storage capacity"):
+                    self.promptForString(" + Data Volume", "db2_data_storage_size", default=self.getParam("db2_data_storage_size"))
+                    self.promptForString(" + Temporary Volume", "db2_temp_storage_size", default=self.getParam("db2_temp_storage_size"))
+                    self.promptForString(" + Metadata Volume", "db2_meta_storage_size", default=self.getParam("db2_meta_storage_size"))
+                    self.promptForString(" + Transaction Logs Volume", "db2_logs_storage_size", default=self.getParam("db2_logs_storage_size"))
+                    self.promptForString(" + Backup Volume", "db2_backup_storage_size", default=self.getParam("db2_backup_storage_size"))
+            else:
+                self.setParam("db2_namespace", "db2u")

--- a/python/src/mas/cli/install/settings/kafkaSettings.py
+++ b/python/src/mas/cli/install/settings/kafkaSettings.py
@@ -24,15 +24,18 @@ class KafkaSettingsMixin():
             if self.yesOrNo("Create system Kafka instance using one of the supported providers"):
                 self.setParam("kafka_action_system", "install")
 
-                self.printDescription([
-                    "",
-                    "Kafka Provider:",
-                    "  1. Strimzi (opensource)",
-                    "  2. Red Hat AMQ Streams (requires a separate license)",
-                    "  3. IBM Cloud Event Streams (paid IBM Cloud service)",
-                    "  4. AWS MSK (paid AWS service)"
-                ])
-                self.promptForListSelect("Select Kafka provider", ["strimzi", "redhat", "ibm", "aws"], "kafka_provider")
+                if self.showAdvancedOptions:
+                    self.printDescription([
+                        "",
+                        "Kafka Provider:",
+                        "  1. Strimzi (opensource)",
+                        "  2. Red Hat AMQ Streams (requires a separate license)",
+                        "  3. IBM Cloud Event Streams (paid IBM Cloud service)",
+                        "  4. AWS MSK (paid AWS service)"
+                    ])
+                    self.promptForListSelect("Select Kafka provider", ["strimzi", "redhat", "ibm", "aws"], "kafka_provider")
+                else:
+                    self.setParam("kafka_provider", "strimzi")
 
                 if self.getParam("kafka_provider") == "strimzi":
                     self.printDescription([
@@ -42,7 +45,8 @@ class KafkaSettingsMixin():
                         " - If you are using the latest available operator catalog then the default version below can be accepted",
                         " - If you are using older operator catalogs (e.g. in a disconnected install) you should confirm the supported versions in your OperatorHub"
                     ])
-                    self.promptForString("Install namespace", "kafka_namespace", default="strimzi")
+                    if self.showAdvancedOptions:
+                        self.promptForString("Strimzi namespace", "kafka_namespace", default="strimzi")
                     self.promptForString("Kafka version", "kafka_version", default="3.7.0")
 
                 elif self.getParam("kafka_provider") == "redhat":

--- a/python/src/mas/cli/install/settings/manageSettings.py
+++ b/python/src/mas/cli/install/settings/manageSettings.py
@@ -125,53 +125,57 @@ class ManageSettingsMixin():
                     exit(1)
 
     def manageSettingsDatabase(self) -> None:
-        self.printH2("Maximo Manage Settings - Database")
-        self.printDescription(["Customise the schema, tablespace, indexspace, and encryption settings used by Manage"])
+        if self.showAdvancedOptions:
+            self.printH2("Maximo Manage Settings - Database")
+            self.printDescription(["Customise the schema, tablespace, indexspace, and encryption settings used by Manage"])
 
-        if self.yesOrNo("Customize database settings"):
-            self.promptForString("Schema", "mas_app_settings_db2_schema", default="maximo")
-            self.promptForString("Tablespace", "mas_app_settings_tablespace", default="MAXDATA")
-            self.promptForString("Indexspace", "mas_app_settings_indexspace", default="MAXINDEX")
+            if self.yesOrNo("Customize database settings"):
+                self.promptForString("Schema", "mas_app_settings_db2_schema", default="maximo")
+                self.promptForString("Tablespace", "mas_app_settings_tablespace", default="MAXDATA")
+                self.promptForString("Indexspace", "mas_app_settings_indexspace", default="MAXINDEX")
 
-            if self.yesOrNo("Customize database encryption settings"):
-                self.promptForString("MXE_SECURITY_CRYPTO_KEY", "mas_app_settings_crypto_key")
-                self.promptForString("MXE_SECURITY_CRYPTOX_KEY", "mas_app_settings_cryptox_key")
-                self.promptForString("MXE_SECURITY_OLD_CRYPTO_KEY", "mas_app_settings_old_crypto_key")
-                self.promptForString("MXE_SECURITY_OLD_CRYPTOX_KEY", "mas_app_settings_old_cryptox_key")
-                self.yesOrNo("Override database encryption secrets with provided keys", "mas_app_settings_override_encryption_secrets_flag")
+                if self.yesOrNo("Customize database encryption settings"):
+                    self.promptForString("MXE_SECURITY_CRYPTO_KEY", "mas_app_settings_crypto_key")
+                    self.promptForString("MXE_SECURITY_CRYPTOX_KEY", "mas_app_settings_cryptox_key")
+                    self.promptForString("MXE_SECURITY_OLD_CRYPTO_KEY", "mas_app_settings_old_crypto_key")
+                    self.promptForString("MXE_SECURITY_OLD_CRYPTOX_KEY", "mas_app_settings_old_cryptox_key")
+                    self.yesOrNo("Override database encryption secrets with provided keys", "mas_app_settings_override_encryption_secrets_flag")
 
     def manageSettingsServerBundleConfig(self) -> None:
-        self.printH2("Maximo Manage Settings - Server Bundles")
-        self.printDescription([
-            "Define how you want to configure Manage servers:",
-            " - You can have one or multiple Manage servers distributing workload",
-            " - Additionally, you can choose to include JMS server for messaging queues",
-            "",
-            "Configurations:",
-            "  1. Deploy the 'all' server pod only (workload is concentrated in just one server pod but consumes less resource)",
-            "  2. Deploy the 'all' and 'jms' bundle pods (workload is concentrated in just one server pod and includes jms server)"
-        ])
-
-        if not self.isSNO():
+        if self.showAdvancedOptions:
+            self.printH2("Maximo Manage Settings - Server Bundles")
             self.printDescription([
-                "  3. Deploy the 'mea', 'report', 'ui' and 'cron' bundle pods (workload is distributed across multiple server pods)",
-                "  4. Deploy the 'mea', 'report', 'ui', 'cron' and 'jms' bundle pods (workload is distributed across multiple server pods and includes jms server)"
+                "Define how you want to configure Manage servers:",
+                " - You can have one or multiple Manage servers distributing workload",
+                " - Additionally, you can choose to include JMS server for messaging queues",
+                "",
+                "Configurations:",
+                "  1. Deploy the 'all' server pod only (workload is concentrated in just one server pod but consumes less resource)",
+                "  2. Deploy the 'all' and 'jms' bundle pods (workload is concentrated in just one server pod and includes jms server)"
             ])
 
-        manageServerBundleSelection = self.promptForString("Select a server bundle configuration")
+            if not self.isSNO():
+                self.printDescription([
+                    "  3. Deploy the 'mea', 'report', 'ui' and 'cron' bundle pods (workload is distributed across multiple server pods)",
+                    "  4. Deploy the 'mea', 'report', 'ui', 'cron' and 'jms' bundle pods (workload is distributed across multiple server pods and includes jms server)"
+                ])
 
-        if manageServerBundleSelection == "1":
-            self.setParam("mas_app_settings_server_bundles_size", "dev")
-        elif manageServerBundleSelection == "2":
-            self.setParam("mas_app_settings_server_bundles_size", "snojms")
-            self.setParam("mas_app_settings_persistent_volumes_flag", "true")
-        elif manageServerBundleSelection == "3":
-            self.setParam("mas_app_settings_server_bundles_size", "small")
-        elif manageServerBundleSelection == "4":
-            self.setParam("mas_app_settings_server_bundles_size", "jms")
-            self.setParam("mas_app_settings_persistent_volumes_flag", "true")
+            manageServerBundleSelection = self.promptForString("Select a server bundle configuration")
+
+            if manageServerBundleSelection == "1":
+                self.setParam("mas_app_settings_server_bundles_size", "dev")
+            elif manageServerBundleSelection == "2":
+                self.setParam("mas_app_settings_server_bundles_size", "snojms")
+                self.setParam("mas_app_settings_persistent_volumes_flag", "true")
+            elif manageServerBundleSelection == "3":
+                self.setParam("mas_app_settings_server_bundles_size", "small")
+            elif manageServerBundleSelection == "4":
+                self.setParam("mas_app_settings_server_bundles_size", "jms")
+                self.setParam("mas_app_settings_persistent_volumes_flag", "true")
+            else:
+                self.fatalError("Invalid selection")
         else:
-            self.fatalError("Invalid selection")
+            self.setParam("mas_app_settings_server_bundles_size", "dev")
 
     def manageSettingsJMS(self) -> None:
         if self.getParam("mas_app_settings_server_bundles_size") in ["jms", "snojms"]:
@@ -219,7 +223,7 @@ class ManageSettingsMixin():
         self.promptForString("Secondary languages", "mas_app_settings_secondary_langs")
 
     def manageSettingsCP4D(self) -> None:
-        if self.getParam("mas_app_channel_manage") in ["8.7.x", "9.0.x"]:
+        if self.getParam("mas_app_channel_manage") in ["8.7.x", "9.0.x"] and self.showAdvancedOptionsshowAdvancedOptions:
             self.printDescription([
                 "Integration with Cognos Analytics provides additional support for reporting features in Maximo Manage, for more information refer to the documentation online: ",
                 "    <u>https://ibm.biz/BdMuxs</u>"
@@ -261,9 +265,11 @@ class ManageSettingsMixin():
             self.promptForString("Storage pipelines bucket", "mas_aibroker_storage_pipelines_bucket")
             self.promptForString("Storage tenants bucket", "mas_aibroker_storage_tenants_bucket")
             self.promptForString("Storage templates bucket", "mas_aibroker_storage_templates_bucket")
+
             self.promptForString("Watsonxai api key", "mas_aibroker_watsonxai_apikey")
             self.promptForString("Watsonxai machine learning url", "mas_aibroker_watsonxai_url")
             self.promptForString("Watsonxai project id", "mas_aibroker_watsonxai_project_id")
+
             self.promptForString("Database host", "mas_aibroker_db_host")
             self.promptForString("Database port", "mas_aibroker_db_port")
             self.promptForString("Database user", "mas_aibroker_db_user")

--- a/python/src/mas/cli/install/settings/mongodbSettings.py
+++ b/python/src/mas/cli/install/settings/mongodbSettings.py
@@ -20,7 +20,8 @@ class MongoDbSettingsMixin():
         ])
 
         if self.architecture != "s390x" and self.yesOrNo("Create MongoDb cluster using MongoDb Community Edition Operator"):
-            self.promptForString("Install namespace", "mongodb_namespace", default="mongoce")
+            if self.showAdvancedOptions:
+                self.promptForString("MongoDb namespace", "mongodb_namespace", default="mongoce")
             self.setParam("mongodb_action", "install")
             self.setParam("sls_mongodb_cfg_file", f"/workspace/configs/mongo-{self.getParam('mongodb_namespace')}.yml")
         else:

--- a/python/src/mas/cli/install/settings/turbonomicSettings.py
+++ b/python/src/mas/cli/install/settings/turbonomicSettings.py
@@ -14,17 +14,18 @@ from mas.devops.mas import isAirgapInstall
 class TurbonomicSettingsMixin():
 
     def configTurbonomic(self) -> None:
-        self.printH1("Configure Turbonomic")
-        self.printDescription([
-            "The IBM Turbonomic hybrid cloud cost optimization platform allows you to eliminate this guesswork with solutions that save time and optimize costs",
-            " - Learn more: <u>https://www.ibm.com/products/turbonomic</u>"
-        ])
+        if self.showAdvancedOptions:
+            self.printH1("Configure Turbonomic")
+            self.printDescription([
+                "The IBM Turbonomic hybrid cloud cost optimization platform allows you to eliminate this guesswork with solutions that save time and optimize costs",
+                " - Learn more: <u>https://www.ibm.com/products/turbonomic</u>"
+            ])
 
-        if isAirgapInstall(self.dynamicClient):
-            self.printHighlight("The Turbonomic Kubernetes Operator does not support disconnected installation at this time")
-        elif self.yesOrNo("Configure IBM Turbonomic integration"):
-            self.promptForString("Turbonomic Target Name", "turbonomic_target_name")
-            self.promptForString("Turbonomic Server URL", "turbonomic_server_url")
-            self.promptForString("Turbonomic Server Version", "turbonomic_server_version")
-            self.promptForString("Turbonomic Username", "turbonomic_username")
-            self.promptForString("Turbonomic Password", "turbonomic_password", isPassword=True)
+            if isAirgapInstall(self.dynamicClient):
+                self.printHighlight("The Turbonomic Kubernetes Operator does not support disconnected installation at this time")
+            elif self.yesOrNo("Configure IBM Turbonomic integration"):
+                self.promptForString("Turbonomic Target Name", "turbonomic_target_name")
+                self.promptForString("Turbonomic Server URL", "turbonomic_server_url")
+                self.promptForString("Turbonomic Server Version", "turbonomic_server_version")
+                self.promptForString("Turbonomic Username", "turbonomic_username")
+                self.promptForString("Turbonomic Password", "turbonomic_password", isPassword=True)


### PR DESCRIPTION
This update provides two interactive install modes'; `mas install --simplified` and `mas install --advanced` can be used to directly invoke the simplified/advanced install modes.

If the use does not chose the install mode using the new command flags they will be prompted as below after choosing their cluster:

![image](https://github.com/user-attachments/assets/f487de44-f4fe-4375-b344-6650148ae6a9)
