### PR TITLE
[patch] Fix typo showAdvancedOptionsshowAdvancedOptions

### DIFF
--- a/python/src/mas/cli/install/settings/manageSettings.py
+++ b/python/src/mas/cli/install/settings/manageSettings.py
@@ -223,7 +223,7 @@ class ManageSettingsMixin():
         self.promptForString("Secondary languages", "mas_app_settings_secondary_langs")
 
     def manageSettingsCP4D(self) -> None:
-        if self.getParam("mas_app_channel_manage") in ["8.7.x", "9.0.x"] and self.showAdvancedOptionsshowAdvancedOptions:
+        if self.getParam("mas_app_channel_manage") in ["8.7.x", "9.0.x"] and self.showAdvancedOptions:
             self.printDescription([
                 "Integration with Cognos Analytics provides additional support for reporting features in Maximo Manage, for more information refer to the documentation online: ",
                 "    <u>https://ibm.biz/BdMuxs</u>"


### PR DESCRIPTION
Fixes: 
```
Define the additional languages to be configured in Maximo Manage. provide a comma-separated list of supported languages codes, for example: 'JA,DE,AR'
A complete list of available language codes is available online:
  https://www.ibm.com/docs/en/mas-cd/mhmpmh-and-p-u/continuous-delivery?topic=deploy-language-support
Secondary languages
Traceback (most recent call last):
 File "/opt/app-root/bin/mas-cli", line 56, in <module>
  app.install(argv[2:])
 File "/opt/app-root/lib64/python3.9/site-packages/mas/cli/install/app.py", line 60, in wrapper
  result = func(self, *args, **kwargs)
 File "/opt/app-root/lib64/python3.9/site-packages/mas/cli/install/app.py", line 940, in install
  self.interactiveMode(simplified=args.simplified, advanced=args.advanced)
 File "/opt/app-root/lib64/python3.9/site-packages/mas/cli/install/app.py", line 60, in wrapper
  result = func(self, *args, **kwargs)
 File "/opt/app-root/lib64/python3.9/site-packages/mas/cli/install/app.py", line 688, in interactiveMode
  self.manageSettings()
 File "/opt/app-root/lib64/python3.9/site-packages/mas/cli/install/settings/manageSettings.py", line 54, in manageSettings
  self.manageSettingsOther()
 File "/opt/app-root/lib64/python3.9/site-packages/mas/cli/install/settings/manageSettings.py", line 252, in manageSettingsOther
  self.manageSettingsCP4D()
 File "/opt/app-root/lib64/python3.9/site-packages/mas/cli/install/settings/manageSettings.py", line 226, in manageSettingsCP4D
  if self.getParam("mas_app_channel_manage") in ["8.7.x", "9.0.x"] and self.showAdvancedOptionsshowAdvancedOptions:
AttributeError: 'InstallApp' object has no attribute 'showAdvancedOptionsshowAdvancedOptions'
```