### PR TITLE
[patch] Increase fvt delay for gitops

### DIFF
--- a/tekton/src/tasks/gitops/gitops-mas-fvt-preparer.yml.j2
+++ b/tekton/src/tasks/gitops/gitops-mas-fvt-preparer.yml.j2
@@ -454,8 +454,8 @@ spec:
 
         fi
 
-        echo "Sleeping for 60 seconds to give postsync job a chance to run before creating sync window"
-        sleep 60
+        echo "Sleeping for 180 seconds to give postsync job a chance to run before creating sync window"
+        sleep 180
 
         echo "argo:argocd proj windows add mas --kind deny --schedule * * * * * --duration 4h --applications *"  
         argocd proj windows add mas --kind deny --schedule "* * * * *" --duration 4h --applications "*.$MAS_INSTANCE_ID"


### PR DESCRIPTION
Increases the delay in gitops before running FVT to ensure that postsync jobs have completed before setting up the sync deny window