### PR TITLE
[doc] Add certification status for IBM Storage Fusion

### DIFF
--- a/docs/catalogs/v9-250206-amd64.md
+++ b/docs/catalogs/v9-250206-amd64.md
@@ -136,6 +136,14 @@ IBM Maximo Application Suite will run anywhere that you can run a supported Open
     <td class="firstColumn"><a href="https://www.oracle.com/cloud/red-hat/">Red Hat on OCI</a></td>
     <td>Compatible</td>
   </tr>
+  <tr>
+    <td class="firstColumn"><a href="https://www.ibm.com/docs/en/fusion-hci-systems/2.9.x?topic=workloads-maximo-applications-support-fusion">Red Hat Openshift on IBM Storage Fusion HCI</a></td>
+    <td>Compatible</td>
+  </tr>
+  <tr>
+    <td class="firstColumn"><a href="https://www.ibm.com/docs/en/fusion-hci-systems/2.9.x?topic=workloads-maximo-applications-support-fusion">Red Hat Openshift on IBM Storage Fusion HCI (HCP)</a></td>
+    <td>Compatible</td>
+  </tr>
 </table>
 
 !!! tip


### PR DESCRIPTION
Include both IBM Storage Fusion HCI / HCP in the Vendor Certification matrix
----

- Listing them as Compatible for now until we can run the certification process to change its status. 
- Testing on both configurations have been carried out mainly by the IBM Storage Fusion team with occasional validations from MAS dev team. 
- If additional information is needed before merging, please let me know. 