### PR TITLE
[patch] update github runner ubuntu-20.04 to ubuntu-24.04

### DIFF
--- a/.github/workflows/build-cli.yml
+++ b/.github/workflows/build-cli.yml
@@ -485,7 +485,7 @@ jobs:
     name: Build Linux CLI
     # We intentionally run on the oldest available Ubuntu runner, as this will result in a binary
     # usable on older and newer versions of linux.
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     if: ${{ !contains(github.event.head_commit.message, '[doc]') }}
     needs:
       - build-tekton

--- a/.github/workflows/build-cli.yml
+++ b/.github/workflows/build-cli.yml
@@ -485,7 +485,7 @@ jobs:
     name: Build Linux CLI
     # We intentionally run on the oldest available Ubuntu runner, as this will result in a binary
     # usable on older and newer versions of linux.
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     if: ${{ !contains(github.event.head_commit.message, '[doc]') }}
     needs:
       - build-tekton


### PR DESCRIPTION
Ref: https://github.com/actions/runner-images/issues/11101

The Ubuntu 20.04 Actions runner image will begin deprecation on 2025-02-01 and will be fully unsupported by 2025-04-15