### PR TITLE
[patch] Make DB2_ARCHIVELOGS_STORAGE_CLASS optional for gitops

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2024-11-25T18:20:01Z",
+  "generated_at": "2024-11-27T10:44:24Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -182,7 +182,7 @@
         "hashed_secret": "1459943ba5fd876f7ef6e48f566a40b448a2bf08",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 450,
+        "line_number": 449,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/image/cli/mascli/functions/gitops_db2u_database
+++ b/image/cli/mascli/functions/gitops_db2u_database
@@ -325,7 +325,6 @@ function gitops_db2u_database_noninteractive() {
   [[ -z "$DB2_META_STORAGE_CLASS" ]] && gitops_db2u_database_help "DB2_META_STORAGE_CLASS is not set"
   [[ -z "$DB2_DATA_STORAGE_CLASS" ]] && gitops_db2u_database_help "DB2_DATA_STORAGE_CLASS is not set"
   [[ -z "$DB2_BACKUP_STORAGE_CLASS" ]] && gitops_db2u_database_help "DB2_BACKUP_STORAGE_CLASS is not set"
-  [[ -z "$DB2_ARCHIVELOGS_STORAGE_CLASS" ]] && gitops_db2u_database_help "DB2_ARCHIVELOGS_STORAGE_CLASS is not set"
   [[ -z "$DB2_LOGS_STORAGE_CLASS" ]] && gitops_db2u_database_help "DB2_LOGS_STORAGE_CLASS is not set"
   [[ -z "$MAS_INSTANCE_ID" ]] && gitops_db2u_database_help "MAS_INSTANCE_ID is not set"
   [[ -z "$MAS_APP_ID" ]] && gitops_db2u_database_help "MAS_APP_ID is not set"


### PR DESCRIPTION
DB2_ARCHIVELOGS_STORAGE_CLASS are now optional and the cli shouldn't check it.