### PR TITLE
[patch] add policing for problematic cp4d upgrades

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -384,7 +384,7 @@
         "hashed_secret": "2582aea6f911bd00fc04cb25e0ec16d5ead62068",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 328,
+        "line_number": 332,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/python/src/mas/cli/update/app.py
+++ b/python/src/mas/cli/update/app.py
@@ -555,6 +555,21 @@ class UpdateApp(BaseApp):
                         else:
                             self.fatalError("Unable to determine the block storage class used in IBM Cloud Pak for Data")
 
+                        # If running 5.0.x and trying to upgrade to 5.1.0 and ElasticSearch is installed and it is at
+                        # version 2.18.x then we cannot do the upgrade
+                        if (currentCpdVersionMajorMinor == "5.0" and cpdTargetVersion == "5.1.0"):
+                            # get all the statefulsets in the cpd instance namespace that are owned by an Elastic search cluster
+                            statefulsetAPI = self.dynamicClient.resources.get(api_version="apps/v1", kind="StatefulSet")
+                            statefulsets = statefulsetAPI.get().to_dict()["items"]
+                            namespaced = [item for item in statefulsets if item.get("metadata").get("namespace") == cpdInstanceNamespace]
+                            owned = [item for item in namespaced if "ownerReferences" in item.get("metadata") and any(ref.get("kind") == "ElasticsearchCluster" for ref in item.get("metadata").get("ownerReferences"))]
+
+                            # if any images for the pods contain "opencontent-opensearch-2.18" then we can't proceed with the upgrade
+                            specs = [obj["spec"]["template"]["spec"] for obj in owned]
+                            containers = [container for obj in specs for container in obj.get("containers", [])]
+                            if any("opencontent-opensearch-2.18" in container.get("image") for container in containers):
+                                self.fatalError("Unable to update IBM Cloud Pak for Data 5.1.0 on this cluster - Please contact IBM support for assistance")
+
                         # Set the desired storage classes (the same ones already in use)
                         self.setParam("storage_class_rwx", cpdFileStorage)
                         self.setParam("storage_class_rwo", cpdBlockStorage)


### PR DESCRIPTION
CP4D 5.0.0 did not specify a version of elasticsearch. As a result some clusters may be running with 2.17 and others with 2.18 depending on when/how the cluster was installed. CP4D 5.1.0 does specify a version which is 2.17. Therefor we need to fail the upgrade if the CP4D upgrade would result in an elasticsearch downgrade.

Screenshot of what it looks like if trying the upgrade when it will fail:
![image](https://github.com/user-attachments/assets/7b1a2c72-a70c-41e8-aa15-b985827eec66)

