### PR TITLE
[patch] OpMap UI test execution after defectdetection exec for 811x fix

### DIFF
--- a/tekton/src/pipelines/taskdefs/fvt-manage-is/phase5.yml.j2
+++ b/tekton/src/pipelines/taskdefs/fvt-manage-is/phase5.yml.j2
@@ -17,7 +17,7 @@
       operator: in
       values: ["$(tasks.fvt-component.results.component_names[*])"]
   runAfter:
-    - fvt-manage-setup-is
+    - fvt-civil-api-defectdetection
 
 - name: fvt-ibm-mas-manage-defectdetection
   {{ lookup('template', 'taskdefs/fvt-manage/ui-cypress/taskref.yml.j2') | indent(2) }}

--- a/tekton/src/pipelines/taskdefs/fvt-manage-is/phase5.yml.j2
+++ b/tekton/src/pipelines/taskdefs/fvt-manage-is/phase5.yml.j2
@@ -44,3 +44,4 @@
       values: ["$(tasks.fvt-component.results.component_names[*])"]
   runAfter:
     - fvt-civil-api-defectdetection
+


### PR DESCRIPTION
- Description
Across the FVT - 811x UI Test case are failing while login the MAS UI , shifting the OP-MAP UI Test case to be executed after the defect detection execution.

- Jira
[MAXMF-2571](https://jsw.ibm.com/browse/MAXMF-2571)