### PR TITLE
[patch] Only check for apikey when cos type is ibm in gitops

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2024-11-13T12:18:26Z",
+  "generated_at": "2024-11-16T12:02:00Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -192,7 +192,7 @@
         "hashed_secret": "2582aea6f911bd00fc04cb25e0ec16d5ead62068",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 176,
+        "line_number": 178,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/image/cli/mascli/functions/gitops_deprovision_cos
+++ b/image/cli/mascli/functions/gitops_deprovision_cos
@@ -126,7 +126,9 @@ function gitops_deprovision_cos_noninteractive() {
 
   [[ -z "$CLUSTER_ID" ]] && gitops_deprovision_cos_help "CLUSTER_ID is not set"
   [[ -z "$COS_TYPE" ]] && gitops_deprovision_cos_help "COS_TYPE is not set"
-  [[ -z "$COS_APIKEY" ]] && gitops_deprovision_cos_help "COS_APIKEY is not set"
+  if [[ "${COS_TYPE}" == "ibm" ]]; then
+    [[ -z "$COS_APIKEY" ]] && gitops_deprovision_cos_help "COS_APIKEY is not set"
+  fi
   [[ -z "$ACCOUNT_ID" ]] && gitops_deprovision_cos_help "ACCOUNT_ID is not set"
   [[ -z "$MAS_INSTANCE_ID" ]] && gitops_deprovision_cos_help "MAS_INSTANCE_ID is not set"
 }


### PR DESCRIPTION
Only check for COS_APIKEY is set when the COS_TYPE is ibm in the deprovision cos function for gitops.