### PR TITLE
[patch] stack db2-manage and db2-setup-facilities to avoid race conditions

### DIFF
--- a/tekton/src/pipelines/install.yml.j2
+++ b/tekton/src/pipelines/install.yml.j2
@@ -214,7 +214,6 @@ spec:
     {{ lookup('template', pipeline_src_dir ~ '/taskdefs/core/suite-config-db2.yml.j2') | indent(4) }}
       runAfter:
         - suite-verify
-        - db2-manage  # db2-manage already waits for db2-system so we don't need to list both
         - suite-db2-setup-facilities
 
     # 5.8 Configure Kafka in MAS
@@ -381,7 +380,7 @@ spec:
     # 15.1 Dedicated Facilities Db2
     {{ lookup('template', pipeline_src_dir ~ '/taskdefs/apps/db2-setup-facilities.yml.j2') | indent(4)}}
       runAfter:
-        - cert-manager
+        - db2-manage
 
     # 15.2 Install Facilities
     {{ lookup('template', pipeline_src_dir ~ '/taskdefs/apps/facilities-app.yml.j2') | indent(4) }}


### PR DESCRIPTION
**Description**
During FVT test, it was reported that the `db2-manage` and `suite-db2-setup-facilities` task were run in parallel and it led to a race condition while creating the certificate for DB2. Therefore, the tasks were chained sequentially to avoid the issue presented.

**Tests**
![image](https://github.com/user-attachments/assets/17972067-b20f-438b-90b8-8bf4c65936e5)

