### PR TITLE
[patch] Fix acm component handling

### DIFF
--- a/python/src/mas/cli/install/settings/manageSettings.py
+++ b/python/src/mas/cli/install/settings/manageSettings.py
@@ -79,7 +79,7 @@ class ManageSettingsMixin():
             if self.yesOrNo(" - Asset Configuration Manager"):
                 self.params["mas_appws_components"] += ",acm=latest"
             if self.yesOrNo(" - Aviation"):
-                self.params["mas_appws_components"] += ",acm=latest"
+                self.params["mas_appws_components"] += ",aviation=latest"
             if self.yesOrNo(" - Civil Infrastructure"):
                 self.params["mas_appws_components"] += ",civil=latest"
             if self.yesOrNo(" - Envizi"):

--- a/python/src/mas/cli/install/summarizer.py
+++ b/python/src/mas/cli/install/summarizer.py
@@ -181,7 +181,7 @@ class InstallSummarizerMixin():
             print_formatted_text(HTML("  <SkyBlue>+ Components</SkyBlue>"))
             self.printSummary("  + ACM", "Enabled" if "acm=" in self.getParam("mas_appws_components") else "Disabled")
             self.printSummary("  + Aviation", "Enabled" if "aviation=" in self.getParam("mas_appws_components") else "Disabled")
-            self.printSummary("  + Civil Infrastructure", "Enabled" if "acm=" in self.getParam("mas_appws_components") else "Disabled")
+            self.printSummary("  + Civil Infrastructure", "Enabled" if "civil=" in self.getParam("mas_appws_components") else "Disabled")
             self.printSummary("  + Envizi", "Enabled" if "envizi=" in self.getParam("mas_appws_components") else "Disabled")
             self.printSummary("  + Health", "Enabled" if "health=" in self.getParam("mas_appws_components") else "Disabled")
             self.printSummary("  + HSE", "Enabled" if "hse=" in self.getParam("mas_appws_components") else "Disabled")


### PR DESCRIPTION
The acm component is being enabled instead of aviation when using the interactive installer, and the acm component flag is being used to determine whether Civil Infrastructure is being installed or not in the rendered install summary.

- Fixes #1334 