### PR TITLE
[patch] Fix handling of mongo namespace with simple prompts

### DIFF
--- a/python/src/mas/cli/install/settings/mongodbSettings.py
+++ b/python/src/mas/cli/install/settings/mongodbSettings.py
@@ -22,6 +22,10 @@ class MongoDbSettingsMixin():
         if self.architecture != "s390x" and self.yesOrNo("Create MongoDb cluster using MongoDb Community Edition Operator"):
             if self.showAdvancedOptions:
                 self.promptForString("MongoDb namespace", "mongodb_namespace", default="mongoce")
+            else:
+                # Even though "" works as the default, we use this value to contruct other values so we need to explicitly set it
+                self.setParam("mongodb_namespace", "mongoce")
+
             self.setParam("mongodb_action", "install")
             self.setParam("sls_mongodb_cfg_file", f"/workspace/configs/mongo-{self.getParam('mongodb_namespace')}.yml")
         else:


### PR DESCRIPTION
When installing MAS using interactive mode, and selecting the simplified prompts we fail to set the MongoDb namespace explicitly, and although this is supported by the MongoDb role (which defaults to mongoce namespace), later in the CLI we use this namespace to determine the name of the config file that will be processed to configure SLS, resulting in:

```
TASK [ibm.mas_devops.sls : Read MongoDb config file] ***************************
fatal: [localhost]: FAILED! => 
  msg: The 'file' lookup had an issue accessing the file '/workspace/configs/mongo-.yml'. file not found, use -vvvvv to see paths searched
```