### PR TITLE
[patch] Fix the race condition of ICD secret getting created simultaneously

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2024-12-09T12:01:09Z",
+  "generated_at": "2024-12-16T05:50:45Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -364,7 +364,7 @@
         "hashed_secret": "effb7852555adce89885fb075fb43a77a1e0e77e",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 715,
+        "line_number": 725,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/image/cli/mascli/functions/gitops_utils
+++ b/image/cli/mascli/functions/gitops_utils
@@ -46,6 +46,7 @@ function sm_update_secret(){
   SECRET_NAME=$1
   SECRET_VALUE=$2
   SECRET_TAGS=$3
+  RETRY="${4:-0}"
 
   echo "Secret Manager: Updating $SECRET_NAME with tags $SECRET_TAGS"
   if [[ "$AVP_TYPE" == "aws" ]]; then
@@ -61,8 +62,17 @@ function sm_update_secret(){
     if [[ "$CURRENT_SECRET_VALUE" == "" ]]; then
       # Create the secret
       echo "- Secret $SECRET_NAME creating"
-      aws secretsmanager create-secret --name ${SECRET_NAME} --secret-string "${SECRET_VALUE}" --tags "${SECRET_TAGS}" || exit 1
-      echo "- Secret $SECRET_NAME created"
+      aws secretsmanager create-secret --name ${SECRET_NAME} --secret-string "${SECRET_VALUE}" --tags "${SECRET_TAGS}"
+      rc=$?
+      if [[ $rc -eq 0 ]]; then
+        echo "- Secret $SECRET_NAME created"
+      elif [[ $RETRY -eq '0' ]]; then
+        echo "Retrying secret update"
+        sleep 120
+        sm_update_secret ${SECRET_NAME} "${SECRET_VALUE}" "${SECRET_TAGS}" "1"
+      else
+        exit 1
+      fi
     elif [[ "$SECRET_VALUE" != "$CURRENT_SECRET_VALUE" ]]; then
       # Update the secret
       echo "- Secret $SECRET_NAME updating"


### PR DESCRIPTION
## Problem
ICD secret is a cluster level secret
It is created during gitops_database_db2u function call. When multiple instances within a same cluster gets triggered at the same time, both attempt to create the secret - one creation works, other fails stating resource already exists and fails

## Solution
In sm_update_secret method, we are invoking the same function again incase of failure after 2 mins sleep. We also retry only once by verifying RETRY value (Default is 0, value is 1 for the retry)

## Testing output
```
Secret Manager: Updating fyre-noble4-dev/noble4/ajw0111/icd with tags [{"Key": "source", "Value": "gitops_db2u_database"}, {"Key": "account", "Value": "fyre-noble4-dev"}, {"Key": "cluster", "Value": "noble4"}]
- Secret fyre-noble4-dev/noble4/ajw0111/icd creating

An error occurred (ResourceExistsException) when calling the CreateSecret operation: The operation failed because the secret fyre-noble4-dev/noble4/ajw0111/icd already exists.
Retrying secret update
Secret Manager: Updating fyre-noble4-dev/noble4/ajw0111/icd with tags [{"Key": "source", "Value": "gitops_db2u_database"}, {"Key": "account", "Value": "fyre-noble4-dev"}, {"Key": "cluster", "Value": "noble4"}]
- Secret fyre-noble4-dev/noble4/ajw0111/icd unchanged
```