### PR TITLE
[patch] Force limited optimizer in SNO

### DIFF
--- a/python/src/mas/cli/install/app.py
+++ b/python/src/mas/cli/install/app.py
@@ -651,9 +651,12 @@ class InstallApp(BaseApp, InstallSettingsMixin, InstallSummarizerMixin, ConfigGe
     def optimizerSettings(self) -> None:
         if self.installOptimizer:
             self.printH1("Configure Maximo Optimizer")
-            self.printDescription(["Customize your Optimizer installation, 'full' and 'limited' install plans are available, refer to the product documentation for more information"])
-
-            self.promptForString("Plan [full/limited]", "mas_app_plan_optimizer", default="full", validator=OptimizerInstallPlanValidator())
+            if self.isSNO():
+                self.printDescription(["Using Optimizer 'limited' plan as it is being installed in a single node cluster"])
+                self.setParam("mas_app_plan_optimizer", "limited")
+            else:
+                self.printDescription(["Customize your Optimizer installation, 'full' and 'limited' install plans are available, refer to the product documentation for more information"])
+                self.promptForString("Plan [full/limited]", "mas_app_plan_optimizer", default="full", validator=OptimizerInstallPlanValidator())
 
     @logMethodCall
     def predictSettings(self) -> None:


### PR DESCRIPTION
We should not pick up a different plan than "limited" when installing Optimizer in an SNO cluster.

<img width="902" alt="image" src="https://github.com/user-attachments/assets/4281ac6d-c47e-4e92-84be-5d907d5fad17" />

<img width="736" alt="image" src="https://github.com/user-attachments/assets/e6cd8c2b-cb91-4e8d-a5b6-bf2f62c9a931" />

<img width="1081" alt="image" src="https://github.com/user-attachments/assets/4a65beee-1a8f-424a-9f9f-12310b54b0e0" />

<img width="1458" alt="image" src="https://github.com/user-attachments/assets/bb76eeb0-31df-43ff-9d12-dec1526957e9" />

<img width="1459" alt="image" src="https://github.com/user-attachments/assets/e75a8a54-a83f-4141-86bd-3e1bc09af5e9" />

