### PR TITLE
[patch] Fix check for specific mas instance for argocd deny window 

### DIFF
--- a/tekton/src/tasks/gitops/gitops-mas-fvt-preparer.yml.j2
+++ b/tekton/src/tasks/gitops/gitops-mas-fvt-preparer.yml.j2
@@ -557,7 +557,7 @@ spec:
 
         # Remove argocd window
         argocd_login
-        ARGOWINDOW=$(argocd proj windows list mas | grep "*.$MAS_INSTANCE_ID" | cut -c1-1)
+        ARGOWINDOW=$(argocd proj windows list mas | grep "*.$MAS_INSTANCE_ID\b" | cut -c1-1)
         echo "argo:argocd proj windows delete mas $ARGOWINDOW"
         argocd proj windows delete mas $ARGOWINDOW
 


### PR DESCRIPTION
When there is more than one sync window in argo, and the name of the instance could match more than one, then it will error. Change the grep call so we only get the exact match for *.$MAS_INSTANCE_ID