### PR TITLE
[patch] copy facilities certificates

### DIFF
--- a/image/cli/app-root/src/copy-certificates.sh
+++ b/image/cli/app-root/src/copy-certificates.sh
@@ -10,6 +10,7 @@ appList=(
   "optimizer"  
   "predict"
   "visualinspection"
+  "facilities"
 )
 
 if [ -e "/workspace/certificates" ]; then


### PR DESCRIPTION
Facilities manual certificates were not copied over to the tasks. it was missing in the `image/cli/app-root/src/copy-certificates.sh`