### PR TITLE
[patch] Re-enable Predict install with MAS 8.10

### DIFF
--- a/python/src/mas/cli/install/app.py
+++ b/python/src/mas/cli/install/app.py
@@ -635,8 +635,7 @@ class InstallApp(BaseApp, InstallSettingsMixin, InstallSummarizerMixin, ConfigGe
         if self.installManage:
             self.configAppChannel("manage")
 
-        # Predict for MAS 8.10 is effectively unsupported now, because it has not shipped support for Cloud Pak for Data 4.8 as of June 2023 catalog update
-        if self.installIoT and self.installManage and self.getParam("mas_channel") != "8.10.x":
+        if self.installIoT and self.installManage:
             self.installPredict = self.yesOrNo("Install Predict")
         else:
             self.installPredict = False


### PR DESCRIPTION
A condition preventing install of Predict for MAS 8.10 was introduced as a temporary measure due to a problem found in CPD 4.8 support in Predict for 8.10 at the time .. see the notification/warning in the catalog: https://ibm-mas.github.io/cli/catalogs/v9-240625-amd64/ ,

> Maximo Predict Customers using Maximo Predict v8.7 should first update to v8.8 before updating to this catalog, Cloud Pak for Data v4.8 support is missing from the v8.7 maintenance stream currently

This condition should have been removed, but was not.  This update addresses that.

Customer Ticket #: **TS019239993**
