### PR TITLE
[patch] Fix for mongodb_v7 upgrade issue in mas update

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -58,7 +58,7 @@ setup(
     description='Python Admin CLI for Maximo Application Suite',
     long_description=long_description,
     install_requires=[
-        'mas-devops >= 1.7.0',  # EPL
+        'mas-devops >= 1.7.1',  # EPL
         'halo',                 # MIT License
         'prompt_toolkit',       # BSD License
         'openshift',            # Apache Software License


### PR DESCRIPTION
Picks up the fix reported in https://github.com/ibm-mas/python-devops/pull/31 related to mongodb upgrade from v6 to v7 not working during `mas update`