### PR TITLE
[patch] change default nvidia driver for gitops

### DIFF
--- a/image/cli/mascli/functions/gitops_nvidia_gpu
+++ b/image/cli/mascli/functions/gitops_nvidia_gpu
@@ -27,7 +27,7 @@ NVIDIA GPU OPERATOR:
       --gpu-namespace ${COLOR_YELLOW}GPU_NAMESPACE${TEXT_RESET}                                 GPU Namespace, defaults to nvidia-gpu-operator
       --gpu-channel ${COLOR_YELLOW}GPU_CHANNEL${TEXT_RESET}                                     GPU Channel, defaults to v24.3
       --gpu-install-plan ${COLOR_YELLOW}GPU_INSTALL_PLAN${TEXT_RESET}                           GPU Subscription install plan, ('Automatic' or 'Manual'. Default is 'Automatic')
-      --gpu-driver-version ${COLOR_YELLOW}GPU_DRIVER_VERSION${TEXT_RESET}                       GPU Driver Version, defaults to 550.90.07
+      --gpu-driver-version ${COLOR_YELLOW}GPU_DRIVER_VERSION${TEXT_RESET}                       GPU Driver Version, defaults to 575.57.08
       --gpu-driver-repository-path ${COLOR_YELLOW}GPU_DRIVER_REPOSITORY_PATH${TEXT_RESET}       GPU Driver Repository, defaults to nvcr.io/nvidia
 
 Automatic GitHub Push:
@@ -233,7 +233,7 @@ function gitops_nvidia_gpu() {
     export GPU_CHANNEL=v24.3
   fi
   if [[ -z "${GPU_DRIVER_VERSION}" ]]; then
-    export GPU_DRIVER_VERSION="550.90.07"
+    export GPU_DRIVER_VERSION="575.57.08"
   fi
   if [[ -z "${GPU_DRIVER_REPOSITORY_PATH}" ]]; then
     export GPU_DRIVER_REPOSITORY_PATH=nvcr.io/nvidia

--- a/tekton/src/pipelines/gitops/gitops-mas-cluster.yml.j2
+++ b/tekton/src/pipelines/gitops/gitops-mas-cluster.yml.j2
@@ -86,7 +86,7 @@ spec:
       default: "Automatic"
     - name: gpu_driver_version
       type: string
-      default: 550.90.07
+      default: 575.57.08
     - name: gpu_driver_repository_path
       type: string
       default: nvcr.io/nvidia


### PR DESCRIPTION
This change is to update nvidia versionndue to below error:
![image](https://github.com/user-attachments/assets/10e42024-0842-4ece-b90b-353430f7878f)

BUG: https://jsw.ibm.com/browse/MASCORE-7846