### PR TITLE
[doc] Update image-mirroring.md with updated versions

### DIFF
--- a/docs/guides/image-mirroring.md
+++ b/docs/guides/image-mirroring.md
@@ -302,6 +302,8 @@ docker run -ti --rm -v $LOCAL_DIR:/mnt/registry $REGISTRY_HOST:$REGISTRY_PORT/ib
   </div>
 </div>
 
+!!! note
+    [Mirror Redhat images](https://ibm-mas.github.io/cli/commands/mirror-redhat-images) to install required redhat dependencies for Mas installation to progress.
 
 Storage Requirements
 -------------------------------------------------------------------------------


### PR DESCRIPTION
Missing Redhat mirror images for Mas installation. A lot of our clients are not mirroring redhat images and creating support tickets. Hence i opened a PR to include a note on mirroring redhat images as well