### PR TITLE
[patch] finalizer fix

### DIFF
--- a/image/cli/app-root/src/finalizer.py
+++ b/image/cli/app-root/src/finalizer.py
@@ -480,7 +480,7 @@ if __name__ == "__main__":
     # -------------------------------------------------------------------------
     try:
         crs = dynClient.resources.get(api_version="sls.ibm.com/v1", kind="LicenseService")
-        cr = crs.get(name="sls", namespace="ibm-sls")
+        cr = crs.get(name="sls", namespace=f"sls-{instanceId}")
         if cr.status and cr.status.versions:
             slsVersion = cr.status.versions.reconciled
             setObject["target.slsVersion"] = slsVersion
@@ -552,7 +552,14 @@ if __name__ == "__main__":
     messageBlocks.append(buildSection(f"Test result summary for *<https://dashboard.masdev.wiotp.sl.hursley.ibm.com/tests/{instanceId}|{instanceId}#{build}>*"))
 
     for product in sorted(result["products"]):
-        version = result["products"][product]["version"]
+
+        try:
+            version = result["products"][product]["version"]
+        except KeyError:
+            print(f"Unable to find version for {product}")
+            version = "unknown"
+
+        print(f"{product} version: {version}")
         tests = 0
         skipped = 0
         errors = 0


### PR DESCRIPTION
Some products do not produce and post a version number to the dashboard, like `ibm-data-dictionary`. That causes the finalizer script to break. 

This pr fixes that probleam and also fixing namespace for sls from ibm-sls to sls-{instanceId} so that information is correctly retrieved.

Successfully tested with image `13.18.0-pre.MAXMOA-8722-finalizer` generated by this branch in `fvt810x`
[mas-fvt-finalize-run-btd25.log](https://github.com/user-attachments/files/19899592/mas-fvt-finalize-run-btd25.log)

Slack thread with test results
https://ibm-watson-iot.slack.com/archives/C07BSLTR6KV/p1745530908424629
