### PR TITLE
[patch]- Remove High Maintenance- Not suitable to FVT category Tests

### DIFF
--- a/tekton/src/pipelines/taskdefs/fvt-manage/phase3.yml.j2
+++ b/tekton/src/pipelines/taskdefs/fvt-manage/phase3.yml.j2
@@ -3,7 +3,6 @@
 # - fvt-manage-base-ui-classification (selenium)
 # - fvt-manage-base-ui-helplinks (selenium)
 # - fvt-manage-base-ui-wo-basic (selenium)
-# - fvt-manage-base-ui-mas-navigation (selenium)
 # - fvt-manage-base-ui-requestreport-pages (selenium)
 # - fvt-manage-base-api-scheduler-qualification (pytest)
 # -------------------------------------------------------------
@@ -46,20 +45,6 @@
       value: base-ui
     - name: fvt_test_suite
       value: wo-basic
-  runAfter:
-    - fvt-manage-base-api-system
-    - fvt-manage-base-api-mif
-
-# Manage FVT Mas Navigation Scenario
-- name: fvt-manage-base-ui-mas-navigation
-  {{ lookup('template', 'taskdefs/fvt-manage/ui/taskref.yml.j2') | indent(2) }}
-  {{ lookup('template', 'taskdefs/fvt-manage/ui/when.yml.j2') | indent(2) }}
-  params:
-    {{ lookup('template', 'taskdefs/fvt-manage/ui/params.yml.j2') | indent(4) }}
-    - name: fvt_test_suite_prefix
-      value: base-ui
-    - name: fvt_test_suite
-      value: mas-navigation
   runAfter:
     - fvt-manage-base-api-system
     - fvt-manage-base-api-mif

--- a/tekton/src/pipelines/taskdefs/fvt-manage/phase4.yml.j2
+++ b/tekton/src/pipelines/taskdefs/fvt-manage/phase4.yml.j2
@@ -21,7 +21,6 @@
     - fvt-manage-base-ui-classification
     - fvt-manage-base-ui-helplinks
     - fvt-manage-base-ui-wo-basic
-    - fvt-manage-base-ui-mas-navigation
     - fvt-manage-base-api-scheduler-qualification
     - fvt-manage-base-ui-requestreport-pages
 
@@ -37,7 +36,6 @@
     - fvt-manage-base-ui-classification
     - fvt-manage-base-ui-helplinks
     - fvt-manage-base-ui-wo-basic
-    - fvt-manage-base-ui-mas-navigation
     - fvt-manage-base-api-scheduler-qualification
     - fvt-manage-base-ui-requestreport-pages
 
@@ -55,7 +53,6 @@
     - fvt-manage-base-ui-classification
     - fvt-manage-base-ui-helplinks
     - fvt-manage-base-ui-wo-basic
-    - fvt-manage-base-ui-mas-navigation
     - fvt-manage-base-api-scheduler-qualification
     - fvt-manage-base-ui-requestreport-pages
 
@@ -73,7 +70,6 @@
     - fvt-manage-base-ui-classification
     - fvt-manage-base-ui-helplinks
     - fvt-manage-base-ui-wo-basic
-    - fvt-manage-base-ui-mas-navigation
     - fvt-manage-base-api-scheduler-qualification
     - fvt-manage-base-ui-requestreport-pages
 
@@ -91,6 +87,5 @@
     - fvt-manage-base-ui-classification
     - fvt-manage-base-ui-helplinks
     - fvt-manage-base-ui-wo-basic
-    - fvt-manage-base-ui-mas-navigation
     - fvt-manage-base-api-scheduler-qualification
     - fvt-manage-base-ui-requestreport-pages

--- a/tekton/src/pipelines/taskdefs/fvt-manage/phase5.yml.j2
+++ b/tekton/src/pipelines/taskdefs/fvt-manage/phase5.yml.j2
@@ -1,7 +1,6 @@
 # -------------------------------------------------------------
 # PHASE 5
 # - fvt-manage-base-ui-sec-audit-log (selenium)
-# - fvt-manage-base-ui-sec-inactive-auth (selenium)
 # - fvt-manage-base-ui-wo-doclink (selenium)
 # - fvt-manage-base-ui-directprint (selenium)
 # - fvt-manage-base-ui-adhoc-report (selenium)
@@ -17,23 +16,6 @@
       value: base-ui
     - name: fvt_test_suite
       value: sec-audit-log
-  runAfter:
-    - fvt-manage-base-ui-escalation-action
-    - fvt-manage-base-ui-birt-report
-    - fvt-manage-base-ui-user-crud
-    - fvt-manage-base-ui-user-consumption
-    - fvt-manage-base-ui-communication-temp
-
-# Manage FVT Inactive User Authentication
-- name: fvt-manage-base-ui-sec-inactive-auth
-  {{ lookup('template', pipeline_src_dir ~ '/taskdefs/fvt-manage/ui/taskref.yml.j2') | indent(2) }}
-  {{ lookup('template', pipeline_src_dir ~ '/taskdefs/fvt-manage/ui/when.yml.j2') | indent(2) }}
-  params:
-    {{ lookup('template', pipeline_src_dir ~ '/taskdefs/fvt-manage/ui/params.yml.j2') | indent(4) }}
-    - name: fvt_test_suite_prefix
-      value: base-ui
-    - name: fvt_test_suite
-      value: sec-inactive-auth
   runAfter:
     - fvt-manage-base-ui-escalation-action
     - fvt-manage-base-ui-birt-report

--- a/tekton/src/tasks/fvt/fvt-manage-last-phase.yml.j2
+++ b/tekton/src/tasks/fvt/fvt-manage-last-phase.yml.j2
@@ -145,21 +145,6 @@ spec:
 
   steps:
 
-    # Manage FVT Application Designer
-    - name: fvt-manage-application-designer
-      image: '$(params.fvt_image_registry)/fvt-manage/fvt-ibm-mas-manage@$(params.fvt_image_digest)'
-      imagePullPolicy: $(params.image_pull_policy)
-      timeout: 150m # Ensure bad FVTs don't run forever
-      onError: continue # Ensure bad FVTs don't break the pipeline
-      resources: {}
-      workingDir: /opt/ibm/test/src
-      volumeMounts:
-        - mountPath: /dev/shm
-          name: dshm
-      env:
-        - name: FVT_TEST_SUITE
-          value: application-designer
-
     # Manage FVT Start Center
     - name: fvt-manage-startcenter-config
       image: '$(params.fvt_image_registry)/fvt-manage/fvt-ibm-mas-manage@$(params.fvt_image_digest)'


### PR DESCRIPTION
Remove High Maintenance Tests:

we have decided to remove these 3 tests which are giving high maintenance. 

base-ui-mas-navigation
Reason: Test includes lot of UI navigations which depends upon availability of apps and many features are being tested at one part of test. Test never passed due to the time it takes to execute. more then 1 hr. Test is good candidate for Regression.

base-ui-sec-inactive-auth
Reason: This is negative test where user is to be inactivated and then verify user is inactivated or NOT. Test is likely to impact other tests due to inactivity of user and failing intermittently on behaviour and timing issue. Test is more applicable to regression suite instead FVT.

fvt-manage-application-designer
Reason: Test never worked in pipeline since its onboard to FVT due to Selenium tekton issue. Test works okay in local. Attempt to make it stable in pipeline is in progress. until then removing from FVT.


<img width="662" alt="image" src="https://github.com/user-attachments/assets/b1d85986-ba62-45e4-82c9-7be82bb87cb0" />

<img width="1285" alt="image" src="https://github.com/user-attachments/assets/1c575bef-ea3d-41ea-8867-06c224b223de" />
