### PR TITLE
[patch] include AI Service in mustgather

### DIFF
--- a/image/cli/mascli/functions/must_gather
+++ b/image/cli/mascli/functions/must_gather
@@ -76,7 +76,7 @@ function mustgather() {
   OCP_REPORT=true
   DEPENDENCY_REPORT=true
   SLS_REPORT=true
-  MAS_APP_IDS="core,add,assist,iot,monitor,manage,optimizer,predict,visualinspection,pipelines,facilities"
+  MAS_APP_IDS="core,add,assist,iot,monitor,manage,optimizer,predict,visualinspection,pipelines,facilities,aibroker"
   EXTRA_NAMESPACES=""
 
 


### PR DESCRIPTION
Include MAS AI Service in the `mustgather` tool for log collection. The application ID is `aibroker`, where the target namespace will be of the form `mas-<instance ID>-aibroker`.