### PR TITLE
[patch] Fix incorrectly running dynamic scan pipeline

### DIFF
--- a/tekton/src/pipelines/fvt-launcher.yml.j2
+++ b/tekton/src/pipelines/fvt-launcher.yml.j2
@@ -897,7 +897,7 @@ spec:
         - name: launchdyncscan_visualinspection
           value: $(params.launchdyncscan_visualinspection)
       when:
-        - input: "$(params.launchdyncscan_core)$(params.launchdyncscan_iot)$(params.launchdyncscan_monitor)$(params.launchdyncscan_manage)($params.launchdyncscan_assist)($params.launchdyncscan_optimizer)($params.launchdyncscan_predict)($params.launchdyncscan_visualinspection)"
+        - input: "$(params.launchdyncscan_core)$(params.launchdyncscan_iot)$(params.launchdyncscan_monitor)$(params.launchdyncscan_manage)$(params.launchdyncscan_assist)$(params.launchdyncscan_optimizer)$(params.launchdyncscan_predict)$(params.launchdyncscan_visualinspection)"
           operator: notin
           values: [ "", "falsefalsefalsefalsefalsefalsefalsefalse", "FalseFalseFalseFalseFalseFalseFalseFalse" ]
       runAfter:


### PR DESCRIPTION
The params had a typo so the when condition was always meet:

![image- 2025-04-04 at 13 39 44@2x](https://github.com/user-attachments/assets/676c7c1f-3ad0-4a3e-abd6-1ea0d3c2c3ce)

which meant the dynamicscan pipeline was always run even if it wasn't set to run anything