### PR TITLE
[minor] Add property for nonshared cluster to pipeline for gitops

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -172,7 +172,7 @@
         "hashed_secret": "b2817467154949a61f8e9ad31d1eeaf03221cbfa",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 438,
+        "line_number": 444,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -564,7 +564,7 @@
         "hashed_secret": "fee2d55ad9a49a95fc89abe8f414dad66704ebfd",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 15,
+        "line_number": 16,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/image/cli/mascli/functions/gitops_cluster
+++ b/image/cli/mascli/functions/gitops_cluster
@@ -260,6 +260,9 @@ function gitops_cluster_noninteractive() {
         export INGRESS=$1 && shift
         ;;
 
+      --nonshared)
+        export NONSHARED=$1 && shift
+        ;;
       --install-selenium-grid)
         export INSTALL_SELENIUM_GRID=true
         ;;
@@ -406,6 +409,8 @@ function gitops_cluster() {
     # Disable provision public ingress controller by default 
     export INGRESS=${INGRESS:-"false"}
   fi
+  export CLUSTER_NONSHARED=${NONSHARED:-"false"}
+  
   echo "${TEXT_DIM}"
   echo_h2 "Target" "    "
   echo_reset_dim "Account ID ..................... ${COLOR_MAGENTA}${ACCOUNT_ID}"
@@ -413,6 +418,7 @@ function gitops_cluster() {
   echo_reset_dim "Cluster ID ..................... ${COLOR_MAGENTA}${CLUSTER_ID}"
   echo_reset_dim "Cluster URL .................... ${COLOR_MAGENTA}${CLUSTER_URL}"
   echo_reset_dim "Cluster Config Directory ....... ${COLOR_MAGENTA}${GITOPS_CLUSTER_DIR}"
+  echo_reset_dim "Nonshared Cluster .............. ${COLOR_MAGENTA}${CLUSTER_NONSHARED}"
   reset_colors
 
   echo "${TEXT_DIM}"

--- a/image/cli/mascli/templates/gitops/appset-configs/cluster/phase1/ibm-mas-cluster-base.yaml.j2
+++ b/image/cli/mascli/templates/gitops/appset-configs/cluster/phase1/ibm-mas-cluster-base.yaml.j2
@@ -9,6 +9,7 @@ region:
 cluster:
   id: {{ CLUSTER_ID }}
   url: {{ CLUSTER_URL }}
+  nonshared: {{ CLUSTER_NONSHARED }}
 
 sm:
   aws_access_key_id: "<path:{{ SECRETS_PATH }}:{{ACCOUNT_ID}}/{{CLUSTER_ID}}/aws#sm_aws_access_key_id>"

--- a/tekton/src/pipelines/gitops/gitops-mas-cluster.yml.j2
+++ b/tekton/src/pipelines/gitops/gitops-mas-cluster.yml.j2
@@ -142,7 +142,7 @@ spec:
     - name: ingress
       type: string
       default: "false"
-    - name: nonshared
+    - name: cluster_nonshared
       type: string
       default: "false"
 
@@ -314,8 +314,8 @@ spec:
           value: $(params.dns_provider)
         - name: ingress
           value: $(params.ingress)
-        - name: nonshared
-          value: $(params.nonshared)
+        - name: cluster_nonshared
+          value: $(params.cluster_nonshared)
 
         - name: group_sync_operator_cron_schedule
           value: $(params.group_sync_operator_cron_schedule)

--- a/tekton/src/pipelines/gitops/gitops-mas-cluster.yml.j2
+++ b/tekton/src/pipelines/gitops/gitops-mas-cluster.yml.j2
@@ -142,6 +142,9 @@ spec:
     - name: ingress
       type: string
       default: "false"
+    - name: nonshared
+      type: string
+      default: "false"
 
     - name: group_sync_operator_cron_schedule
       type: string
@@ -311,6 +314,8 @@ spec:
           value: $(params.dns_provider)
         - name: ingress
           value: $(params.ingress)
+        - name: nonshared
+          value: $(params.nonshared)
 
         - name: group_sync_operator_cron_schedule
           value: $(params.group_sync_operator_cron_schedule)

--- a/tekton/src/tasks/gitops/gitops-cluster.yml.j2
+++ b/tekton/src/tasks/gitops/gitops-cluster.yml.j2
@@ -84,7 +84,7 @@ spec:
     - name: ingress
       type: string
       default: "false"
-    - name: nonshared
+    - name: cluster_nonshared
       type: string
       default: "false"
 
@@ -218,7 +218,7 @@ spec:
       - name: INGRESS
         value: $(params.ingress)
       - name: NONSHARED
-        value: $(params.nonshared)
+        value: $(params.cluster_nonshared)
 
       - name: REDHAT_CERT_MANAGER_INSTALL_PLAN
         value: $(params.redhat_cert_manager_install_plan)

--- a/tekton/src/tasks/gitops/gitops-cluster.yml.j2
+++ b/tekton/src/tasks/gitops/gitops-cluster.yml.j2
@@ -84,6 +84,9 @@ spec:
     - name: ingress
       type: string
       default: "false"
+    - name: nonshared
+      type: string
+      default: "false"
 
     - name: redhat_cert_manager_install_plan
       type: string
@@ -214,6 +217,8 @@ spec:
         value: $(params.ocp_cluster_domain)
       - name: INGRESS
         value: $(params.ingress)
+      - name: NONSHARED
+        value: $(params.nonshared)
 
       - name: REDHAT_CERT_MANAGER_INSTALL_PLAN
         value: $(params.redhat_cert_manager_install_plan)


### PR DESCRIPTION
### Description
Introduce a new cluster parameter for the support of identifying clusters as dedicated(nonshared) or shared. This is in support of EPIC MASR-2103 and Story MASCORE-5932
```
cluster:
  nonshared: true|false
```
Parameter value is defaulted to false if unset. 

### Related Issues
https://github.ibm.com/maximoappsuite/saas-deploy-py/pull/188 (already closed)
https://github.ibm.com/maximoappsuite/saas-tekton/pull/139
https://github.ibm.com/maximoappsuite/saas-envs-starter/pull/82

### Testing completed
Test 1: Parameter set to true
Updated saas-envs repo cluster-params.yaml file to include nonshared: true 
Log from dev-gitops-mas-cluster pipeline
<img width="707" alt="image" src="https://github.com/user-attachments/assets/7a3f4ab0-afbb-4f89-be65-da5f805c3315" />
Validated correct setting in gitops-envs repo for cluster under test.

Test 2: Parameter unset
Updates saas-envs repo to remove cluster-params.yaml file to remove nonshared cluster param.
Log from dev-gitops-mas-cluster pipeline
<img width="651" alt="image" src="https://github.com/user-attachments/assets/24550363-a0f4-4fde-8432-5f57350521b6" />
Validated setting false in gitops-envs repo for cluster under test.
