### PR TITLE
[patch] Rename authorization services tests

### DIFF
--- a/tekton/src/pipelines/taskdefs/fvt-manage/phase1.yml.j2
+++ b/tekton/src/pipelines/taskdefs/fvt-manage/phase1.yml.j2
@@ -17,11 +17,11 @@
   runAfter:
     - ivtcore-manage
     
-- name: fvt-manage-authorization-services
+- name: fvt-manage-foundation-api-auth
   {{ lookup('template', pipeline_src_dir ~ '/taskdefs/fvt-manage/api/taskref.yml.j2') | indent(2) }}
   params:
     {{ lookup('template', pipeline_src_dir ~ '/taskdefs/fvt-manage/api/params.yml.j2') | indent(4) }}
     - name: fvt_test_suite
-      value: authorization-services
+      value: foundation-api-auth
   runAfter:
     - ivtcore-manage

--- a/tekton/src/pipelines/taskdefs/fvt-manage/phase2.yml.j2
+++ b/tekton/src/pipelines/taskdefs/fvt-manage/phase2.yml.j2
@@ -13,7 +13,7 @@
       value: base-api-system
   runAfter:
     - fvt-manage-base-api-ivt
-    - fvt-manage-authorization-services
+    - fvt-manage-foundation-api-auth
 
 # Manage FVT MIF
 - name: fvt-manage-base-api-mif
@@ -24,4 +24,4 @@
       value: base-api-mif
   runAfter:
     - fvt-manage-base-api-ivt
-    - fvt-manage-authorization-services
+    - fvt-manage-foundation-api-auth


### PR DESCRIPTION
Added new tests for authorization services in the FVT-Manage pipeline, using the updated naming convention as per the defined pattern

test result:
![image](https://github.com/user-attachments/assets/56d0d997-430c-4b10-9008-690178bb12dd)

