### PR TITLE
[patch] Updating CLI docs as rebranding Assist to Collaborate

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2025-05-05T09:43:59Z",
+  "generated_at": "2025-05-12T09:07:27Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -112,7 +112,7 @@
         "hashed_secret": "b60d121b438a380c343d5ec3c2037564b82ffef3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 185,
+        "line_number": 186,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/docs/guides/install.md
+++ b/docs/guides/install.md
@@ -154,7 +154,7 @@ The interactive install will guide you through a series of questioned designed t
       <ul>
         <li>Monitor is only available for install if IoT is selected</li>
         <li>Assist and Predict are only available for install if Monitor is selected</li>
-        <li>From now on Assist will be labeled as collaborate. So while installing the assist you will see assist right now but after logging in you will find collaborate in place of assist. Soon this is also gonna be improved and while installing also you will be able to see collaborate.</li>
+        <li>From now on Assist will be labeled as Collaborate. Although while installing the Assist you will see Assist right now but after logging in you will find Collaborate in place of Assist. Soon this is also gonna be improved and while installing also you will be able to see Collaborate.</li>
       </ul>
     </cds-accordion-item>
     <cds-accordion-item title="Application Configuration">

--- a/docs/guides/install.md
+++ b/docs/guides/install.md
@@ -154,6 +154,7 @@ The interactive install will guide you through a series of questioned designed t
       <ul>
         <li>Monitor is only available for install if IoT is selected</li>
         <li>Assist and Predict are only available for install if Monitor is selected</li>
+        <li>The plan is to deliver Label change functionality in two phases, In first phase we are delivering UI changes so while installing the assist you will see assist             but after logging you may find collaborate in place of assist. In second release this is gonna be improved and while installing also you will see collaborate.                </li>
       </ul>
     </cds-accordion-item>
     <cds-accordion-item title="Application Configuration">

--- a/docs/guides/install.md
+++ b/docs/guides/install.md
@@ -154,7 +154,7 @@ The interactive install will guide you through a series of questioned designed t
       <ul>
         <li>Monitor is only available for install if IoT is selected</li>
         <li>Assist and Predict are only available for install if Monitor is selected</li>
-        <li>The plan is to deliver Label change functionality in two phases, In first phase we are delivering UI changes so while installing the assist you will see assist             but after logging you may find collaborate in place of assist. In second release this is gonna be improved and while installing also you will see collaborate.                </li>
+        <li>From now on Assist will be labeled as collaborate. So while installing the assist you will see assist right now but after logging in you will find collaborate in place of assist. Soon this is also gonna be improved and while installing also you will be able to see collaborate.</li>
       </ul>
     </cds-accordion-item>
     <cds-accordion-item title="Application Configuration">


### PR DESCRIPTION
As we are rebranding Assist to Collaborate, updating the document in application install section so that external will understand Assist is now labeled as Collaborate after logging in application.
