### PR TITLE
[patch] Fix missing install_plans for MAS, DB2 and SLS for gitops

### DIFF
--- a/tekton/src/pipelines/gitops/gitops-mas-cluster.yml.j2
+++ b/tekton/src/pipelines/gitops/gitops-mas-cluster.yml.j2
@@ -63,16 +63,6 @@ spec:
       type: string
       default: "Automatic"
 
-    - name: db2_channel
-      type: string
-      default: ""
-    - name: db2_action
-      type: string
-      default: ""
-    - name: db2_subscription_install_plan
-      type: string
-      default: "Automatic"
-
     - name: nvidia_gpu_action
       type: string
       default: ""

--- a/tekton/src/pipelines/gitops/gitops-mas-instance.yml.j2
+++ b/tekton/src/pipelines/gitops/gitops-mas-instance.yml.j2
@@ -53,6 +53,12 @@ spec:
       type: string
     - name: mas_workspace_name
       type: string
+    - name: mas_install_plan
+      type: string
+      default: "Automatic"
+    - name: sls_install_plan
+      type: string
+      default: "Automatic"
     - name: docdb_user_action
       type: string
       default: add
@@ -179,9 +185,11 @@ spec:
     - name: db2_channel
       type: string
       default: ""
-
     - name: db2_action
       type: string
+    - name: db2_subscription_install_plan
+      type: string
+      default: "Automatic"
 
     # gitops-license-generator parameters
     # ------------------------------------------------------------------------- 
@@ -234,6 +242,8 @@ spec:
           value: $(params.db2_channel)
         - name: avp_aws_secret_region
           value: $(params.avp_aws_secret_region)
+        - name: db2_subscription_install_plan
+          value: $(params.db2_subscription_install_plan)
       workspaces:
         - name: configs
           workspace: configs
@@ -340,6 +350,10 @@ spec:
           value: $(params.custom_labels)
         - name: mas_domain
           value: $(params.mas_domain)
+        - name: mas_install_plan
+          value: $(params.mas_install_plan)
+        - name: sls_install_plan
+          value: $(params.sls_install_plan)
         - name: github_pat
           value: $(params.github_pat)
         - name: avp_aws_secret_region


### PR DESCRIPTION
The sls, db2 and mas install_plan was missing from the gitops piplines and so was not being passed through. This change adds them  back in. It also removes the db2 details from the cluster pipeline as it has moved to the intstance pipeline.

Tested in dev:

![image- 2025-03-26 at 11 17 13@2x](https://github.com/user-attachments/assets/e3106d15-5865-4cf5-baf4-e4f1d1326913)
