### PR TITLE
[patch] Deal with change to aws cli for gitops

### DIFF
--- a/tekton/src/tasks/gitops/gitops-deprovision-kafka.yml.j2
+++ b/tekton/src/tasks/gitops/gitops-deprovision-kafka.yml.j2
@@ -60,10 +60,10 @@ spec:
         aws configure set default.region $(params.avp_aws_secret_region)
 
         # Note the - after cluster name. this is to distinguish between different similar named clusters
-        vpc_name=$(aws ec2 describe-vpcs --output yaml | grep $CLUSTER_NAME- | yq '.[].Value // ""' | xargs
+        vpc_name=$(aws ec2 describe-vpcs --output yaml | grep $CLUSTER_NAME- | yq '.[].Value // ""' | xargs)
         if [ -z "$vpc_name" ]; then
           # Needed if there is only one cluster in account
-          vpc_name=$(aws ec2 describe-vpcs --output yaml | grep $CLUSTER_NAME- | yq '.Value // ""' | xargs
+          vpc_name=$(aws ec2 describe-vpcs --output yaml | grep $CLUSTER_NAME- | yq '.Value // ""' | xargs)
         fi
         export VPC_ID=$(aws ec2 describe-vpcs --filters '[{"Name": "tag:Name", "Values": ["'$vpc_name'"]}]' --output yaml | yq '.Vpcs[].VpcId' )
         

--- a/tekton/src/tasks/gitops/gitops-deprovision-kafka.yml.j2
+++ b/tekton/src/tasks/gitops/gitops-deprovision-kafka.yml.j2
@@ -60,10 +60,10 @@ spec:
         aws configure set default.region $(params.avp_aws_secret_region)
 
         # Note the - after cluster name. this is to distinguish between different similar named clusters
-        vpc_name=$(aws ec2 describe-vpcs --output yaml | grep $CLUSTER_NAME- | yq '.[].Value')
+        vpc_name=$(aws ec2 describe-vpcs --output yaml | grep $CLUSTER_NAME- | yq '.[].Value // ""' | xargs
         if [ -z "$vpc_name" ]; then
           # Needed if there is only one cluster in account
-          vpc_name=$(aws ec2 describe-vpcs --output yaml | grep $CLUSTER_NAME- | yq '.Value')
+          vpc_name=$(aws ec2 describe-vpcs --output yaml | grep $CLUSTER_NAME- | yq '.Value // ""' | xargs
         fi
         export VPC_ID=$(aws ec2 describe-vpcs --filters '[{"Name": "tag:Name", "Values": ["'$vpc_name'"]}]' --output yaml | yq '.Vpcs[].VpcId' )
         

--- a/tekton/src/tasks/gitops/gitops-deprovision-mongo.yml.j2
+++ b/tekton/src/tasks/gitops/gitops-deprovision-mongo.yml.j2
@@ -54,10 +54,10 @@ spec:
         aws configure set default.region $(params.avp_aws_secret_region)
 
         # Note the - after cluster name. this is to distinguish between different similar named clusters
-        vpc_name=$(aws ec2 describe-vpcs --output yaml | grep $CLUSTER_NAME- | yq '.[].Value // ""' | xargs
+        vpc_name=$(aws ec2 describe-vpcs --output yaml | grep $CLUSTER_NAME- | yq '.[].Value // ""' | xargs)
         if [ -z "$vpc_name" ]; then
           # Needed if there is only one cluster in account
-          vpc_name=$(aws ec2 describe-vpcs --output yaml | grep $CLUSTER_NAME- | yq '.Value // ""' | xargs
+          vpc_name=$(aws ec2 describe-vpcs --output yaml | grep $CLUSTER_NAME- | yq '.Value // ""' | xargs)
         fi
         export VPC_ID=$(aws ec2 describe-vpcs --filters '[{"Name": "tag:Name", "Values": ["'$vpc_name'"]}]' --output yaml | yq '.Vpcs[].VpcId' )
         

--- a/tekton/src/tasks/gitops/gitops-deprovision-mongo.yml.j2
+++ b/tekton/src/tasks/gitops/gitops-deprovision-mongo.yml.j2
@@ -54,10 +54,10 @@ spec:
         aws configure set default.region $(params.avp_aws_secret_region)
 
         # Note the - after cluster name. this is to distinguish between different similar named clusters
-        vpc_name=$(aws ec2 describe-vpcs --output yaml | grep $CLUSTER_NAME- | yq '.[].Value')
+        vpc_name=$(aws ec2 describe-vpcs --output yaml | grep $CLUSTER_NAME- | yq '.[].Value // ""' | xargs
         if [ -z "$vpc_name" ]; then
           # Needed if there is only one cluster in account
-          vpc_name=$(aws ec2 describe-vpcs --output yaml | grep $CLUSTER_NAME- | yq '.Value')
+          vpc_name=$(aws ec2 describe-vpcs --output yaml | grep $CLUSTER_NAME- | yq '.Value // ""' | xargs
         fi
         export VPC_ID=$(aws ec2 describe-vpcs --filters '[{"Name": "tag:Name", "Values": ["'$vpc_name'"]}]' --output yaml | yq '.Vpcs[].VpcId' )
         

--- a/tekton/src/tasks/gitops/gitops-kafka.yml.j2
+++ b/tekton/src/tasks/gitops/gitops-kafka.yml.j2
@@ -71,10 +71,10 @@ spec:
         aws configure set default.region $(params.avp_aws_secret_region)
 
         # Note the - after cluster name. this is to distinguish between different similar named clusters
-        vpc_name=$(aws ec2 describe-vpcs --output yaml | grep $CLUSTER_NAME- | yq '.[].Value')
+        vpc_name=$(aws ec2 describe-vpcs --output yaml | grep $CLUSTER_NAME- | yq '.[].Value // ""' | xargs
         if [ -z "$vpc_name" ]; then
           # Needed if there is only one cluster in account
-          vpc_name=$(aws ec2 describe-vpcs --output yaml | grep $CLUSTER_NAME- | yq '.Value')
+          vpc_name=$(aws ec2 describe-vpcs --output yaml | grep $CLUSTER_NAME- | yq '.Value // ""' | xargs
         fi
         export VPC_ID=$(aws ec2 describe-vpcs --filters '[{"Name": "tag:Name", "Values": ["'$vpc_name'"]}]' --output yaml | yq '.Vpcs[].VpcId' )
         

--- a/tekton/src/tasks/gitops/gitops-kafka.yml.j2
+++ b/tekton/src/tasks/gitops/gitops-kafka.yml.j2
@@ -71,10 +71,10 @@ spec:
         aws configure set default.region $(params.avp_aws_secret_region)
 
         # Note the - after cluster name. this is to distinguish between different similar named clusters
-        vpc_name=$(aws ec2 describe-vpcs --output yaml | grep $CLUSTER_NAME- | yq '.[].Value // ""' | xargs
+        vpc_name=$(aws ec2 describe-vpcs --output yaml | grep $CLUSTER_NAME- | yq '.[].Value // ""' | xargs)
         if [ -z "$vpc_name" ]; then
           # Needed if there is only one cluster in account
-          vpc_name=$(aws ec2 describe-vpcs --output yaml | grep $CLUSTER_NAME- | yq '.Value // ""' | xargs
+          vpc_name=$(aws ec2 describe-vpcs --output yaml | grep $CLUSTER_NAME- | yq '.Value // ""' | xargs)
         fi
         export VPC_ID=$(aws ec2 describe-vpcs --filters '[{"Name": "tag:Name", "Values": ["'$vpc_name'"]}]' --output yaml | yq '.Vpcs[].VpcId' )
         

--- a/tekton/src/tasks/gitops/gitops-mongo.yml.j2
+++ b/tekton/src/tasks/gitops/gitops-mongo.yml.j2
@@ -59,10 +59,10 @@ spec:
         aws configure set default.region $(params.avp_aws_secret_region)
 
         # Note the - after cluster name. this is to distinguish between different similar named clusters
-        vpc_name=$(aws ec2 describe-vpcs --output yaml | grep $CLUSTER_NAME- | yq '.[].Value // ""' | xargs
+        vpc_name=$(aws ec2 describe-vpcs --output yaml | grep $CLUSTER_NAME- | yq '.[].Value // ""' | xargs)
         if [ -z "$vpc_name" ]; then
           # Needed if there is only one cluster in account
-          vpc_name=$(aws ec2 describe-vpcs --output yaml | grep $CLUSTER_NAME- | yq '.Value // ""' | xargs
+          vpc_name=$(aws ec2 describe-vpcs --output yaml | grep $CLUSTER_NAME- | yq '.Value // ""' | xargs)
         fi
         export VPC_ID=$(aws ec2 describe-vpcs --filters '[{"Name": "tag:Name", "Values": ["'$vpc_name'"]}]' --output yaml | yq '.Vpcs[].VpcId' )
         

--- a/tekton/src/tasks/gitops/gitops-mongo.yml.j2
+++ b/tekton/src/tasks/gitops/gitops-mongo.yml.j2
@@ -59,10 +59,10 @@ spec:
         aws configure set default.region $(params.avp_aws_secret_region)
 
         # Note the - after cluster name. this is to distinguish between different similar named clusters
-        vpc_name=$(aws ec2 describe-vpcs --output yaml | grep $CLUSTER_NAME- | yq '.[].Value')
+        vpc_name=$(aws ec2 describe-vpcs --output yaml | grep $CLUSTER_NAME- | yq '.[].Value // ""' | xargs
         if [ -z "$vpc_name" ]; then
           # Needed if there is only one cluster in account
-          vpc_name=$(aws ec2 describe-vpcs --output yaml | grep $CLUSTER_NAME- | yq '.Value')
+          vpc_name=$(aws ec2 describe-vpcs --output yaml | grep $CLUSTER_NAME- | yq '.Value // ""' | xargs
         fi
         export VPC_ID=$(aws ec2 describe-vpcs --filters '[{"Name": "tag:Name", "Values": ["'$vpc_name'"]}]' --output yaml | yq '.Vpcs[].VpcId' )
         

--- a/tekton/src/tasks/gitops/gitops-process-mongo-user.yml.j2
+++ b/tekton/src/tasks/gitops/gitops-process-mongo-user.yml.j2
@@ -66,10 +66,10 @@ spec:
         aws configure set default.region $(params.avp_aws_secret_region)
 
         # Note the - after cluster name. this is to distinguish between different similar named clusters
-        vpc_name=$(aws ec2 describe-vpcs --output yaml | grep $CLUSTER_NAME- | yq '.[].Value')
+        vpc_name=$(aws ec2 describe-vpcs --output yaml | grep $CLUSTER_NAME- | yq '.[].Value // ""' | xargs
         if [ -z "$vpc_name" ]; then
           # Needed if there is only one cluster in account
-          vpc_name=$(aws ec2 describe-vpcs --output yaml | grep $CLUSTER_NAME- | yq '.Value')
+          vpc_name=$(aws ec2 describe-vpcs --output yaml | grep $CLUSTER_NAME- | yq '.Value // ""' | xargs
         fi
         export VPC_ID=$(aws ec2 describe-vpcs --filters '[{"Name": "tag:Name", "Values": ["'$vpc_name'"]}]' --output yaml | yq '.Vpcs[].VpcId' )
 

--- a/tekton/src/tasks/gitops/gitops-process-mongo-user.yml.j2
+++ b/tekton/src/tasks/gitops/gitops-process-mongo-user.yml.j2
@@ -66,10 +66,10 @@ spec:
         aws configure set default.region $(params.avp_aws_secret_region)
 
         # Note the - after cluster name. this is to distinguish between different similar named clusters
-        vpc_name=$(aws ec2 describe-vpcs --output yaml | grep $CLUSTER_NAME- | yq '.[].Value // ""' | xargs
+        vpc_name=$(aws ec2 describe-vpcs --output yaml | grep $CLUSTER_NAME- | yq '.[].Value // ""' | xargs)
         if [ -z "$vpc_name" ]; then
           # Needed if there is only one cluster in account
-          vpc_name=$(aws ec2 describe-vpcs --output yaml | grep $CLUSTER_NAME- | yq '.Value // ""' | xargs
+          vpc_name=$(aws ec2 describe-vpcs --output yaml | grep $CLUSTER_NAME- | yq '.Value // ""' | xargs)
         fi
         export VPC_ID=$(aws ec2 describe-vpcs --filters '[{"Name": "tag:Name", "Values": ["'$vpc_name'"]}]' --output yaml | yq '.Vpcs[].VpcId' )
 


### PR DESCRIPTION
The aws cli has changed its output so the search for the vpc now returns more than one result from the grep as a new key of `sigs.k8s.io/cluster-api-provider-aws/cluster/yourclustername` has been added. The change will make sure we still only get one result.