### PR TITLE
[doc] Add supported MongoDB version information to docs

### DIFF
--- a/docs/catalogs/index.md
+++ b/docs/catalogs/index.md
@@ -33,6 +33,7 @@ The MAS CLI maintains a rolling window of approximately four months worth of sup
     <th>Catalog</th>
     <th>OCP Support</th>
     <th>CPD Support</th>
+    <th>MongoDB Support (CE or EE)</th>
     <th>Recommended CLI</th>
     <th>Support Notes</th>
     </tr>
@@ -42,6 +43,7 @@ The MAS CLI maintains a rolling window of approximately four months worth of sup
     <td><a href="v9-250109-amd64/">v9-250109-amd64</a>, <a href="v9-250109-s390x/">v9-250109-s390x</a></td>
     <td>4.14 - 4.16</td>
     <td>5.0.0</td>
+    <td>6.0 - 7.0</td>
     <td>latest</td>
     <td>OCP 4.16 EOS June 27, 2026</td>
     </tr>
@@ -49,6 +51,7 @@ The MAS CLI maintains a rolling window of approximately four months worth of sup
     <td><a href="v9-241205-amd64/">v9-241205-amd64</a>, <a href="v9-241205-s390x/">v9-241205-s390x</a></td>
     <td>4.14 - 4.16</td>
     <td>5.0.0</td>
+    <td>6.0 - 7.0</td>
     <td>latest</td>
     <td>OCP 4.16 EOS June 27, 2026</td>
     </tr>
@@ -56,6 +59,7 @@ The MAS CLI maintains a rolling window of approximately four months worth of sup
     <td><a href="v9-241107-amd64/">v9-241107-amd64</a>, <a href="v9-241107-s390x/">v9-241107-s390x</a></td>
     <td>4.12 - 4.15</td>
     <td>4.8.0</td>
+    <td>6.0 - 7.0</td>
     <td>latest</td>
     <td>OCP 4.14 EOS October 31, 2025</td>
     </tr>
@@ -63,6 +67,7 @@ The MAS CLI maintains a rolling window of approximately four months worth of sup
     <td><a href="v9-241003-amd64/">v9-241003-amd64</a></td>
     <td>4.12 - 4.15</td>
     <td>4.8.0</td>
+    <td>5.0 - 7.0</td>
     <td>latest</td>
     <td>OCP 4.14 EOS October 31, 2025</td>
     </tr>
@@ -70,6 +75,7 @@ The MAS CLI maintains a rolling window of approximately four months worth of sup
     <td><a href="v9-240827-amd64/">v9-240827-amd64</a></td>
     <td>4.12 - 4.15</td>
     <td>4.8.0</td>
+    <td>5.0 - 7.0</td>
     <td>11.11.3</td>
     <td>OCP 4.14 EOS October 31, 2025</td>
     </tr>
@@ -77,6 +83,7 @@ The MAS CLI maintains a rolling window of approximately four months worth of sup
     <td><a href="v9-240730-amd64/">v9-240730-amd64</a></td>
     <td>4.12 - 4.15</td>
     <td>4.8.0</td>
+    <td>5.0 - 7.0</td>
     <td>11.5.0</td>
     <td>OCP 4.14 EOS October 31, 2025</td>
     </tr>
@@ -84,6 +91,7 @@ The MAS CLI maintains a rolling window of approximately four months worth of sup
     <td><a href="v9-240625-amd64/">v9-240625-amd64</a></td>
     <td>4.12 - 4.14</td>
     <td>4.8.0</td>
+    <td>5.0 - 7.0</td>
     <td>10.9.2</td>
     <td>OCP 4.14 EOS October 31, 2025</td>
     </tr>
@@ -91,6 +99,7 @@ The MAS CLI maintains a rolling window of approximately four months worth of sup
     <td><a href="v8-240528-amd64/">v8-240528-amd64</a></td>
     <td>4.12 - 4.14</td>
     <td>4.6.6</td>
+    <td>5.0 - 7.0</td>
     <td>10.8.1</td>
     <td>OCP 4.14 EOS October 31, 2025</td>
     </tr>
@@ -98,6 +107,7 @@ The MAS CLI maintains a rolling window of approximately four months worth of sup
     <td><a href="v8-240430-amd64/">v8-240430-amd64</a></td>
     <td>4.12 - 4.14</td>
     <td>4.6.6</td>
+    <td>5.0 - 7.0</td>
     <td>9.4.0</td>
     <td>OCP 4.14 EOS October 31, 2025</td>
     </tr>
@@ -105,6 +115,7 @@ The MAS CLI maintains a rolling window of approximately four months worth of sup
     <td><a href="v8-240405-amd64/">v8-240405-amd64</a></td>
     <td>4.12 - 4.14</td>
     <td>4.6.6</td>
+    <td>5.0 - 7.0</td>
     <td>9.4.0</td>
     <td>OCP 4.14 EOS October 31, 2025</td>
     </tr>
@@ -112,6 +123,7 @@ The MAS CLI maintains a rolling window of approximately four months worth of sup
     <td><a href="v8-240326-amd64/">v8-240326-amd64</a></td>
     <td>4.12 - 4.14</td>
     <td>4.6.6</td>
+    <td>5.0 - 7.0</td>
     <td>9.4.0</td>
     <td>OCP 4.14 EOS October 31, 2025</td>
     </tr>
@@ -119,6 +131,7 @@ The MAS CLI maintains a rolling window of approximately four months worth of sup
     <td><a href="v8-240227-amd64/">v8-240227-amd64</a></td>
     <td>4.12</td>
     <td>4.6.6</td>
+    <td>5.0 - 7.0</td>
     <td>8.2.2</td>
     <td>OCP 4.12 EOS January 17, 2025</td>
     </tr>
@@ -126,6 +139,7 @@ The MAS CLI maintains a rolling window of approximately four months worth of sup
     <td><a href="v8-240130-amd64/">v8-240130-amd64</a></td>
     <td>4.12</td>
     <td>4.6.6</td>
+    <td>5.0 - 7.0</td>
     <td>8.2.2</td>
     <td>OCP 4.12 EOS January 17, 2025</td>
     </tr>

--- a/docs/catalogs/v9-250109-amd64.md
+++ b/docs/catalogs/v9-250109-amd64.md
@@ -179,6 +179,17 @@ This catalog is certified compatible with **IBM Cloud Pak for Data v5.0.0**.
 For more information on Cloud Pak for Data's support policy review this [IBM Cloud Pak for Data Software Support Lifecycle Addendum](https://www.ibm.com/support/pages/node/6593147).
 
 
+MongoDB and DocumentDB Compatibility
+-------------------------------------------------------------------------------
+This catalog is certified compatible with **MongoDB 6.0, 7.0 and AWS DocumentDB 5.0**.
+
+The MongoDB prerequisite for Maximo Application Suite may be satisfied by installing and configuring MongoDB Community Edition (CE) within the same OpenShift cluster where Maximo Application Suite is installed. The Maximo Application Suite CLI utility can optionally be used to install MongoDB CE by installing and configuring the [MongoDB Community Kubernetes Operator](https://github.com/mongodb/mongodb-kubernetes-operator).
+
+Alternatively, any hosted MongoDB [6.0](https://www.mongodb.com/docs/v6.0/) or [7.0](https://www.mongodb.com/docs/v7.0/) instance may be used to satisfy the MongoDB prerequisite for Maximo Application Suite. This includes MongoDB CE and MongoDB Enterprise Edition (EE). The MongoDB instance can be hosted on-prem or hosted by a third party such as [IBM Cloud Databases for MongoDB](https://www.ibm.com/products/databases-for-mongodb) or [MongoDB Atlas](https://www.mongodb.com/products/platform/atlas-database). 
+
+[AWS DocumentDB](https://aws.amazon.com/documentdb/) 5.0 is also supported as an alternative to MongoDB 6.0 or 7.0. 
+
+
 Package Manifest
 -------------------------------------------------------------------------------
 

--- a/docs/catalogs/v9-250109-amd64.md
+++ b/docs/catalogs/v9-250109-amd64.md
@@ -179,15 +179,16 @@ This catalog is certified compatible with **IBM Cloud Pak for Data v5.0.0**.
 For more information on Cloud Pak for Data's support policy review this [IBM Cloud Pak for Data Software Support Lifecycle Addendum](https://www.ibm.com/support/pages/node/6593147).
 
 
-MongoDB and DocumentDB Compatibility
+MongoDB Compatibility
 -------------------------------------------------------------------------------
-This catalog is certified compatible with **MongoDB 6.0, 7.0 and AWS DocumentDB 5.0**.
+This catalog is certified compatible with MongoDB **[v6.0](https://www.mongodb.com/docs/v6.0/)** and **[v7.0](https://www.mongodb.com/docs/v7.0/)**, this applies to both MongoDB Community Edition (CE) and MongoDB Enterprise Edition (EE).
 
-The MongoDB prerequisite for Maximo Application Suite may be satisfied by installing and configuring MongoDB Community Edition (CE) within the same OpenShift cluster where Maximo Application Suite is installed. The Maximo Application Suite CLI utility can optionally be used to install MongoDB CE by installing and configuring the [MongoDB Community Kubernetes Operator](https://github.com/mongodb/mongodb-kubernetes-operator).
+By default an in-cluster MongoDb (CE) instance will be created when you install MAS, using the [MongoDB Community Kubernetes Operator](https://github.com/mongodb/mongodb-kubernetes-operator); however MAS supports use with any type of MongoDb instance, including but not limited to the following hosted solutions:
 
-Alternatively, any hosted MongoDB [6.0](https://www.mongodb.com/docs/v6.0/) or [7.0](https://www.mongodb.com/docs/v7.0/) instance may be used to satisfy the MongoDB prerequisite for Maximo Application Suite. This includes MongoDB CE and MongoDB Enterprise Edition (EE). The MongoDB instance can be hosted on-prem or hosted by a third party such as [IBM Cloud Databases for MongoDB](https://www.ibm.com/products/databases-for-mongodb) or [MongoDB Atlas](https://www.mongodb.com/products/platform/atlas-database). 
+- [IBM Cloud Databases for MongoDB](https://www.ibm.com/products/databases-for-mongodb)
+- [MongoDB Atlas](https://www.mongodb.com/products/platform/atlas-database)
 
-[AWS DocumentDB](https://aws.amazon.com/documentdb/) 5.0 is also supported as an alternative to MongoDB 6.0 or 7.0. 
+[Amazon DocumentDB](https://aws.amazon.com/documentdb/) provides [MongoDb compatability](https://docs.aws.amazon.com/documentdb/latest/developerguide/compatibility.html) and may be used as an alternative to MongoDb.  This catalog is certified compatible with **DocumentDb Engine Version v5.0.0**.
 
 
 Package Manifest


### PR DESCRIPTION
## Incorporate information related to supported MongoDB versions

The documentation should be updated to detail which versions of MongoDB may be used to satisfy the prerequisite to Maximo Application Suite. This should include:

- the versions of MongoDB that are supported
- emphasize that either MongoDB CE and EE may be used
- that the CLI utility can be used to configure MongoDB CE via Kubernetes operator
- that AWS DocumentDB is a viable option