### PR TITLE
[patch] Fix skip_pre_check condition

### DIFF
--- a/tekton/src/pipelines/taskdefs/cluster-setup/ocp-verify-all.yml.j2
+++ b/tekton/src/pipelines/taskdefs/cluster-setup/ocp-verify-all.yml.j2
@@ -13,4 +13,4 @@
   when:
     - input: "$(params.skip_pre_check)"
       operator: notin
-      values: ["True"]
+      values: ["True", "true"]

--- a/tekton/src/pipelines/taskdefs/cluster-setup/ocp-verify.yml.j2
+++ b/tekton/src/pipelines/taskdefs/cluster-setup/ocp-verify.yml.j2
@@ -25,4 +25,4 @@
   when:
     - input: "$(params.skip_pre_check)"
       operator: notin
-      values: ["True"]
+      values: ["True", "true"]


### PR DESCRIPTION
The `skip_pre_check` parameter is currently only respected if it's set to `True`, this update also allows the use of `true` - which is what the CLI is actually setting it to when it starts a pipeline run.