### PR TITLE
[patch] Add support for new OCP 4.17  NFD image in Gitops

### DIFF
--- a/image/cli/mascli/functions/gitops_nvidia_gpu
+++ b/image/cli/mascli/functions/gitops_nvidia_gpu
@@ -23,6 +23,7 @@ NVIDIA GPU OPERATOR:
       --nfd-namespace ${COLOR_YELLOW}NFD_NAMESPACE${TEXT_RESET}                                 NFD Namespace, defaults to openshift-nfd
       --nfd-channel ${COLOR_YELLOW}NFD_CHANNEL${TEXT_RESET}                                     NFD Channel, defaults to stable
       --nfd-install-plan ${COLOR_YELLOW}NFD_INSTALL_PLAN${TEXT_RESET}                           NFD Subscription install plan, ('Automatic' or 'Manual'. Default is 'Automatic')
+      --nfd-image ${COLOR_YELLOW}NFD_IMAGE${TEXT_RESET}                                         NFD Image for worker nodes, default is for ocp version 4.17 and up. Set if ocp version is below 4.17
       --gpu-namespace ${COLOR_YELLOW}GPU_NAMESPACE${TEXT_RESET}                                 GPU Namespace, defaults to nvidia-gpu-operator
       --gpu-channel ${COLOR_YELLOW}GPU_CHANNEL${TEXT_RESET}                                     GPU Channel, defaults to v24.3
       --gpu-install-plan ${COLOR_YELLOW}GPU_INSTALL_PLAN${TEXT_RESET}                           GPU Subscription install plan, ('Automatic' or 'Manual'. Default is 'Automatic')
@@ -111,6 +112,9 @@ function gitops_nvidia_gpu_noninteractive() {
         ;;
       --gpu-driver-repository-path)
         export GPU_DRIVER_REPOSITORY_PATH=$1 && shift
+        ;;
+      --nfd_image)
+        export NFD_IMAGE=$1 && shift
         ;;
 
       # Automatic GitHub Push
@@ -234,6 +238,8 @@ function gitops_nvidia_gpu() {
   if [[ -z "${GPU_DRIVER_REPOSITORY_PATH}" ]]; then
     export GPU_DRIVER_REPOSITORY_PATH=nvcr.io/nvidia
   fi
+  if [[ -z "${NFD_IMAGE}" ]]; then
+    export NFD_IMAGE="registry.redhat.io/openshift4/ose-node-feature-discovery-rhel9@sha256:45192fef5a1250ee573975ced1e897662116d5a30a1f8f4baa4497f64933fba3"
 
 
   echo "${TEXT_DIM}"
@@ -241,6 +247,7 @@ function gitops_nvidia_gpu() {
   echo_reset_dim "NFD_NAMESPACE ............................. ${COLOR_MAGENTA}${NFD_NAMESPACE}"
   echo_reset_dim "NFD_CHANNEL ............................... ${COLOR_MAGENTA}${NFD_CHANNEL}"
   echo_reset_dim "NFD_INSTALL_PLAN .......................... ${COLOR_MAGENTA}${NFD_INSTALL_PLAN}"
+  echo_reset_dim "NFD_IMAGE ................................. ${COLOR_MAGENTA}${NFD_IMAGE}"
   echo_reset_dim "GPU_NAMESPACE ............................. ${COLOR_MAGENTA}${GPU_NAMESPACE}"
   echo_reset_dim "GPU_CHANNEL ............................... ${COLOR_MAGENTA}${GPU_CHANNEL}"
   echo_reset_dim "GPU_INSTALL_PLAN .......................... ${COLOR_MAGENTA}${GPU_INSTALL_PLAN}"

--- a/image/cli/mascli/functions/gitops_nvidia_gpu
+++ b/image/cli/mascli/functions/gitops_nvidia_gpu
@@ -240,6 +240,7 @@ function gitops_nvidia_gpu() {
   fi
   if [[ -z "${NFD_IMAGE}" ]]; then
     export NFD_IMAGE="registry.redhat.io/openshift4/ose-node-feature-discovery-rhel9@sha256:45192fef5a1250ee573975ced1e897662116d5a30a1f8f4baa4497f64933fba3"
+  fi
 
 
   echo "${TEXT_DIM}"

--- a/image/cli/mascli/templates/gitops/appset-configs/cluster/nvidia-gpu-operator.yaml.j2
+++ b/image/cli/mascli/templates/gitops/appset-configs/cluster/nvidia-gpu-operator.yaml.j2
@@ -4,6 +4,7 @@ nvidia_gpu_operator:
   nfd_namespace: {{ NFD_NAMESPACE }}
   nfd_channel: {{ NFD_CHANNEL }}
   nfd_install_plan: {{ NFD_INSTALL_PLAN }}
+  nfd_image: {{ NFD_IMAGE }}
   gpu_namespace: {{ GPU_NAMESPACE }}
   gpu_channel: {{ GPU_CHANNEL }}
   gpu_driver_version: {{ GPU_DRIVER_VERSION }}

--- a/tekton/src/pipelines/gitops/gitops-mas-cluster.yml.j2
+++ b/tekton/src/pipelines/gitops/gitops-mas-cluster.yml.j2
@@ -100,6 +100,9 @@ spec:
     - name: gpu_driver_repository_path
       type: string
       default: nvcr.io/nvidia
+    - name: nfd_image
+      type: string
+      default: "registry.redhat.io/openshift4/ose-node-feature-discovery-rhel9@sha256:45192fef5a1250ee573975ced1e897662116d5a30a1f8f4baa4497f64933fba3"
     
     - name: cis_compliance_install_plan
       type: string
@@ -411,6 +414,8 @@ spec:
           value: $(params.nfd_channel)
         - name: nfd_install_plan
           value: $(params.nfd_install_plan)
+        - name: nfd_image
+          value: $(params.nfd_image)
         - name: gpu_namespace
           value: $(params.gpu_namespace)
         - name: gpu_channel

--- a/tekton/src/tasks/gitops/gitops-nvidia-gpu.yml.j2
+++ b/tekton/src/tasks/gitops/gitops-nvidia-gpu.yml.j2
@@ -42,6 +42,8 @@ spec:
     - name: gpu_install_plan
       type: string
       default: "Automatic"
+    - name: nfd_image
+      type: string
 
   stepTemplate:
     name: gitops-nvidia-gpu
@@ -72,6 +74,8 @@ spec:
         value: $(params.nfd_channel)
       - name: NFD_INSTALL_PLAN
         value: $(params.nfd_install_plan)
+      - name: NFD_IMAGE
+        value: $(params.nfd_image)
       - name: GPU_NAMESPACE
         value: $(params.gpu_namespace)
       - name: GPU_CHANNEL


### PR DESCRIPTION
NFD supports different images based on the ocp version. When ocp is version 4.17 and above, the image is expected to be `http://registry.redhat.io/openshift4/ose-node-feature-discovery-rhel9@sha256:45192fef5a1250ee573975ced1e897662116d5a30a1f8f4baa4497f64933fba3` and when it is below 4.17, the image should be `registry.redhat.io/openshift4/ose-node-feature-discovery@sha256:cc09665d75447c53a86a5acb5926f9b9fb59294533e04bfa432001d2b41efebc`
This change sets the default to the former and if in the case of the latter, there is a variable that can be set. 
Test was performed in noble6 cluster with version 4.14 and so a value was inserted. Passed
Other test will be performed in fvtsaas-tran which has 4.17
Jira issue: [MASCORE-6014](https://jsw.ibm.com/browse/MASCORE-6014)