### PR TITLE
[patch] fix for main function call in mobilever script

### DIFF
--- a/image/cli/app-root/src/mobilever.py
+++ b/image/cli/app-root/src/mobilever.py
@@ -373,7 +373,7 @@ if __name__ == "__main__":
         os.remove(MobVersion.output_filename)
 
     print("Retrieving Graphite versions for Manage apps")
-    graphite_versions = MobVersion.get_graphite_versions()
+    graphite_versions = MobVersion.get_graphite_versions(mas_ver=os.getenv("PRODUCT_CHANNEL"))
 
     print("Retrieving image versions for Manage IS and Add-ons ")
     img_versions = MobVersion.get_mobile_and_is_image_tags()


### PR DESCRIPTION
The main function was failing to retrieve the mobile versions because of the missing channel info.
Fix has been successfully verified in mobcicd fyre cluster

[mas-fvt-mobile-pytest-run-hkj89-pod-step-fvt-mobile-version.log](https://github.com/user-attachments/files/21167415/mas-fvt-mobile-pytest-run-hkj89-pod-step-fvt-mobile-version.log)
