### PR TITLE
[patch] Fix handling no --additional-configs flag

### DIFF
--- a/python/src/mas/cli/install/app.py
+++ b/python/src/mas/cli/install/app.py
@@ -774,7 +774,7 @@ class InstallApp(BaseApp, InstallSettingsMixin, InstallSummarizerMixin, ConfigGe
             elif key == "additional_configs":
                 self.localConfigDir = value
                 # If there is a file named mongodb-system.yaml we will use this as a BYO MongoDB datasource
-                if path.exists(path.join(self.localConfigDir, "mongodb-system.yaml")):
+                if self.localConfigDir is not None and path.exists(path.join(self.localConfigDir, "mongodb-system.yaml")):
                     self.setParam("mongodb_action", "byo")
                     self.setParam("sls_mongodb_cfg_file", "/workspace/additional-configs/mongodb-system.yaml")
 


### PR DESCRIPTION
Almost all our internal testing is using `--additional-configs`, so we missed this case initially.