### PR TITLE
[patch] Increase the time to wait for mongo argo app in FVT gitops

### DIFF
--- a/tekton/src/tasks/gitops/gitops-mas-fvt-preparer.yml.j2
+++ b/tekton/src/tasks/gitops/gitops-mas-fvt-preparer.yml.j2
@@ -405,7 +405,7 @@ spec:
           WORKSPACE_APP="${MAS_WORKSPACE_ID}.suite.${CLUSTER_NAME}.${MAS_INSTANCE_ID}"
 
           check_argo_app_healthy "${SLS_APP_NAME}" 180 #90 minutes
-          check_argo_app_healthy "${MONGO_CONFIG_APP}" 30 #15 minutes
+          check_argo_app_healthy "${MONGO_CONFIG_APP}" 60 #30 minutes
           check_argo_app_healthy "${SLS_CONFIG_APP}" 30
           check_argo_app_healthy "${BAS_CONFIG_APP}" 30
           check_argo_app_healthy "${SUITE_APP_NAME}" 30


### PR DESCRIPTION
Depending on timing with cert-manager and trust-store manager, the 15 minute wait for mongo app in gitops FVT preparer task is quite close to being breached. Increasing to 30 minutes allow more room for environmental slowness.