### PR TITLE
[patch] Check for no customizationArchiveCredentials in manage customization for gitops

### DIFF
--- a/image/cli/mascli/functions/gitops_suite_app_config
+++ b/image/cli/mascli/functions/gitops_suite_app_config
@@ -492,7 +492,7 @@ function gitops_suite_app_config() {
     echo_h2 "Using application spec provided for $MAS_APP_ID at $MAS_APPWS_SPEC_YAML"
     export MAS_APPWS_SPEC=$(cat ${MAS_APPWS_SPEC_YAML} | yq '.' --output-format yaml)
     if [[ "${MAS_APP_ID}" == "manage" ]]; then
-      yq eval '.mas_appws_spec.settings.customizationList  | to_entries | .[].value.customizationArchiveCredentials.secretName | [] + .' ${MAS_APPWS_SPEC_YAML} | yq '{"CUSTOMIZATION_ARCHIVE_SECRET_NAMES": [] + .}'  > $ADDITIONAL_JINJA_PARAMS_FILE
+      yq eval '.mas_appws_spec.settings.customizationList  | to_entries | map(select(.value.customizationArchiveCredentials | .[].value.customizationArchiveCredentials.secretName | [] + .' ${MAS_APPWS_SPEC_YAML} | yq '{"CUSTOMIZATION_ARCHIVE_SECRET_NAMES": [] + .}'  > $ADDITIONAL_JINJA_PARAMS_FILE
       export MANAGE_LOGGING_SECRET_NAME=$(yq eval '.mas_appws_spec.settings.deployment.loggingS3Destination.secretKey.secretName // ""' ${MAS_APPWS_SPEC_YAML})
       export MANAGE_LOGGING_SECRET=${ACCOUNT_ID}${SECRETS_KEY_SEPERATOR}${CLUSTER_ID}${SECRETS_KEY_SEPERATOR}${MAS_INSTANCE_ID}${SECRETS_KEY_SEPERATOR}manage_logging${SECRETS_KEY_SEPERATOR}
       if [[ -n "${MANAGE_LOGGING_SECRET_NAME}" ]]; then


### PR DESCRIPTION
Checks to see if an customizationArchiveCredentials actually exists in the customiztion, otherwise it passes an empty string to the next level resulting in the error 

```
yq eval '.mas_appws_spec.settings.customizationList  | to_entries | .[].value.customizationArchiveCredentials.secretName | [] + .' ${MAS_APPWS_SPEC_YAML} | yq '{"CUSTOMIZATION_ARCHIVE_SECRET_NAMES": [] + .}'
CUSTOMIZATION_ARCHIVE_SECRET_NAMES: []
Error: bad file '-': yaml: line 1: did not find expected <document start>
```

With the change we get back an empty list:
```
yq eval '.mas_appws_spec.settings.customizationList  | to_entries | map(select(.value.customizationArchiveCredentials | length > 0)) | .[].value.customizationArchiveCredentials.secretName | [] + .' ${MAS_APPWS_SPEC_YAML} | yq '{"CUSTOMIZATION_ARCHIVE_SECRET_NAMES": [] + .}'
CUSTOMIZATION_ARCHIVE_SECRET_NAMES: []
```

and when a archiveCredentials does exist then we still get the entry:
```
yq eval '.mas_appws_spec.settings.customizationList  | to_entries | map(select(.value.customizationArchiveCredentials | length > 0)) | .[].value.customizationArchiveCredentials.secretName | [] + .' ${MAS_APPWS_SPEC_YAML} | yq '{"CUSTOMIZATION_ARCHIVE_SECRET_NAMES": [] + .}'
CUSTOMIZATION_ARCHIVE_SECRET_NAMES:
  - bob
```