### PR TITLE
[patch] Don't enforce watson studio secret for gitops

### DIFF
--- a/image/cli/mascli/functions/gitops_mas_config
+++ b/image/cli/mascli/functions/gitops_mas_config
@@ -829,7 +829,7 @@ function gitops_mas_config() {
       export SECRET_KEY_WATSON_STUDIO_USERNAME=${WATSON_STUDIO_SECRET}#username
       export SECRET_KEY_WATSON_STUDIO_PASSWORD=${WATSON_STUDIO_SECRET}#password
       export SECRET_KEY_WATSON_STUDIO_URL=${WATSON_STUDIO_SECRET}#url
-      sm_verify_secret_exists $WATSON_STUDIO_SECRET "username,password,url"
+      sm_verify_secret_exists $WATSON_STUDIO_SECRET "username,password,url" false
     fi
 
     echo


### PR DESCRIPTION
The watson studio config secret would only exist at this point if the watson studio config is being provided. For clusters that have watson studio installed, then this will likely not be present until the cp4d install is installed via argocd.