### PR TITLE
[doc] Update doc on setting up IDMS for rehat catalogs

### DIFF
--- a/docs/guides/install.md
+++ b/docs/guides/install.md
@@ -79,7 +79,10 @@ Your cluster must be configured to use the private registry as a mirror for the 
 ```bash
 docker run -ti --pull always quay.io/ibmmas/cli mas configure-airgap
 ```
-
+To set up Red Hat Operator, Community, and Certified catalogs with IDMS, run the below command. (Needed to install DRO and Grafana operators)
+```bash
+docker run -ti --pull always quay.io/ibmmas/cli mas configure-airgap --setup-redhat-catalogs
+```
 You will be prompted to provide information about the private registry, including the CA certificate necessary to configure your cluster to trust the private registry.
 
 This command can also be ran non-interactive, for full details refer to the [configure-airgap](../commands/configure-airgap.md) command documentation.


### PR DESCRIPTION
Receiving Many tickets as clients are not seeing idms and unable to create catalog sources for redhat,community and certified operators. Received several escalations for the past 6 months and need this included to documentation.

Example - 
oc get idms
NAME                  AGE
mas-ibm-catalog       2d19h
mas-redhat-catalogs   2d19h

mas configure-airgap is setting up IDMS with name "mas-ibm-catalog" but not "mas-redhat-catalogs" unless we run the command mas configure-airgap --setup-redhat-catalogs