### PR TITLE
[patch] Fix Kafka defaults in cli

### DIFF
--- a/python/src/mas/cli/install/settings/kafkaSettings.py
+++ b/python/src/mas/cli/install/settings/kafkaSettings.py
@@ -47,7 +47,7 @@ class KafkaSettingsMixin():
                     ])
                     if self.showAdvancedOptions:
                         self.promptForString("Strimzi namespace", "kafka_namespace", default="strimzi")
-                    self.promptForString("Kafka version", "kafka_version", default="3.7.0")
+                    self.promptForString("Kafka version", "kafka_version", default="3.9.0")
 
                 elif self.getParam("kafka_provider") == "redhat":
                     self.printDescription([
@@ -58,7 +58,7 @@ class KafkaSettingsMixin():
                         " - If you are using older operator catalogs (e.g. in a disconnected install) you should confirm the supported versions in your OperatorHub"
                     ])
                     self.promptForString("Install namespace", "kafka_namespace", default="amq-streams")
-                    self.promptForString("Kafka version", "kafka_version", default="3.5.0")
+                    self.promptForString("Kafka version", "kafka_version", default="3.8.0")
 
                 elif self.getParam("kafka_provider") == "ibm":
                     print()


### PR DESCRIPTION
The Kafka defaults have changed https://github.com/ibm-mas/ansible-devops/blob/master/ibm/mas_devops/roles/kafka/defaults/main.yaml#L9 but the cli was defaulting to versions that no longer work (strimzi 3.7.0)