### PR TITLE
[patch] add prefix to customer-scoped AWS sendgrid_subuser secret for gitops

### DIFF
--- a/tekton/src/tasks/gitops/gitops-deprovision-suite-sendgrid-subuser.yml.j2
+++ b/tekton/src/tasks/gitops/gitops-deprovision-suite-sendgrid-subuser.yml.j2
@@ -102,7 +102,7 @@ spec:
         fi
 
         if [[ "${DELETED_SUBUSER}" == "true" ]]; then
-          SECRET_NAME_SENDGRID="${ICN}/sendgrid_subuser"
+          SECRET_NAME_SENDGRID="ibm-customer/${ICN}/sendgrid_subuser"
           echo "Subuser was deleted, cleaning up ${SECRET_NAME_SENDGRID} secret"
           sm_delete_secret "${SECRET_NAME_SENDGRID}"
         fi

--- a/tekton/src/tasks/gitops/gitops-mas-fvt-preparer.yml.j2
+++ b/tekton/src/tasks/gitops/gitops-mas-fvt-preparer.yml.j2
@@ -412,8 +412,8 @@ spec:
           export AVP_TYPE="aws" # required by sm_login (only AWS supported at present)
           sm_login || exit 1
 
-          # lookup <ICN>/sendgrid_subuser#username from AWS SM
-          SECRET_NAME_SENDGRID="${ICN}/sendgrid_subuser"
+          # lookup ibm-customer/<ICN>/sendgrid_subuser#username from AWS SM
+          SECRET_NAME_SENDGRID="ibm-customer/${ICN}/sendgrid_subuser"
           echo "Getting ${SECRET_NAME_SENDGRID} from AWS SM"
           export SENDGRID_SUBUSER_USERNAME="$(sm_get_secret_value "${SECRET_NAME_SENDGRID}" "username")" # pragma: allowlist secret
           echo "Subuser username: ${SENDGRID_SUBUSER_USERNAME}"

--- a/tekton/src/tasks/gitops/gitops-suite-smtp-config-sendgrid.yml.j2
+++ b/tekton/src/tasks/gitops/gitops-suite-smtp-config-sendgrid.yml.j2
@@ -153,7 +153,7 @@ spec:
         # this is our only opportunity to store the password we generated for the subuser
         update_subuser_secret_rc="0"
         if [[ -n "${SUBUSER_PASSWORD}" ]]; then
-          SECRET_NAME_SENDGRID="${ICN}/sendgrid_subuser"
+          SECRET_NAME_SENDGRID="ibm-customer/${ICN}/sendgrid_subuser"
           TAGS="[{\"Key\": \"source\", \"Value\": \"gitops_suite_smtp_config_sendgrid\"}]"
           echo "Putting generated subuser credentials in ${SECRET_NAME_SENDGRID}"
           (sm_update_secret "${SECRET_NAME_SENDGRID}" "{\"username\": \"$SUBUSER_USERNAME\", \"password\": \"$SUBUSER_PASSWORD\"}" "${TAGS}")


### PR DESCRIPTION
https://jsw.ibm.com/browse/MASCORE-5060

This is an internal-only feature - see https://github.ibm.com/maximoappsuite/saas-tekton/pull/87 for more details including test results