### PR TITLE
[minor] Allow optional spec entries for suite CR in gitops

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2025-04-28T08:17:24Z",
+  "generated_at": "2025-04-30T11:00:30Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -344,7 +344,7 @@
         "hashed_secret": "b2817467154949a61f8e9ad31d1eeaf03221cbfa",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 542,
+        "line_number": 547,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2025-04-24T08:34:58Z",
+  "generated_at": "2025-04-28T08:17:24Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -344,7 +344,7 @@
         "hashed_secret": "b2817467154949a61f8e9ad31d1eeaf03221cbfa",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 537,
+        "line_number": 542,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/image/cli/mascli/functions/gitops_suite
+++ b/image/cli/mascli/functions/gitops_suite
@@ -720,8 +720,10 @@ function gitops_suite() {
 
   # Set Suite Spec additional properties
   # ---------------------------------------------------------------------------
+  ls /workspace/shared-gitops-configs
+  cat $SUITE_SPEC_ADDITIONAL_PROPERTIES_YAML
   if [[ -n "$SUITE_SPEC_ADDITIONAL_PROPERTIES_YAML" && -s "$SUITE_SPEC_ADDITIONAL_PROPERTIES_YAML" ]]; then
-    export SUITE_SPEC_ADDITIONAL_PROPERTIES=$(yq eval '.podTemplates' ${SUITE_SPEC_ADDITIONAL_PROPERTIES_YAML})
+    export SUITE_SPEC_ADDITIONAL_PROPERTIES=$(yq eval ${SUITE_SPEC_ADDITIONAL_PROPERTIES_YAML})
     echo -e "\n - SUITE_SPEC_ADDITIONAL_PROPERTIES CONTENT ............... ${SUITE_SPEC_ADDITIONAL_PROPERTIES}"
   fi
 

--- a/image/cli/mascli/functions/gitops_suite
+++ b/image/cli/mascli/functions/gitops_suite
@@ -720,7 +720,7 @@ function gitops_suite() {
 
   # Set Suite Spec additional properties
   # ---------------------------------------------------------------------------
-  echo_h2 "Generating Suite Spec additional properties'
+  echo_h2 "Generating Suite Spec additional properties"
   ls /workspace/shared-gitops-configs
   echo -e "\n Suite spec yaml - ${SUITE_SPEC_ADDITIONAL_PROPERTIES_YAML}"
   echo -e "\n Display yaml file content"

--- a/image/cli/mascli/functions/gitops_suite
+++ b/image/cli/mascli/functions/gitops_suite
@@ -30,20 +30,21 @@ IBM Suite License Service:
       --sls-install-plan ${COLOR_YELLOW}SLS_INSTALL_PLAN${TEXT_RESET}  IBM Suite License Service Subscription Install Plan ('Automatic' or 'Manual'. Default is 'Automatic')
 
 IBM Maximo Application Suite:
-      --mas-annotations ${COLOR_YELLOW}MAS_ANNOTATIONS${TEXT_RESET}                   MAS Annotations definition in dict format
-      --mas-channel ${COLOR_YELLOW}MAS_CHANNEL${TEXT_RESET}                           MAS Core Platform Subscription Channel
-      --mas-install-plan ${COLOR_YELLOW}MAS_INSTALL_PLAN${TEXT_RESET}                 MAS Core Platform Subscription Install Plan ('Automatic' or 'Manual'. Default is 'Automatic')
-      --mas-domain ${COLOR_YELLOW}MAS_DOMAIN${TEXT_RESET}                             MAS Domain
-      --mas-image-tags ${COLOR_YELLOW}MAS_IMAGE_TAGS${TEXT_RESET}                     MAS Image tags definition in dict format
-      --mas-labels ${COLOR_YELLOW}MAS_LABELS${TEXT_RESET}                             MAS Labels definition in dict format
-      --mas-manual-cert-mgmt ${COLOR_YELLOW}MAS_MANUAL_CERT_MGMT${TEXT_RESET}         MAS Manual Cert Management
-      --mas-manual-certs-yaml ${COLOR_YELLOW}MAS_MANUAL_CERTS_YAML${TEXT_RESET}       YAML file location containing combined MAS Manual Certs of core and all other apps
-      --mas-pod-template-yaml ${COLOR_YELLOW}MAS_POD_TEMPLATE_YAML${TEXT_RESET}       The location of a file containing the POD template
-      --allow-list ${COLOR_YELLOW}ALLOW_LIST${TEXT_RESET}                             List of IPs or CIDR range to whitelist
-      --additional-vpn ${COLOR_YELLOW}ADDITIONAL_VPN{TEXT_RESET}                      Manage additional client VPN
-      --extensions ${COLOR_YELLOW}EXTENSIONS${TEXT_RESET}                             To enable JAVA or 3rd party code extensions
-      --enhanced-dr ${COLOR_YELLOW}ENHANCED_DR${TEXT_RESET}                           To enable Enhanced Disaster Recovery
-      --is-non-shared-cluster ${COLOR_YELLOW}IS_NON_SHARED_CLUSTER${TEXT_RESET}       To enable Non shared cluster
+      --mas-annotations ${COLOR_YELLOW}MAS_ANNOTATIONS${TEXT_RESET}                                              MAS Annotations definition in dict format
+      --mas-channel ${COLOR_YELLOW}MAS_CHANNEL${TEXT_RESET}                                                      MAS Core Platform Subscription Channel
+      --mas-install-plan ${COLOR_YELLOW}MAS_INSTALL_PLAN${TEXT_RESET}                                            MAS Core Platform Subscription Install Plan ('Automatic' or 'Manual'. Default is 'Automatic')
+      --mas-domain ${COLOR_YELLOW}MAS_DOMAIN${TEXT_RESET}                                                        MAS Domain
+      --mas-image-tags ${COLOR_YELLOW}MAS_IMAGE_TAGS${TEXT_RESET}                                                MAS Image tags definition in dict format
+      --mas-labels ${COLOR_YELLOW}MAS_LABELS${TEXT_RESET}                                                        MAS Labels definition in dict format
+      --mas-manual-cert-mgmt ${COLOR_YELLOW}MAS_MANUAL_CERT_MGMT${TEXT_RESET}                                    MAS Manual Cert Management
+      --mas-manual-certs-yaml ${COLOR_YELLOW}MAS_MANUAL_CERTS_YAML${TEXT_RESET}                                  YAML file location containing combined MAS Manual Certs of core and all other apps
+      --mas-pod-template-yaml ${COLOR_YELLOW}MAS_POD_TEMPLATE_YAML${TEXT_RESET}                                  The location of a file containing the POD template
+      --allow-list ${COLOR_YELLOW}ALLOW_LIST${TEXT_RESET}                                                        List of IPs or CIDR range to whitelist
+      --additional-vpn ${COLOR_YELLOW}ADDITIONAL_VPN{TEXT_RESET}                                                 Manage additional client VPN
+      --extensions ${COLOR_YELLOW}EXTENSIONS${TEXT_RESET}                                                        To enable JAVA or 3rd party code extensions
+      --enhanced-dr ${COLOR_YELLOW}ENHANCED_DR${TEXT_RESET}                                                      To enable Enhanced Disaster Recovery
+      --is-non-shared-cluster ${COLOR_YELLOW}IS_NON_SHARED_CLUSTER${TEXT_RESET}                                  To enable Non shared cluster
+      --suite-spec-additional-properties-yaml ${COLOR_YELLOW}SUITE_SPEC_ADDITIONAL_PROPERTIES_YAML${TEXT_RESET}  Additional properties to be set in Suite CR
 
       Below is a sample yaml file template representing manual_certs dictionary ( key: << value base64 encoded content of cert file >>) 
       where key is <<app>>_<<filename . replaced by _>> name and value will be base64 encoded of the respective ca/tls file, 
@@ -224,6 +225,9 @@ function gitops_suite_noninteractive() {
 
       --mas-wipe-mongo-data)
         export MAS_WIPE_MONGO_DATA=$1 && shift
+        ;;
+      --suite-spec-additional-properties-yaml)
+        export SUITE_SPEC_ADDITIONAL_PROPERTIES_YAML=$1 && shift
         ;;
 
       # Addons
@@ -525,6 +529,7 @@ function gitops_suite() {
   echo_reset_dim "Enhanced Disaster Recovery ........ ${COLOR_MAGENTA}${ENHANCED_DR}"
   echo_reset_dim "Non shared cluster ................ ${COLOR_MAGENTA}${IS_NON_SHARED_CLUSTER}"
   echo_reset_dim "Java or 3rd Party Code Extensions . ${COLOR_MAGENTA}${EXTENSIONS}"
+  echo_reset_dim "Suite Spec Additional Properties .. ${COLOR_MAGENTA}${SUITE_SPEC_ADDITIONAL_PROPERTIES_YAML}"
   reset_colors
 
   if [[ -n "$DNS_PROVIDER" ]]; then
@@ -711,6 +716,13 @@ function gitops_suite() {
   if [[ -n "$MAS_POD_TEMPLATE_YAML" && -s "$MAS_POD_TEMPLATE_YAML" ]]; then
     export MAS_POD_TEMPLATE=$(yq eval '.podTemplates' ${MAS_POD_TEMPLATE_YAML})
     echo -e "\n - MAS_POD_TEMPLATE CONTENT .................. ${MAS_POD_TEMPLATE}"
+  fi
+
+  # Set Suite Spec additional properties
+  # ---------------------------------------------------------------------------
+  if [[ -n "$SUITE_SPEC_ADDITIONAL_PROPERTIES_YAML" && -s "$SUITE_SPEC_ADDITIONAL_PROPERTIES_YAML" ]]; then
+    export SUITE_SPEC_ADDITIONAL_PROPERTIES=$(yq eval '.podTemplates' ${SUITE_SPEC_ADDITIONAL_PROPERTIES_YAML})
+    echo -e "\n - SUITE_SPEC_ADDITIONAL_PROPERTIES CONTENT ............... ${SUITE_SPEC_ADDITIONAL_PROPERTIES}"
   fi
 
   # Generate ArgoApps

--- a/image/cli/mascli/functions/gitops_suite
+++ b/image/cli/mascli/functions/gitops_suite
@@ -30,21 +30,22 @@ IBM Suite License Service:
       --sls-install-plan ${COLOR_YELLOW}SLS_INSTALL_PLAN${TEXT_RESET}  IBM Suite License Service Subscription Install Plan ('Automatic' or 'Manual'. Default is 'Automatic')
 
 IBM Maximo Application Suite:
-      --mas-annotations ${COLOR_YELLOW}MAS_ANNOTATIONS${TEXT_RESET}                                              MAS Annotations definition in dict format
-      --mas-channel ${COLOR_YELLOW}MAS_CHANNEL${TEXT_RESET}                                                      MAS Core Platform Subscription Channel
-      --mas-install-plan ${COLOR_YELLOW}MAS_INSTALL_PLAN${TEXT_RESET}                                            MAS Core Platform Subscription Install Plan ('Automatic' or 'Manual'. Default is 'Automatic')
-      --mas-domain ${COLOR_YELLOW}MAS_DOMAIN${TEXT_RESET}                                                        MAS Domain
-      --mas-image-tags ${COLOR_YELLOW}MAS_IMAGE_TAGS${TEXT_RESET}                                                MAS Image tags definition in dict format
-      --mas-labels ${COLOR_YELLOW}MAS_LABELS${TEXT_RESET}                                                        MAS Labels definition in dict format
-      --mas-manual-cert-mgmt ${COLOR_YELLOW}MAS_MANUAL_CERT_MGMT${TEXT_RESET}                                    MAS Manual Cert Management
-      --mas-manual-certs-yaml ${COLOR_YELLOW}MAS_MANUAL_CERTS_YAML${TEXT_RESET}                                  YAML file location containing combined MAS Manual Certs of core and all other apps
-      --mas-pod-template-yaml ${COLOR_YELLOW}MAS_POD_TEMPLATE_YAML${TEXT_RESET}                                  The location of a file containing the POD template
-      --allow-list ${COLOR_YELLOW}ALLOW_LIST${TEXT_RESET}                                                        List of IPs or CIDR range to whitelist
-      --additional-vpn ${COLOR_YELLOW}ADDITIONAL_VPN{TEXT_RESET}                                                 Manage additional client VPN
-      --extensions ${COLOR_YELLOW}EXTENSIONS${TEXT_RESET}                                                        To enable JAVA or 3rd party code extensions
-      --enhanced-dr ${COLOR_YELLOW}ENHANCED_DR${TEXT_RESET}                                                      To enable Enhanced Disaster Recovery
-      --is-non-shared-cluster ${COLOR_YELLOW}IS_NON_SHARED_CLUSTER${TEXT_RESET}                                  To enable Non shared cluster
-      --suite-spec-additional-properties-yaml ${COLOR_YELLOW}SUITE_SPEC_ADDITIONAL_PROPERTIES_YAML${TEXT_RESET}  Additional properties to be set in Suite CR
+      --mas-annotations ${COLOR_YELLOW}MAS_ANNOTATIONS${TEXT_RESET}                                                       MAS Annotations definition in dict format
+      --mas-channel ${COLOR_YELLOW}MAS_CHANNEL${TEXT_RESET}                                                               MAS Core Platform Subscription Channel
+      --mas-install-plan ${COLOR_YELLOW}MAS_INSTALL_PLAN${TEXT_RESET}                                                     MAS Core Platform Subscription Install Plan ('Automatic' or 'Manual'. Default is 'Automatic')
+      --mas-domain ${COLOR_YELLOW}MAS_DOMAIN${TEXT_RESET}                                                                 MAS Domain
+      --mas-image-tags ${COLOR_YELLOW}MAS_IMAGE_TAGS${TEXT_RESET}                                                         MAS Image tags definition in dict format
+      --mas-labels ${COLOR_YELLOW}MAS_LABELS${TEXT_RESET}                                                                 MAS Labels definition in dict format
+      --mas-manual-cert-mgmt ${COLOR_YELLOW}MAS_MANUAL_CERT_MGMT${TEXT_RESET}                                             MAS Manual Cert Management
+      --mas-manual-certs-yaml ${COLOR_YELLOW}MAS_MANUAL_CERTS_YAML${TEXT_RESET}                                           YAML file location containing combined MAS Manual Certs of core and all other apps
+      --mas-pod-template-yaml ${COLOR_YELLOW}MAS_POD_TEMPLATE_YAML${TEXT_RESET}                                           The location of a file containing the POD template
+      --allow-list ${COLOR_YELLOW}ALLOW_LIST${TEXT_RESET}                                                                 List of IPs or CIDR range to whitelist
+      --additional-vpn ${COLOR_YELLOW}ADDITIONAL_VPN{TEXT_RESET}                                                          Manage additional client VPN
+      --extensions ${COLOR_YELLOW}EXTENSIONS${TEXT_RESET}                                                                 To enable JAVA or 3rd party code extensions
+      --enhanced-dr ${COLOR_YELLOW}ENHANCED_DR${TEXT_RESET}                                                               To enable Enhanced Disaster Recovery
+      --is-non-shared-cluster ${COLOR_YELLOW}IS_NON_SHARED_CLUSTER${TEXT_RESET}                                           To enable Non shared cluster
+      --suite-spec-additional-properties-yaml ${COLOR_YELLOW}SUITE_SPEC_ADDITIONAL_PROPERTIES_YAML${TEXT_RESET}           Additional properties to be set in Suite CR spec
+      --suite-spec-settings-additional-properties-yaml ${COLOR_YELLOW}SUITE_SPEC_SETTINGS_ADDITIONAL_PROPERTIES_YAML${TEXT_RESET}  Additional properties to be set in Suite CR spec.settings
 
       Below is a sample yaml file template representing manual_certs dictionary ( key: << value base64 encoded content of cert file >>) 
       where key is <<app>>_<<filename . replaced by _>> name and value will be base64 encoded of the respective ca/tls file, 
@@ -228,6 +229,9 @@ function gitops_suite_noninteractive() {
         ;;
       --suite-spec-additional-properties-yaml)
         export SUITE_SPEC_ADDITIONAL_PROPERTIES_YAML=$1 && shift
+        ;;
+      --suite-spec-settings-additional-properties-yaml)
+        export SUITE_SPEC_SETTINGS_ADDITIONAL_PROPERTIES_YAML=$1 && shift
         ;;
 
       # Addons
@@ -511,25 +515,26 @@ function gitops_suite() {
 
   echo "${TEXT_DIM}"
   echo_h4 "IBM Maximo Application Suite" "    "
-  echo_reset_dim "Subscription Channel .............. ${COLOR_MAGENTA}${MAS_CHANNEL}"
-  echo_reset_dim "Subscription Install Plan ......... ${COLOR_MAGENTA}${MAS_INSTALL_PLAN}"
-  echo_reset_dim "MAS Domain ........................ ${COLOR_MAGENTA}${MAS_DOMAIN}"
-  echo_reset_dim "Domain ............................ ${COLOR_MAGENTA}${DOMAIN}"
-  echo_reset_dim "Image Tags ........................ ${COLOR_MAGENTA}${MAS_IMAGE_TAGS}"
-  echo_reset_dim "Annotations ....................... ${COLOR_MAGENTA}${MAS_ANNOTATIONS}"
-  echo_reset_dim "Labels ............................ ${COLOR_MAGENTA}${MAS_LABELS}"
-  echo_reset_dim "MAS Manual Cert Mgt ............... ${COLOR_MAGENTA}${MAS_MANUAL_CERT_MGMT}"
-  echo_reset_dim "MAS MANUAL CERTS YAML ............. ${COLOR_MAGENTA}${MAS_MANUAL_CERTS_YAML}"
-  echo_reset_dim "Cert Manager Namespace ............ ${COLOR_MAGENTA}${CERT_MANAGER_NAMESPACE}"
-  echo_reset_dim "DNS Provider ...................... ${COLOR_MAGENTA}${DNS_PROVIDER}"
-  echo_reset_dim "Pod Template YAML File  ........... ${COLOR_MAGENTA}${MAS_POD_TEMPLATE_YAML}"
-  echo_reset_dim "OIDC Config ....................... ${COLOR_MAGENTA}${OIDC_CONFIG}"
-  echo_reset_dim "Allow List ........................ ${COLOR_MAGENTA}${ALLOW_LIST}"
-  echo_reset_dim "Additional VPN .................... ${COLOR_MAGENTA}${ADDITIONAL_VPN}"
-  echo_reset_dim "Enhanced Disaster Recovery ........ ${COLOR_MAGENTA}${ENHANCED_DR}"
-  echo_reset_dim "Non shared cluster ................ ${COLOR_MAGENTA}${IS_NON_SHARED_CLUSTER}"
-  echo_reset_dim "Java or 3rd Party Code Extensions . ${COLOR_MAGENTA}${EXTENSIONS}"
-  echo_reset_dim "Suite Spec Additional Properties .. ${COLOR_MAGENTA}${SUITE_SPEC_ADDITIONAL_PROPERTIES_YAML}"
+  echo_reset_dim "Subscription Channel ....................... ${COLOR_MAGENTA}${MAS_CHANNEL}"
+  echo_reset_dim "Subscription Install Plan .................. ${COLOR_MAGENTA}${MAS_INSTALL_PLAN}"
+  echo_reset_dim "MAS Domain ................................. ${COLOR_MAGENTA}${MAS_DOMAIN}"
+  echo_reset_dim "Domain ..................................... ${COLOR_MAGENTA}${DOMAIN}"
+  echo_reset_dim "Image Tags ................................. ${COLOR_MAGENTA}${MAS_IMAGE_TAGS}"
+  echo_reset_dim "Annotations ................................ ${COLOR_MAGENTA}${MAS_ANNOTATIONS}"
+  echo_reset_dim "Labels ..................................... ${COLOR_MAGENTA}${MAS_LABELS}"
+  echo_reset_dim "MAS Manual Cert Mgt ........................ ${COLOR_MAGENTA}${MAS_MANUAL_CERT_MGMT}"
+  echo_reset_dim "MAS MANUAL CERTS YAML ...................... ${COLOR_MAGENTA}${MAS_MANUAL_CERTS_YAML}"
+  echo_reset_dim "Cert Manager Namespace ..................... ${COLOR_MAGENTA}${CERT_MANAGER_NAMESPACE}"
+  echo_reset_dim "DNS Provider ............................... ${COLOR_MAGENTA}${DNS_PROVIDER}"
+  echo_reset_dim "Pod Template YAML File  .................... ${COLOR_MAGENTA}${MAS_POD_TEMPLATE_YAML}"
+  echo_reset_dim "OIDC Config ................................ ${COLOR_MAGENTA}${OIDC_CONFIG}"
+  echo_reset_dim "Allow List ................................. ${COLOR_MAGENTA}${ALLOW_LIST}"
+  echo_reset_dim "Additional VPN ............................. ${COLOR_MAGENTA}${ADDITIONAL_VPN}"
+  echo_reset_dim "Enhanced Disaster Recovery ................. ${COLOR_MAGENTA}${ENHANCED_DR}"
+  echo_reset_dim "Non shared cluster ......................... ${COLOR_MAGENTA}${IS_NON_SHARED_CLUSTER}"
+  echo_reset_dim "Java or 3rd Party Code Extensions .......... ${COLOR_MAGENTA}${EXTENSIONS}"
+  echo_reset_dim "Suite Spec Additional Properties ........... ${COLOR_MAGENTA}${SUITE_SPEC_ADDITIONAL_PROPERTIES_YAML}"
+  echo_reset_dim "Suite Spec Settings Additional Properties .. ${COLOR_MAGENTA}${SUITE_SPEC_SETTINGS_ADDITIONAL_PROPERTIES_YAML}"
   reset_colors
 
   if [[ -n "$DNS_PROVIDER" ]]; then
@@ -724,6 +729,11 @@ function gitops_suite() {
   if [[ -n "$SUITE_SPEC_ADDITIONAL_PROPERTIES_YAML" && -s "$SUITE_SPEC_ADDITIONAL_PROPERTIES_YAML" ]]; then
     export SUITE_SPEC_ADDITIONAL_PROPERTIES=$(yq eval ${SUITE_SPEC_ADDITIONAL_PROPERTIES_YAML})
     echo -e "\n - SUITE_SPEC_ADDITIONAL_PROPERTIES CONTENT ............... ${SUITE_SPEC_ADDITIONAL_PROPERTIES}"
+  fi
+  echo_h2 "Generating Suite Spec Settings additional properties"
+  if [[ -n "$SUITE_SPEC_SETTINGS_ADDITIONAL_PROPERTIES_YAML" && -s "$SUITE_SPEC_SETTINGS_ADDITIONAL_PROPERTIES_YAML" ]]; then
+    export SUITE_SPEC_SETTINGS_ADDITIONAL_PROPERTIES=$(yq eval ${SUITE_SPEC_SETTINGS_ADDITIONAL_PROPERTIES_YAML})
+    echo -e "\n - SUITE_SPEC_SETTINGS_ADDITIONAL_PROPERTIES CONTENT ............... ${SUITE_SPEC_SETTINGS_ADDITIONAL_PROPERTIES}"
   fi
 
   # Generate ArgoApps

--- a/image/cli/mascli/functions/gitops_suite
+++ b/image/cli/mascli/functions/gitops_suite
@@ -721,11 +721,6 @@ function gitops_suite() {
   # Set Suite Spec additional properties
   # ---------------------------------------------------------------------------
   echo_h2 "Generating Suite Spec additional properties"
-  ls /workspace/shared-gitops-configs
-  echo -e "\n Suite spec yaml - ${SUITE_SPEC_ADDITIONAL_PROPERTIES_YAML}"
-  echo -e "\n Display yaml file content"
-  cat ${SUITE_SPEC_ADDITIONAL_PROPERTIES_YAML}
-  echo -e "\n Done "
   if [[ -n "$SUITE_SPEC_ADDITIONAL_PROPERTIES_YAML" && -s "$SUITE_SPEC_ADDITIONAL_PROPERTIES_YAML" ]]; then
     export SUITE_SPEC_ADDITIONAL_PROPERTIES=$(yq eval ${SUITE_SPEC_ADDITIONAL_PROPERTIES_YAML})
     echo -e "\n - SUITE_SPEC_ADDITIONAL_PROPERTIES CONTENT ............... ${SUITE_SPEC_ADDITIONAL_PROPERTIES}"

--- a/image/cli/mascli/functions/gitops_suite
+++ b/image/cli/mascli/functions/gitops_suite
@@ -720,8 +720,12 @@ function gitops_suite() {
 
   # Set Suite Spec additional properties
   # ---------------------------------------------------------------------------
+  echo_h2 "Generating Suite Spec additional properties'
   ls /workspace/shared-gitops-configs
-  cat $SUITE_SPEC_ADDITIONAL_PROPERTIES_YAML
+  echo -e "\n Suite spec yaml - ${SUITE_SPEC_ADDITIONAL_PROPERTIES_YAML}"
+  echo -e "\n Display yaml file content"
+  cat ${SUITE_SPEC_ADDITIONAL_PROPERTIES_YAML}
+  echo -e "\n Done "
   if [[ -n "$SUITE_SPEC_ADDITIONAL_PROPERTIES_YAML" && -s "$SUITE_SPEC_ADDITIONAL_PROPERTIES_YAML" ]]; then
     export SUITE_SPEC_ADDITIONAL_PROPERTIES=$(yq eval ${SUITE_SPEC_ADDITIONAL_PROPERTIES_YAML})
     echo -e "\n - SUITE_SPEC_ADDITIONAL_PROPERTIES CONTENT ............... ${SUITE_SPEC_ADDITIONAL_PROPERTIES}"

--- a/image/cli/mascli/templates/gitops/appset-configs/cluster/instance/ibm-mas-suite.yaml.j2
+++ b/image/cli/mascli/templates/gitops/appset-configs/cluster/instance/ibm-mas-suite.yaml.j2
@@ -86,3 +86,8 @@ ibm_mas_suite:
 {% if ALLOW_LIST is defined and ALLOW_LIST != '' %}
   allow_list: {{ALLOW_LIST}}
 {% endif %}
+
+{% if SUITE_SPEC_ADDITIONAL_PROPERTIES is defined and SUITE_SPEC_ADDITIONAL_PROPERTIES != '' %}
+suite_spec_additional_properties:
+  {{ SUITE_SPEC_ADDITIONAL_PROPERTIES | indent(2) }}
+{% endif %}

--- a/image/cli/mascli/templates/gitops/appset-configs/cluster/instance/ibm-mas-suite.yaml.j2
+++ b/image/cli/mascli/templates/gitops/appset-configs/cluster/instance/ibm-mas-suite.yaml.j2
@@ -91,3 +91,8 @@ ibm_mas_suite:
   suite_spec_additional_properties:
     {{ SUITE_SPEC_ADDITIONAL_PROPERTIES | indent(4) }}
 {% endif %}
+
+{% if SUITE_SPEC_SETTINGS_ADDITIONAL_PROPERTIES is defined and SUITE_SPEC_SETTINGS_ADDITIONAL_PROPERTIES != '' %}
+  suite_spec_settings_additional_properties:
+    {{ SUITE_SPEC_SETTINGS_ADDITIONAL_PROPERTIES | indent(4) }}
+{% endif %}

--- a/image/cli/mascli/templates/gitops/appset-configs/cluster/instance/ibm-mas-suite.yaml.j2
+++ b/image/cli/mascli/templates/gitops/appset-configs/cluster/instance/ibm-mas-suite.yaml.j2
@@ -88,6 +88,6 @@ ibm_mas_suite:
 {% endif %}
 
 {% if SUITE_SPEC_ADDITIONAL_PROPERTIES is defined and SUITE_SPEC_ADDITIONAL_PROPERTIES != '' %}
-suite_spec_additional_properties:
-  {{ SUITE_SPEC_ADDITIONAL_PROPERTIES | indent(2) }}
+  suite_spec_additional_properties:
+    {{ SUITE_SPEC_ADDITIONAL_PROPERTIES | indent(4) }}
 {% endif %}

--- a/tekton/src/pipelines/gitops/gitops-mas-instance.yml.j2
+++ b/tekton/src/pipelines/gitops/gitops-mas-instance.yml.j2
@@ -186,6 +186,9 @@ spec:
     - name: suite_spec_additional_properties_yaml
       type: string
       default: ""
+    - name: suite_spec_settings_additional_properties_yaml
+      type: string
+      default: ""
 
     - name: db2_channel
       type: string
@@ -422,6 +425,8 @@ spec:
           value: $(params.mas_wipe_mongo_data)
         - name: suite_spec_additional_properties_yaml
           value: $(params.suite_spec_additional_properties_yaml)
+        - name: suite_spec_settings_additional_properties_yaml
+          value: $(params.suite_spec_settings_additional_properties_yaml)
         - name: oidc
           value: $(params.oidc)
         - name: allow_list

--- a/tekton/src/pipelines/gitops/gitops-mas-instance.yml.j2
+++ b/tekton/src/pipelines/gitops/gitops-mas-instance.yml.j2
@@ -183,6 +183,9 @@ spec:
     - name: mas_smtpcfg_pod_template_yaml
       type: string
       default: ""
+    - name: suite_spec_additional_properties_yaml
+      type: string
+      default: ""
 
     - name: db2_channel
       type: string
@@ -417,6 +420,8 @@ spec:
           value: $(params.mas_pod_template_yaml)
         - name: mas_wipe_mongo_data
           value: $(params.mas_wipe_mongo_data)
+        - name: suite_spec_additional_properties_yaml
+          value: $(params.suite_spec_additional_properties_yaml)
         - name: oidc
           value: $(params.oidc)
         - name: allow_list

--- a/tekton/src/tasks/gitops/gitops-suite.yml.j2
+++ b/tekton/src/tasks/gitops/gitops-suite.yml.j2
@@ -125,6 +125,9 @@ spec:
     - name: mas_wipe_mongo_data
       type: string
       default: "false"
+    - name: suite_spec_additional_properties_yaml
+      type: string
+      default: ""
     - name: oidc
       type: string
     - name: allow_list
@@ -234,6 +237,8 @@ spec:
         value: $(params.mas_pod_template_yaml)
       - name: MAS_WIPE_MONGO_DATA
         value: $(params.mas_wipe_mongo_data)
+      - name: SUITE_SPEC_ADDITIONAL_PROPERTIES_YAML
+        value: $(params.suite_spec_additional_properties_yaml)
 
       - name: OIDC_CONFIG
         value: $(params.oidc)

--- a/tekton/src/tasks/gitops/gitops-suite.yml.j2
+++ b/tekton/src/tasks/gitops/gitops-suite.yml.j2
@@ -128,6 +128,9 @@ spec:
     - name: suite_spec_additional_properties_yaml
       type: string
       default: ""
+    - name: suite_spec_settings_additional_properties_yaml
+      type: string
+      default: ""
     - name: oidc
       type: string
     - name: allow_list
@@ -239,6 +242,8 @@ spec:
         value: $(params.mas_wipe_mongo_data)
       - name: SUITE_SPEC_ADDITIONAL_PROPERTIES_YAML
         value: $(params.suite_spec_additional_properties_yaml)
+      - name: SUITE_SPEC_SETTINGS_ADDITIONAL_PROPERTIES_YAML
+        value: $(params.suite_spec_settings_additional_properties_yaml)
 
       - name: OIDC_CONFIG
         value: $(params.oidc)


### PR DESCRIPTION
Issue: [MASCORE-5959](https://jsw.ibm.com/browse/MASCORE-5959)

## Description
Support for optional entires in Suite CR under spec and spec.settings

## Testing
Tested in noble4 and more details available in https://github.ibm.com/maximoappsuite/saas-tekton/pull/124