### PR TITLE
[patch] Add missing param for facilities in gitops pipeline

### DIFF
--- a/tekton/src/pipelines/gitops/gitops-mas-fvt-preparer-pipeline.yml.j2
+++ b/tekton/src/pipelines/gitops/gitops-mas-fvt-preparer-pipeline.yml.j2
@@ -65,6 +65,8 @@ spec:
       type: string
     - name: fvt_version_sls
       type: string
+    - name: fvt_version_facilities
+      type: string
 
     - name: fvt_blacklist_core
       type: string


### PR DESCRIPTION
The fvt_version_facilities param was missing from the gitops fvt preparer