### PR TITLE
[patch] fix interactive mode of mirror-images

### DIFF
--- a/image/cli/mascli/functions/mirror_images
+++ b/image/cli/mascli/functions/mirror_images
@@ -361,8 +361,9 @@ function mirror_to_registry_interactive() {
   fi
 
   echo
-  echo_h2 "Configure Static Catalog Version"
-  choose_mas_version
+  echo_h2 "Configure Static Catalog Version (see https://ibm-mas.github.io/cli/catalogs/ for details on catalogs)"
+  prompt_for_input "MAS Catalog Version" MAS_CATALOG_VERSION
+  prompt_for_input "MAS Channel" MAS_CHANNEL
 
   echo
   echo_h2 "Configure Images to Mirror"


### PR DESCRIPTION
This isn't as great as the all singing and dancing version we had where it would list the catalogs and the channels but this at least means a customer can use interactive mode again (has been broken since June) and it hasn't introduced a new location to update when we release a patch. Ideally we would interogate the catalogs provided in python-devops and do something clever, but we can always do that later if demand is high enough.

Tested by running an image and running the mas mirror-images command and verifying it mirrored the correct content.