### PR TITLE
[patch] fix missing facilities verify when condition

### DIFF
--- a/tekton/src/pipelines/taskdefs/apps/facilities-verify.yml.j2
+++ b/tekton/src/pipelines/taskdefs/apps/facilities-verify.yml.j2
@@ -25,3 +25,7 @@
     # Custom Label Support
     - name: custom_labels
       value: $(params.custom_labels)
+  when:
+    - input: "$(params.mas_app_channel_facilities)"
+      operator: notin
+      values: [""]


### PR DESCRIPTION
When condition is required so that this task is only executed when we set facilities to be configured in the install pipeline.