### PR TITLE
[patch] Add missing db2_tls_version to gitops task

### DIFF
--- a/tekton/src/tasks/gitops/gitops-db2u-database.yml.j2
+++ b/tekton/src/tasks/gitops/gitops-db2u-database.yml.j2
@@ -102,6 +102,8 @@ spec:
       type: string
     - name: db2_timezone
       type: string
+    - name: db2_tls_version
+      type: string
     - name: mas_instance_id
       type: string
     - name: mas_app_id
@@ -210,6 +212,8 @@ spec:
         value: $(params.db2_tolerate_effect)
       - name: DB2_TIMEZONE
         value: $(params.db2_timezone)
+      - name: DB2_TLS_VERSION
+        value: $(params.db2_tls_version)
       - name: MAS_APP_ID
         value: $(params.mas_app_id)
       - name: JDBC_ROUTE


### PR DESCRIPTION
Adds the missing db2_tls_version to the task that was resulting in the function using the default value