### PR TITLE
[patch] Mobile pipeline fvt launcher reorder

### DIFF
--- a/tekton/src/pipelines/fvt-launcher.yml.j2
+++ b/tekton/src/pipelines/fvt-launcher.yml.j2
@@ -541,7 +541,7 @@ spec:
           operator: in
           values: ["true", "True"]
       runAfter:
-        - manage-setup
+        - approval-manage
 
 
     # 7. Application FVT - Monitor


### PR DESCRIPTION
Adjusting Mobile pipeline so that it runs only after Manage tests in order to avoid conflicts in Object Structure Generation in Manage done by the mobile tests setup.

![image](https://github.com/user-attachments/assets/ae4cb605-653b-448a-b811-eddc45df86b0)
