### PR TITLE
[patch] PromptSesssion carries over validators

### DIFF
--- a/python/src/mas/cli/cli.py
+++ b/python/src/mas/cli/cli.py
@@ -25,7 +25,7 @@ from kubernetes.client import api_client, Configuration
 from openshift.dynamic import DynamicClient
 from openshift.dynamic.exceptions import NotFoundError
 
-from prompt_toolkit import prompt, print_formatted_text, HTML, PromptSession
+from prompt_toolkit import prompt, print_formatted_text, HTML
 
 from mas.devops.mas import isAirgapInstall
 from mas.devops.ocp import connect, isSNO, getNodes
@@ -173,7 +173,6 @@ class BaseApp(PrintMixin, PromptMixin):
                 "visualinspection": ["8.8.x", "8.7.x"]
             }
         }
-        self.promptSession = PromptSession()
 
         self.spinner = {
             "interval": 80,

--- a/python/src/mas/cli/displayMixins.py
+++ b/python/src/mas/cli/displayMixins.py
@@ -9,7 +9,7 @@
 # *****************************************************************************
 
 from os import getenv
-from prompt_toolkit import prompt, print_formatted_text, HTML
+from prompt_toolkit import prompt, print_formatted_text, HTML, PromptSession
 from prompt_toolkit.completion import WordCompleter
 from prompt_toolkit.validation import Validator
 
@@ -91,9 +91,10 @@ class PromptMixin():
             default = getenv(param.upper(), default="")
 
         if completer is not None:
-            response = self.promptSession.prompt(masPromptValue(message), is_password=isPassword, default=default, completer=completer, validator=validator, validate_while_typing=False, pre_run=self.promptSession.default_buffer.start_completion)
+            promptSession = PromptSession()
+            response = promptSession.prompt(masPromptValue(message), is_password=isPassword, default=default, completer=completer, validator=validator, validate_while_typing=False, pre_run=promptSession.default_buffer.start_completion)
         else:
-            response = self.promptSession.prompt(masPromptValue(message), is_password=isPassword, default=default, completer=completer, validator=validator, validate_while_typing=False)
+            response = prompt(masPromptValue(message), is_password=isPassword, default=default, completer=completer, validator=validator, validate_while_typing=False)
 
         if param is not None:
             self.params[param] = response


### PR DESCRIPTION
The `PromptSession` carries over any validators attached to it, so we don't want to use a single session for the entire interactive flow.

- Fixes #1370

![image](https://github.com/user-attachments/assets/9ef2fea6-6372-41ca-9fe0-3869555bfa1c)
