### PR TITLE
[minor] Add Selenium Grid install via gitops

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2024-11-05T11:35:44Z",
+  "generated_at": "2024-11-12T09:23:41Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -162,7 +162,7 @@
         "hashed_secret": "b2817467154949a61f8e9ad31d1eeaf03221cbfa",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 347,
+        "line_number": 353,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/image/cli/mascli/functions/gitops_cluster
+++ b/image/cli/mascli/functions/gitops_cluster
@@ -68,6 +68,9 @@ DevOps Details (Optional):
 Notifications (Optional):
       --slack-channel-id ${COLOR_YELLOW}SLACK_CHANNEL_ID${TEXT_RESET}                                           Slack channel for ArgoCD to notify when an app sync has completed or failed
 
+Selenium Grid (Optional):
+      --install-selenium-grid ${COLOR_YELLOW}INSTALL_SELENIUM_GRID${TEXT_RESET}                                 Install Selenium Grid
+
 Other Commands:
   -h, --help                              Show this help message
 EOM
@@ -233,6 +236,9 @@ function gitops_cluster_noninteractive() {
         export INGRESS=$1 && shift
         ;;
 
+      --install-selenium-grid)
+        export INSTALL_SELENIUM_GRID=true
+        ;;
 
       # Other Commands
       -h|--help)
@@ -391,6 +397,11 @@ function gitops_cluster() {
   echo_reset_dim "Devops Mongo Uri ................ ${COLOR_MAGENTA}${DEVOPS_MONGO_URI:0:8}<snip>"
   reset_colors
 
+  echo "${TEXT_DIM}"
+  echo_h2 "Selenium Grid" "    "
+  echo_reset_dim "Install Selenium Grid ........... ${COLOR_MAGENTA}${INSTALL_SELENIUM_GRID}"
+  reset_colors
+
   # Set up secrets
   # ---------------------------------------------------------------------------
   echo
@@ -485,7 +496,12 @@ function gitops_cluster() {
 
   echo "- Redhat Cert Manager"
   jinja -X .+ $CLI_DIR/templates/gitops/appset-configs/cluster/phase1/redhat-cert-manager.yaml.j2 -o ${GITOPS_CLUSTER_DIR}/redhat-cert-manager.yaml
-  
+
+  if [[ "$INSTALL_SELENIUM_GRID" == "true" ]]; then
+    echo "- Selenium Grid"
+    jinja -X .+ $CLI_DIR/templates/gitops/appset-configs/cluster/phase1/selenium-grid.yaml.j2 -o ${GITOPS_CLUSTER_DIR}/selenium-grid.yaml
+  fi
+
   if [[ "$CLUSTER_PROMOTION" == "true" ]]; then
     ESCAPED_CLUSTER_VALUES=${CLUSTER_PROMOTION_CLUSTER_VALUES//\"/\\\"}
     export ESCAPED_CLUSTER_VALUES=${ESCAPED_CLUSTER_VALUES//$'\n'/\\n}

--- a/image/cli/mascli/functions/gitops_deprovision_cluster
+++ b/image/cli/mascli/functions/gitops_deprovision_cluster
@@ -221,6 +221,14 @@ function gitops_deprovision_cluster() {
   echo
   echo_h2 "Deleting application configuration files"
 
+  echo "- Delete Selenium Grid"
+  rm -rf ${GITOPS_CLUSTER_DIR}/selenium-grid.yaml
+  if [ "$GITHUB_PUSH" == "true" ]; then
+    echo
+    echo_h2 "Commit and push changes to GitHub repo $GITHUB_ORG $GITHUB_REPO"
+    save_to_target_git_repo $GITHUB_HOST $GITHUB_ORG $GITHUB_REPO $GIT_BRANCH "${GITOPS_WORKING_DIR}/${GITHUB_REPO}" "${GIT_COMMIT_MSG}"
+  fi
+
   echo "- Delete Cluster Promotion"
   rm -rf ${GITOPS_CLUSTER_DIR}/cluster-promotion.yaml
   if [ "$GITHUB_PUSH" == "true" ]; then

--- a/image/cli/mascli/functions/gitops_mas_fvt_preparer
+++ b/image/cli/mascli/functions/gitops_mas_fvt_preparer
@@ -78,9 +78,11 @@ function gitops_mas_fvt_preparer() {
 
   # Set SLS Namespace
   export SLS_NAMESPACE="mas-${MAS_INSTANCE_ID}-sls"
-  #Don't wait for install process
+  # Don't wait for install process
   export SYNC_WITH_INSTALL=false
-  #If this is the FVT Core run then don't call finalize at the end of this run
+  # Don't install selenium as it is installed via gitops
+  export SKIP_SELENIUM_GRID_INSTALL=true
+  # If this is the FVT Core run then don't call finalize at the end of this run
   if [[ "$LAUNCHER_ID" == "core" ]]; then
     export FINALIZE=false
     export SET_FINISHED=false

--- a/image/cli/mascli/templates/gitops/appset-configs/cluster/phase1/selenium-grid.yaml.j2
+++ b/image/cli/mascli/templates/gitops/appset-configs/cluster/phase1/selenium-grid.yaml.j2
@@ -1,0 +1,33 @@
+merge-key: "{{ ACCOUNT_ID }}/{{ CLUSTER_ID }}"
+
+selenium_grid:
+  namespace: selenium
+  version: 0.36.1
+  values:
+    hub:
+      imageTag: 4.23.0-20240727
+    chromeNode:
+      imageTag: 4.23.0-20240727
+      imageName: node-chromium
+      resources:
+        requests:
+          memory: "1Gi"
+          cpu: "1"
+        limits:
+          memory: "2Gi"
+          cpu: "1"
+    firefoxNode:
+      enabled: false
+    edgeNode:
+      enabled: false
+    autoscaling:
+      enabled: true
+      scalingType: job
+      scaledOptions:
+        maxReplicaCount: 999
+      scaledJobOptions:
+        scalingStrategy:
+          strategy: default
+    ingress:
+      hostname: selenium-grid.local
+      path: /selenium

--- a/tekton/src/pipelines/gitops/gitops-mas-cluster.yml.j2
+++ b/tekton/src/pipelines/gitops/gitops-mas-cluster.yml.j2
@@ -129,6 +129,9 @@ spec:
     - name: cluster_promotion_cluster_values
       type: string
       default: ''
+    - name: install_selenium_grid
+      type: string
+      default: ''
     - name: devops_build_number
       type: string
       default: ''
@@ -195,6 +198,9 @@ spec:
           value: $(params.cluster_promotion_target_pr_title)
         - name: cluster_promotion_cluster_values
           value: $(params.cluster_promotion_cluster_values)
+
+        - name: install_selenium_grid
+          value: ${params.install_selenium_grid)
 
         - name: devops_build_number
           value: $(params.devops_build_number)

--- a/tekton/src/tasks/gitops/gitops-cluster.yml.j2
+++ b/tekton/src/tasks/gitops/gitops-cluster.yml.j2
@@ -63,6 +63,10 @@ spec:
       type: string
       default: ''
 
+    - name: install_selenium_grid
+      type: string
+      default: ''
+
     - name: devops_build_number
       type: string
       default: ''
@@ -130,6 +134,9 @@ spec:
       - name: CLUSTER_PROMOTION_CLUSTER_VALUES
         value: $(params.cluster_promotion_cluster_values)
       
+      - name: INSTALL_SELENIUM_GRID
+        value: $(params.install_selenium_grid)
+
       - name: DEVOPS_BUILD_NUMBER
         value: $(params.devops_build_number)
 


### PR DESCRIPTION
Adds the selenium grid install that goes with https://github.com/ibm-mas/gitops/pull/220. The selenium grid will be used by FVT and for running sanity tests. At the moment we don't want to expose too much configuration, hence why the default values are set just as-is.

This also sets the SKIP_SELENIUM_GRID_INSTALL in fvt-preparer so we don't install it via ansible-fvt

https://jsw.ibm.com/browse/MASCORE-3670