### PR TITLE
[minor] Simplify handling of ISV groups variable for gitops

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2024-11-22T12:20:31Z",
+  "generated_at": "2024-11-26T12:13:03Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -394,7 +394,7 @@
         "hashed_secret": "fee2d55ad9a49a95fc89abe8f414dad66704ebfd",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 21,
+        "line_number": 7,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2024-11-26T12:13:03Z",
+  "generated_at": "2024-11-26T16:34:56Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -394,7 +394,7 @@
         "hashed_secret": "fee2d55ad9a49a95fc89abe8f414dad66704ebfd",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 7,
+        "line_number": 22,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/image/cli/mascli/templates/gitops/appset-configs/cluster/group-sync-operator.yaml.j2
+++ b/image/cli/mascli/templates/gitops/appset-configs/cluster/group-sync-operator.yaml.j2
@@ -1,7 +1,7 @@
 merge-key: "{{ ACCOUNT_ID }}/{{ CLUSTER_ID }}"
 
 {#- Parses the ISV groups from a string representation of a list of maps #}
-{#- Example: "- name: 'admin'\n  id: 645001Z1WP\n- name: developer'\n  id: 645001Z1WR\n" #}
+{#- Example: "- name: 'admin'\n  id: 645001Z1WP\n- name: 'developer'\n  id: 645001Z1WR\n" #}
 {%- set group_namespace = namespace(isv_groups = []) %}
 {%- set group_strs = GROUP_SYNC_OPERATOR_ISV_GROUPS.split('-') %}
 {%- set _ = group_strs.remove('') %}

--- a/image/cli/mascli/templates/gitops/appset-configs/cluster/group-sync-operator.yaml.j2
+++ b/image/cli/mascli/templates/gitops/appset-configs/cluster/group-sync-operator.yaml.j2
@@ -1,18 +1,4 @@
 merge-key: "{{ ACCOUNT_ID }}/{{ CLUSTER_ID }}"
-
-{#- Parses the ISV groups from a string representation of a list of maps #}
-{#- Example: isv_groups: "name:'a1',id:'a2'; name:'a3',id:'a4'" #}
-{%- set group_namespace = namespace(isv_groups = []) %}
-{%- set group_strs = GROUP_SYNC_OPERATOR_ISV_GROUPS.split(';') %}
-{%- for group_str in group_strs %}
-  {%- set group_loop = loop %}
-  {%- set _ = group_namespace.isv_groups.append(dict()) %}
-  {%- set pairs = group_str.split(',') %}
-  {%- for pair in pairs %}
-    {%- set items = pair.split(':') %}
-    {%- set _ = group_namespace.isv_groups[group_loop.index - 1].__setitem__(items[0].strip().strip("'"), items[1].strip().strip("'")) %}
-  {%- endfor %}
-{%- endfor %}
    
 group_sync_operator:
   cron_schedule: "{{ GROUP_SYNC_OPERATOR_CRON_SCHEDULE }}"
@@ -20,4 +6,4 @@ group_sync_operator:
   isv_client_id: "<path:{{ SECRETS_PATH }}:{{ SECRET_KEY_ISV_CLIENT_ID }}>"
   isv_client_secret: "<path:{{ SECRETS_PATH }}:{{ SECRET_KEY_ISV_CLIENT_SECRET }}>"
   isv_groups:
-    {{ group_namespace.isv_groups }}
+    {{ GROUP_SYNC_OPERATOR_ISV_GROUPS }}

--- a/image/cli/mascli/templates/gitops/appset-configs/cluster/group-sync-operator.yaml.j2
+++ b/image/cli/mascli/templates/gitops/appset-configs/cluster/group-sync-operator.yaml.j2
@@ -1,9 +1,24 @@
 merge-key: "{{ ACCOUNT_ID }}/{{ CLUSTER_ID }}"
-   
+
+{#- Parses the ISV groups from a string representation of a list of maps #}
+{#- Example: "- name: 'admin'\n  id: 645001Z1WP\n- name: developer'\n  id: 645001Z1WR\n" #}
+{%- set group_namespace = namespace(isv_groups = []) %}
+{%- set group_strs = GROUP_SYNC_OPERATOR_ISV_GROUPS.split('-') %}
+{%- set _ = group_strs.remove('') %}
+{%- for group_str in group_strs %}
+  {%- set group_loop = loop %}
+  {%- set _ = group_namespace.isv_groups.append(dict()) %}
+  {%- set pairs = group_str.strip('\n').split('\n') %}
+  {%- for pair in pairs %}
+    {%- set items = pair.split(':') %}
+    {%- set _ = group_namespace.isv_groups[group_loop.index - 1].__setitem__(items[0].strip().strip("'"), items[1].strip().strip("'")) %}
+  {%- endfor %}
+{%- endfor %}
+
 group_sync_operator:
   cron_schedule: "{{ GROUP_SYNC_OPERATOR_CRON_SCHEDULE }}"
   isv_tenant_url: "{{ GROUP_SYNC_OPERATOR_ISV_TENANT_URL }}"
   isv_client_id: "<path:{{ SECRETS_PATH }}:{{ SECRET_KEY_ISV_CLIENT_ID }}>"
   isv_client_secret: "<path:{{ SECRETS_PATH }}:{{ SECRET_KEY_ISV_CLIENT_SECRET }}>"
   isv_groups:
-    {{ GROUP_SYNC_OPERATOR_ISV_GROUPS }}
+    {{ group_namespace.isv_groups }}


### PR DESCRIPTION
See: MASCORE-4459

The Group Sync Operator's list of ISV groups is currently rendered from a string variable that represents a YAML list of maps in a custom format:
```
"name:'a1',id:'a2'; name:'a3',id:'a4'"
```

Rather than the above custom format, the list should now be defined as a standard YAML string block (using the pipe character):
```
  isv_groups: |
    - name: 'admin'
      id: 645001Z1WP
    - name: 'developer'
      id: 645001Z1WR
```
The above as a string is given as 
```
"- name: 'admin'\n  id: 645001Z1WP\n- name: developer'\n  id: 645001Z1WR\n"
```
It is this format which is now processed during rendering, avoiding the need for a custom string representation.