### PR TITLE
[patch] Fix support for auto-cp4d versioning

### DIFF
--- a/python/src/mas/cli/install/app.py
+++ b/python/src/mas/cli/install/app.py
@@ -245,9 +245,9 @@ class InstallApp(BaseApp, InstallSettingsMixin, InstallSummarizerMixin, ConfigGe
             self.promptForString("Select catalog source", "mas_catalog_version", default="v9-master-amd64")
             self.promptForString("Select channel", "mas_channel", default="9.1.x-dev")
         else:
-            catalogInfo = getCurrentCatalog(self.dynamicClient)
+            self.catalogInfo = getCurrentCatalog(self.dynamicClient)
 
-            if catalogInfo is None:
+            if self.catalogInfo is None:
                 self.printDescription([
                     "The catalog you choose dictates the version of everything that is installed, with Maximo Application Suite this is the only version you need to remember; all other versions are determined by this choice.",
                     "Older catalogs can still be used, but we recommend using an older version of the CLI that aligns with the release date of the catalog.",
@@ -267,9 +267,9 @@ class InstallApp(BaseApp, InstallSettingsMixin, InstallSummarizerMixin, ConfigGe
                 self.chosenCatalog = getCatalog(self.getParam("mas_catalog_version"))
             else:
                 self.printDescription([
-                    f"The IBM Maximo Operator Catalog is already installed in this cluster ({catalogInfo['catalogId']}).  If you wish to install MAS using a newer version of the catalog please first update the catalog using mas update."
+                    f"The IBM Maximo Operator Catalog is already installed in this cluster ({self.catalogInfo['catalogId']}).  If you wish to install MAS using a newer version of the catalog please first update the catalog using mas update."
                 ])
-                self.setParam("mas_catalog_version", catalogInfo["catalogId"])
+                self.setParam("mas_catalog_version", self.catalogInfo["catalogId"])
 
             self.chosenCatalog = getCatalog(self.getParam("mas_catalog_version"))
             catalogSummary = self.processCatalogChoice()
@@ -342,6 +342,7 @@ class InstallApp(BaseApp, InstallSettingsMixin, InstallSummarizerMixin, ConfigGe
     @logMethodCall
     def configCP4D(self):
         if self.getParam("mas_catalog_version") in self.catalogOptions:
+            # Note: this will override any version provided by the user (which is intentional!)
             logger.debug(f"Using automatic CP4D product version: {self.getParam('cpd_product_version')}")
             self.setParam("cpd_product_version", self.catalogInfo["cpd_product_version_default"])
         elif self.getParam("cpd_product_version") == "":

--- a/python/src/mas/cli/update/app.py
+++ b/python/src/mas/cli/update/app.py
@@ -204,18 +204,18 @@ class UpdateApp(BaseApp):
                     print()
 
     def reviewCurrentCatalog(self) -> None:
-        catalogInfo = getCurrentCatalog(self.dynamicClient)
+        self.catalogInfo = getCurrentCatalog(self.dynamicClient)
         self.installedCatalogId = None
-        if catalogInfo is None:
+        if self.catalogInfo is None:
             self.fatalError("Unable to locate existing install of the IBM Maximo Operator Catalog")
-        elif catalogInfo["catalogId"] is None:
+        elif self.catalogInfo["catalogId"] is None:
             self.printWarning("Unable to determine identity & version of currently installed ibm-maximo-operator-catalog")
         else:
-            self.installedCatalogId = catalogInfo["catalogId"]
+            self.installedCatalogId = self.catalogInfo["catalogId"]
             self.printH1("Review Installed Catalog")
             self.printDescription([
-                f"The currently installed Maximo Operator Catalog is <u>{catalogInfo['displayName']}</u>",
-                f" <u>{catalogInfo['image']}</u>"
+                f"The currently installed Maximo Operator Catalog is <u>{self.catalogInfo['displayName']}</u>",
+                f" <u>{self.catalogInfo['image']}</u>"
             ])
 
     def reviewMASInstance(self) -> None:

--- a/python/src/mas/cli/update/app.py
+++ b/python/src/mas/cli/update/app.py
@@ -204,18 +204,18 @@ class UpdateApp(BaseApp):
                     print()
 
     def reviewCurrentCatalog(self) -> None:
-        self.catalogInfo = getCurrentCatalog(self.dynamicClient)
+        catalogInfo = getCurrentCatalog(self.dynamicClient)
         self.installedCatalogId = None
-        if self.catalogInfo is None:
+        if catalogInfo is None:
             self.fatalError("Unable to locate existing install of the IBM Maximo Operator Catalog")
-        elif self.catalogInfo["catalogId"] is None:
+        elif catalogInfo["catalogId"] is None:
             self.printWarning("Unable to determine identity & version of currently installed ibm-maximo-operator-catalog")
         else:
-            self.installedCatalogId = self.catalogInfo["catalogId"]
+            self.installedCatalogId = catalogInfo["catalogId"]
             self.printH1("Review Installed Catalog")
             self.printDescription([
-                f"The currently installed Maximo Operator Catalog is <u>{self.catalogInfo['displayName']}</u>",
-                f" <u>{self.catalogInfo['image']}</u>"
+                f"The currently installed Maximo Operator Catalog is <u>{catalogInfo['displayName']}</u>",
+                f" <u>{catalogInfo['image']}</u>"
             ])
 
     def reviewMASInstance(self) -> None:


### PR DESCRIPTION
Fixes this error, we are looking for a class property that was never initialized.

```
Traceback (most recent call last):
  File "/opt/app-root/bin/mas-cli", line 56, in <module>
    app.install(argv[2:])
  File "/opt/app-root/lib64/python3.9/site-packages/mas/cli/install/app.py", line 64, in wrapper
    result = func(self, *args, **kwargs)
  File "/opt/app-root/lib64/python3.9/site-packages/mas/cli/install/app.py", line 1037, in install
    self.configCP4D()
  File "/opt/app-root/lib64/python3.9/site-packages/mas/cli/install/app.py", line 64, in wrapper
    result = func(self, *args, **kwargs)
  File "/opt/app-root/lib64/python3.9/site-packages/mas/cli/install/app.py", line 346, in configCP4D
    self.setParam("cpd_product_version", self.catalogInfo["cpd_product_version_default"])
AttributeError: 'InstallApp' object has no attribute 'catalogInfo'
```