### PR TITLE
[minor] Add gitops-license-generator

### DIFF
--- a/tekton/generate-tekton-tasks.yml
+++ b/tekton/generate-tekton-tasks.yml
@@ -202,6 +202,7 @@
         - gitops-kafka
         - gitops-kafka-config
         - gitops-license
+        - gitops-license-generator
         - gitops-mas-fvt-preparer
         - gitops-mas-initiator
         - gitops-mongo

--- a/tekton/src/pipelines/gitops/gitops-mas-instance.yml.j2
+++ b/tekton/src/pipelines/gitops/gitops-mas-instance.yml.j2
@@ -169,6 +169,18 @@ spec:
     - name: db2_action
       type: string
 
+    # gitops-license-generator parameters
+    # ------------------------------------------------------------------------- 
+    - name: sls_license_expiry_date
+      type: string
+    - name: sls_license_app_points
+      type: string
+    - name: sls_license_customer_name
+      type: string
+    - name: sls_license_country
+      type: string
+    - name: sls_license_icn
+      type: string
 
   tasks:
 
@@ -229,12 +241,46 @@ spec:
       taskRef:
         kind: Task
         name: gitops-license
+      when:
+        - input: "$(params.sls_license_app_points)"
+          operator: in
+          values: [""]
+
+    - name: gitops-license-generator
+      params:
+        - name: cluster_name
+          value: $(params.cluster_name)
+        - name: account
+          value: $(params.account)
+        - name: mas_instance_id
+          value: $(params.mas_instance_id)
+        - name: avp_aws_secret_region
+          value: $(params.avp_aws_secret_region)
+
+        - name: expiry_date
+          value: $(params.sls_license_expiry_date)
+        - name: app_points
+          value: $(params.sls_license_app_points)
+        - name: customer_name
+          value: $(params.sls_license_customer_name)
+        - name: country
+          value: $(params.sls_license_country)
+        - name: icn
+          value: $(params.sls_license_icn)
+      taskRef:
+        kind: Task
+        name: gitops-license-generator
+      when:
+        - input: "$(params.sls_license_app_points)"
+          operator: notin
+          values: [""]
 
     # 2. MAS Suite
     # -------------------------------------------------------------------------
     - name: gitops-suite
       runAfter:
         - gitops-license
+        - gitops-license-generator
       params:
         - name: cluster_name
           value: $(params.cluster_name)

--- a/tekton/src/tasks/gitops/gitops-license-generator.yml.j2
+++ b/tekton/src/tasks/gitops/gitops-license-generator.yml.j2
@@ -1,0 +1,72 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: gitops-license-generator
+spec:
+  params:
+    - name: cluster_name
+      type: string
+    - name: account
+      type: string
+    - name: mas_instance_id
+      type: string
+    - name: avp_aws_secret_region
+      type: string
+
+    - name: expiry_date
+      type: string
+    - name: app_points
+      type: string
+    - name: customer_name
+      type: string
+    - name: country
+      type: string
+    - name: icn
+      type: string
+  stepTemplate:
+    name: gitops-license-generator
+    env:
+      - name: CLUSTER_NAME
+        value: $(params.cluster_name)
+      - name: ACCOUNT
+        value: $(params.account)
+      - name: MAS_INSTANCE_ID
+        value: $(params.mas_instance_id)
+      - name: SM_AWS_REGION
+        value: $(params.avp_aws_secret_region)
+
+      - name: EXPIRY_DATE
+        value: $(params.expiry_date)
+      - name: APP_POINTS
+        value: $(params.app_points)
+      - name: CUSTOMER_NAME
+        value: $(params.customer_name)
+      - name: COUNTRY
+        value: $(params.country)
+      - name: ICN
+        value: $(params.icn)
+    envFrom:
+      - configMapRef:
+          name: environment-properties
+          optional: true
+      - secretRef:
+          name: secure-properties
+  steps:
+    - args:
+      - |-
+        ansible-playbook ibm.mas_saas.generate_saas_license_file || exit 1
+
+        mas gitops-license \
+          -a $ACCOUNT \
+          -c $CLUSTER_NAME \
+          -m $MAS_INSTANCE_ID \
+          --license-file /tmp/authorized_entitlement_saas.lic
+
+        exit $?
+      command:
+        - /bin/sh
+        - -c
+      name: gitops-license-generator
+      imagePullPolicy: Always
+      image: docker-na-public.artifactory.swg-devops.com/wiotp-docker-local/mas/saas-task:latest


### PR DESCRIPTION
This PR adds the `gitops-license-generator` alternative to the existing `gitops-license` Task. Instead of accepting a pre-generated license file, this task will generate a license based on provided parameters (`expiry_date`, `app_points`, `customer_name`,  `country` and `icn`).

> NOTE: The `gitops-license-generator` task depends on a proprietary docker image and is for IBM internal usage only.

https://jsw.ibm.com/browse/MASCORE-3409


## Testing

### Fyre

When
```
sls:
  entitlement_lic: <ref:gitops/fyre-dev/us-east-2/noble5/mascore3061/authorized_entitlement_saas.lic>
```

existing [`gitops-license` task runs](https://cloud.ibm.com/devops/pipelines/tekton/8445f6a9-217b-4ceb-92e8-d3c25dd9fc22/runs/2f57993b-68a0-4164-9ab3-b88939528735/gitops-license/gitops-license?env_id=ibm:yp:us-south):
![image](https://github.com/user-attachments/assets/25f64b81-065b-4d88-a401-63a11d45862e)



When:
```
sls:
  license:
    expiry_date: "28-feb-2025"
    app_points: 1000
    customer_name: "customer_name"
    country: "US"
    icn: "0X1"
```

new [gitops-license-generator task runs](https://cloud.ibm.com/devops/pipelines/tekton/8445f6a9-217b-4ceb-92e8-d3c25dd9fc22/runs/e8712378-860e-4d97-b3fb-f6fc3138bf6a/gitops-license-generator/gitops-license-generator?env_id=ibm:yp:us-south) instead:
![image](https://github.com/user-attachments/assets/91977e83-e535-4d22-9634-1056cf5a2c70)



License file uploaded to AWS SM:
![image](https://github.com/user-attachments/assets/adccf84a-133a-4fb6-ad9f-821f13ab8e53)


Picked up SLS, valid license file recognised by MAS and has expected parameter values:
![image](https://github.com/user-attachments/assets/5dd84239-e987-4614-8f33-2433a830ee10)


Updated app_points and expiry_date:
```
sls:
  channel: 3.x
  license:
    expiry_date: "28-feb-2026"
    app_points: 1500
    customer_name: "customer_name"
    country: "US"
    icn: "0X1"
```

Pipeline reruns. Hard refresh SLS ArgoCD Application to pickup updated license file. Updated parameters reflected in MAS:
![image](https://github.com/user-attachments/assets/abf5723e-f37a-4494-834a-70908c2384ab)


### ROSA (fvtsaas)

```
sls:
  channel: 3.x
  license:
    expiry_date: "28-feb-2029"
    app_points: 1000
    customer_name: "Maximo Operation - Internal"
    country: "US"
    icn: "0X1"
```

![image](https://github.com/user-attachments/assets/c22be150-336a-46c9-bc16-3df5848c4172)

![image](https://github.com/user-attachments/assets/24fa5368-4280-45ea-8833-b5c9b5f3c65e)

![image](https://github.com/user-attachments/assets/890a5941-58a8-4504-afdf-aa55f4971142)

