### PR TITLE
[patch] Default cis props to "false" if unspecified for gitops function gitops-suite

### DIFF
--- a/image/cli/mascli/functions/gitops_suite
+++ b/image/cli/mascli/functions/gitops_suite
@@ -437,13 +437,13 @@ function gitops_suite() {
 
   export DOMAIN=${MAS_DOMAIN}
   if [[ "${DNS_PROVIDER}" == "cis" ]]; then
-    export CIS_ENHANCED_SECURITY=${CIS_ENHANCED_SECURITY:-"true"}
+    export CIS_ENHANCED_SECURITY=${CIS_ENHANCED_SECURITY:-"false"}
     export CIS_PROXY=${CIS_PROXY:-"false"}
-    export OVERRIDE_EDGE_CERTS=${OVERRIDE_EDGE_CERTS:-"true"}
+    export OVERRIDE_EDGE_CERTS=${OVERRIDE_EDGE_CERTS:-"false"}
 
-    export CIS_WAF=${CIS_WAF:-"true"}
-    export UPDATE_DNS_ENTRIES=${UPDATE_DNS_ENTRIES:-"true"}
-    export DELETE_WILDCARDS=${DELETE_WILDCARDS:-"true"}
+    export CIS_WAF=${CIS_WAF:-"false"}
+    export UPDATE_DNS_ENTRIES=${UPDATE_DNS_ENTRIES:-"false"}
+    export DELETE_WILDCARDS=${DELETE_WILDCARDS:-"false"}
 
     export DOMAIN=${CIS_MAS_DOMAIN}
     # Disable provision public ingress controller by default

--- a/image/cli/mascli/functions/gitops_suite
+++ b/image/cli/mascli/functions/gitops_suite
@@ -437,13 +437,13 @@ function gitops_suite() {
 
   export DOMAIN=${MAS_DOMAIN}
   if [[ "${DNS_PROVIDER}" == "cis" ]]; then
-    export CIS_ENHANCED_SECURITY=${CIS_ENHANCED_SECURITY:-"false"}
+    export CIS_ENHANCED_SECURITY=${CIS_ENHANCED_SECURITY:-"true"}
     export CIS_PROXY=${CIS_PROXY:-"false"}
-    export OVERRIDE_EDGE_CERTS=${OVERRIDE_EDGE_CERTS:-"false"}
+    export OVERRIDE_EDGE_CERTS=${OVERRIDE_EDGE_CERTS:-"true"}
 
-    export CIS_WAF=${CIS_WAF:-"false"}
-    export UPDATE_DNS_ENTRIES=${UPDATE_DNS_ENTRIES:-"false"}
-    export DELETE_WILDCARDS=${DELETE_WILDCARDS:-"false"}
+    export CIS_WAF=${CIS_WAF:-"true"}
+    export UPDATE_DNS_ENTRIES=${UPDATE_DNS_ENTRIES:-"true"}
+    export DELETE_WILDCARDS=${DELETE_WILDCARDS:-"true"}
 
     export DOMAIN=${CIS_MAS_DOMAIN}
     # Disable provision public ingress controller by default

--- a/tekton/src/tasks/gitops/gitops-suite.yml.j2
+++ b/tekton/src/tasks/gitops/gitops-suite.yml.j2
@@ -266,6 +266,27 @@ spec:
         export CUSTOM_LABELS=$(echo "${CUSTOM_LABELS}" | yq --output-format yaml)
         echo " CUSTOM_LABELS = ${CUSTOM_LABELS}"
 
+        # Tekton interprets false (boolean) values as the string ""
+        # The gitops-suite function defaults the following flags to "true" when their value is ""
+        # We'll fix this here by setting these values to "false" explicitly before we call
+        # (these are all required parameters in the pipeline so we don't have to worry about
+        # any impliciations of changing their defaults in this task)
+        if [[ -z "${CIS_ENHANCED_SECURITY}" ]]; then
+          CIS_ENHANCED_SECURITY="false"
+        fi
+        if [[ -z "${OVERRIDE_EDGE_CERTS}" ]]; then
+          OVERRIDE_EDGE_CERTS="false"
+        fi
+        if [[ -z "${CIS_WAF}" ]]; then
+          CIS_WAF="false"
+        fi
+        if [[ -z "${UPDATE_DNS_ENTRIES}" ]]; then
+          UPDATE_DNS_ENTRIES="false"
+        fi
+        if [[ -z "${DELETE_WILDCARDS}" ]]; then
+          DELETE_WILDCARDS="false"
+        fi
+
         sed -n -e 's/^.*api.fvtsaas.//p' | cut -d: -f1
         mkdir -p /tmp/init-suite
         mas gitops-suite -a $ACCOUNT -c $CLUSTER_NAME -m $MAS_INSTANCE_ID \


### PR DESCRIPTION
# Description

This is due to the fact that Tekton does not actually support type: boolean params as inputs . When a boolean parameter is encountered in the input, true -> "true" but false -> "".

The defaulting behaviour in the [gitops-suite function](https://github.com/ibm-mas/cli/blob/cb67ca9eb795292ade449f942734856602219310/image/cli/mascli/functions/gitops_suite#L439) for the dns.cis properties was not compatible with this; there was no way of setting them to false via the pipelines.


If set to `false` in the pipelines, they would be passed into the script as `""`. E.g. 

`mas-instance-params.yaml`:
```yaml
dns:
   cis:
      enhanced_security: false
```

results in `""` being passed to the `CIS_ENHANCED_SECURITY` env var of the gitops-suite task pod.

In the script:
```
CIS_ENHANCED_SECURITY=${CIS_ENHANCED_SECURITY:-"true"}
```
`CIS_ENHANCED_SECURITY` evaluates to `"true"`


This PR fixes this issue by adding some logic into the gitops-suite Task definition to ensure that "" is mapped to false. NOTE: we are not changing the defaulting behaviour of the gitops-suite function itself (so we don't have to worry about affecting other users of the function).

Since these are required properties of mas-instance-params.yaml (when `dns.cis` is specified):
![image](https://github.com/user-attachments/assets/bdc533e3-facd-49b0-8e06-763e138e92e9)
([schema docs](https://github.ibm.com/maximoappsuite/saas-deploy-py/blob/master/schema_docs/mas-instance.md#dns_cis)) changing their defaulting behaviour in the pipelines (only) will not have any unintended consequences.

https://jsw.ibm.com/browse/MASCORE-6261


# Testing

## all false

mas-instance-params.yaml:
```
dns:
  cis:
    enhanced_security: false
    proxy: false
    waf: false
    update_dns_entries: false
    delete_wildcards: false
    override_edge_certs: false
```

[gitops-suite task run](https://cloud.ibm.com/devops/pipelines/tekton/8445f6a9-217b-4ceb-92e8-d3c25dd9fc22/runs/48f6907b-b4b3-4fdc-b9ab-906533975328/gitops-suite/gitops-suite?env_id=ibm:yp:us-south)

merged_params:
```
   "dns": {
      "cis": {
        "enhanced_security": false,
        "proxy": false,
        "waf": false,
        "update_dns_entries": false,
        "delete_wildcards": false,
        "override_edge_certs": false
      }
    }
```

gitops-suite log:
```
    CIS enhanced security Flag...... false
    CIS WAF ........................ false
    CIS proxy ...................... false
    Update DNS entries Flag ........ false
    DELETE_WILDCARDS Flag .......... false
    OVERRIDE_EDGE_CERTS Flag ....... false
```

## all true

mas-instance-params.yaml:
```
dns:
  cis:
    enhanced_security: true
    proxy: true
    waf: true
    update_dns_entries: true
    delete_wildcards: true
    override_edge_certs: true
```

[gitops-suite task run](https://cloud.ibm.com/devops/pipelines/tekton/8445f6a9-217b-4ceb-92e8-d3c25dd9fc22/runs/b8202eb6-0359-4dce-9b7f-bbe3070c22a7/gitops-suite/gitops-suite?env_id=ibm:yp:us-south)

merged_params:
```
   "dns": {
      "cis": {
        "enhanced_security": true,
        "proxy": true,
        "waf": true,
        "update_dns_entries": true,
        "delete_wildcards": true,
        "override_edge_certs": true
      }
    }
```

gitops-suite log:
```
    CIS enhanced security Flag...... true
    CIS WAF ........................ true
    CIS proxy ...................... true
    Update DNS entries Flag ........ true
    DELETE_WILDCARDS Flag .......... true
    OVERRIDE_EDGE_CERTS Flag ....... true
```
