### PR TITLE
[patch] SendGrid subuser deprovisioning fixes

### DIFF
--- a/tekton/src/pipelines/gitops/deprovision-mas-instance.yml.j2
+++ b/tekton/src/pipelines/gitops/deprovision-mas-instance.yml.j2
@@ -60,6 +60,9 @@ spec:
       type: string
     - name: cis_mas_domain
       type: string
+    - name: smtp_use_sendgrid
+      type: string
+      default: ""
   tasks:
     # Deprovision workspace
     # -------------------------------------------------------------------------
@@ -112,6 +115,11 @@ spec:
         - input: "$(params.sls_license_icn)"
           operator: notin
           values: [""]
+
+        # only attempt Subuser teardown if the instance was configured to use automated sendgrid subuser management at the time of deprovisioning
+        - input: "$(params.smtp_use_sendgrid)"
+          operator: in
+          values: ["true"]
       workspaces:
         - name: configs
           workspace: configs

--- a/tekton/src/tasks/gitops/gitops-deprovision-suite-sendgrid-subuser.yml.j2
+++ b/tekton/src/tasks/gitops/gitops-deprovision-suite-sendgrid-subuser.yml.j2
@@ -63,12 +63,15 @@ spec:
 
         # Fetch CIS API Key from AWS SM.
         # This is suitable for use with CIS instances used by MAS instances in the cluster we are targetting
-        SECRET_NAME_CIS="${ACCOUNT_ID}/${CLUSTER_ID}/cis"
-        echo "Getting ${SECRET_NAME_CIS} from AWS SM"
-        export CIS_APIKEY="$(sm_get_secret_value "${SECRET_NAME_CIS}" "ibm_apikey")" # pragma: allowlist secret
-        if [[ -z "${CIS_APIKEY}" || "${CIS_APIKEY}" == "null" ]]; then
-          echo "Required AWS SM secret "${SECRET_NAME_CIS}" not found or invalid"
-          exit 1
+        # This secret is only required if the instance is configured with CIS
+        if [[ -n "${CIS_CRN}" ]]; then
+          SECRET_NAME_CIS="${ACCOUNT_ID}/${CLUSTER_ID}/cis"
+          echo "Getting ${SECRET_NAME_CIS} from AWS SM"
+          export CIS_APIKEY="$(sm_get_secret_value "${SECRET_NAME_CIS}" "ibm_apikey")" # pragma: allowlist secret
+          if [[ -z "${CIS_APIKEY}" || "${CIS_APIKEY}" == "null" ]]; then
+            echo "Required AWS SM secret "${SECRET_NAME_CIS}" not found or invalid"
+            exit 1
+          fi
         fi
 
         mkdir -p /tmp/gitops-deprovision-suite-sendgrid-subuser
@@ -101,8 +104,6 @@ spec:
         if [[ "${DELETED_SUBUSER}" == "true" ]]; then
           SECRET_NAME_SENDGRID="${ICN}/sendgrid_subuser"
           echo "Subuser was deleted, cleaning up ${SECRET_NAME_SENDGRID} secret"
-
-          # will fail task if this fails (due to use of "set +o pipefail" in the function)
           sm_delete_secret "${SECRET_NAME_SENDGRID}"
         fi
 


### PR DESCRIPTION
Only attempt sendgrid teardown if instance is configured to use sendgrid at the time of deprovisioning

Only attempt CIS APIKEY lookup from AWS SM if instance is configured with CIS at the time of deprovisioning

https://jsw.ibm.com/browse/MASCORE-4805

# Testing

See https://github.ibm.com/maximoappsuite/saas-tekton/pull/86