### PR TITLE
[patch] Update gitops bootstrap for latest gitops operator + avp plugin

### DIFF
--- a/image/cli/mascli/functions/gitops_utils
+++ b/image/cli/mascli/functions/gitops_utils
@@ -723,7 +723,7 @@ function argocd_login() {
       exit 1
     fi
     echo "argo:argocd_login : ARGOCD_URL=$ARGOCD_URL ARGOCD_USERNAME=$ARGOCD_USERNAME ARGOCD_PASSWORD=${ARGOCD_PASSWORD:0:8}<snip> ..."
-    argocd login $ARGOCD_URL --username $ARGOCD_USERNAME --password $ARGOCD_PASSWORD --insecure --skip-test-tls
+    argocd login $ARGOCD_URL --username $ARGOCD_USERNAME --password $ARGOCD_PASSWORD --insecure --skip-test-tls --grpc-web
     return_code=$?
     echo "argo:argocd_login : return_code=$return_code"
 
@@ -746,7 +746,7 @@ function argocd_sync(){
   APP_NAME=$1
   echo
   echo "Force Application $APP_NAME to Sync ..."
-  argocd app sync $APP_NAME --force --timeout 30 --assumeYes
+  argocd app sync $APP_NAME --force --timeout 30 --assumeYes --grpc-web
   RC=$?
   echo "ArgoCD response for Force Application $APP_NAME to Sync: $RC"
 }
@@ -754,7 +754,7 @@ function argocd_sync(){
 function argocd_prune_sync(){
   APP_NAME=$1
   echo "Force Application $APP_NAME to Sync with --prune ..."
-  argocd app sync $APP_NAME --prune
+  argocd app sync $APP_NAME --prune --grpc-web
   RC=$?
   echo "ArgoCD response for Force Application $APP_NAME to Sync with --prune: $RC"
 }
@@ -762,7 +762,7 @@ function argocd_prune_sync(){
 function argocd_hard_refresh(){
   APP_NAME=$1
   echo "Force Application $APP_NAME to hard refresh ..."
-  argocd app get $APP_NAME --hard-refresh
+  argocd app get $APP_NAME --hard-refresh --grpc-web
   RC=$?
   echo "ArgoCD response for Force Application $APP_NAME to hard refresh: $RC"
 }

--- a/image/cli/mascli/templates/gitops/bootstrap/argocd.yaml
+++ b/image/cli/mascli/templates/gitops/bootstrap/argocd.yaml
@@ -1399,7 +1399,7 @@ spec:
           - '-c'
         env:
           - name: AVP_VERSION
-            value: 1.11.0
+            value: 1.18.1
         image: registry.access.redhat.com/ubi8
         name: download-tools
         securityContext:

--- a/image/cli/mascli/templates/gitops/bootstrap/subscription.yaml
+++ b/image/cli/mascli/templates/gitops/bootstrap/subscription.yaml
@@ -5,7 +5,7 @@ metadata:
   name: openshift-gitops
   namespace: openshift-operators
 spec:
-    channel: gitops-1.13
+    channel: gitops-1.16
     installPlanApproval: Automatic
     name: openshift-gitops-operator
     source: redhat-operators

--- a/tekton/src/tasks/gitops/gitops-mas-fvt-preparer.yml.j2
+++ b/tekton/src/tasks/gitops/gitops-mas-fvt-preparer.yml.j2
@@ -543,8 +543,8 @@ spec:
           WINDOW_DURATION=4
         fi
 
-        echo "argo:argocd proj windows add mas --kind deny --schedule * * * * * --duration ${WINDOW_DURATION}h --applications *"  
-        argocd proj windows add mas --kind deny --schedule "* * * * *" --duration ${WINDOW_DURATION}h --applications "*.$MAS_INSTANCE_ID"
+        echo "argo:argocd proj windows add mas --kind deny --schedule * * * * * --duration ${WINDOW_DURATION}h --applications *.$CLUSTER_NAME.$MAS_INSTANCE_ID.*,*.$CLUSTER_NAME.$MAS_INSTANCE_ID,$MAS_INSTANCE_ID-*"  
+        argocd proj windows add mas --kind deny --schedule "* * * * *" --duration ${WINDOW_DURATION}h --applications "*.$CLUSTER_NAME.$MAS_INSTANCE_ID.*,*.$CLUSTER_NAME.$MAS_INSTANCE_ID,$MAS_INSTANCE_ID-*" --grpc-web
 
         UNESCAPED_LDAP_CRT=$(</workspace/shared-additional-configs/ldap_masdeps1_cert.pem)
         ESCAPED_LDAP_CRT=${UNESCAPED_LDAP_CRT//\"/\\\"}
@@ -557,9 +557,9 @@ spec:
 
         # Remove argocd window
         argocd_login
-        ARGOWINDOW=$(argocd proj windows list mas | grep "*.$MAS_INSTANCE_ID\b" | cut -c1-1)
+        ARGOWINDOW=$(argocd proj windows list mas | grep "$CLUSTER_NAME.$MAS_INSTANCE_ID\b" | cut -c1-1)
         echo "argo:argocd proj windows delete mas $ARGOWINDOW"
-        argocd proj windows delete mas $ARGOWINDOW
+        argocd proj windows delete mas $ARGOWINDOW --grpc-web
 
         # Set auto_delete: true, to allow ArgoCD to automatically delete resources when the deprovision pipelines run
         if [[ "$LAUNCHER_ID" == "apps" ]]; then
@@ -567,7 +567,7 @@ spec:
           CLUSTER_ROOT_APP="cluster.${CLUSTER_NAME}"
           INSTANCE_ROOT_APP="instance.${CLUSTER_NAME}.${MAS_INSTANCE_ID}"
 
-          argocd app set ${ACCOUNT_ROOT_APP} --parameter auto_delete=true
+          argocd app set ${ACCOUNT_ROOT_APP} --parameter auto_delete=true --grpc-web
 
           # wait for the root apps to sync to make sure the setting has been applied everywhere
           check_argo_app_synced "${ACCOUNT_ROOT_APP}"


### PR DESCRIPTION
Updates the gitops bootstrap code to use the latest gitops-operator subscription channel which causes ArgoCD 2.14.7 to be deployed. Also updates the AVP plugin to the latest 1.18.1 https://github.com/argoproj-labs/argocd-vault-plugin/releases level.

Deployed in noble6 and ArgoCD still functioning as expected and apps can be synced via the new AVP plugin

![image- 2025-04-07 at 17 09 55@2x](https://github.com/user-attachments/assets/b5089bf4-ce13-4335-af5a-28f9989eacc2)
