### PR TITLE
[patch] Setting self.installFacilities to False when upgrading from 9.0.x to 9.1.x and installing Manage Foundation

### DIFF
--- a/python/src/mas/cli/upgrade/app.py
+++ b/python/src/mas/cli/upgrade/app.py
@@ -108,6 +108,7 @@ class UpgradeApp(BaseApp, UpgradeSettingsMixin):
             self.manageAppName = "Manage foundation"
             self.showAdvancedOptions = False
             self.installIoT = False
+            self.installFacilities = False
             self.installManage = True
             self.isManageFoundation = True
             self.printDescription([f"{self.manageAppName} installs the following capabilities: User, Security groups, Application configurator and Mobile configurator."])


### PR DESCRIPTION
Setting `self.installFacilities` to False when upgrading from 9.0.x to 9.1.x and installing Manage Foundation, since `self.installFacilities` is a new flag that is being accessed by `self.configDb2()` and ManageFoundation installation triggers `self.configDb2()` which will access `self.installFacilities` at some point, so it needs to be defined to avoid a runtime error.