### PR TITLE
[patch] Add missing tls secret name for Facilities when using manual certificates in gitops

### DIFF
--- a/image/cli/mascli/functions/gitops_suite_app_config
+++ b/image/cli/mascli/functions/gitops_suite_app_config
@@ -550,7 +550,7 @@ function gitops_suite_app_config() {
   export MAS_APP_NAMESPACE="mas-${MAS_INSTANCE_ID}-${MAS_APP_ID}"
 
 
-  # Set certs only if manual cert is True (to create k8s secret in gitops) only required for manage
+  # Set certs only if manual cert is True (to create k8s secret in gitops) only required for manage, facilites
   # ---------------------------------------------------------------------------
   if [ "${MAS_MANUAL_CERT_MGMT}" == "true" ] ; then
     if [[ -n "$MAS_MANUAL_CERTS_YAML" ]] && [[ -s "$MAS_MANUAL_CERTS_YAML" ]]; then
@@ -558,7 +558,8 @@ function gitops_suite_app_config() {
       declare -A tls_secret_name
       tls_secret_name['health']="${MAS_INSTANCE_ID}-${MAS_WORKSPACE_ID}-cert-public-81"
       tls_secret_name['manage']="${MAS_INSTANCE_ID}-${MAS_WORKSPACE_ID}-cert-public-81"
-      
+      tls_secret_name['facilities']="${MAS_INSTANCE_ID}-${MAS_WORKSPACE_ID}-public-facilities-tls"
+
       if [[ -n "${tls_secret_name[$MAS_APP_ID]}" ]]; then
 
         echo

--- a/tekton/src/tasks/gitops/gitops-mas-fvt-preparer.yml.j2
+++ b/tekton/src/tasks/gitops/gitops-mas-fvt-preparer.yml.j2
@@ -525,7 +525,7 @@ spec:
           fi
           if [[ "$LAUNCHFVT_FACILITIES" == "true" ]]; then
             MASAPP_APP="facilities.${CLUSTER_NAME}.${MAS_INSTANCE_ID}"
-            check_argo_app_healthy "${MAS_WORKSPACE_ID}.${MASAPP_APP}" 120
+            check_argo_app_healthy "${MAS_WORKSPACE_ID}.${MASAPP_APP}" 480
           fi
           # Fourth wave
           if [[ "$LAUNCHFVT_MONITOR" == "true" ]]; then


### PR DESCRIPTION
For Manual certificates use in gitops, the name of the tls secret needs to be present so we add the cert details to the template file. This was missing for Facilities, so adding it in. Also the timeout for waiting for Facilities is increased to 4 hours before running FVT.

Tested in fvtsaas