### PR TITLE
[patch] mobile version commitId finalizer update

### DIFF
--- a/image/cli/app-root/src/finalizer.py
+++ b/image/cli/app-root/src/finalizer.py
@@ -392,6 +392,7 @@ if __name__ == "__main__":
 
         setObject["products.ibm-mas-mobile.buildId"] = "NA"
         setObject["products.ibm-mas-mobile.buildNumber"] = "NA"
+        setObject["products.ibm-mas-mobile.commitId"] = "NA"
         setObject["products.ibm-mas-mobile.version"] = mobileComponents["navigator"]["mobileVersion"]
         setObject["products.ibm-mas-mobile.components"] = treatedComponents
     except Exception as e:


### PR DESCRIPTION
Fix a problem where Mobile packages version are not displayed in the dashboard lookup.
![image](https://github.com/user-attachments/assets/9a061945-ff6c-43ff-a551-b71d4cccf2fe)

This fix adds a placeholder commitID for mobile so that the remaining info can be displayed. 
Mobile does not have an operator so there is no commitID that can be displayed.