### PR TITLE
[patch] Remove duplicate requirements definition

### DIFF
--- a/image/cli/install/install-ansible-collections.sh
+++ b/image/cli/install/install-ansible-collections.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
 
-ansible-galaxy collection install -r /tmp/install/requirements.yml -p $ANSIBLE_COLLECTIONS_PATH
-
 if [[ -e /tmp/install/ibm-mas_devops.tar.gz ]]
 then ansible-galaxy collection install /tmp/install/ibm-mas_devops.tar.gz -p $ANSIBLE_COLLECTIONS_PATH
 else ansible-galaxy collection install ibm.mas_devops

--- a/image/cli/install/requirements.yml
+++ b/image/cli/install/requirements.yml
@@ -1,7 +1,0 @@
----
-collections:
-  - name: kubernetes.core
-    version: "2.2.3"
-  - name: operator_sdk.util
-    version: "0.2.0"
-


### PR DESCRIPTION
We have an Ansible requirements file in the image, but the requirements should be coming from the requirements inside the ibm.mas_devops collection (https://github.com/ibm-mas/ansible-devops/blob/master/ibm/mas_devops/galaxy.yml); we should not need to duplication them here (and thus need to maintain them in two places).