### PR TITLE
[patch] Increase core test timeout to 12 hours

### DIFF
--- a/image/cli/masfvt/templates/mas-fvt-core.yml.j2
+++ b/image/cli/masfvt/templates/mas-fvt-core.yml.j2
@@ -12,7 +12,7 @@ spec:
 
   serviceAccountName: pipeline
   timeouts:
-    pipeline: "10h"
+    pipeline: "12h"
 
   params:
     # Pull Policy


### PR DESCRIPTION
We need more time to run fvt-core pipeline, currently it is taking more than 10 hours:
Most time consuming test suites are:

ibm-mas/licensingapi: 2 hours
ibm-mas/imagescan: 2 hours
ibm-mas/coreidp-ldap: 2:20 hours
ibm-mas/coreidp-saml-ui: 1:40 hours
ibm-mas/smtp: 1:10 hours