### PR TITLE
[patch] Correct db2_action param names

### DIFF
--- a/python/src/mas/cli/install/argBuilder.py
+++ b/python/src/mas/cli/install/argBuilder.py
@@ -226,10 +226,10 @@ class installArgBuilderMixin():
 
         # IBM Db2 Universal Operator
         # -----------------------------------------------------------------------------
-        if self.getParam('db2_system') == "install" or self.getParam('db2_manage') == "install":
-            if self.getParam('db2_system') == "install":
+        if self.getParam('db2_action_system') == "install" or self.getParam('db2_action_manage') == "install":
+            if self.getParam('db2_action_system') == "install":
                 command += f"  --db2-system{newline}"
-            if self.getParam('db2_manage') == "install":
+            if self.getParam('db2_action_manage') == "install":
                 command += f"  --db2-manage{newline}"
 
             if self.getParam('db2_channel') != "":


### PR DESCRIPTION
From support ticket: TS017415330

> MASCLI v10.9.2 or latest v11.0.0 mas interactive install generate a defected Non-Interactive Install Command at the end missing the db2 installation as you can see in the attached document pint screens (Non-Interactive Install Command.docx).
> 
> When tested a new mas install in other cluster with this generated Non-Interactive Install Command, mas core is installed but the manage dont get installed because db2 is missing.