### PR TITLE
[minor] gitops: automated configtool oidc registration

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2025-01-10T17:50:50Z",
+  "generated_at": "2025-01-14T14:06:07Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -344,7 +344,7 @@
         "hashed_secret": "b2817467154949a61f8e9ad31d1eeaf03221cbfa",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 450,
+        "line_number": 502,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2024-12-17T09:42:21Z",
+  "generated_at": "2025-01-10T17:50:50Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -152,7 +152,7 @@
         "hashed_secret": "b6f30c2855008e26d901927d33cfcb970c62fe00",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 264,
+        "line_number": 281,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2025-01-14T14:06:07Z",
+  "generated_at": "2025-01-14T17:01:44Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -344,7 +344,7 @@
         "hashed_secret": "b2817467154949a61f8e9ad31d1eeaf03221cbfa",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 502,
+        "line_number": 510,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/image/cli/mascli/functions/configtool_oidc
+++ b/image/cli/mascli/functions/configtool_oidc
@@ -36,8 +36,11 @@ So far only trust ui prefix is supported to update. Same as register command.
 ${COLOR_YELLOW}### mas oidc [-h|--help]${TEXT_RESET}
 Show this help message
 
-${COLOR_YELLOW}4. Options for command${TEXT_RESET}
-Cluster Credentials (Required):
+OAuth Admin Credentials (Optional)
+  ${COLOR_YELLOW}OAUTH_ADMIN_USERNAME${TEXT_RESET}.                       If not set, the script will attempt to retrieve this from the {INSTANCE_NAME}-credentials-oauth-admin secret in the mas core namespace
+  ${COLOR_YELLOW}OAUTH_ADMIN_PWD${TEXT_RESET}.                            If not set, the script will attempt to retrieve this from the {INSTANCE_NAME}-credentials-oauth-admin secret in the mas core namespace
+
+Cluster Credentials (Required unless both OAUTH_ADMIN_USERNAME and OAUTH_ADMIN_PWD env vars are set):
   -t, --token ${COLOR_YELLOW}CLUSTER_TOKEN${TEXT_RESET}                     Cluster's token
   -s, --server ${COLOR_YELLOW}CLUSTER_SERVER${TEXT_RESET}                   Cluster server
 
@@ -81,9 +84,12 @@ function configtool_oidc_noninteractive() {
       esac
   done
 
-  # check all args have been set
-  [[ -z "$CLUSTER_TOKEN" ]] && configtool_oidc_help "CLUSTER_TOKEN is not set"
-  [[ -z "$CLUSTER_SERVER" ]] && configtool_oidc_help "CLUSTER_SERVER is not set"
+
+  if [[ -z "$OAUTH_ADMIN_USERNAME" || -z "$OAUTH_ADMIN_PWD" ]]; then
+    [[ -z "$CLUSTER_TOKEN" ]] && configtool_oidc_help "CLUSTER_TOKEN must be set if either OAUTH_ADMIN_USERNAME or OAUTH_ADMIN_PWD env vars are not provided"
+    [[ -z "$CLUSTER_SERVER" ]] && configtool_oidc_help "CLUSTER_SERVER must be set if either OAUTH_ADMIN_USERNAME or OAUTH_ADMIN_PWD env vars are not provided"
+  fi
+  
   [[ -z "$MAS_HOME" ]] && configtool_oidc_help "MAS_HOME is not set"
   [[ -z "$TRUST_UI_PREFIX" ]] && configtool_oidc_help "TRUST_UI_PREFIX is not set"
 }
@@ -145,10 +151,6 @@ function configtool_oidc() {
   export TRUST_UI_PREFIX
   export MAS_INSTANCE_ID
 
-  # login cluster
-  echo Login $CLUSTER_SERVER...
-  oc login --token=$CLUSTER_TOKEN --server=$CLUSTER_SERVER
-
   # instance name and domain
   echo preparing for $MAS_HOME...
   if [[ -z $MAS_HOME ]]; then
@@ -186,10 +188,23 @@ function configtool_oidc() {
   if [[ ! -z $MAS_INSTANCE_ID ]]; then
     INSTANCE_NAME=$MAS_INSTANCE_ID
   fi
-  echo "entering mas-${INSTANCE_NAME}-core project"
-  oc project mas-${INSTANCE_NAME}-core
-  OAUTH_ADMIN_USERNAME=`oc get secret ${INSTANCE_NAME}-credentials-oauth-admin -o jsonpath="{.data['oauth-admin-username']}" | base64 -d`
-  OAUTH_ADMIN_PWD=`oc get secret ${INSTANCE_NAME}-credentials-oauth-admin -o jsonpath="{.data['oauth-admin-password']}" | base64 -d`
+
+
+  # lookup oauth admin credentials from k8s secret if either were not specified as environment vars
+  if [[ -z "$OAUTH_ADMIN_USERNAME" || -z "$OAUTH_ADMIN_PWD" ]]; then
+    echo Login $CLUSTER_SERVER...
+    oc login --token=$CLUSTER_TOKEN --server=$CLUSTER_SERVER
+    echo "Entering mas-${INSTANCE_NAME}-core project"
+    oc project mas-${INSTANCE_NAME}-core
+    if [[ -z "${OAUTH_ADMIN_USERNAME}" ]]; then
+      echo "Lookup ${INSTANCE_NAME}-credentials-oauth-admin / oauth-admin-username"
+      OAUTH_ADMIN_USERNAME=`oc get secret ${INSTANCE_NAME}-credentials-oauth-admin -o jsonpath="{.data['oauth-admin-username']}" | base64 -d`
+    fi
+    if [[ -z "${OAUTH_ADMIN_PWD}" ]]; then
+      echo "Lookup ${INSTANCE_NAME}-credentials-oauth-admin / oauth-admin-password"
+      OAUTH_ADMIN_PWD=`oc get secret ${INSTANCE_NAME}-credentials-oauth-admin -o jsonpath="{.data['oauth-admin-password']}" | base64 -d`
+    fi
+  fi
 
   # unregister
   echo checking if $CLIENT_CONFIGTOOL existed

--- a/image/cli/mascli/functions/configtool_oidc
+++ b/image/cli/mascli/functions/configtool_oidc
@@ -212,7 +212,7 @@ function configtool_oidc() {
   echo "status_code: $status_code"
   echo running $OIDC_OP
   if [[ "$status_code" -eq 200 ]] ; then
-    curl --fail -k --user $OAUTH_ADMIN_USERNAME:$OAUTH_ADMIN_PWDx \
+    curl --fail -k --user $OAUTH_ADMIN_USERNAME:$OAUTH_ADMIN_PWD \
       -H 'Content-Type: application/json' \
       -X DELETE $OAUTH_URL_CONFIGTOOL || exit $?
     echo ""

--- a/image/cli/mascli/functions/configtool_oidc
+++ b/image/cli/mascli/functions/configtool_oidc
@@ -155,7 +155,7 @@ function configtool_oidc() {
   echo preparing for $MAS_HOME...
   if [[ -z $MAS_HOME ]]; then
     echo "${COLOR_RED}MAS_HOME must be provided and not empty. sample: export MAS_HOME=\"masdev.home.mobfound1.masdev.suite.maximo.com\"${TEXT_RESET}"
-    exit 0
+    exit 1
   fi
   MAS_PARTS=(`echo $MAS_HOME | tr "." " "`)
   DOT="."
@@ -175,7 +175,7 @@ function configtool_oidc() {
   done
   if [[ $i -lt 4 ]]; then
     echo "${COLOR_RED}MAS_HOME is incorrect. sample: \"masdev.home.mobfound1.masdev.suite.maximo.com\"${TEXT_RESET}"
-    exit 0
+    exit 1
   fi
 
   # OAUTH information
@@ -212,7 +212,9 @@ function configtool_oidc() {
   echo "status_code: $status_code"
   echo running $OIDC_OP
   if [[ "$status_code" -eq 200 ]] ; then
-    curl -k -w %{http_code} -s -o /dev/null -I --user $OAUTH_ADMIN_USERNAME:$OAUTH_ADMIN_PWD -H 'Content-Type: application/json' -X DELETE $OAUTH_URL_CONFIGTOOL
+    curl --fail -k --user $OAUTH_ADMIN_USERNAME:$OAUTH_ADMIN_PWDx \
+      -H 'Content-Type: application/json' \
+      -X DELETE $OAUTH_URL_CONFIGTOOL || exit $?
     echo ""
     if [[ "$OIDC_OP" == "unregister" ]]; then
       echo "$OIDC_OP" Client $CLIENT_CONFIGTOOL.
@@ -225,19 +227,19 @@ function configtool_oidc() {
     fi
   else
     echo Some issue occurred in MAS OIDC server. Please try again later.
-    exit 0
+    exit 1
   fi
 
   # trust ui prefix
   echo TRUST_UI_PREFIX: $TRUST_UI_PREFIX
   if [[ -z $TRUST_UI_PREFIX ]]; then
     echo "${COLOR_RED}TRUST_UI_PREFIX must be provided and not empty. sample: export TRUST_UI_PREFIX=\"http://localhost:3000,http://localhost:3001\"${TEXT_RESET}"
-    exit 0
+    exit 1
   fi
   TRUST_UI_PARTS=(`echo $TRUST_UI_PREFIX | tr "," " "`)
   if [[ ${#TRUST_UI_PARTS[@]} -eq 0 ]]; then
     echo "${COLOR_RED}TRUST_UI_PREFIX is empty, at least define one URL. \"http://localhost:3000\"${TEXT_RESET}"
-    exit 0
+    exit 1
   fi
   CALLBACK="/auth/callback"
   TRUST_UIS="["
@@ -260,7 +262,7 @@ function configtool_oidc() {
   # register or update (the same as register)
   if [[ "$OIDC_OP" == "register" || "$OIDC_OP" == "update" ]]; then
     echo "$OIDC_OP" Client $CLIENT_CONFIGTOOL.
-    curl -k --user $OAUTH_ADMIN_USERNAME:$OAUTH_ADMIN_PWD \
+    curl --fail -k --user $OAUTH_ADMIN_USERNAME:$OAUTH_ADMIN_PWD \
     -H 'Accept: application/json' \
     -H 'Content-type: application/json' \
     -X POST $OAUTH_URL \
@@ -292,6 +294,6 @@ function configtool_oidc() {
 "redirect_uris": $REDIRECT_UIS
 }
 EOF
-)
+) || exit $?
   fi
 }

--- a/image/cli/mascli/functions/gitops_suite
+++ b/image/cli/mascli/functions/gitops_suite
@@ -76,6 +76,12 @@ IBM Maximo Application Suite:
 
       --mas-wipe-mongo-data ${COLOR_YELLOW}MAS_WIPE_MONGO_DATA${TEXT_RESET}           Set to "true" to wipe all mongo data for this MAS instance on uninstall (optional, defaults to false)
 
+      --oidc-config ${COLOR_YELLOW}OIDC_CONFIG${TEXT_RESET} YAML string for defining the OpenID clients (OIDC) that will be registered automatically after the suite is installed.
+        Currently supported:
+          "configtool" client suitable to use by the Maximo Application Framework (MAF) configurator tool. Specify as follows:
+            --oidc-config '{"configtool": {"trusted_uri_prefixes": ["https://example.com:443", "https://otherexample.com:8443"]}}'
+            
+            "trusted_uri_prefixes" field is optional, if omitted ArgoCD will use the default ["http://localhost:3000", "http://localhost:3001", "http://localhost:3006"]
 
 Target Cluster (Optional):
       --cluster-url ${COLOR_YELLOW}CLUSTER_URL${TEXT_RESET}       Set to target a remote Kubernetes cluster (defaults to 'https://kubernetes.default.svc')
@@ -289,6 +295,11 @@ function gitops_suite_noninteractive() {
         export OVERRIDE_EDGE_CERTS=$1 && shift
         ;;
 
+      --oidc-config)
+        export OIDC_CONFIG=$1 && shift
+        ;;
+
+
       # Automatic GitHub Push
       -P|--github-push)
         export GITHUB_PUSH=true
@@ -353,6 +364,46 @@ function gitops_suite_noninteractive() {
     [[ -z "$GITHUB_ORG" ]] && gitops_suite_help "GITHUB_ORG is not set"
     [[ -z "$GITHUB_REPO" ]] && gitops_suite_help "GITHUB_REPO is not set"
     [[ -z "$GIT_BRANCH" ]] && gitops_suite_help "GIT_BRANCH is not set"
+  fi
+
+  if [[ -n "${OIDC_CONFIG}" ]]; then
+
+    # Validate any OIDC_CONFIG passed in
+    export OIDC_CONFIG_YAML
+    OIDC_CONFIG_YAML=$(echo $OIDC_CONFIG | yq -P) || gitops_suite_help "OIDC_CONFIG is not valid YAML"
+
+    # Check configtool is the only top-level key
+    # If we add more supported keys in future, add to the filter expression as such: filter(. != "configtool" and . != "otherkey")
+    echo "${OIDC_CONFIG_YAML}" | yq eval  --exit-status=1 \
+      'keys | filter(. != "configtool" ) |  length == 0' \
+      1> /dev/null 2>&1 \
+      || gitops_suite_help "OIDC_CONFIG is invalid; only the 'configtool' key is supported at the top-level"
+
+    # If configtool is specified, check that "trusted_uri_prefixes" is the only child key
+    # If we add more supported keys in future, add to the filter expression as such: filter(. != "trusted_uri_prefixes" and . != otherkey)
+    echo "${OIDC_CONFIG_YAML}" | yq eval  --exit-status=1 \
+      '(. | has("configtool")) == false or 
+       (.configtool | keys | filter(. != "trusted_uri_prefixes") | length == 0)' \
+      1> /dev/null 2>&1 \
+      || gitops_suite_help "OIDC_CONFIG is invalid,; only the 'trusted_uri_properties' key is supported under 'configtool'"
+
+    # if specified, .configtool.trusted_uri_prefixes must be an array
+    echo "${OIDC_CONFIG_YAML}" | yq eval  --exit-status=1 \
+      '(. | has("configtool")) == false or 
+       (.configtool | has("trusted_uri_prefixes")) == false or 
+       (.configtool.trusted_uri_prefixes | type == "!!seq")' \
+      1> /dev/null 2>&1 \
+      || gitops_suite_help "OIDC_CONFIG is invalid; if specified, the value of 'configtool.trusted_uri_properties' must be an array"
+
+    # if specified, all elements of .configtool.trusted_uri_prefixes must be an array containing only strings
+    echo "${OIDC_CONFIG_YAML}" | yq eval  --exit-status=1 \
+      '(. | has("configtool")) == false or
+       (.configtool | has("trusted_uri_prefixes")) == false or
+       (.configtool.trusted_uri_prefixes | length == 0) or
+       (.configtool.trusted_uri_prefixes.[] | type == "!!str") as $item ireduce (true; . and $item)' \
+       1> /dev/null 2>&1 \
+       || gitops_suite_help "OIDC_CONFIG is invalid; if specified, the value of 'configtool.trusted_uri_properties' must be an array containing only strings"
+
   fi
 
 }
@@ -438,6 +489,7 @@ function gitops_suite() {
   echo_reset_dim "Cert Manager Namespace ......... ${COLOR_MAGENTA}${CERT_MANAGER_NAMESPACE}"
   echo_reset_dim "DNS Provider ................... ${COLOR_MAGENTA}${DNS_PROVIDER}"
   echo_reset_dim "Pod Template YAML File  ........ ${COLOR_MAGENTA}${MAS_POD_TEMPLATE_YAML}"
+  echo_reset_dim "OIDC Config .................... ${COLOR_MAGENTA}${OIDC_CONFIG}"
   reset_colors
 
   if [[ -n "$DNS_PROVIDER" ]]; then

--- a/image/cli/mascli/functions/gitops_suite
+++ b/image/cli/mascli/functions/gitops_suite
@@ -81,7 +81,7 @@ IBM Maximo Application Suite:
           "configtool" client suitable to use by the Maximo Application Framework (MAF) configurator tool. Specify as follows:
             --oidc-config '{"configtool": {"trusted_uri_prefixes": ["https://example.com:443", "https://otherexample.com:8443"]}}'
             
-            "trusted_uri_prefixes" field is optional, if omitted ArgoCD will use the default ["http://localhost:3000", "http://localhost:3001", "http://localhost:3006"]
+            "trusted_uri_prefixes" field is optional, defaults to ["http://localhost:3000", "http://localhost:3001", "http://localhost:3006"]
 
 Target Cluster (Optional):
       --cluster-url ${COLOR_YELLOW}CLUSTER_URL${TEXT_RESET}       Set to target a remote Kubernetes cluster (defaults to 'https://kubernetes.default.svc')
@@ -403,6 +403,14 @@ function gitops_suite_noninteractive() {
        (.configtool.trusted_uri_prefixes.[] | type == "!!str") as $item ireduce (true; . and $item)' \
        1> /dev/null 2>&1 \
        || gitops_suite_help "OIDC_CONFIG is invalid; if specified, the value of 'configtool.trusted_uri_properties' must be an array containing only strings"
+
+    # if no trusted_uri_prefixes field specified under configtool, set some defaults
+    if $(echo "${OIDC_CONFIG_YAML}" | yq eval --exit-status=1 \
+      '(. | has("configtool")) == true and
+       (.configtool | has("trusted_uri_prefixes")) == false' \
+       1> /dev/null 2>&1); then
+      OIDC_CONFIG_YAML=$(echo "${OIDC_CONFIG_YAML}" | yq '.configtool.trusted_uri_prefixes = ["http://localhost:3000","http://localhost:3001","http://localhost:3006"]')
+    fi
 
   fi
 

--- a/image/cli/mascli/templates/gitops/appset-configs/cluster/instance/ibm-mas-suite.yaml.j2
+++ b/image/cli/mascli/templates/gitops/appset-configs/cluster/instance/ibm-mas-suite.yaml.j2
@@ -77,3 +77,8 @@ ibm_mas_suite:
   mas_pod_templates:
     {{ MAS_POD_TEMPLATE | indent(4) }}
 {% endif %}
+
+{% if OIDC_CONFIG_YAML is defined and OIDC_CONFIG_YAML !='' %}
+  oidc:
+    {{ OIDC_CONFIG_YAML | indent(4) }}
+{% endif %}

--- a/tekton/src/pipelines/gitops/gitops-mas-instance.yml.j2
+++ b/tekton/src/pipelines/gitops/gitops-mas-instance.yml.j2
@@ -194,6 +194,11 @@ spec:
     - name: sls_license_icn
       type: string
 
+    # oidc parameters
+    # ------------------------------------------------------------------------- 
+    - name: oidc
+      type: string
+
   tasks:
 
     # 0. Per-instance DB2U Operator
@@ -382,6 +387,8 @@ spec:
           value: $(params.mas_pod_template_yaml)
         - name: mas_wipe_mongo_data
           value: $(params.mas_wipe_mongo_data)
+        - name: oidc
+          value: $(params.oidc)
       taskRef:
         kind: Task
         name: gitops-suite

--- a/tekton/src/tasks/gitops/gitops-suite.yml.j2
+++ b/tekton/src/tasks/gitops/gitops-suite.yml.j2
@@ -122,6 +122,8 @@ spec:
     - name: mas_wipe_mongo_data
       type: string
       default: "false"
+    - name: oidc
+      type: string
   stepTemplate:
     name: gitops-suite
     env:
@@ -217,6 +219,9 @@ spec:
         value: $(params.mas_pod_template_yaml)
       - name: MAS_WIPE_MONGO_DATA
         value: $(params.mas_wipe_mongo_data)
+
+      - name: OIDC_CONFIG
+        value: $(params.oidc)
     envFrom:
       - configMapRef:
           name: environment-properties


### PR DESCRIPTION
# Description

These changes are part of the work to automate the registration of an OIDC client to support usage of the MAS Application Framework (MAF) configuration tool (https://jsw.ibm.com/browse/MASCORE-3763)

## gitops-suite function changes

Accepts optional `--oidc-config` parameter: this is a YAML string for defining the OpenID clients (OIDC) that will be registered automatically after the suite is installed.

E.g. `mas gitops-suite --oidc-config '{"configtool": {"trusted_uri_prefixes": ["https://example.com:443", "https://otherexample.com:8443"]}}'`

is rendered into generated `ibm-mas-suite-.yaml` config file as:
```
  oidc:
    configtool:
      trusted_uri_prefixes:
        - http://localhost:3000
        - http://localhost:3001
        - http://localhost:3006
```

This is used by the changes in https://github.com/ibm-mas/gitops/pull/247 to render a Job to perform the OIDC registration step.

## Gitops Tekton changes

Passes `oidc` configuration from `mas-instance-params.yaml` into the `gitops-mas-suite` Task as YAML. These changes are copied into saas-tekton here: https://github.ibm.com/maximoappsuite/saas-tekton/pull/89


## Make configtool_oidc function suitable for use in automation

Some minor changes were required to the `configtool_oidc` function to make it suitable for use by a Job inside the cluster. This PR changes two things necessary for this to work properly. The changes are backwards compatible.
1. skip lookup of oauth admin creds from k8s secret (and related oc commands) if already provided as env vars. cluster server/token params are not required if so. This is because we will be obtaining these values by mounting the k8s secret to the file system instead (so we do not have to grant unnecessary secret retrieval permissions to the pod's service account).
2. exit with non-zero if something goes wrong. This is to ensure any failures will be detected / reported by automation.

> Question to reviewer: Is there some good reason this tool was coded to exit with a 0 status code in most failure cases? If so, I won't be able to use this script for my purposes.


# Testing (Fyre)

## Configure configtool OIDC with default trusted_uri_prefixes:
mas-instance-params.yaml:
```
oidc:
  configtool: {}
```

[gitops-mas-instance pipeline run](https://cloud.ibm.com/devops/pipelines/tekton/8445f6a9-217b-4ceb-92e8-d3c25dd9fc22/runs/d5823c0c-ebd7-48d4-abc9-84023cbcb341/gitops-suite/gitops-suite?env_id=ibm:yp:us-south)

gitops-envs [commit](https://github.ibm.com/maximoappsuite/gitops-envs/commit/83246757e1d6e9c146dadb498eb3532b95fbe6dd):

ibm-mas-suite.yaml:
```
  oidc:
    configtool:
      trusted_uri_prefixes:
        - http://localhost:3000
        - http://localhost:3001
        - http://localhost:3006
```

postsync job runs:
![image](https://github.com/user-attachments/assets/d245f472-0e9e-49c3-b898-7b79d1b51418)

Local MAF instance running on `localhost:3001`
![image](https://github.com/user-attachments/assets/2fc63f90-7e16-490e-9381-abd2e15e96e2)

Forwards to MAS for login:
![image](https://github.com/user-attachments/assets/313636a7-1f22-4dc0-a49c-d3ffb7e42f23)

MAF tool login successful:
![image](https://github.com/user-attachments/assets/8b779cf2-9512-4201-a837-455ef903409c)



## Configure configtool OIDC with non-default trusted_uri_prefixes:
mas-instance-params.yaml:
```
oidc:
  configtool:
    trusted_uri_prefixes:
      - http://localhost:3001
```

[gitops-mas-instance pipeline run](https://cloud.ibm.com/devops/pipelines/tekton/8445f6a9-217b-4ceb-92e8-d3c25dd9fc22/runs/ba9632c3-0956-4183-8252-ae75da130bdd/gitops-suite/gitops-suite?env_id=ibm:yp:us-south)

gitops-envs [commit](https://github.ibm.com/maximoappsuite/gitops-envs/commit/5c644f1e0dee26220b031a9cfebdf32c684dda51):

ibm-mas-suite.yaml:
```
  oidc:
    configtool:
      trusted_uri_prefixes:
        - http://localhost:3001
```

postsync job runs:
![image](https://github.com/user-attachments/assets/dbd8a3d6-9d12-4b2a-bfd5-7ba3a9957b72)


Local MAF instance running on `localhost:3001`
![image](https://github.com/user-attachments/assets/2fc63f90-7e16-490e-9381-abd2e15e96e2)

Forwards to MAS for login:
![image](https://github.com/user-attachments/assets/313636a7-1f22-4dc0-a49c-d3ffb7e42f23)

MAF tool login successful:
![image](https://github.com/user-attachments/assets/8b779cf2-9512-4201-a837-455ef903409c)


## Remove OIDC configtool configuration

No oidc element in mas-instance-params.yaml

[gitops-mas-instance pipeline run](https://cloud.ibm.com/devops/pipelines/tekton/8445f6a9-217b-4ceb-92e8-d3c25dd9fc22/runs/5ebf35d0-4dac-46f2-89d3-95168cc7b78c/gitops-suite/gitops-suite?env_id=ibm:yp:us-south)

gitops-envs [commit](https://github.ibm.com/maximoappsuite/gitops-envs/commit/eb0d01841a73d0e3fd7003a19f5608a6e8a69de9):

oidc element removed from in ibm-mas-suite.yaml

postsync job runs:

![image](https://github.com/user-attachments/assets/1354e069-fa57-44c9-8754-e433b7f6b612)

Local MAF instance running on `localhost:3001`:
![image](https://github.com/user-attachments/assets/2fc63f90-7e16-490e-9381-abd2e15e96e2)

Login fails as expected:
![image](https://github.com/user-attachments/assets/00307781-d8dd-4bd5-945f-73e7f29036e8)


# Testing (ROSA / fvtsaas)
