### PR TITLE
[minor] Add manage onlineUpgrade support for gitops + skip deprovision tasks based on edition

### DIFF
--- a/image/cli/mascli/functions/gitops_suite_app_config
+++ b/image/cli/mascli/functions/gitops_suite_app_config
@@ -57,7 +57,7 @@ Maximo Manage:
       masdev-manage-d-sbNascsn: <<base64 encoded content of masdev-manage-dsbNasc-sn.xml>>
 
   --mas-app-global-secrets-yaml ${COLOR_YELLOW}MAS_APP_GLOBAL_SECRETS_YAML${TEXT_RESET} yaml file location containing secret key/values that will be added to the Manage encryption secret
-
+  --manage-update-schedule ${COLOR_YELLOW}MANAGE_UPDATE_SCHEDULE${TEXT_RESET} cron based schedule to indicate when manage will do the offline update when the onlineUpgrade is set in the ManageWorkspace CR. Optional as default is  "0 0 * * *"
 
 Secrets Manager:
   --secrets-path ${COLOR_YELLOW}SECRETS_PATH${TEXT_RESET}                                                 Secrets Manager path
@@ -182,6 +182,9 @@ function gitops_suite_app_config_noninteractive() {
         ;;
       --mas-app-global-secrets-yaml)
         export MAS_APP_GLOBAL_SECRETS_YAML=$1 && shift
+        ;;
+      --manage-update-schedule)
+        export MANAGE_UPDATE_SCHEDULE=$1 && shift
         ;;
 
       # Automatic GitHub Push
@@ -331,6 +334,7 @@ function gitops_suite_app_config() {
   echo_reset_dim "Application WS Spec Yaml file ........... ${COLOR_MAGENTA}${MAS_APPWS_SPEC_YAML}"
   echo_reset_dim "Combined additional server configs ...... ${COLOR_MAGENTA}${MAS_APP_SERVER_BUNDLES_COMBINED_ADD_SERVER_CONFIG_YAML}"
   echo_reset_dim "Global Secrets (Manage) ................. ${COLOR_MAGENTA}${MAS_APP_GLOBAL_SECRETS_YAML}"
+  echo_reset_dim "Manage Update Schedule  ................. ${COLOR_MAGENTA}${MANAGE_UPDATE_SCHEDULE}"
 
   if [[ -n "$MAS_APPWS_SPEC_YAML" ]] && [[ -s "$MAS_APPWS_SPEC_YAML" ]]; then
     echo_reset_dim "Using Default Application Spec ........ ${COLOR_MAGENTA}False"

--- a/image/cli/mascli/templates/gitops/appset-configs/cluster/instance/db2-databases/ibm-db2u-database.yaml.j2
+++ b/image/cli/mascli/templates/gitops/appset-configs/cluster/instance/db2-databases/ibm-db2u-database.yaml.j2
@@ -43,12 +43,16 @@ db2_logs_storage_accessmode: {{DB2_LOGS_STORAGE_ACCESSMODE}}
 db2_audit_logs_storage_class: {{DB2_AUDIT_LOGS_STORAGE_CLASS}}
 db2_audit_logs_storage_size: {{DB2_AUDIT_LOGS_STORAGE_SIZE}}
 db2_audit_logs_storage_accessmode: {{DB2_AUDIT_LOGS_STORAGE_ACCESSMODE}}
+{% if DB2_TEMP_STORAGE_CLASS %}
 db2_temp_storage_class: {{DB2_TEMP_STORAGE_CLASS}}
 db2_temp_storage_size: {{DB2_TEMP_STORAGE_SIZE}}
 db2_temp_storage_accessmode: {{DB2_TEMP_STORAGE_ACCESSMODE}}
+{% endif %}
+{% if DB2_ARCHIVELOGS_STORAGE_CLASS %}
 db2_archivelogs_storage_class: {{DB2_ARCHIVELOGS_STORAGE_CLASS}}
 db2_archivelogs_storage_size: {{DB2_ARCHIVELOGS_STORAGE_SIZE}}
 db2_archivelogs_storage_accessmode: {{DB2_ARCHIVELOGS_STORAGE_ACCESSMODE}}
+{% endif %}
 db2_cpu_requests: {{DB2_CPU_REQUESTS}}
 db2_cpu_limits: {{DB2_CPU_LIMITS}}
 db2_memory_requests: {{DB2_MEMORY_REQUESTS}}

--- a/image/cli/mascli/templates/gitops/appset-configs/cluster/instance/masapp/ibm-mas-masapp-config.yaml.j2
+++ b/image/cli/mascli/templates/gitops/appset-configs/cluster/instance/masapp/ibm-mas-masapp-config.yaml.j2
@@ -27,6 +27,10 @@ manage_logging_access_secret_key: <path:{{ SECRETS_PATH }}:{{ MANAGE_LOGGING_SEC
 {{ MAS_APP_GLOBAL_SECRETS | indent(2) }}
 {%- endif %}
 
+{%- if MANAGE_UPDATE_SCHEDULE is defined and MANAGE_UPDATE_SCHEDULE !='' %}
+manage_update_schedule: {{ MANAGE_UPDATE_SCHEDULE }}
+{%- endif %}
+
 {{ MAS_APPWS_SPEC | indent(2) }}
 
 {% if MAS_MANUAL_CERT_MGMT == 'true' %}

--- a/tekton/src/pipelines/gitops/gitops-mas-apps.yml.j2
+++ b/tekton/src/pipelines/gitops/gitops-mas-apps.yml.j2
@@ -355,6 +355,9 @@ spec:
     - name: mas_app_global_secrets_yaml_manage
       type: string
       default: ""
+    - name: manage_update_schedule
+      type: string
+      default: ""
 
     - name: mas_app_channel_monitor
       type: string

--- a/tekton/src/pipelines/gitops/gitops-mas-apps.yml.j2
+++ b/tekton/src/pipelines/gitops/gitops-mas-apps.yml.j2
@@ -704,7 +704,7 @@ spec:
         - name: configs
           workspace: configs
         - name: shared-gitops-configs
-          workspace: shared-gitops-configs          
+          workspace: shared-gitops-configs
       taskRef:
         kind: Task
         name: gitops-jdbc-config
@@ -1395,6 +1395,9 @@ spec:
         - input: "$(params.monitor_workspace_action)"
           operator: in
           values: ["deactivate", ""]
+        - input: "$(params.mas_edition)"
+          operator: in
+          values: ["standard", "premium"]
 
     # 1.2 Monitor App Deprovision
     - name: gitops-deprovision-mas-app-install-monitor
@@ -1420,6 +1423,9 @@ spec:
         - input: "$(params.mas_app_channel_monitor)"
           operator: in
           values: [""]
+        - input: "$(params.mas_edition)"
+          operator: in
+          values: ["standard", "premium"]
 
     # 2. Predict Deprovision
     # -------------------------------------------------------------------------
@@ -1447,6 +1453,9 @@ spec:
         - input: "$(params.predict_workspace_action)"
           operator: in
           values: ["deactivate", ""]
+        - input: "$(params.mas_edition)"
+          operator: in
+          values: ["standard", "premium"]
 
     # 2.2 Predict App
     - name: gitops-deprovision-mas-app-install-predict
@@ -1472,6 +1481,9 @@ spec:
         - input: "$(params.mas_app_channel_predict)"
           operator: in
           values: [""]
+        - input: "$(params.mas_edition)"
+          operator: in
+          values: ["standard", "premium"]
 
     # 3. Visualinspection Deprovision
     # -------------------------------------------------------------------------
@@ -1499,6 +1511,9 @@ spec:
         - input: "$(params.visualinspection_workspace_action)"
           operator: in
           values: ["deactivate", ""]
+        - input: "$(params.mas_edition)"
+          operator: in
+          values: ["essentials-inspection", "standard", "premium"]
 
     # 3.2 Visualinspection App
     - name: gitops-deprovision-mas-app-install-visualinspection
@@ -1524,6 +1539,9 @@ spec:
         - input: "$(params.mas_app_channel_visualinspection)"
           operator: in
           values: [""]
+        - input: "$(params.mas_edition)"
+          operator: in
+          values: ["essentials-inspection", "standard", "premium"]
 
     # 4. Optimizer Deprovision
     # -------------------------------------------------------------------------
@@ -1551,6 +1569,9 @@ spec:
         - input: "$(params.optimizer_workspace_action)"
           operator: in
           values: ["deactivate", ""]
+        - input: "$(params.mas_edition)"
+          operator: in
+          values: ["essentials-maintenance", "standard", "premium"]
 
     # 4.2 Optimizer App
     - name: gitops-deprovision-mas-app-install-optimizer
@@ -1576,6 +1597,9 @@ spec:
         - input: "$(params.mas_app_channel_optimizer)"
           operator: in
           values: [""]
+        - input: "$(params.mas_edition)"
+          operator: in
+          values: ["essentials-maintenance", "standard", "premium"]
 
     # 5. Assist Deprovision
     # -------------------------------------------------------------------------
@@ -1592,6 +1616,9 @@ spec:
           value: $(params.mas_workspace_id)
         - name: mas_app_id
           value: assist
+        - input: "$(params.mas_edition)"
+          operator: in
+          values: ["standard", "premium"]
 
       taskRef:
         kind: Task
@@ -1628,6 +1655,9 @@ spec:
         - input: "$(params.mas_app_channel_assist)"
           operator: in
           values: [""]
+        - input: "$(params.mas_edition)"
+          operator: in
+          values: ["standard", "premium"]
 
     # 6. Manage Deprovision
     # -------------------------------------------------------------------------
@@ -1659,6 +1689,9 @@ spec:
         - input: "$(params.manage_workspace_action)"
           operator: in
           values: ["deactivate", ""]
+        - input: "$(params.mas_edition)"
+          operator: in
+          values: ["essentials-maintenance", "standard", "premium"]
 
     # 6.2 Manage App
     - name: gitops-deprovision-mas-app-install-manage
@@ -1684,7 +1717,9 @@ spec:
         - input: "$(params.mas_app_channel_manage)"
           operator: in
           values: [""]
-
+        - input: "$(params.mas_edition)"
+          operator: in
+          values: ["essentials-maintenance", "standard", "premium"]
 
     # 6.3 Manage Database
     - name: gitops-deprovision-db2u-database-manage
@@ -1710,6 +1745,9 @@ spec:
         - input: "$(params.mas_app_channel_manage)"
           operator: in
           values: [""]
+        - input: "$(params.mas_edition)"
+          operator: in
+          values: ["essentials-maintenance", "standard", "premium"]
 
     # 6.4 Manage JDBC Config
     - name: gitops-delete-jdbc-config-manage
@@ -1748,6 +1786,9 @@ spec:
         - input: "$(params.mas_app_channel_manage)"
           operator: in
           values: [""]
+        - input: "$(params.mas_edition)"
+          operator: in
+          values: ["essentials-maintenance", "standard", "premium"]
   
     # 7. IoT Deprovision
     # -------------------------------------------------------------------------
@@ -1777,6 +1818,9 @@ spec:
         - input: "$(params.iot_workspace_action)"
           operator: in
           values: ["deactivate", ""]
+        - input: "$(params.mas_edition)"
+          operator: in
+          values: ["standard", "premium"]
 
     # 7.2 IoT App
     - name: gitops-deprovision-mas-app-install-iot
@@ -1802,6 +1846,9 @@ spec:
         - input: "$(params.mas_app_channel_iot)"
           operator: in
           values: [""]
+        - input: "$(params.mas_edition)"
+          operator: in
+          values: ["standard", "premium"]
 
     # 7.3 IoT Database
     - name: gitops-deprovision-db2u-database-iot
@@ -1827,6 +1874,9 @@ spec:
         - input: "$(params.mas_app_channel_iot)"
           operator: in
           values: [""]
+        - input: "$(params.mas_edition)"
+          operator: in
+          values: ["standard", "premium"]
 
     # 8. Deprovision Kafka config
     # -------------------------------------------------------------------------
@@ -1851,6 +1901,9 @@ spec:
         - input: "$(params.mas_app_channel_iot)"
           operator: in
           values: [""]
+        - input: "$(params.mas_edition)"
+          operator: in
+          values: ["standard", "premium"]
 
     # 9. Deprovision Objectstorage config
     # -------------------------------------------------------------------------
@@ -1876,6 +1929,9 @@ spec:
         - input: "$(params.mas_app_channel_assist)$(params.mas_app_channel_visualinspection)"
           operator: in
           values: [""]
+        - input: "$(params.mas_edition)"
+          operator: in
+          values: ["essentials-inspection", "standard", "premium"]
 
     # 10. Deprovision Watson Studio config
     # -------------------------------------------------------------------------
@@ -1900,3 +1956,6 @@ spec:
         - input: "$(params.mas_app_channel_predict)"
           operator: in
           values: [""]
+        - input: "$(params.mas_edition)"
+          operator: in
+          values: ["standard", "premium"]

--- a/tekton/src/pipelines/gitops/gitops-mas-apps.yml.j2
+++ b/tekton/src/pipelines/gitops/gitops-mas-apps.yml.j2
@@ -1627,6 +1627,9 @@ spec:
         - input: "$(params.assist_workspace_action)"
           operator: in
           values: ["deactivate", ""]
+        - input: "$(params.mas_edition)"
+          operator: in
+          values: ["standard", "premium"]
 
     # 5.2 Assist App
     - name: gitops-deprovision-mas-app-install-assist

--- a/tekton/src/pipelines/gitops/gitops-mas-apps.yml.j2
+++ b/tekton/src/pipelines/gitops/gitops-mas-apps.yml.j2
@@ -1616,9 +1616,6 @@ spec:
           value: $(params.mas_workspace_id)
         - name: mas_app_id
           value: assist
-        - input: "$(params.mas_edition)"
-          operator: in
-          values: ["standard", "premium"]
 
       taskRef:
         kind: Task

--- a/tekton/src/pipelines/taskdefs/gitops/apps/manage-workspace.yml.j2
+++ b/tekton/src/pipelines/taskdefs/gitops/apps/manage-workspace.yml.j2
@@ -42,6 +42,8 @@
       value: $(params.ingress)
     - name: run_sanity_test
       value: $(params.run_sanity_test)
+    - name: manage_update_schedule
+      value: $(params.manage_update_schedule)
   taskRef:
     name: gitops-suite-app-config
     kind: Task

--- a/tekton/src/tasks/gitops/gitops-suite-app-config.yml.j2
+++ b/tekton/src/tasks/gitops/gitops-suite-app-config.yml.j2
@@ -76,6 +76,9 @@ spec:
     - name: run_sanity_test
       type: string
       default: "false"
+    - name: manage_update_schedule
+      type: string
+      default: ""
 
   stepTemplate:
     name: gitops-suite-app-config
@@ -136,6 +139,8 @@ spec:
         value: $(params.ingress)
       - name: RUN_SANITY_TEST
         value: $(params.run_sanity_test)
+      - name: MANAGE_UPDATE_SCHEDULE
+        value: $(params.manage_update_schedule)
     envFrom:
       - configMapRef:
           name: environment-properties


### PR DESCRIPTION
Adds support for the manage onlineUpgrade cronjob, that will automatically run the offlineupdate phase of manage based on a schedule. The schedule defaults to midnight each night, but this PR gives the option to override it. See https://github.com/ibm-mas/gitops/pull/238 for more details. https://jsw.ibm.com/browse/MASCORE-4544

This PR also adds support to skip some deprovision tasks for apps that won't be in a certain edition, as were just no-ops buy consumed resource to run.  https://jsw.ibm.com/browse/MASCORE-4622

Lastly, the DB2 change is to remove the db2 archive and temp entries in the template if the storageclass is not set. These are optional, but the fact that the keys are still present (with no value) was causing some confusion. https://jsw.ibm.com/browse/MASCORE-4614