### PR TITLE
[patch] Check for logging secret for Manage only if it is set in gitops.

### DIFF
--- a/image/cli/mascli/functions/gitops_suite_app_config
+++ b/image/cli/mascli/functions/gitops_suite_app_config
@@ -495,8 +495,9 @@ function gitops_suite_app_config() {
       yq eval '.mas_appws_spec.settings.customizationList  | to_entries | .[].value.customizationArchiveCredentials.secretName | [] + .' ${MAS_APPWS_SPEC_YAML} | yq '{"CUSTOMIZATION_ARCHIVE_SECRET_NAMES": [] + .}'  > $ADDITIONAL_JINJA_PARAMS_FILE
       export MANAGE_LOGGING_SECRET_NAME=$(yq eval '.mas_appws_spec.settings.deployment.loggingS3Destination.secretKey.secretName // ""' ${MAS_APPWS_SPEC_YAML})
       export MANAGE_LOGGING_SECRET=${ACCOUNT_ID}${SECRETS_KEY_SEPERATOR}${CLUSTER_ID}${SECRETS_KEY_SEPERATOR}${MAS_INSTANCE_ID}${SECRETS_KEY_SEPERATOR}manage_logging${SECRETS_KEY_SEPERATOR}
-      sm_verify_secret_exists ${MANAGE_LOGGING_SECRET}${MANAGE_LOGGING_SECRET_NAME} "access_secret_key,bucketName,endpointURL,accessKey" 
-     
+      if [[ -n "${MANAGE_LOGGING_SECRET_NAME}" ]]; then
+        sm_verify_secret_exists ${MANAGE_LOGGING_SECRET}${MANAGE_LOGGING_SECRET_NAME} "access_secret_key,bucketName,endpointURL,accessKey" 
+      fi
       yq '.mas_appws_spec.settings.deployment.serverBundles[].bundleLevelProperties // ""' ${MAS_APPWS_SPEC_YAML} > all_bundle_props.props
       cat all_bundle_props.props | grep "<path:arn:" | awk -F= '{print $2}' >> bundlesecretrefs.txt
       while read BUNDLE_SECRET_REF; do

--- a/image/cli/mascli/functions/gitops_suite_app_config
+++ b/image/cli/mascli/functions/gitops_suite_app_config
@@ -499,17 +499,19 @@ function gitops_suite_app_config() {
         sm_verify_secret_exists ${MANAGE_LOGGING_SECRET}${MANAGE_LOGGING_SECRET_NAME} "access_secret_key,bucketName,endpointURL,accessKey" 
       fi
       yq '.mas_appws_spec.settings.deployment.serverBundles[].bundleLevelProperties // ""' ${MAS_APPWS_SPEC_YAML} > all_bundle_props.props
-      cat all_bundle_props.props | grep "<path:arn:" | awk -F= '{print $2}' >> bundlesecretrefs.txt
-      if [[ -s bundlesecretrefs.txt ]]; then
-        while read BUNDLE_SECRET_REF; do
-          if [[ $BUNDLE_SECRET_REF == "<path:arn"* ]]; then
-            BUNDLE_SECRET_NAME=$(echo $BUNDLE_SECRET_REF | awk -F: '{print $8}' | awk -F# '{print $1}')
-            BUNDLE_SECRET_KEY=$(echo $BUNDLE_SECRET_REF | awk -F: '{print $8}' | awk -F# '{print substr($2, 1, length($2)-1)}')
-            sm_verify_secret_exists $BUNDLE_SECRET_NAME $BUNDLE_SECRET_KEY 
-          fi
-        done < bundlesecretrefs.txt
+      if [[ -s all_bundle_props.props ]]; then
+        cat all_bundle_props.props | grep "<path:arn:" | awk -F= '{print $2}' >> bundlesecretrefs.txt
+        if [[ -s bundlesecretrefs.txt ]]; then
+          while read BUNDLE_SECRET_REF; do
+            if [[ $BUNDLE_SECRET_REF == "<path:arn"* ]]; then
+              BUNDLE_SECRET_NAME=$(echo $BUNDLE_SECRET_REF | awk -F: '{print $8}' | awk -F# '{print $1}')
+              BUNDLE_SECRET_KEY=$(echo $BUNDLE_SECRET_REF | awk -F: '{print $8}' | awk -F# '{print substr($2, 1, length($2)-1)}')
+              sm_verify_secret_exists $BUNDLE_SECRET_NAME $BUNDLE_SECRET_KEY 
+            fi
+          done < bundlesecretrefs.txt
+        fi
+        rm -f bundlesecretrefs.txt
       fi
-      rm -f bundlesecretrefs.txt
       rm -f all_bundle_props.props
     fi
   else

--- a/image/cli/mascli/functions/gitops_suite_app_config
+++ b/image/cli/mascli/functions/gitops_suite_app_config
@@ -500,7 +500,7 @@ function gitops_suite_app_config() {
       fi
       yq '.mas_appws_spec.settings.deployment.serverBundles[].bundleLevelProperties // ""' ${MAS_APPWS_SPEC_YAML} > all_bundle_props.props
       if [[ -s all_bundle_props.props ]]; then
-        cat all_bundle_props.props | grep "<path:arn:" | awk -F= '{print $2}' >> bundlesecretrefs.txt
+        cat all_bundle_props.props | awk -F= '{print $2}' >> bundlesecretrefs.txt
         if [[ -s bundlesecretrefs.txt ]]; then
           while read BUNDLE_SECRET_REF; do
             if [[ $BUNDLE_SECRET_REF == "<path:arn"* ]]; then

--- a/image/cli/mascli/functions/gitops_suite_app_config
+++ b/image/cli/mascli/functions/gitops_suite_app_config
@@ -500,13 +500,15 @@ function gitops_suite_app_config() {
       fi
       yq '.mas_appws_spec.settings.deployment.serverBundles[].bundleLevelProperties // ""' ${MAS_APPWS_SPEC_YAML} > all_bundle_props.props
       cat all_bundle_props.props | grep "<path:arn:" | awk -F= '{print $2}' >> bundlesecretrefs.txt
-      while read BUNDLE_SECRET_REF; do
-        if [[ $BUNDLE_SECRET_REF == "<path:arn"* ]]; then
-          BUNDLE_SECRET_NAME=$(echo $BUNDLE_SECRET_REF | awk -F: '{print $8}' | awk -F# '{print $1}')
-          BUNDLE_SECRET_KEY=$(echo $BUNDLE_SECRET_REF | awk -F: '{print $8}' | awk -F# '{print substr($2, 1, length($2)-1)}')
-          sm_verify_secret_exists $BUNDLE_SECRET_NAME $BUNDLE_SECRET_KEY 
-        fi
-      done < bundlesecretrefs.txt
+      if [[ -s bundlesecretrefs.txt ]]; then
+        while read BUNDLE_SECRET_REF; do
+          if [[ $BUNDLE_SECRET_REF == "<path:arn"* ]]; then
+            BUNDLE_SECRET_NAME=$(echo $BUNDLE_SECRET_REF | awk -F: '{print $8}' | awk -F# '{print $1}')
+            BUNDLE_SECRET_KEY=$(echo $BUNDLE_SECRET_REF | awk -F: '{print $8}' | awk -F# '{print substr($2, 1, length($2)-1)}')
+            sm_verify_secret_exists $BUNDLE_SECRET_NAME $BUNDLE_SECRET_KEY 
+          fi
+        done < bundlesecretrefs.txt
+      fi
       rm -f bundlesecretrefs.txt
       rm -f all_bundle_props.props
     fi


### PR DESCRIPTION
In the gitops function for the mas app config, we check if secrets exist, but that check fails if no logging is setup for manage. We should only check for the secret existing if the manage config states it is using a logging secret. Also removes the grep from the bundle level properties as this fails if no secret path is found (as bundle properties might not have secrets), but it isn't required as there is a check later on for if a property is a secret path or not.