### PR TITLE
[patch] fix promptForDir call

### DIFF
--- a/python/src/mas/cli/install/settings/additionalConfigs.py
+++ b/python/src/mas/cli/install/settings/additionalConfigs.py
@@ -89,7 +89,7 @@ class AdditionalConfigsMixin():
             elif podTemplateChoice == 2:
                 self.setParam("mas_pod_templates_dir", path.join(self.templatesDir, "pod-templates", "best-effort"))
             elif podTemplateChoice == 3:
-                self.promptForDir("Pod templates directory", "mas_pod_templates_dir", mustExist=True)
+                self.setParam("mas_pod_templates_dir", self.promptForDir("Pod templates directory", mustExist=True))
             else:
                 self.fatalError(f"Invalid selection: {podTemplateChoice}")
 


### PR DESCRIPTION
While using cli interactive mode to install MAS with pod-templates enabled, it fails to prompt the user for the pod-templates directory path. It looks like the promptForDir method signature has been modified. Hence, it's failing due to an extra parameter passed in the call ("mas_pod_template_dir"). The fix addresses this issue. 

Reference bug: MASCORE-5425

Error before the fix:
<img width="770" alt="image" src="https://github.com/user-attachments/assets/cfe80504-8b4b-4915-a6fa-791e0164a89b" />

With the fix:
<img width="463" alt="image" src="https://github.com/user-attachments/assets/684c2c13-845c-4c0f-b1a1-872fefafcbfc" />
