### PR TITLE
[doc] add known issue in April patch

### DIFF
--- a/docs/catalogs/v9-250403-amd64.md
+++ b/docs/catalogs/v9-250403-amd64.md
@@ -29,6 +29,8 @@ Known Issues
 - Customers using Maximo Assist v8.7 or v8.8 should not update and must instead contact IBM Support for guidance regarding the removal of IBM Watson Discovery and upgrading to Maximo Assist v9.0
 - If your Maximo usage is significantly reliant on Maximo Mobile / Maximo's Role Based Applications, it is advised to bypass this Patch 9.0.11 release and await the subsequent patch release for 9.0.12 . Due to the recently encountered issue, this particular patch may not function as intended for Maximo Mobile/Role Based Applications' work order Change Status feature if you have industry solutions layered on top of the core Manage. However, if you still need to apply this patch, we can offer a Limited Availability Fix (LA Fix) in the event you encounter this issue. Please note that you will need to submit a LA Fix request for this
 
+You can click the link below for further details. https://www.ibm.com/support/pages/bmxaa9238e-when-changing-status-wo-after-applying-managemobile-9011
+
 Manual Installation
 -------------------------------------------------------------------------------
 `oc apply -f https://raw.githubusercontent.com/ibm-mas/cli/master/catalogs/v9-250403-amd64.yaml`

--- a/docs/catalogs/v9-250403-amd64.md
+++ b/docs/catalogs/v9-250403-amd64.md
@@ -28,7 +28,7 @@ Known Issues
 -------------------------------------------------------------------------------
 - Customers using Maximo Assist v8.7 or v8.8 should not update and must instead contact IBM Support for guidance regarding the removal of IBM Watson Discovery and upgrading to Maximo Assist v9.0
 - If your Maximo usage is significantly reliant on Maximo Mobile / Maximo's Role Based Applications, it is advised to bypass this Patch 9.0.11 release and await the subsequent patch release for 9.0.12 . Due to the recently encountered issue, this particular patch may not function as intended for Maximo Mobile/Role Based Applications' work order Change Status feature if you have industry solutions layered on top of the core Manage. However, if you still need to apply this patch, we can offer a Limited Availability Fix (LA Fix) in the event you encounter this issue. Please note that you will need to submit a LA Fix request for this
-- You can click the link below for further details. <a href="https://www.ibm.com/support/pages/bmxaa9238e-when-changing-status-wo-after-applying-managemobile-9011"> </a>
+- You can click the link below for further details. <a href="https://www.ibm.com/support/pages/bmxaa9238e-when-changing-status-wo-after-applying-managemobile-9011"> www.ibm.com/support/pages/bmxaa9238e-when-changing-status-wo-after-applying-managemobile-9011 </a>
 
 Manual Installation
 -------------------------------------------------------------------------------

--- a/docs/catalogs/v9-250403-amd64.md
+++ b/docs/catalogs/v9-250403-amd64.md
@@ -28,7 +28,7 @@ Known Issues
 -------------------------------------------------------------------------------
 - Customers using Maximo Assist v8.7 or v8.8 should not update and must instead contact IBM Support for guidance regarding the removal of IBM Watson Discovery and upgrading to Maximo Assist v9.0
 - If your Maximo usage is significantly reliant on Maximo Mobile / Maximo's Role Based Applications, it is advised to bypass this Patch 9.0.11 release and await the subsequent patch release for 9.0.12 . Due to the recently encountered issue, this particular patch may not function as intended for Maximo Mobile/Role Based Applications' work order Change Status feature if you have industry solutions layered on top of the core Manage. However, if you still need to apply this patch, we can offer a Limited Availability Fix (LA Fix) in the event you encounter this issue. Please note that you will need to submit a LA Fix request for this
-- You can click the link below for further details. https://www.ibm.com/support/pages/bmxaa9238e-when-changing-status-wo-after-applying-managemobile-9011
+- You can click the link below for further details. <a href="https://www.ibm.com/support/pages/bmxaa9238e-when-changing-status-wo-after-applying-managemobile-9011"> </a>
 
 Manual Installation
 -------------------------------------------------------------------------------

--- a/docs/catalogs/v9-250403-amd64.md
+++ b/docs/catalogs/v9-250403-amd64.md
@@ -27,7 +27,7 @@ What's New
 Known Issues
 -------------------------------------------------------------------------------
 - Customers using Maximo Assist v8.7 or v8.8 should not update and must instead contact IBM Support for guidance regarding the removal of IBM Watson Discovery and upgrading to Maximo Assist v9.0
-
+- If your Maximo usage is significantly reliant on Maximo Mobile / Maximo's Role Based Applications, it is advised to bypass this Patch 9.0.11 release and await the subsequent patch release for 9.0.12 . Due to the recently encountered issue, this particular patch may not function as intended for Maximo Mobile/Role Based Applications' work order Change Status feature if you have industry solutions layered on top of the core Manage. However, if you still need to apply this patch, we can offer a Limited Availability Fix (LA Fix) in the event you encounter this issue. Please note that you will need to submit a LA Fix request for this
 
 Manual Installation
 -------------------------------------------------------------------------------

--- a/docs/catalogs/v9-250403-amd64.md
+++ b/docs/catalogs/v9-250403-amd64.md
@@ -28,8 +28,7 @@ Known Issues
 -------------------------------------------------------------------------------
 - Customers using Maximo Assist v8.7 or v8.8 should not update and must instead contact IBM Support for guidance regarding the removal of IBM Watson Discovery and upgrading to Maximo Assist v9.0
 - If your Maximo usage is significantly reliant on Maximo Mobile / Maximo's Role Based Applications, it is advised to bypass this Patch 9.0.11 release and await the subsequent patch release for 9.0.12 . Due to the recently encountered issue, this particular patch may not function as intended for Maximo Mobile/Role Based Applications' work order Change Status feature if you have industry solutions layered on top of the core Manage. However, if you still need to apply this patch, we can offer a Limited Availability Fix (LA Fix) in the event you encounter this issue. Please note that you will need to submit a LA Fix request for this
-
-You can click the link below for further details. https://www.ibm.com/support/pages/bmxaa9238e-when-changing-status-wo-after-applying-managemobile-9011
+- You can click the link below for further details. https://www.ibm.com/support/pages/bmxaa9238e-when-changing-status-wo-after-applying-managemobile-9011
 
 Manual Installation
 -------------------------------------------------------------------------------


### PR DESCRIPTION
Add Alert into Known issue for the April patch:

```
If your Maximo usage is significantly reliant on Maximo Mobile / Maximo's Role Based Applications, it is advised to bypass this Patch 9.0.11 release and await the subsequent patch release for 9.0.12 . Due to the recently encountered issue, this particular patch may not function as intended for Maximo Mobile/Role Based Applications' work order Change Status feature if you have industry solutions layered on top of the core Manage. However, if you still need to apply this patch, we can offer a Limited Availability Fix (LA Fix) in the event you encounter this issue. Please note that you will need to submit a LA Fix request for this
```