### PR TITLE
[patch] fix install for old catalogs

### DIFF
--- a/python/src/mas/cli/install/app.py
+++ b/python/src/mas/cli/install/app.py
@@ -199,11 +199,12 @@ class InstallApp(BaseApp, InstallSettingsMixin, InstallSummarizerMixin, ConfigGe
         # Generate catalogTable
         for application, key in applications.items():
             # Add 9.1-feature channel based off 9.0 to those apps that have not onboarded yet
-            tempChosenCatalog = self.chosenCatalog[key].copy()
-            if '9.1.x-feature' not in tempChosenCatalog:
-                tempChosenCatalog.update({"9.1.x-feature": tempChosenCatalog["9.0.x"]})
+            if key in self.chosenCatalog:
+                tempChosenCatalog = self.chosenCatalog[key].copy()
+                if '9.1.x-feature' not in tempChosenCatalog:
+                    tempChosenCatalog.update({"9.1.x-feature": tempChosenCatalog["9.0.x"]})
 
-            self.catalogTable.append({"": application} | {key.replace(".x", ""): value for key, value in sorted(tempChosenCatalog.items(), reverse=True)})
+                self.catalogTable.append({"": application} | {key.replace(".x", ""): value for key, value in sorted(tempChosenCatalog.items(), reverse=True)})
 
         if self.architecture == "s390x" or self.architecture == "ppc64le":
             summary = [


### PR DESCRIPTION
"Generate catalogTable" logic was failing as it couldn't find Facilities in old catalog.

```
3) IBM Maximo Operator Catalog Selection
The IBM Maximo Operator Catalog is already installed in this cluster (v9-250501-amd64).  If you wish to install MAS using a newer version of the catalog please first update the catalog using mas update.
Traceback (most recent call last):
  File "/opt/app-root/bin/mas-cli", line 56, in <module>
    app.install(argv[2:])
  File "/opt/app-root/lib64/python3.9/site-packages/mas/cli/install/app.py", line 69, in wrapper
    result = func(self, *args, **kwargs)
  File "/opt/app-root/lib64/python3.9/site-packages/mas/cli/install/app.py", line 1196, in install
    self.interactiveMode(simplified=args.simplified, advanced=args.advanced)
  File "/opt/app-root/lib64/python3.9/site-packages/mas/cli/install/app.py", line 69, in wrapper
    result = func(self, *args, **kwargs)
  File "/opt/app-root/lib64/python3.9/site-packages/mas/cli/install/app.py", line 873, in interactiveMode
    self.configCatalog()
  File "/opt/app-root/lib64/python3.9/site-packages/mas/cli/install/app.py", line 69, in wrapper
    result = func(self, *args, **kwargs)
  File "/opt/app-root/lib64/python3.9/site-packages/mas/cli/install/app.py", line 262, in configCatalog
    catalogSummary = self.processCatalogChoice()
  File "/opt/app-root/lib64/python3.9/site-packages/mas/cli/install/app.py", line 69, in wrapper
    result = func(self, *args, **kwargs)
  File "/opt/app-root/lib64/python3.9/site-packages/mas/cli/install/app.py", line 202, in processCatalogChoice
    tempChosenCatalog = self.chosenCatalog[key].copy()
KeyError: 'mas_facilities_version'
```


this change fixes it.
<img width="1211" alt="Screenshot 2025-06-06 at 23 49 33" src="https://github.com/user-attachments/assets/0f3e9cfe-92d6-48a2-a278-2eb73b3033ca" />


slack thread: https://ibm-watson-iot.slack.com/archives/CNDB5GZ3P/p1749245964301429