### PR TITLE
[doc] add MREF external DB setup guide to nav

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -15,6 +15,7 @@ nav:
       - "Update": guides/update.md
       - "Upgrade": guides/upgrade.md
       - "Uninstall": guides/uninstall.md
+      - "MRE&F External DB Setup": guides/facilities-external-db.md
   - "Examples":
       - "EAM Migration": examples/eam-migration.md
       - "Mirror Db2 Images": examples/mirror-db2.md


### PR DESCRIPTION
MREF guide Link in the Navigation menu was missing. 