### PR TITLE
[patch] set replacement value for provisioner_domain and copy order-status folder

### DIFF
--- a/image/cli/mascli/functions/gitops_cluster
+++ b/image/cli/mascli/functions/gitops_cluster
@@ -554,10 +554,10 @@ function gitops_cluster() {
   export SECRET_NAME_INSTANA=${ACCOUNT_ID}${SM_DELIM}${CLUSTER_ID}${SM_DELIM}instana
   export SECRET_KEY_INSTANA_KEY=${SECRET_NAME_INSTANA}#key
 
-  export SECRET_NAME_SYSLOG_PULLSECRET=${SYSLOG_PULLSECRET_SECRET_NAME:-"aws-dev/syslog_pullsecret"}
+  export SECRET_NAME_SYSLOG_PULLSECRET=${ACCOUNT_ID}${SM_DELIM}syslog_pullsecret
   export SECRET_KEY_SYSLOG_PULLSECRET=${SECRET_NAME_SYSLOG_PULLSECRET}#pullsecret
 
-  export SECRET_NAME_LOG_FORWARDER_DLC_CERT=${DLC_CERT_SECRET_NAME:-"aws-dev/dlc_cert"}
+  export SECRET_NAME_LOG_FORWARDER_DLC_CERT=${ACCOUNT_ID}${SM_DELIM}dlc_cert
   export SECRET_KEY_LOG_FORWARDER_DLC_CA_BUNDLE=${SECRET_NAME_LOG_FORWARDER_DLC_CERT}#ca_bundle
 
 
@@ -590,6 +590,19 @@ function gitops_cluster() {
     TAGS="[{\"Key\": \"source\", \"Value\": \"gitops_cluster\"}, {\"Key\": \"account\", \"Value\": \"${ACCOUNT_ID}\"}, {\"Key\": \"cluster\", \"Value\": \"${CLUSTER_ID}\"}]"
     sm_update_secret $SECRET_NAME_INSTANA "{\"key\": \"${INSTANA_KEY}\"}" "${TAGS}"
   fi
+
+  if [ -n "$SYSLOG_PULLSECRET" ]; then
+    echo "- Update SYSLOG_PULLSECRET secret"
+    TAGS="[{\"Key\": \"source\", \"Value\": \"gitops_cluster\"}, {\"Key\": \"account\", \"Value\": \"${ACCOUNT_ID}\"}]"
+    sm_update_secret $SECRET_NAME_SYSLOG_PULLSECRET "{\"pullsecret\": \"${SYSLOG_PULLSECRET}\"}" "${TAGS}"
+  fi
+
+  if [ -n "$DLC_CERT" ]; then
+    echo "- Update DLC_CERT secret"
+    TAGS="[{\"Key\": \"source\", \"Value\": \"gitops_cluster\"}, {\"Key\": \"account\", \"Value\": \"${ACCOUNT_ID}\"}]"
+    sm_update_secret $SECRET_NAME_LOG_FORWARDER_DLC_CERT "{\"ca_bundle\": \"${DLC_CERT}\"}" "${TAGS}"
+  fi
+
 
   if [ -z $GIT_SSH ]; then
     export GIT_SSH="false"

--- a/tekton/src/tasks/gitops/gitops-mas-initiator.yml.j2
+++ b/tekton/src/tasks/gitops/gitops-mas-initiator.yml.j2
@@ -328,6 +328,9 @@ spec:
         yq -i '.cluster.url = env(OCP_SERVER)' gitops/$ACCOUNT/$REGION/$CLUSTER_NAME/cluster-params.yaml
         yq -i '.cluster.domain = env(APPSDOMAIN)' gitops/$ACCOUNT/$REGION/$CLUSTER_NAME/cluster-params.yaml
 
+        # Update the provisioner_domain in the cluster-params.yml.
+        yq -i '.mas_provisioner.provisioner_domain = env(APPSDOMAIN)' gitops/$ACCOUNT/$REGION/$CLUSTER_NAME/cluster-params.yaml
+
         # Update the channel in the mas-instance-params.yaml. 
         yq -i '.mas_instance.channel = env(MAS_CHANNEL)' gitops/$ACCOUNT/$REGION/$CLUSTER_NAME/$MAS_INSTANCE_ID/mas-instance-params.yaml
 

--- a/tekton/src/tasks/gitops/gitops-mas-initiator.yml.j2
+++ b/tekton/src/tasks/gitops/gitops-mas-initiator.yml.j2
@@ -272,6 +272,10 @@ spec:
         cp --no-clobber $SOURCE_LOCAL_DIR/$SOURCE_GITHUB_REPO/$SOURCE_PATH/gitops/$ACCOUNT/$REGION/$CLUSTER_NAME/* $TARGET_LOCAL_DIR/$TARGET_GITHUB_REPO/gitops/$ACCOUNT/$REGION/$CLUSTER_NAME
         set -e -o pipefail
 
+        mkdir -p $TARGET_LOCAL_DIR/$TARGET_GITHUB_REPO/gitops/$ACCOUNT/$REGION/order-status
+        echo "copy $SOURCE_LOCAL_DIR/$SOURCE_GITHUB_REPO/order-status/* to $TARGET_LOCAL_DIR/$TARGET_GITHUB_REPO/gitops/$ACCOUNT/$REGION/order-status"
+        cp -r $SOURCE_LOCAL_DIR/$SOURCE_GITHUB_REPO/order-status/* $TARGET_LOCAL_DIR/$TARGET_GITHUB_REPO/gitops/$ACCOUNT/$REGION/order-status
+
         mkdir -p $TARGET_LOCAL_DIR/$TARGET_GITHUB_REPO/gitops/$ACCOUNT/$REGION/$CLUSTER_NAME/$MAS_INSTANCE_ID
         echo "copying $SOURCE_LOCAL_DIR/$SOURCE_GITHUB_REPO/$SOURCE_PATH/gitops/$ACCOUNT/$REGION/$CLUSTER_NAME/$MAS_INSTANCE_ID/* to $TARGET_LOCAL_DIR/$TARGET_GITHUB_REPO/gitops/$ACCOUNT/$REGION/$CLUSTER_NAME/$MAS_INSTANCE_ID"
         cp -r $SOURCE_LOCAL_DIR/$SOURCE_GITHUB_REPO/$SOURCE_PATH/gitops/$ACCOUNT/$REGION/$CLUSTER_NAME/$MAS_INSTANCE_ID/* $TARGET_LOCAL_DIR/$TARGET_GITHUB_REPO/gitops/$ACCOUNT/$REGION/$CLUSTER_NAME/$MAS_INSTANCE_ID/
@@ -328,8 +332,8 @@ spec:
         yq -i '.cluster.url = env(OCP_SERVER)' gitops/$ACCOUNT/$REGION/$CLUSTER_NAME/cluster-params.yaml
         yq -i '.cluster.domain = env(APPSDOMAIN)' gitops/$ACCOUNT/$REGION/$CLUSTER_NAME/cluster-params.yaml
 
-        # Update the provisioner_domain in the cluster-params.yml.
-        yq -i '.mas_provisioner.provisioner_domain = env(APPSDOMAIN)' gitops/$ACCOUNT/$REGION/$CLUSTER_NAME/cluster-params.yaml
+        # Update the provisioner_domain in cluster-params.yaml.
+        yq -i '(. | select(has("mas_provisioner")) |  .mas_provisioner.provisioner_domain) = env(APPSDOMAIN)' gitops/$ACCOUNT/$REGION/$CLUSTER_NAME/cluster-params.yaml
 
         # Update the channel in the mas-instance-params.yaml. 
         yq -i '.mas_instance.channel = env(MAS_CHANNEL)' gitops/$ACCOUNT/$REGION/$CLUSTER_NAME/$MAS_INSTANCE_ID/mas-instance-params.yaml


### PR DESCRIPTION
Set value for provisioner_domain 
Copy order-status folder into the master for fvt test

I added some last minute changes for syslog pullsecret and dlc certs aws secrets to be updated in gitops-cluster when the secrets are set