### PR TITLE
[patch] conditionally sending slack messaged based on setFinished

### DIFF
--- a/image/cli/app-root/src/finalizer.py
+++ b/image/cli/app-root/src/finalizer.py
@@ -527,6 +527,10 @@ if __name__ == "__main__":
         print("FVT_SLACK_TOKEN is not set")
         sys.exit(0)
 
+    if setFinished.lower() == "false":
+        print("FVT Run is not yet completed. Skipping slack message with results to report channel")
+        sys.exit(0)
+
     if instanceId.startswith("fvt"):
         # To generate the channel name we remove the "fvt" prefix from the instanceId
         FVT_SLACK_CHANNEL = f"mas-fvtreports-{instanceId.replace('fvt', '')}"


### PR DESCRIPTION
Adding condition to finalizer script so that it only sends slack message with fvt results when `SET_FINISHED="True"`.
The objective is to have only one slack message per fvt run instead of two we get today. Since this task is executed both the `fvt-launcher` and `fvt-finally` pipelines.

**fvt-launcher** pipeline already sets this var to `false` for the _finalize_ task, as seen here:
https://github.com/ibm-mas/cli/blob/master/tekton/src/pipelines/fvt-launcher.yml.j2#L1036-L1037

**fvt-finally** pipeline sets this var to `true` as seen here
https://github.com/ibm-mas/cli/blob/master/tekton/src/pipelines/fvt-finally.yml.j2#L21-L24

Successful test with using tkn command in a fyre cluster:
```
tkn task start mas-fvt-finalize -s pipeline -n mas-mobcicd-pipelines --use-param-defaults --timeout 4h \
-p set_finished="False"
TaskRun started: mas-fvt-finalize-run-t5sbd
```

[mas-fvt-finalize-run-t5sbd-pod-step-finalize.log](https://github.com/user-attachments/files/19949037/mas-fvt-finalize-run-t5sbd-pod-step-finalize.log)
