### PR TITLE
[patch] Fix deprovision not removing all yaml files from gitops-envs

### DIFF
--- a/image/cli/mascli/functions/gitops_deprovision_cp4d
+++ b/image/cli/mascli/functions/gitops_deprovision_cp4d
@@ -128,10 +128,6 @@ function gitops_deprovision_cp4d_noninteractive() {
   # MAS
   [[ -z "$MAS_INSTANCE_ID" ]] && gitops_deprovision_cp4d_help "MAS_INSTANCE_ID is not set"
 
-#   [[ -z "$CPD_PRODUCT_VERSION" ]] && gitops_deprovision_cp4d_help "CPD_PRODUCT_VERSION is not set"
-#   [[ -z "$CPD_PRIMARY_STORAGE_CLASS" ]] && gitops_deprovision_cp4d_help "CPD_PRIMARY_STORAGE_CLASS is not set"
-#   [[ -z "$CPD_METADATA_STORAGE_CLASS" ]] && gitops_deprovision_cp4d_help "CPD_METADATA_STORAGE_CLASS is not set"
-
   if [[ "$GITHUB_PUSH" == "true" ]]; then
     [[ -z "$GITHUB_HOST" ]] && gitops_deprovision_cp4d_help "GITHUB_HOST is not set"
     [[ -z "$GITHUB_ORG" ]] && gitops_deprovision_cp4d_help "GITHUB_ORG is not set"
@@ -158,9 +154,6 @@ function gitops_deprovision_cp4d() {
 
   mkdir -p ${GITOPS_WORKING_DIR}
   GITOPS_INSTANCE_DIR=${GITOPS_WORKING_DIR}/${GITHUB_REPO}/${ACCOUNT_ID}/${CLUSTER_ID}/${MAS_INSTANCE_ID}
-
-#   export CPD_OPERATORS_NAMESPACE=${CPD_OPERATORS_NAMESPACE:-"ibm-cpd-${MAS_INSTANCE_ID}-operators"}
-#   export CPD_INSTANCE_NAMESPACE=${CPD_INSTANCE_NAMESPACE:-"ibm-cpd-${MAS_INSTANCE_ID}-instance"}
 
   echo
   reset_colors
@@ -192,20 +185,6 @@ function gitops_deprovision_cp4d() {
     echo_reset_dim "Automatic Push ........................ ${COLOR_RED}Disabled"
     echo_reset_dim "Working Directory ..................... ${COLOR_MAGENTA}${GITOPS_WORKING_DIR}"
   fi
-  reset_colors
-
-#   echo "${TEXT_DIM}"
-#   echo_h2 "CP4D" "    "
-#   echo_reset_dim "CPD_PRODUCT_VERSION  ..................... ${COLOR_MAGENTA}${CPD_PRODUCT_VERSION}"
-#   echo_reset_dim "CPD_OPERATORS_NAMESPACE  ................. ${COLOR_MAGENTA}${CPD_OPERATORS_NAMESPACE}"
-#   echo_reset_dim "CPD_INSTANCE_NAMESPACE  .................. ${COLOR_MAGENTA}${CPD_INSTANCE_NAMESPACE}"
-#   echo_reset_dim "CPD_PRIMARY_STORAGE_CLASS  ............... ${COLOR_MAGENTA}${CPD_PRIMARY_STORAGE_CLASS}"
-#   echo_reset_dim "CPD_METADATA_STORAGE_CLASS  .............. ${COLOR_MAGENTA}${CPD_METADATA_STORAGE_CLASS}"
-#   echo_reset_dim "CPD_PLATFORM_INSTALL_PLAN  ............... ${COLOR_MAGENTA}${CPD_PLATFORM_INSTALL_PLAN}"
-#   echo_reset_dim "NAMESPACE_SCOPE_INSTALL_PLAN  ............ ${COLOR_MAGENTA}${NAMESPACE_SCOPE_INSTALL_PLAN}"
-#   echo_reset_dim "CPD_LICENSING_INSTALL_PLAN  .............. ${COLOR_MAGENTA}${CPD_LICENSING_INSTALL_PLAN}"
-#   echo_reset_dim "CPFS_INSTALL_PLAN  ....................... ${COLOR_MAGENTA}${CPFS_INSTALL_PLAN}"
-
   reset_colors
 
   if [ -z $GIT_SSH ]; then

--- a/image/cli/mascli/functions/gitops_deprovision_cp4d
+++ b/image/cli/mascli/functions/gitops_deprovision_cp4d
@@ -1,0 +1,238 @@
+#!/usr/bin/env bash
+
+function gitops_deprovision_cp4d_help() {
+  [[ -n "$1" ]] && echo_warning "$1"
+  reset_colors
+  cat << EOM
+Usage:
+  mas gitops-deprovision-cp4d [options]
+Where ${COLOR_YELLOW}specified${TEXT_RESET} each option may also be defined by setting the appropriate environment variable.
+When no options are specified on the command line, interactive-mode will be enabled by default.
+
+GitOps Configuration:
+  -d, --dir ${COLOR_YELLOW}GITOPS_WORKING_DIR${TEXT_RESET}            Directory for GitOps repository
+  -a, --account-id ${COLOR_YELLOW}ACCOUNT_ID${TEXT_RESET}             Account ID
+  -r, --region-id ${COLOR_YELLOW}REGION${TEXT_RESET}                  Region ID
+  -c, --cluster-id ${COLOR_YELLOW}CLUSTER_ID${TEXT_RESET}             Cluster ID
+
+IBM Maximo Application Suite:
+  -m, --mas-instance-id ${COLOR_YELLOW}MAS_INSTANCE_ID${TEXT_RESET}   IBM Suite Maximo Application Suite Instance ID
+
+Secrets Manager:
+      --secrets-path ${COLOR_YELLOW}SECRETS_PATH${TEXT_RESET}                     Secrets Manager path
+      --secrets-key-seperator ${COLOR_YELLOW}SECRETS_KEY_SEPERATOR${TEXT_RESET}   Secrets Manager key seperator string
+
+Automatic GitHub Push:
+  -P, --github-push ${COLOR_YELLOW}GITHUB_PUSH${TEXT_RESET}           Enable automatic push to GitHub
+  -H, --github-host ${COLOR_YELLOW}GITHUB_HOST${TEXT_RESET}           GitHub Hostname for your GitOps repository
+  -O, --github-org  ${COLOR_YELLOW}GITHUB_ORG${TEXT_RESET}            Github org for your GitOps repository
+  -R, --github-repo ${COLOR_YELLOW}GITHUB_REPO${TEXT_RESET}           Github repo for your GitOps repository
+  -B, --git-branch ${COLOR_YELLOW}GIT_BRANCH${TEXT_RESET}             Git branch to commit to of your GitOps repository
+  -M, --git-commit-msg ${COLOR_YELLOW}GIT_COMMIT_MSG${TEXT_RESET}     Git commit message to use when committing to of your GitOps repository
+  -S , --github-ssh  ${COLOR_YELLOW}GIT_SSH${TEXT_RESET}              Git ssh key path
+Other Commands:
+  -h, --help                              Show this help message
+EOM
+  [[ -n "$1" ]] && exit 1 || exit 0
+}
+
+function gitops_deprovision_cp4d_noninteractive() {
+  GITOPS_WORKING_DIR=$PWD/working-dir
+  SECRETS_KEY_SEPERATOR="/"
+  GIT_COMMIT_MSG="gitops-deprovision-cp4d commit"
+
+  export REGION_ID=${REGION_ID:-${SM_AWS_REGION}}
+  export CPD_PLATFORM_INSTALL_PLAN=${CPD_PLATFORM_INSTALL_PLAN:-"Automatic"}
+  export NAMESPACE_SCOPE_INSTALL_PLAN=${NAMESPACE_SCOPE_INSTALL_PLAN:-"Automatic"}
+  export CPD_LICENSING_INSTALL_PLAN=${CPD_LICENSING_INSTALL_PLAN:-"Automatic"}
+  export CPFS_INSTALL_PLAN=${CPFS_INSTALL_PLAN:-"Automatic"}
+
+  while [[ $# -gt 0 ]]
+  do
+    key="$1"
+    shift
+    case $key in
+      # GitOps Configuration
+      -d|--dir)
+        export GITOPS_WORKING_DIR=$1 && shift
+        ;;
+      -g|--gitops-version)
+        echo "${COLOR_YELLOW}WARNING: the -g|--gitops-version parameter is deprecated; it has no effect and will be removed in a future release${COLOR_RESET}"
+        shift
+        ;;
+      -a|--account-id)
+        export ACCOUNT_ID=$1 && shift
+        ;;
+      -c|--cluster-id)
+        export CLUSTER_ID=$1 && shift
+        ;;
+      -r|--region-id)
+        export REGION_ID=$1 && shift
+        ;;
+
+      # MAS
+      -m|--mas-instance-id)
+        export MAS_INSTANCE_ID=$1 && shift
+        ;;
+
+      # Secrets Manager
+      --secrets-path)
+        export SECRETS_PATH=$1 && shift
+        ;;
+      --secrets-key-seperator)
+        export SECRETS_KEY_SEPERATOR=$1 && shift
+        ;;
+
+      # Automatic GitHub Push
+      -P|--github-push)
+        export GITHUB_PUSH=true
+        ;;
+      -H|--github-host)
+        export GITHUB_HOST=$1 && shift
+        ;;
+      -O|--github-org)
+        export GITHUB_ORG=$1 && shift
+        ;;
+      -R|--github-repo)
+        export GITHUB_REPO=$1 && shift
+        ;;
+      -B|--git-branch)
+        export GIT_BRANCH=$1 && shift
+        ;;
+      -M|--git-commit-msg)
+        export GIT_COMMIT_MSG=$1 && shift
+        ;;
+        
+      -S|--github-ssh)
+        export GIT_SSH=$1 && shift
+        ;;
+
+      # Other Commands
+      -h|--help)
+        gitops_deprovision_cp4d_help
+        ;;
+      *)
+        # unknown option
+        echo -e "${COLOR_RED}Usage Error: Unsupported option \"${key}\"${COLOR_RESET}\n"
+        gitops_deprovision_cp4d_help  "Usage Error: Unsupported option \"${key}\" "
+        exit 1
+        ;;
+      esac
+  done
+
+  [[ -z "$GITOPS_WORKING_DIR" ]] && gitops_deprovision_cp4d_help "GITOPS_WORKING_DIR is not set"
+  [[ -z "$ACCOUNT_ID" ]] && gitops_deprovision_cp4d_help "ACCOUNT_ID is not set"
+  [[ -z "$CLUSTER_ID" ]] && gitops_deprovision_cp4d_help "CLUSTER_ID is not set"
+  [[ -z "$REGION_ID" ]] && gitops_deprovision_cp4d_help "REGION_ID is not set"
+
+  # MAS
+  [[ -z "$MAS_INSTANCE_ID" ]] && gitops_deprovision_cp4d_help "MAS_INSTANCE_ID is not set"
+
+#   [[ -z "$CPD_PRODUCT_VERSION" ]] && gitops_deprovision_cp4d_help "CPD_PRODUCT_VERSION is not set"
+#   [[ -z "$CPD_PRIMARY_STORAGE_CLASS" ]] && gitops_deprovision_cp4d_help "CPD_PRIMARY_STORAGE_CLASS is not set"
+#   [[ -z "$CPD_METADATA_STORAGE_CLASS" ]] && gitops_deprovision_cp4d_help "CPD_METADATA_STORAGE_CLASS is not set"
+
+  if [[ "$GITHUB_PUSH" == "true" ]]; then
+    [[ -z "$GITHUB_HOST" ]] && gitops_deprovision_cp4d_help "GITHUB_HOST is not set"
+    [[ -z "$GITHUB_ORG" ]] && gitops_deprovision_cp4d_help "GITHUB_ORG is not set"
+    [[ -z "$GITHUB_REPO" ]] && gitops_deprovision_cp4d_help "GITHUB_REPO is not set"
+    [[ -z "$GIT_BRANCH" ]] && gitops_deprovision_cp4d_help "GIT_BRANCH is not set"
+  fi
+
+}
+
+function gitops_deprovision_cp4d() {
+    # Take the first parameter off (it will be create-gitops)
+  shift
+  if [[ $# -gt 0 ]]; then
+    gitops_deprovision_cp4d_noninteractive "$@"
+  else
+    echo "Not supported yet"
+    exit 1
+    gitops_deprovision_cp4d_interactive
+  fi
+
+  # catch errors
+  set -o pipefail
+  trap 'echo "[ERROR] Error occurred at $BASH_SOURCE, line $LINENO, exited with $?"; exit 1' ERR
+
+  mkdir -p ${GITOPS_WORKING_DIR}
+  GITOPS_INSTANCE_DIR=${GITOPS_WORKING_DIR}/${GITHUB_REPO}/${ACCOUNT_ID}/${CLUSTER_ID}/${MAS_INSTANCE_ID}
+
+#   export CPD_OPERATORS_NAMESPACE=${CPD_OPERATORS_NAMESPACE:-"ibm-cpd-${MAS_INSTANCE_ID}-operators"}
+#   export CPD_INSTANCE_NAMESPACE=${CPD_INSTANCE_NAMESPACE:-"ibm-cpd-${MAS_INSTANCE_ID}-instance"}
+
+  echo
+  reset_colors
+  echo_h2 "Review Settings"
+
+  echo "${TEXT_DIM}"
+  echo_h2 "Target" "    "
+  echo_reset_dim "Account ID ............................ ${COLOR_MAGENTA}${ACCOUNT_ID}"
+  echo_reset_dim "Cluster ID ............................ ${COLOR_MAGENTA}${CLUSTER_ID}"
+  echo_reset_dim "Instance Config Directory ............. ${COLOR_MAGENTA}${GITOPS_INSTANCE_DIR}"
+  reset_colors
+
+  echo "${TEXT_DIM}"
+  echo_h2 "Secrets Manager" "    "
+  echo_reset_dim "Secrets Path .......................... ${COLOR_MAGENTA}${SECRETS_PATH}"
+  reset_colors
+
+  echo "${TEXT_DIM}"
+  if [[ "$GITHUB_PUSH" == "true" ]]; then
+    echo_h2 "GitOps Target" "    "
+    echo_reset_dim "Automatic Push ........................ ${COLOR_GREEN}Enabled"
+    echo_reset_dim "Working Directory ..................... ${COLOR_MAGENTA}${GITOPS_WORKING_DIR}"
+    echo_reset_dim "Host .................................. ${COLOR_MAGENTA}${GITHUB_HOST}"
+    echo_reset_dim "Organization .......................... ${COLOR_MAGENTA}${GITHUB_ORG}"
+    echo_reset_dim "Repository ............................ ${COLOR_MAGENTA}${GITHUB_REPO}"
+    echo_reset_dim "Branch ................................ ${COLOR_MAGENTA}${GIT_BRANCH}"
+  else
+    echo_h2 "GitOps Target" "    "
+    echo_reset_dim "Automatic Push ........................ ${COLOR_RED}Disabled"
+    echo_reset_dim "Working Directory ..................... ${COLOR_MAGENTA}${GITOPS_WORKING_DIR}"
+  fi
+  reset_colors
+
+#   echo "${TEXT_DIM}"
+#   echo_h2 "CP4D" "    "
+#   echo_reset_dim "CPD_PRODUCT_VERSION  ..................... ${COLOR_MAGENTA}${CPD_PRODUCT_VERSION}"
+#   echo_reset_dim "CPD_OPERATORS_NAMESPACE  ................. ${COLOR_MAGENTA}${CPD_OPERATORS_NAMESPACE}"
+#   echo_reset_dim "CPD_INSTANCE_NAMESPACE  .................. ${COLOR_MAGENTA}${CPD_INSTANCE_NAMESPACE}"
+#   echo_reset_dim "CPD_PRIMARY_STORAGE_CLASS  ............... ${COLOR_MAGENTA}${CPD_PRIMARY_STORAGE_CLASS}"
+#   echo_reset_dim "CPD_METADATA_STORAGE_CLASS  .............. ${COLOR_MAGENTA}${CPD_METADATA_STORAGE_CLASS}"
+#   echo_reset_dim "CPD_PLATFORM_INSTALL_PLAN  ............... ${COLOR_MAGENTA}${CPD_PLATFORM_INSTALL_PLAN}"
+#   echo_reset_dim "NAMESPACE_SCOPE_INSTALL_PLAN  ............ ${COLOR_MAGENTA}${NAMESPACE_SCOPE_INSTALL_PLAN}"
+#   echo_reset_dim "CPD_LICENSING_INSTALL_PLAN  .............. ${COLOR_MAGENTA}${CPD_LICENSING_INSTALL_PLAN}"
+#   echo_reset_dim "CPFS_INSTALL_PLAN  ....................... ${COLOR_MAGENTA}${CPFS_INSTALL_PLAN}"
+
+  reset_colors
+
+  if [ -z $GIT_SSH ]; then
+    export GIT_SSH="false"
+  fi
+
+  # Clone github target repo
+  # ---------------------------------------------------------------------------
+  if [ "$GITHUB_PUSH" == "true" ]; then
+    echo
+    echo_h2 "Cloning GitHub repo $GITHUB_ORG $GITHUB_REPO"
+    clone_target_git_repo $GITHUB_HOST $GITHUB_ORG $GITHUB_REPO $GIT_BRANCH $GITOPS_WORKING_DIR $GIT_SSH
+  fi
+  mkdir -p ${GITOPS_INSTANCE_DIR}
+
+
+  # Delete Application config
+  # ---------------------------------------------------------------------------
+  echo
+  echo_h2 "Deleting application configuration files"
+
+  echo "Deleting IBM CP4D file ${GITOPS_INSTANCE_DIR}/ibm-cp4d.yaml"
+  rm -rf ${GITOPS_INSTANCE_DIR}/ibm-cp4d.yaml
+  if [ "$GITHUB_PUSH" == "true" ]; then
+    echo
+    echo_h2 "Commit and push changes to GitHub repo $GITHUB_ORG $GITHUB_REPO"
+    save_to_target_git_repo $GITHUB_HOST $GITHUB_ORG $GITHUB_REPO $GIT_BRANCH "${GITOPS_WORKING_DIR}/${GITHUB_REPO}" "${GIT_COMMIT_MSG}"
+  fi
+
+}

--- a/image/cli/mascli/functions/gitops_deprovision_cp4d_service
+++ b/image/cli/mascli/functions/gitops_deprovision_cp4d_service
@@ -24,6 +24,7 @@ Secrets Manager:
 
 IBM CP4D Service:
       --cpd-service-name ${COLOR_YELLOW}CPD_SERVICE_NAME${TEXT_RESET}                                   CP4D Service Name
+      --delete-cpd-base ${COLOR_YELLOW}DELETE_CPD_BASE${TEXT_RESET}                                     Whether to delete cpd base file
 
 
 Automatic GitHub Push:
@@ -96,6 +97,9 @@ function gitops_deprovision_cp4d_service_noninteractive() {
       --cpd-service-name)
         export CPD_SERVICE_NAME=$1 && shift
         ;;
+      --delete-cpd-base)
+        export DELETE_CPD_BASE=$1 && shift
+        ;;
 
       # Automatic GitHub Push
       -P|--github-push)
@@ -143,6 +147,7 @@ function gitops_deprovision_cp4d_service_noninteractive() {
   [[ -z "$MAS_INSTANCE_ID" ]] && gitops_deprovision_cp4d_service_help "MAS_INSTANCE_ID is not set"
 
   [[ -z "$CPD_SERVICE_NAME" ]] && gitops_deprovision_cp4d_service_help "CPD_SERVICE_NAME is not set"
+  [[ -z "$DELETE_CPD_BASE" ]] && gitops_deprovision_cp4d_service_help "DELETE_CPD_BASE is not set"
 
   if [[ "$GITHUB_PUSH" == "true" ]]; then
     [[ -z "$GITHUB_HOST" ]] && gitops_deprovision_cp4d_service_help "GITHUB_HOST is not set"
@@ -246,7 +251,7 @@ function gitops_deprovision_cp4d_service() {
    echo
   echo_h2 "Deleting CPD Service (${CPD_SERVICE_NAME}) Application"
 
-  if [[ "$CPD_SERVICE_NAME" == "wsl" || "$CPD_SERVICE_NAME" == "wml" || "$CPD_SERVICE_NAME" == "spss" ]]; then
+  if [[ "$DELETE_CPD_BASE" == "true" ]]; then
     echo "Deleting IBM CPD Service file ${GITOPS_INSTANCE_DIR}/ibm-cp4d-services-base.yaml"
     rm -rf ${GITOPS_INSTANCE_DIR}/ibm-cp4d-services-base.yaml
   fi

--- a/image/cli/mascli/functions/gitops_deprovision_cp4d_service
+++ b/image/cli/mascli/functions/gitops_deprovision_cp4d_service
@@ -23,8 +23,10 @@ Secrets Manager:
       --secrets-key-seperator ${COLOR_YELLOW}SECRETS_KEY_SEPERATOR${TEXT_RESET}  Secrets Manager key seperator string
 
 IBM CP4D Service:
-      --cpd-service-name ${COLOR_YELLOW}CPD_SERVICE_NAME${TEXT_RESET}                                   CP4D Service Name
-      --delete-cpd-base ${COLOR_YELLOW}DELETE_CPD_BASE${TEXT_RESET}                                     Whether to delete cpd base file
+      --cpd-service-name ${COLOR_YELLOW}CPD_SERVICE_NAME${TEXT_RESET}                                         CP4D Service Name
+      --cp4d-wsl-action ${COLOR_YELLOW}CP4D_WSL_ACTION${TEXT_RESET}                                           Whether WSL service to be uninstalled
+      --cp4d-watson-machine-learning-action ${COLOR_YELLOW}CP4D_WATSON_MACHINE_LEARNING_ACTION${TEXT_RESET}   Whether WML service to be uninstalled
+      --cp4d-spss-modeler-action ${COLOR_YELLOW}CP4D_SPSS_MODELER_ACTION${TEXT_RESET}                         Whether SPSS service to be uninstalled
 
 
 Automatic GitHub Push:
@@ -97,8 +99,14 @@ function gitops_deprovision_cp4d_service_noninteractive() {
       --cpd-service-name)
         export CPD_SERVICE_NAME=$1 && shift
         ;;
-      --delete-cpd-base)
-        export DELETE_CPD_BASE=$1 && shift
+      --cp4d-wsl-action)
+        export CP4D_WSL_ACTION=$1 && shift
+        ;;
+      --cp4d-watson-machine-learning-action)
+        export CP4D_WATSON_MACHINE_LEARNING_ACTION=$1 && shift
+        ;;
+      --cp4d-spss-modeler-action)
+        export CP4D_SPSS_MODELER_ACTION=$1 && shift
         ;;
 
       # Automatic GitHub Push
@@ -147,7 +155,9 @@ function gitops_deprovision_cp4d_service_noninteractive() {
   [[ -z "$MAS_INSTANCE_ID" ]] && gitops_deprovision_cp4d_service_help "MAS_INSTANCE_ID is not set"
 
   [[ -z "$CPD_SERVICE_NAME" ]] && gitops_deprovision_cp4d_service_help "CPD_SERVICE_NAME is not set"
-  [[ -z "$DELETE_CPD_BASE" ]] && gitops_deprovision_cp4d_service_help "DELETE_CPD_BASE is not set"
+  [[ -z "$CP4D_WSL_ACTION" ]] && gitops_deprovision_cp4d_service_help "CP4D_WSL_ACTION is not set"
+  [[ -z "$CP4D_WATSON_MACHINE_LEARNING_ACTION" ]] && gitops_deprovision_cp4d_service_help "CP4D_WATSON_MACHINE_LEARNING_ACTION is not set"
+  [[ -z "$CP4D_SPSS_MODELER_ACTION" ]] && gitops_deprovision_cp4d_service_help "CP4D_SPSS_MODELER_ACTION is not set"
 
   if [[ "$GITHUB_PUSH" == "true" ]]; then
     [[ -z "$GITHUB_HOST" ]] && gitops_deprovision_cp4d_service_help "GITHUB_HOST is not set"
@@ -198,6 +208,14 @@ function gitops_deprovision_cp4d_service() {
   reset_colors
 
   echo "${TEXT_DIM}"
+  echo_h2 "CP4D service" "    "
+  echo_reset_dim "CPD Service Name ........................ ${COLOR_MAGENTA}${CPD_SERVICE_NAME}"
+  echo_reset_dim "CPD WSL Action .......................... ${COLOR_MAGENTA}${CP4D_WSL_ACTION}"
+  echo_reset_dim "CPD WML Action .......................... ${COLOR_MAGENTA}${CP4D_WATSON_MACHINE_LEARNING_ACTION}"
+  echo_reset_dim "CPD SPSS Action ......................... ${COLOR_MAGENTA}${CP4D_SPSS_MODELER_ACTION}"
+  reset_colors
+
+  echo "${TEXT_DIM}"
   if [[ "$GITHUB_PUSH" == "true" ]]; then
     echo_h2 "GitOps Target" "    "
     echo_reset_dim "Automatic Push ........................ ${COLOR_GREEN}Enabled"
@@ -213,24 +231,9 @@ function gitops_deprovision_cp4d_service() {
   fi
   reset_colors
 
-#   echo "${TEXT_DIM}"
-#   echo_h2 "CP4D Service" "    "
-#   echo_reset_dim "CPD_OPERATORS_NAMESPACE  .................... ${COLOR_MAGENTA}${CPD_OPERATORS_NAMESPACE}"
-#   echo_reset_dim "CPD_INSTANCE_NAMESPACE  ..................... ${COLOR_MAGENTA}${CPD_INSTANCE_NAMESPACE}"
-#   echo_reset_dim "CPD_SERVICE_NAME  ........................... ${COLOR_MAGENTA}${CPD_SERVICE_NAME}"
-#   echo_reset_dim "CPD_SERVICE_INSTALLPLAN_APPROVAL  ........... ${COLOR_MAGENTA}${CPD_SERVICE_INSTALLPLAN_APPROVAL}"
-#   echo_reset_dim "CPD_SERVICE_BLOCK_STORAGE_CLASS  ............ ${COLOR_MAGENTA}${CPD_SERVICE_BLOCK_STORAGE_CLASS}"
-#   echo_reset_dim "CPD_SERVICE_STORAGE_CLASS  .................. ${COLOR_MAGENTA}${CPD_SERVICE_STORAGE_CLASS}"
-#   echo_reset_dim "CPD_SERVICE_DEPLOYMENT_TYPE  ................ ${COLOR_MAGENTA}${CPD_SERVICE_DEPLOYMENT_TYPE}"
-#   echo_reset_dim "CPD_CCS_INSTALL_PLAN  ....................... ${COLOR_MAGENTA}${CPD_CCS_INSTALL_PLAN}"
-#   echo_reset_dim "CPD_DATAREFINERY_INSTALL_PLAN  .............. ${COLOR_MAGENTA}${CPD_DATAREFINERY_INSTALL_PLAN}"
-#   echo_reset_dim "CPD_WS_INSTALL_PLAN  ........................ ${COLOR_MAGENTA}${CPD_WS_INSTALL_PLAN}"
-#   echo_reset_dim "RABBITMQ_INSTALL_PLAN  ...................... ${COLOR_MAGENTA}${RABBITMQ_INSTALL_PLAN}"
-#   echo_reset_dim "ELASTICSEARCH_INSTALL_PLAN  ................. ${COLOR_MAGENTA}${ELASTICSEARCH_INSTALL_PLAN}"
-  reset_colors
-
   GIT_LOCK_BRANCH=$(git_lock_branch_name "gitops-deprovision-cp4d-service" "${ACCOUNT_ID}" "${CLUSTER_ID}" "${MAS_INSTANCE_ID}")
   CURRENT_DIR=$PWD
+  CPD_SERVICE_LIST=(wsl wml spss spark)
 
   if [ -z $GIT_SSH ]; then
     export GIT_SSH=false
@@ -251,16 +254,24 @@ function gitops_deprovision_cp4d_service() {
    echo
   echo_h2 "Deleting CPD Service (${CPD_SERVICE_NAME}) Application"
 
-  if [[ "$DELETE_CPD_BASE" == "true" ]]; then
+  if [[ "$CP4D_WSL_ACTION" == "uninstall" && "$CP4D_WATSON_MACHINE_LEARNING_ACTION" == "uninstall" && "$CP4D_SPSS_MODELER_ACTION" == "uninstall" ]]; then
     echo "Deleting IBM CPD Service file ${GITOPS_INSTANCE_DIR}/ibm-cp4d-services-base.yaml"
     rm -rf ${GITOPS_INSTANCE_DIR}/ibm-cp4d-services-base.yaml
   fi
   
-  echo
-  echo "- ${CPD_SERVICE_NAME} operator"
+  if [[ "$CPD_SERVICE_NAME" == "all" ]]; then
+    for CPD_SERVICE in "${CPD_SERVICE_LIST[@]}"
+    do
+      echo "Deleting IBM CPD Service file ${GITOPS_INSTANCE_DIR}/ibm-${CPD_SERVICE}.yaml"
+      rm -rf ${GITOPS_INSTANCE_DIR}/ibm-${CPD_SERVICE}.yaml
+    done
+  else
+    echo
+    echo "- ${CPD_SERVICE_NAME} operator"
 
-  echo "Deleting IBM CPD Service file ${GITOPS_INSTANCE_DIR}/ibm-${CPD_SERVICE_NAME}.yaml"
-  rm -rf ${GITOPS_INSTANCE_DIR}/ibm-${CPD_SERVICE_NAME}.yaml
+    echo "Deleting IBM CPD Service file ${GITOPS_INSTANCE_DIR}/ibm-${CPD_SERVICE_NAME}.yaml"
+    rm -rf ${GITOPS_INSTANCE_DIR}/ibm-${CPD_SERVICE_NAME}.yaml
+  fi
 
   # Commit and push to github target repo
   # ---------------------------------------------------------------------------

--- a/image/cli/mascli/functions/gitops_deprovision_cp4d_service
+++ b/image/cli/mascli/functions/gitops_deprovision_cp4d_service
@@ -1,0 +1,268 @@
+#!/usr/bin/env bash
+
+function gitops_deprovision_cp4d_service_help() {
+  [[ -n "$1" ]] && echo_warning "$1"
+  reset_colors
+  cat << EOM
+Usage:
+  mas gitops_deprovision_cp4d_service [options]
+Where ${COLOR_YELLOW}specified${TEXT_RESET} each option may also be defined by setting the appropriate environment variable.
+When no options are specified on the command line, interactive-mode will be enabled by default.
+
+GitOps Configuration:
+  -d, --dir ${COLOR_YELLOW}GITOPS_WORKING_DIR${TEXT_RESET}           Directory for GitOps repository
+  -a, --account-id ${COLOR_YELLOW}ACCOUNT_ID${TEXT_RESET}            Account name that the cluster belongs to
+  -c, --cluster-id ${COLOR_YELLOW}CLUSTER_ID${TEXT_RESET}            Cluster ID
+  -r, --region-id ${COLOR_YELLOW}REGION_ID${TEXT_RESET}              Region ID
+
+IBM Maximo Application Suite:
+  -m, --mas-instance-id ${COLOR_YELLOW}MAS_INSTANCE_ID${TEXT_RESET}   IBM Suite Maximo Application Suite Instance ID
+
+Secrets Manager:
+      --secrets-path ${COLOR_YELLOW}SECRETS_PATH${TEXT_RESET}                    Secrets Manager path
+      --secrets-key-seperator ${COLOR_YELLOW}SECRETS_KEY_SEPERATOR${TEXT_RESET}  Secrets Manager key seperator string
+
+IBM CP4D Service:
+      --cpd-service-name ${COLOR_YELLOW}CPD_SERVICE_NAME${TEXT_RESET}                                   CP4D Service Name
+
+
+Automatic GitHub Push:
+  -P, --github-push ${COLOR_YELLOW}GITHUB_PUSH${TEXT_RESET}        Enable automatic push to GitHub
+  -H, --github-host ${COLOR_YELLOW}GITHUB_HOST${TEXT_RESET}        GitHub Hostname for your GitOps repository
+  -O, --github-org  ${COLOR_YELLOW}GITHUB_ORG${TEXT_RESET}         Github org for your GitOps repository
+  -R, --github-repo ${COLOR_YELLOW}GITHUB_REPO${TEXT_RESET}        Github repo for your GitOps repository
+  -B, --git-branch ${COLOR_YELLOW}GIT_BRANCH${TEXT_RESET}          Git branch to commit to of your GitOps repository
+  -M, --git-commit-msg ${COLOR_YELLOW}GIT_COMMIT_MSG${TEXT_RESET}  Git commit message to use when committing to of your GitOps repository
+  -S, --github-ssh  ${COLOR_YELLOW}GIT_SSH${TEXT_RESET}            Git ssh key path
+
+Other Commands:
+  -h, --help                                      Show this help message
+EOM
+  [[ -n "$1" ]] && exit 1 || exit 0
+}
+
+function gitops_deprovision_cp4d_service_noninteractive() {
+  GITOPS_WORKING_DIR=$PWD/working-dir
+  SECRETS_KEY_SEPERATOR="/"
+  GIT_COMMIT_MSG="gitops-deprovision-cp4d-service commit"
+
+  export REGION_ID=${REGION_ID:-${SM_AWS_REGION}}
+  export CPD_SERVICE_INSTALLPLAN_APPROVAL=${CPD_SERVICE_INSTALLPLAN_APPROVAL:-"Automatic"}
+  export CPD_CCS_INSTALL_PLAN=${CPD_CCS_INSTALL_PLAN:-"Automatic"}
+  export CPD_DATAREFINERY_INSTALL_PLAN=${CPD_DATAREFINERY_INSTALL_PLAN:-"Automatic"}
+  export CPD_WS_INSTALL_PLAN=${CPD_WS_INSTALL_PLAN:-"Automatic"}
+  export RABBITMQ_INSTALL_PLAN=${RABBITMQ_INSTALL_PLAN:-"Automatic"}
+  export ELASTICSEARCH_INSTALL_PLAN=${ELASTICSEARCH_INSTALL_PLAN:-"Automatic"}
+  export CANVASBASE_INSTALL_PLAN=${CANVASBASE_INSTALL_PLAN:-"Automatic"}
+
+
+  while [[ $# -gt 0 ]]
+  do
+    key="$1"
+    shift
+    case $key in
+      # GitOps Configuration
+      -d|--dir)
+        export GITOPS_WORKING_DIR=$1 && shift
+        ;;
+      -g|--gitops-version)
+        echo "${COLOR_YELLOW}WARNING: the -g|--gitops-version parameter is deprecated; it has no effect and will be removed in a future release${COLOR_RESET}"
+        shift
+        ;;
+      -a|--account-id)
+        export ACCOUNT_ID=$1 && shift
+        ;;
+      -c|--cluster-id)
+        export CLUSTER_ID=$1 && shift
+        ;;
+      -r|--region-id)
+        export REGION_ID=$1 && shift
+        ;;
+
+      # MAS
+      -m|--mas-instance-id)
+        export MAS_INSTANCE_ID=$1 && shift
+        ;;
+
+      # Secrets Manager
+      --secrets-path)
+        export SECRETS_PATH=$1 && shift
+        ;;
+      --secrets-key-seperator)
+        export SECRETS_KEY_SEPERATOR=$1 && shift
+        ;;
+
+      # CP4D Service
+      --cpd-service-name)
+        export CPD_SERVICE_NAME=$1 && shift
+        ;;
+
+      # Automatic GitHub Push
+      -P|--github-push)
+        export GITHUB_PUSH=true
+        ;;
+      -H|--github-host)
+        export GITHUB_HOST=$1 && shift
+        ;;
+      -O|--github-org)
+        export GITHUB_ORG=$1 && shift
+        ;;
+      -R|--github-repo)
+        export GITHUB_REPO=$1 && shift
+        ;;
+      -B|--git-branch)
+        export GIT_BRANCH=$1 && shift
+        ;;
+      -M|--git-commit-msg)
+        export GIT_COMMIT_MSG=$1 && shift
+        ;;
+        
+      -S|--github-ssh)
+        export GIT_SSH=$1 && shift
+        ;;
+
+      # Other Commands
+      -h|--help)
+        gitops_deprovision_cp4d_service_help
+        ;;
+      *)
+        # unknown option
+        echo -e "${COLOR_RED}Usage Error: Unsupported option \"${key}\"${COLOR_RESET}\n"
+        gitops_deprovision_cp4d_service_help  "Usage Error: Unsupported option \"${key}\" "
+        exit 1
+        ;;
+      esac
+  done
+
+  [[ -z "$GITOPS_WORKING_DIR" ]] && gitops_deprovision_cp4d_service_help "GITOPS_WORKING_DIR is not set"
+  [[ -z "$ACCOUNT_ID" ]] && gitops_deprovision_cp4d_service_help "ACCOUNT_ID is not set"
+  [[ -z "$CLUSTER_ID" ]] && gitops_deprovision_cp4d_service_help "CLUSTER_ID is not set"
+  [[ -z "$REGION_ID" ]] && gitops_deprovision_cp4d_service_help "REGION_ID is not set"
+
+  #MAS
+  [[ -z "$MAS_INSTANCE_ID" ]] && gitops_deprovision_cp4d_service_help "MAS_INSTANCE_ID is not set"
+
+  [[ -z "$CPD_SERVICE_NAME" ]] && gitops_deprovision_cp4d_service_help "CPD_SERVICE_NAME is not set"
+
+  if [[ "$GITHUB_PUSH" == "true" ]]; then
+    [[ -z "$GITHUB_HOST" ]] && gitops_deprovision_cp4d_service_help "GITHUB_HOST is not set"
+    [[ -z "$GITHUB_ORG" ]] && gitops_deprovision_cp4d_service_help "GITHUB_ORG is not set"
+    [[ -z "$GITHUB_REPO" ]] && gitops_deprovision_cp4d_service_help "GITHUB_REPO is not set"
+    [[ -z "$GIT_BRANCH" ]] && gitops_deprovision_cp4d_service_help "GIT_BRANCH is not set"
+  fi
+
+}
+
+function gitops_deprovision_cp4d_service() {
+  # Take the first parameter off (it will be create-gitops)
+  shift
+  if [[ $# -gt 0 ]]; then
+    gitops_deprovision_cp4d_service_noninteractive "$@"
+  else
+    echo "Not supported yet"
+    exit 1
+    gitops_deprovision_cp4d_service_interactive
+  fi
+
+  # catch errors
+  set -o pipefail
+  trap 'echo "[ERROR] Error occurred at $BASH_SOURCE, line $LINENO, exited with $?"; exit 1' ERR
+
+  mkdir -p ${GITOPS_WORKING_DIR}
+  GITOPS_INSTANCE_DIR=${GITOPS_WORKING_DIR}/${GITHUB_REPO}/${ACCOUNT_ID}/${CLUSTER_ID}/${MAS_INSTANCE_ID}
+
+  echo
+  reset_colors
+  echo_h2 "Review Settings"
+
+  echo "${TEXT_DIM}"
+  echo_h2 "Target" "    "
+  echo_reset_dim "Account ID ............................ ${COLOR_MAGENTA}${ACCOUNT_ID}"
+  echo_reset_dim "Cluster ID ............................ ${COLOR_MAGENTA}${CLUSTER_ID}"
+  echo_reset_dim "Instance Config Directory ............. ${COLOR_MAGENTA}${GITOPS_INSTANCE_DIR}"
+  reset_colors
+
+  echo "${TEXT_DIM}"
+  echo_h2 "Secrets Manager" "    "
+  echo_reset_dim "Secrets Path .......................... ${COLOR_MAGENTA}${SECRETS_PATH}"
+  reset_colors
+
+  echo "${TEXT_DIM}"
+  echo_h2 "IBM Maximo Application Suite" "    "
+  echo_reset_dim "Instance ID ............................. ${COLOR_MAGENTA}${MAS_INSTANCE_ID}"
+  reset_colors
+
+  echo "${TEXT_DIM}"
+  if [[ "$GITHUB_PUSH" == "true" ]]; then
+    echo_h2 "GitOps Target" "    "
+    echo_reset_dim "Automatic Push ........................ ${COLOR_GREEN}Enabled"
+    echo_reset_dim "Working Directory ..................... ${COLOR_MAGENTA}${GITOPS_WORKING_DIR}"
+    echo_reset_dim "Host .................................. ${COLOR_MAGENTA}${GITHUB_HOST}"
+    echo_reset_dim "Organization .......................... ${COLOR_MAGENTA}${GITHUB_ORG}"
+    echo_reset_dim "Repository ............................ ${COLOR_MAGENTA}${GITHUB_REPO}"
+    echo_reset_dim "Branch ................................ ${COLOR_MAGENTA}${GIT_BRANCH}"
+  else
+    echo_h2 "GitOps Target" "    "
+    echo_reset_dim "Automatic Push ........................ ${COLOR_RED}Disabled"
+    echo_reset_dim "Working Directory ..................... ${COLOR_MAGENTA}${GITOPS_WORKING_DIR}"
+  fi
+  reset_colors
+
+#   echo "${TEXT_DIM}"
+#   echo_h2 "CP4D Service" "    "
+#   echo_reset_dim "CPD_OPERATORS_NAMESPACE  .................... ${COLOR_MAGENTA}${CPD_OPERATORS_NAMESPACE}"
+#   echo_reset_dim "CPD_INSTANCE_NAMESPACE  ..................... ${COLOR_MAGENTA}${CPD_INSTANCE_NAMESPACE}"
+#   echo_reset_dim "CPD_SERVICE_NAME  ........................... ${COLOR_MAGENTA}${CPD_SERVICE_NAME}"
+#   echo_reset_dim "CPD_SERVICE_INSTALLPLAN_APPROVAL  ........... ${COLOR_MAGENTA}${CPD_SERVICE_INSTALLPLAN_APPROVAL}"
+#   echo_reset_dim "CPD_SERVICE_BLOCK_STORAGE_CLASS  ............ ${COLOR_MAGENTA}${CPD_SERVICE_BLOCK_STORAGE_CLASS}"
+#   echo_reset_dim "CPD_SERVICE_STORAGE_CLASS  .................. ${COLOR_MAGENTA}${CPD_SERVICE_STORAGE_CLASS}"
+#   echo_reset_dim "CPD_SERVICE_DEPLOYMENT_TYPE  ................ ${COLOR_MAGENTA}${CPD_SERVICE_DEPLOYMENT_TYPE}"
+#   echo_reset_dim "CPD_CCS_INSTALL_PLAN  ....................... ${COLOR_MAGENTA}${CPD_CCS_INSTALL_PLAN}"
+#   echo_reset_dim "CPD_DATAREFINERY_INSTALL_PLAN  .............. ${COLOR_MAGENTA}${CPD_DATAREFINERY_INSTALL_PLAN}"
+#   echo_reset_dim "CPD_WS_INSTALL_PLAN  ........................ ${COLOR_MAGENTA}${CPD_WS_INSTALL_PLAN}"
+#   echo_reset_dim "RABBITMQ_INSTALL_PLAN  ...................... ${COLOR_MAGENTA}${RABBITMQ_INSTALL_PLAN}"
+#   echo_reset_dim "ELASTICSEARCH_INSTALL_PLAN  ................. ${COLOR_MAGENTA}${ELASTICSEARCH_INSTALL_PLAN}"
+  reset_colors
+
+  GIT_LOCK_BRANCH=$(git_lock_branch_name "gitops-deprovision-cp4d-service" "${ACCOUNT_ID}" "${CLUSTER_ID}" "${MAS_INSTANCE_ID}")
+  CURRENT_DIR=$PWD
+
+  if [ -z $GIT_SSH ]; then
+    export GIT_SSH=false
+  fi
+
+  # Clone github target repo
+  # ---------------------------------------------------------------------------
+  if [ "$GITHUB_PUSH" == "true" ]; then
+    # only create the lock branch if we plan to actually push changes to git
+    clone_and_lock_target_git_repo  "${GITHUB_HOST}" "${GITHUB_ORG}" "${GITHUB_REPO}" "${GIT_BRANCH}" "${GITOPS_WORKING_DIR}" "${GIT_SSH}" "${GIT_LOCK_BRANCH}"
+  else
+    # even though we don't want to push anything to git,
+    # because this script modifies the existing suite-configs.yaml file, we still need to checkout the repo
+    clone_target_git_repo $GITHUB_HOST $GITHUB_ORG $GITHUB_REPO $GIT_BRANCH $GITOPS_WORKING_DIR $GIT_SSH
+  fi
+  mkdir -p ${GITOPS_INSTANCE_DIR}
+
+   echo
+  echo_h2 "Deleting CPD Service (${CPD_SERVICE_NAME}) Application"
+
+  if [[ "$CPD_SERVICE_NAME" == "wsl" || "$CPD_SERVICE_NAME" == "wml" || "$CPD_SERVICE_NAME" == "spss" ]]; then
+    echo "Deleting IBM CPD Service file ${GITOPS_INSTANCE_DIR}/ibm-cp4d-services-base.yaml"
+    rm -rf ${GITOPS_INSTANCE_DIR}/ibm-cp4d-services-base.yaml
+  fi
+  
+  echo
+  echo "- ${CPD_SERVICE_NAME} operator"
+
+  echo "Deleting IBM CPD Service file ${GITOPS_INSTANCE_DIR}/ibm-${CPD_SERVICE_NAME}.yaml"
+  rm -rf ${GITOPS_INSTANCE_DIR}/ibm-${CPD_SERVICE_NAME}.yaml
+
+  # Commit and push to github target repo
+  # ---------------------------------------------------------------------------
+  if [ "$GITHUB_PUSH" == "true" ]; then
+    echo
+    echo_h2 "Commit and push changes to GitHub repo $GITHUB_ORG $GITHUB_REPO"
+    save_and_unlock_target_git_repo "${GITHUB_REPO}" "${GIT_BRANCH}" "${GITOPS_WORKING_DIR}" "${GIT_COMMIT_MSG}" "${GIT_LOCK_BRANCH}" CP4D_SERVICE_CHANGED
+    remove_git_repo_clone $GITOPS_WORKING_DIR/$GITHUB_REPO
+  fi
+}

--- a/image/cli/mascli/functions/gitops_deprovision_cp4d_service
+++ b/image/cli/mascli/functions/gitops_deprovision_cp4d_service
@@ -254,7 +254,7 @@ function gitops_deprovision_cp4d_service() {
    echo
   echo_h2 "Deleting CPD Service (${CPD_SERVICE_NAME}) Application"
 
-  if [[ "$CP4D_WSL_ACTION" == "uninstall" && "$CP4D_WATSON_MACHINE_LEARNING_ACTION" == "uninstall" && "$CP4D_SPSS_MODELER_ACTION" == "uninstall" ]]; then
+  if [[ ("$CPD_SERVICE_NAME" == "all") || ("$CP4D_WSL_ACTION" == "uninstall" && "$CP4D_WATSON_MACHINE_LEARNING_ACTION" == "uninstall" && "$CP4D_SPSS_MODELER_ACTION" == "uninstall") ]]; then
     echo "Deleting IBM CPD Service file ${GITOPS_INSTANCE_DIR}/ibm-cp4d-services-base.yaml"
     rm -rf ${GITOPS_INSTANCE_DIR}/ibm-cp4d-services-base.yaml
   fi

--- a/image/cli/mascli/mas
+++ b/image/cli/mascli/mas
@@ -81,6 +81,8 @@ mkdir -p $CONFIG_DIR
 . $CLI_DIR/functions/gitops_rosa
 . $CLI_DIR/functions/gitops_deprovision_rosa
 . $CLI_DIR/functions/gitops_deprovision_cluster
+. $CLI_DIR/functions/gitops_deprovision_cp4d
+. $CLI_DIR/functions/gitops_deprovision_cp4d_service
 . $CLI_DIR/functions/gitops_deprovision_mongo
 . $CLI_DIR/functions/gitops_deprovision_efs
 . $CLI_DIR/functions/gitops_deprovision_kafka
@@ -564,6 +566,22 @@ case $1 in
     echo
     reset_colors
     gitops_mas_provisioner "$@"
+    ;;
+
+  gitops-deprovision-cp4d)
+    echo "${TEXT_UNDERLINE}IBM Maximo Application Suite GitOps Manager (v${VERSION})${TEXT_RESET}"
+    echo "Powered by ${COLOR_CYAN}${TEXT_UNDERLINE}https://github.com/ibm-mas/gitops/${TEXT_RESET}"
+    echo
+    reset_colors
+    gitops_deprovision_cp4d "$@"
+    ;;
+
+  gitops-deprovision-cp4d-service)
+    echo "${TEXT_UNDERLINE}IBM Maximo Application Suite GitOps Manager (v${VERSION})${TEXT_RESET}"
+    echo "Powered by ${COLOR_CYAN}${TEXT_UNDERLINE}https://github.com/ibm-mas/gitops/${TEXT_RESET}"
+    echo
+    reset_colors
+    gitops_deprovision_cp4d_service "$@"
     ;;
 
   *)

--- a/tekton/generate-tekton-tasks.yml
+++ b/tekton/generate-tekton-tasks.yml
@@ -193,6 +193,8 @@
         - gitops-deprovision-app-install
         - gitops-deprovision-cluster
         - gitops-deprovision-cos
+        - gitops-deprovision-cp4d
+        - gitops-deprovision-cp4d-service
         - gitops-deprovision-db2u
         - gitops-deprovision-db2u-database
         - gitops-deprovision-efs

--- a/tekton/src/pipelines/gitops/gitops-mas-apps.yml.j2
+++ b/tekton/src/pipelines/gitops/gitops-mas-apps.yml.j2
@@ -3043,9 +3043,9 @@ spec:
 
     # 13. CP4D Deprovision
     # -------------------------------------------------------------------------
-    - name: gitops-deprovision-cp4d-uninstall
+    - name: gitops-deprovision-cp4d
       runAfter:
-        - gitops-deprovision-cp4d
+        - gitops-deprovision-cp4d-spss
       params:
         {{ lookup('template', pipeline_src_dir ~ '/taskdefs/gitops/common/gitops-params.yml.j2') | indent(8) }}
         {{ lookup('template', pipeline_src_dir ~ '/taskdefs/gitops/common/secrets-params.yml.j2') | indent(8) }}

--- a/tekton/src/pipelines/gitops/gitops-mas-apps.yml.j2
+++ b/tekton/src/pipelines/gitops/gitops-mas-apps.yml.j2
@@ -2877,3 +2877,190 @@ spec:
         - input: "$(params.mas_edition)"
           operator: in
           values: ["essentials-lease-management", "essentials-space-management", "essentials-capital-planning", "standard", "premium"]
+
+    # 12. CP4D Services Deprovision
+    # -------------------------------------------------------------------------
+    # 12.1 Deprovision cp4d service for all
+    - name: gitops-deprovision-cp4d-all
+      runAfter:
+        - gitops-deprovision-db2u-replica-database-facilities
+      params:
+        {{ lookup('template', pipeline_src_dir ~ '/taskdefs/gitops/common/gitops-params.yml.j2') | indent(8) }}
+        {{ lookup('template', pipeline_src_dir ~ '/taskdefs/gitops/common/secrets-params.yml.j2') | indent(8) }}
+        {{ lookup('template', pipeline_src_dir ~ '/taskdefs/gitops/common/git-params.yml.j2') | indent(8) }}
+
+        - name: mas_instance_id
+          value: $(params.mas_instance_id)
+
+        - name: cpd_service_name
+          value: 'all'
+        - name: cp4d_wsl_action
+          value: $(params.cp4d_wsl_action)
+        - name: cp4d_watson_machine_learning_action
+          value: $(params.cp4d_watson_machine_learning_action)
+        - name: cp4d_spss_modeler_action
+          value: $(params.cp4d_spss_modeler_action)
+
+      taskRef:
+        kind: Task
+        name: gitops-deprovision-cp4d-service
+      workspaces:
+        - name: configs
+          workspace: configs
+      when:
+        - input: "$(params.mas_app_channel_predict)"
+          operator: in
+          values: [""]
+
+    # 12.2 Deprovision cp4d service for wsl
+    - name: gitops-deprovision-cp4d-wsl
+      runAfter:
+        - gitops-deprovision-cp4d-all
+      params:
+        {{ lookup('template', pipeline_src_dir ~ '/taskdefs/gitops/common/gitops-params.yml.j2') | indent(8) }}
+        {{ lookup('template', pipeline_src_dir ~ '/taskdefs/gitops/common/secrets-params.yml.j2') | indent(8) }}
+        {{ lookup('template', pipeline_src_dir ~ '/taskdefs/gitops/common/git-params.yml.j2') | indent(8) }}
+
+        - name: mas_instance_id
+          value: $(params.mas_instance_id)
+
+        - name: cpd_service_name
+          value: 'wsl'
+        - name: cp4d_wsl_action
+          value: $(params.cp4d_wsl_action)
+        - name: cp4d_watson_machine_learning_action
+          value: $(params.cp4d_watson_machine_learning_action)
+        - name: cp4d_spss_modeler_action
+          value: $(params.cp4d_spss_modeler_action)
+
+      taskRef:
+        kind: Task
+        name: gitops-deprovision-cp4d-service
+      workspaces:
+        - name: configs
+          workspace: configs
+      when:
+        - input: "$(params.cp4d_wsl_action)"
+          operator: in
+          values: ["uninstall"]
+
+
+    # 12.3 Deprovision cp4d service for wml
+    - name: gitops-deprovision-cp4d-wml
+      runAfter:
+        - gitops-deprovision-cp4d-wsl
+      params:
+        {{ lookup('template', pipeline_src_dir ~ '/taskdefs/gitops/common/gitops-params.yml.j2') | indent(8) }}
+        {{ lookup('template', pipeline_src_dir ~ '/taskdefs/gitops/common/secrets-params.yml.j2') | indent(8) }}
+        {{ lookup('template', pipeline_src_dir ~ '/taskdefs/gitops/common/git-params.yml.j2') | indent(8) }}
+
+        - name: mas_instance_id
+          value: $(params.mas_instance_id)
+
+        - name: cpd_service_name
+          value: 'wml'
+        - name: cp4d_wsl_action
+          value: $(params.cp4d_wsl_action)
+        - name: cp4d_watson_machine_learning_action
+          value: $(params.cp4d_watson_machine_learning_action)
+        - name: cp4d_spss_modeler_action
+          value: $(params.cp4d_spss_modeler_action)
+
+      taskRef:
+        kind: Task
+        name: gitops-deprovision-cp4d-service
+      workspaces:
+        - name: configs
+          workspace: configs
+      when:
+        - input: "$(params.cp4d_watson_machine_learning_action)"
+          operator: in
+          values: ["uninstall"]
+
+    # 12.4 Deprovision cp4d service for spark
+    - name: gitops-deprovision-cp4d-spark
+      runAfter:
+        - gitops-deprovision-cp4d-wml
+      params:
+        {{ lookup('template', pipeline_src_dir ~ '/taskdefs/gitops/common/gitops-params.yml.j2') | indent(8) }}
+        {{ lookup('template', pipeline_src_dir ~ '/taskdefs/gitops/common/secrets-params.yml.j2') | indent(8) }}
+        {{ lookup('template', pipeline_src_dir ~ '/taskdefs/gitops/common/git-params.yml.j2') | indent(8) }}
+
+        - name: mas_instance_id
+          value: $(params.mas_instance_id)
+
+        - name: cpd_service_name
+          value: 'spark'
+        - name: cp4d_wsl_action
+          value: $(params.cp4d_wsl_action)
+        - name: cp4d_watson_machine_learning_action
+          value: $(params.cp4d_watson_machine_learning_action)
+        - name: cp4d_spss_modeler_action
+          value: $(params.cp4d_spss_modeler_action)
+
+      taskRef:
+        kind: Task
+        name: gitops-deprovision-cp4d-service
+      workspaces:
+        - name: configs
+          workspace: configs
+      when:
+        - input: "$(params.cp4d_analytics_engine_action)"
+          operator: in
+          values: ["uninstall"]
+
+    # 12.5 Deprovision cp4d service for spss
+    - name: gitops-deprovision-cp4d-spss
+      runAfter:
+        - gitops-deprovision-cp4d-spark
+      params:
+        {{ lookup('template', pipeline_src_dir ~ '/taskdefs/gitops/common/gitops-params.yml.j2') | indent(8) }}
+        {{ lookup('template', pipeline_src_dir ~ '/taskdefs/gitops/common/secrets-params.yml.j2') | indent(8) }}
+        {{ lookup('template', pipeline_src_dir ~ '/taskdefs/gitops/common/git-params.yml.j2') | indent(8) }}
+
+        - name: mas_instance_id
+          value: $(params.mas_instance_id)
+
+        - name: cpd_service_name
+          value: 'spss'
+        - name: cp4d_wsl_action
+          value: $(params.cp4d_wsl_action)
+        - name: cp4d_watson_machine_learning_action
+          value: $(params.cp4d_watson_machine_learning_action)
+        - name: cp4d_spss_modeler_action
+          value: $(params.cp4d_spss_modeler_action)
+
+      taskRef:
+        kind: Task
+        name: gitops-deprovision-cp4d-service
+      workspaces:
+        - name: configs
+          workspace: configs
+      when:
+        - input: "$(params.cp4d_spss_modeler_action)"
+          operator: in
+          values: ["uninstall"]
+
+    # 13. CP4D Deprovision
+    # -------------------------------------------------------------------------
+    - name: gitops-deprovision-cp4d-uninstall
+      runAfter:
+        - gitops-deprovision-cp4d
+      params:
+        {{ lookup('template', pipeline_src_dir ~ '/taskdefs/gitops/common/gitops-params.yml.j2') | indent(8) }}
+        {{ lookup('template', pipeline_src_dir ~ '/taskdefs/gitops/common/secrets-params.yml.j2') | indent(8) }}
+        {{ lookup('template', pipeline_src_dir ~ '/taskdefs/gitops/common/git-params.yml.j2') | indent(8) }}
+
+        - name: mas_instance_id
+          value: $(params.mas_instance_id)
+
+      taskRef:
+        kind: Task
+        name: gitops-deprovision-cp4d
+      workspaces:
+        - name: configs
+          workspace: configs
+      when:
+        - input: "$(params.cp4d_action)"
+          operator: in
+          values: ["uninstall"]

--- a/tekton/src/tasks/gitops/gitops-deprovision-cp4d-service.yml.j2
+++ b/tekton/src/tasks/gitops/gitops-deprovision-cp4d-service.yml.j2
@@ -97,6 +97,6 @@ spec:
         - -c
       name: gitops-deprovision-cp4d-service
       imagePullPolicy: IfNotPresent
-      image: quay.io/ibmmas/cli:13.27.2-pre.mascore6404
+      image: quay.io/ibmmas/cli:latest
   workspaces:
     - name: configs

--- a/tekton/src/tasks/gitops/gitops-deprovision-cp4d-service.yml.j2
+++ b/tekton/src/tasks/gitops/gitops-deprovision-cp4d-service.yml.j2
@@ -1,0 +1,102 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: gitops-deprovision-cp4d-service
+spec:
+  params:
+    - name: cluster_name
+      type: string
+    - name: cluster_url
+      type: string
+      default: ""
+    - name: account
+      type: string
+    - name: git_branch
+      type: string
+    - name: github_org
+      type: string
+    - name: github_repo
+      type: string
+    - name: github_host
+      type: string
+    - name: secrets_path
+      type: string
+    - name: avp_aws_secret_region
+      type: string
+    - name: mas_instance_id
+      type: string
+    - name: cpd_service_name
+      type: string
+    - name: cp4d_wsl_action
+      type: string
+    - name: cp4d_watson_machine_learning_action
+      type: string
+    - name: cp4d_spss_modeler_action
+      type: string
+  stepTemplate:
+    name: gitops-deprovision-cp4d-service
+    env:
+      - name: CLUSTER_NAME
+        value: $(params.cluster_name)
+      - name: CLUSTER_URL
+        value: $(params.cluster_url)
+      - name: OCP_SERVER
+        value: $(params.cluster_url)
+      - name: ACCOUNT
+        value: $(params.account)
+      - name: SECRET_PATH
+        value: $(params.secrets_path)
+      - name: GIT_BRANCH
+        value: $(params.git_branch)
+      - name: GITHUB_ORG
+        value: $(params.github_org)
+      - name: GITHUB_HOST
+        value: $(params.github_host)
+      - name: GITHUB_REPO
+        value: $(params.github_repo)
+      - name: SM_AWS_REGION
+        value: $(params.avp_aws_secret_region)
+      - name: MAS_INSTANCE_ID
+        value: $(params.mas_instance_id)
+      - name: CPD_SERVICE_NAME
+        value: $(params.cpd_service_name)
+      - name: CP4D_WSL_ACTION
+        value: $(params.cp4d_wsl_action)
+      - name: CP4D_WATSON_MACHINE_LEARNING_ACTION
+        value: $(params.cp4d_watson_machine_learning_action)
+      - name: CP4D_SPSS_MODELER_ACTION
+        value: $(params.cp4d_spss_modeler_action)
+    envFrom:
+      - configMapRef:
+          name: environment-properties
+          optional: true
+      - secretRef:
+          name: secure-properties
+  steps:
+    - args:
+      - |-
+        git config --global user.name "MAS Automation"
+        git config --global user.email "you@example.com"
+        git config --global user.password $GITHUB_PAT
+
+        mkdir -p /tmp/deprovision-cp4d-service
+        
+        mas gitops-deprovision-cp4d-service -a $ACCOUNT -c $CLUSTER_NAME \
+        --dir /tmp/deprovision-cp4d-service \
+        --secrets-path $SECRET_PATH \
+        --github-push \
+        --github-host $GITHUB_HOST \
+        --github-org $GITHUB_ORG \
+        --github-repo $GITHUB_REPO \
+        --git-branch $GIT_BRANCH
+
+        exit $?
+      command:
+        - /bin/sh
+        - -c
+      name: gitops-deprovision-cp4d-service
+      imagePullPolicy: IfNotPresent
+      image: quay.io/ibmmas/cli:13.27.2-pre.mascore6404
+  workspaces:
+    - name: configs

--- a/tekton/src/tasks/gitops/gitops-deprovision-cp4d.yml.j2
+++ b/tekton/src/tasks/gitops/gitops-deprovision-cp4d.yml.j2
@@ -1,0 +1,85 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: gitops-deprovision-cp4d
+spec:
+  params:
+    - name: cluster_name
+      type: string
+    - name: cluster_url
+      type: string
+      default: ""
+    - name: account
+      type: string
+    - name: git_branch
+      type: string
+    - name: github_org
+      type: string
+    - name: github_repo
+      type: string
+    - name: github_host
+      type: string
+    - name: secrets_path
+      type: string
+    - name: avp_aws_secret_region
+      type: string
+    - name: mas_instance_id
+      type: string
+  stepTemplate:
+    name: gitops-deprovision-cp4d
+    env:
+      - name: CLUSTER_NAME
+        value: $(params.cluster_name)
+      - name: OCP_SERVER
+        value: $(params.cluster_url)
+      - name: ACCOUNT
+        value: $(params.account)
+      - name: GITHUB_REPO
+        value: $(params.github_repo)
+      - name: SECRET_PATH
+        value: $(params.secrets_path)
+      - name: GIT_BRANCH
+        value: $(params.git_branch)
+      - name: GITHUB_ORG
+        value: $(params.github_org)
+      - name: GITHUB_HOST
+        value: $(params.github_host)
+      - name: GITHUB_REPO
+        value: $(params.github_repo)
+      - name: SM_AWS_REGION
+        value: $(params.avp_aws_secret_region)
+      - name: MAS_INSTANCE_ID
+        value: $(params.mas_instance_id)
+    envFrom:
+      - configMapRef:
+          name: environment-properties
+          optional: true
+      - secretRef:
+          name: secure-properties
+  steps:
+    - args:
+      - |-
+        git config --global user.name "MAS Automation"
+        git config --global user.email "you@example.com"
+        git config --global user.password $GITHUB_PAT
+        
+        mkdir -p /tmp/deprovision-cp4d
+        mas gitops-deprovision-cp4d -a $ACCOUNT -c $CLUSTER_NAME -m $MAS_INSTANCE_ID \
+        --dir /tmp/deprovision-cp4d \
+        --secrets-path $SECRET_PATH \
+        --github-push \
+        --github-host $GITHUB_HOST \
+        --github-org $GITHUB_ORG \
+        --github-repo $GITHUB_REPO \
+        --git-branch $GIT_BRANCH
+
+        exit $?
+      command:
+        - /bin/sh
+        - -c
+      name: gitops-deprovision-cp4d
+      imagePullPolicy: IfNotPresent
+      image: quay.io/ibmmas/cli:13.27.2-pre.mascore6404
+  workspaces:
+    - name: configs

--- a/tekton/src/tasks/gitops/gitops-deprovision-cp4d.yml.j2
+++ b/tekton/src/tasks/gitops/gitops-deprovision-cp4d.yml.j2
@@ -80,6 +80,6 @@ spec:
         - -c
       name: gitops-deprovision-cp4d
       imagePullPolicy: IfNotPresent
-      image: quay.io/ibmmas/cli:13.27.2-pre.mascore6404
+      image: quay.io/ibmmas/cli:latest
   workspaces:
     - name: configs


### PR DESCRIPTION
Issue: [MASCORE-6404](https://jsw.ibm.com/browse/MASCORE-6404)

## Description
Deprovision of CP4D and CP4D services were not happening
Hence added deprovisioning cli functions and added corresponding task run in gitops-mas-apps yaml
If predict app channel is not defined, it will deprovision all cp4d services
We also deprovision specific cp4d service based on it's corresponding action set to 'uninstall'
We deprovision cp4d if c4d action is uninstall

## Testing
Verified by disabling specific actions
Verified by disabling predict feature
Verified by deleting the entire instance in saas-envs
Deletion of instance which deletes all the cp4d and cp4d service related files [https://github.ibm.com/maximoappsuite/gitops-envs/commit/862741d3bc4b88709f38320d2120ba170066039c]
[https://github.ibm.com/maximoappsuite/gitops-envs/commit/3d838d732af7f35e534af26e121fdbce430e2782]