### PR TITLE
[minor] Updates for OCP v4.17 support in new catalog

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2025-04-14T16:21:42Z",
+  "generated_at": "2025-04-15T02:39:35Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -384,7 +384,7 @@
         "hashed_secret": "2582aea6f911bd00fc04cb25e0ec16d5ead62068",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 311,
+        "line_number": 321,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2025-04-03T07:53:34Z",
+  "generated_at": "2025-04-14T16:21:42Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -384,7 +384,7 @@
         "hashed_secret": "2582aea6f911bd00fc04cb25e0ec16d5ead62068",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 307,
+        "line_number": 311,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -394,7 +394,7 @@
         "hashed_secret": "e62334bcf07206e5aacba407fb29c1b85540d61f",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 207,
+        "line_number": 211,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/docs/catalogs/v9-250501-amd64.md
+++ b/docs/catalogs/v9-250501-amd64.md
@@ -13,6 +13,7 @@ Details
 
 What's New tbc
 -------------------------------------------------------------------------------
+-  **Openshift 4.17 support** Openshift Container Platform 4.17 support has been added. Refer OCP 4.17 release notes [here](https://docs.openshift.com/container-platform/4.17/release_notes/ocp-4-17-release-notes.html)
 - **Security updates and bug fixes**
     - IBM Maximo Application Suite Core Platform v8.10, v8.11, v9.0
     - IBM Maximo IoT v8.7, v8.8 and v9.0
@@ -64,6 +65,13 @@ IBM Maximo Application Suite customers receive a standard Red Hat OpenShift Cont
     <th>Standard Support</th>
     <th>Extended Support</th>
     <th>Supported MAS Releases</th>
+  </tr>
+  <tr>
+    <td class="firstColumn">4.17</td>
+    <td>October 1, 2024</td>
+    <td>April 1, 2026</td>
+    <td>N/A</td>
+    <td>8.10 - 9.0</td>
   </tr>
   <tr>
     <td class="firstColumn">4.16</td>

--- a/docs/catalogs/v9-250501-s390x.md
+++ b/docs/catalogs/v9-250501-s390x.md
@@ -17,6 +17,7 @@ Details
 
 What's New
 -------------------------------------------------------------------------------
+-  **Openshift 4.17 support** Openshift Container Platform 4.17 support has been added. Refer OCP 4.17 release notes [here](https://docs.openshift.com/container-platform/4.17/release_notes/ocp-4-17-release-notes.html)
 - **Security updates and bug fixes**
     - IBM Maximo Application Suite Core Platform v9.0
     - IBM Maximo Manage v9.0
@@ -57,6 +58,13 @@ IBM Maximo Application Suite customers receive a standard Red Hat OpenShift Cont
     <th>Standard Support</th>
     <th>Extended Support</th>
     <th>Supported MAS Releases</th>
+  </tr>
+  <tr>
+    <td class="firstColumn">4.17</td>
+    <td>October 1, 2024</td>
+    <td>April 1, 2026</td>
+    <td>N/A</td>
+    <td>8.10 - 9.0</td>
   </tr>
   <tr>
     <td class="firstColumn">4.16</td>

--- a/image/cli/mascli/functions/mirror_redhat
+++ b/image/cli/mascli/functions/mirror_redhat
@@ -135,9 +135,10 @@ function mirror_redhat_interactive() {
   echo "${TEXT_DIM}Select the release to mirror content for:"
 
   echo "Supported OCP Releases:"
-  echo "  1) 4.16"
-  echo "  2) 4.15"
-  echo "  3) 4.14"
+  echo "  1) 4.17"
+  echo "  2) 4.16"
+  echo "  3) 4.15"
+  echo "  4) 4.14"
   reset_colors
 
   echo
@@ -145,12 +146,15 @@ function mirror_redhat_interactive() {
 
   case $OCP_RELEASE_SELECTION in
     1)
-      OCP_RELEASE=4.16
+      OCP_RELEASE=4.17
       ;;
     2)
-      OCP_RELEASE=4.15
+      OCP_RELEASE=4.16
       ;;
     3)
+      OCP_RELEASE=4.15
+      ;;
+    4)
       OCP_RELEASE=4.14
       ;;
     *)

--- a/image/cli/mascli/functions/provision_aws
+++ b/image/cli/mascli/functions/provision_aws
@@ -15,7 +15,7 @@ AWS Credentials (Required):
 
 Cluster Configuration (Required):
   -c, --cluster-name ${COLOR_YELLOW}CLUSTER_NAME${TEXT_RESET}               Name of the cluster to be provisioned
-  -v, --ocp-version ${COLOR_YELLOW}OCP_VERSION${TEXT_RESET}                 OCP version to use (e.g 4.15_openshift, 4.16_openshift)
+  -v, --ocp-version ${COLOR_YELLOW}OCP_VERSION${TEXT_RESET}                 OCP version to use (e.g 4.17_openshift, 4.16_openshift)
 
 IPI Configuration (Required):
   -r, --region-name ${COLOR_YELLOW}IPI_REGION${TEXT_RESET}                  Region of the cluster to be provisioned (e.g. us-east-1, us-east-2)
@@ -153,19 +153,23 @@ function provision_aws_interactive() {
   # prompt_ocp_version                  # OCP_VERSION
   echo
   echo "OCP Version:"
-  echo "  1. 4.16 (MAS 8.10-9.0)"
-  echo "  2. 4.15 (MAS 8.10-9.0)"
-  echo "  3. 4.14 (MAS 8.10-9.0)"
+  echo "  1. 4.17 (MAS 8.10-9.0)"
+  echo "  2. 4.16 (MAS 8.10-9.0)"
+  echo "  3. 4.15 (MAS 8.10-9.0)"
+  echo "  4. 4.14 (MAS 8.10-9.0)"
   prompt_for_input "Select Version" OCP_VERSION_SELECTION "1"
 
   case $OCP_VERSION_SELECTION in
-    1|4.16)
+    1|4.17)
+      export OCP_VERSION=latest-4.17
+      ;;
+    2|4.16)
       export OCP_VERSION=latest-4.16
       ;;
-    2|4.15)
+    3|4.15)
       export OCP_VERSION=latest-4.15
       ;;
-    3|4.14)
+    4|4.14)
       export OCP_VERSION=latest-4.14
       ;;
     *)

--- a/image/cli/mascli/functions/provision_fyre
+++ b/image/cli/mascli/functions/provision_fyre
@@ -19,7 +19,7 @@ Cluster Configuration (Required):
   -q, --quota-type ${COLOR_YELLOW}FYRE_QUOTA_TYPE${TEXT_RESET}        Declare the quota to use when provisioning the cluster ("quick_burn" or "product_group")
   -c, --cluster-name ${COLOR_YELLOW}CLUSTER_NAME${TEXT_RESET}         Name of the cluster to be provisioned (lowercase only)
   -t, --cluster-platform ${COLOR_YELLOW}CLUSTER_PLATFORM${TEXT_RESET} Cluster platform ("x", "p", "pvm", "z", default is "x")
-  -v, --ocp-version ${COLOR_YELLOW}OCP_VERSION${TEXT_RESET}           OCP version to use (e.g 4.15, 4.16)
+  -v, --ocp-version ${COLOR_YELLOW}OCP_VERSION${TEXT_RESET}           OCP version to use (e.g 4.15, 4.16, 4.17)
   -d, --description ${COLOR_YELLOW}FYRE_DESCRIPTION${TEXT_RESET}      Description of the OCP cluster
   -l, --location ${COLOR_YELLOW}FYRE_SITE${TEXT_RESET}                FYRE site where cluster will be provisioned (default is "svl")
 
@@ -169,19 +169,23 @@ function provision_fyre_interactive() {
 
   echo
   echo "OCP Version:"
-  echo "  1. 4.16"
-  echo "  2. 4.15"
-  echo "  3. 4.14"
+  echo "  1. 4.17"
+  echo "  2. 4.16"
+  echo "  3. 4.15"
+  echo "  4. 4.14"
   prompt_for_input "Select Version" OCP_VERSION_SELECTION "1"
 
   case $OCP_VERSION_SELECTION in
-    1|4.16)
+    1|4.17)
+      export OCP_VERSION=4.17
+      ;;
+    2|4.16)
       export OCP_VERSION=4.16
       ;;
-    2|4.15)
+    3|4.15)
       export OCP_VERSION=4.15
       ;;
-    3|4.14)
+    4|4.14)
       export OCP_VERSION=4.14
       ;;
     *)

--- a/image/cli/mascli/functions/provision_roks
+++ b/image/cli/mascli/functions/provision_roks
@@ -15,7 +15,7 @@ IBMCloud Credentials (Required):
 Cluster Configuration (Required):
   -r, --resource-group ${COLOR_YELLOW}IBMCLOUD_RESOURCEGROUP${TEXT_RESET}   IBMCloud resource group to deploy the cluster in
   -c, --cluster-name ${COLOR_YELLOW}CLUSTER_NAME${TEXT_RESET}               Name of the cluster to be provisioned
-  -v, --ocp-version ${COLOR_YELLOW}OCP_VERSION${TEXT_RESET}                 OCP version to use (e.g 4.16_openshift, 4.15_openshift)
+  -v, --ocp-version ${COLOR_YELLOW}OCP_VERSION${TEXT_RESET}                 OCP version to use (e.g 4.17_openshift, 4.16_openshift)
 
 Worker Node Configuration (Required):
       --worker-count ${COLOR_YELLOW}ROKS_WORKERS${TEXT_RESET}               Number of worker nodes to provision
@@ -123,19 +123,23 @@ function provision_roks_interactive() {
 
   echo
   echo "OCP Version:"
-  echo "  1. 4.16 (MAS 8.10-9.0)"
-  echo "  2. 4.15 (MAS 8.10-9.0)"
-  echo "  3. 4.14 (MAS 8.10-9.0)"
+  echo "  1. 4.17 (MAS 8.10-9.0)"
+  echo "  2. 4.16 (MAS 8.10-9.0)"
+  echo "  3. 4.15 (MAS 8.10-9.0)"
+  echo "  4. 4.14 (MAS 8.10-9.0)"
   prompt_for_input "Select Version" OCP_VERSION_SELECTION "1"
 
   case $OCP_VERSION_SELECTION in
-    1|4.16)
+    1|4.17)
+      export OCP_VERSION=4.17_openshift
+      ;;
+    2|4.16)
       export OCP_VERSION=4.16_openshift
       ;;
-    2|4.15)
+    3|4.15)
       export OCP_VERSION=4.15_openshift
       ;;
-    3|4.14)
+    4|4.14)
       export OCP_VERSION=4.14_openshift
       ;;
 

--- a/python/src/mas/cli/install/settings/db2Settings.py
+++ b/python/src/mas/cli/install/settings/db2Settings.py
@@ -138,8 +138,8 @@ class Db2SettingsMixin():
                     f"Note that the same settings are applied to both the IoT and {self.manageAppName} Db2 instances",
                     "Use existing node labels and taints to control scheduling of the Db2 workload in your cluster",
                     "For more information refer to the Red Hat documentation:",
-                    " - <Orange><u>https://docs.openshift.com/container-platform/4.16/nodes/scheduling/nodes-scheduler-node-affinity.html</u></Orange>",
-                    " - <Orange><u>https://docs.openshift.com/container-platform/4.16/nodes/scheduling/nodes-scheduler-taints-tolerations.html</u></Orange>"
+                    " - <Orange><u>https://docs.openshift.com/container-platform/4.17/nodes/scheduling/nodes-scheduler-node-affinity.html</u></Orange>",
+                    " - <Orange><u>https://docs.openshift.com/container-platform/4.17/nodes/scheduling/nodes-scheduler-taints-tolerations.html</u></Orange>"
                 ])
 
                 if self.yesOrNo("Configure node affinity"):


### PR DESCRIPTION
Updated below files as part of OCP v4.17 support:

Ref : https://jsw.ibm.com/browse/MASCORE-5253

docs/catalogs/v9-250501-amd64.md
docs/catalogs/v9-250501-s390x.md
image/cli/mascli/functions/mirror_redhat
image/cli/mascli/functions/provision_aws
image/cli/mascli/functions/provision_fyre
image/cli/mascli/functions/provision_roks
python/src/mas/cli/install/settings/db2Settings.py

