### PR TITLE
[patch] Add condition to MangeWorkspace for gitops

### DIFF
--- a/image/cli/mascli/templates/gitops/bootstrap/argocd.yaml
+++ b/image/cli/mascli/templates/gitops/bootstrap/argocd.yaml
@@ -238,6 +238,19 @@ spec:
               end
             end
           end
+          if obj.spec ~= nil then
+            if obj.spec.settings ~= nil then
+              if obj.spec.settings.deployment ~= nill then
+                if obj.spec.settings.deployment.mode ~= nil then
+                  if obj.spec.settings.deployment.mode == "down" then
+                    hs.status = "Healthy"
+                    hs.message = "Manage mode is down"
+                    return hs
+                  end
+                end
+              end
+            end
+          end
           hs.status = "Progressing"
           hs.message = ""
           return hs


### PR DESCRIPTION
Updates the healthcheck for ArgoCD for the Manageworkspace, so that if the manage mode is `down` in the spec i.e. it is intentionally set to be down, then we don't put the health into inprogress, but instead put it into healthy. This is cause Argo won't complete the next sync if the current one is still classed as inprogress. As Manage is intended to be down then it should just sync the change anyway.

If there is a Failure state that it will still show degraded.

Tested by setting the healthcheck then bringing down Manage:
![image- 2025-05-16 at 12 41 21@2x](https://github.com/user-attachments/assets/1dd5acbe-99ae-4631-b8db-20489d2e49f6)
![image- 2025-05-16 at 12 41 40@2x](https://github.com/user-attachments/assets/72c90ad8-530a-4d50-9036-3c7f5f0fa9b2)

state shows inprogress with the updated status message
![image- 2025-05-16 at 12 41 50@2x](https://github.com/user-attachments/assets/c9b5d1ba-e128-44da-893b-ed9fdcd51640)
