### PR TITLE
[patch] Make cp4d deprovision optional param to support all and no action defined for gitops

### DIFF
--- a/image/cli/mascli/functions/gitops_deprovision_cp4d_service
+++ b/image/cli/mascli/functions/gitops_deprovision_cp4d_service
@@ -155,9 +155,6 @@ function gitops_deprovision_cp4d_service_noninteractive() {
   [[ -z "$MAS_INSTANCE_ID" ]] && gitops_deprovision_cp4d_service_help "MAS_INSTANCE_ID is not set"
 
   [[ -z "$CPD_SERVICE_NAME" ]] && gitops_deprovision_cp4d_service_help "CPD_SERVICE_NAME is not set"
-  [[ -z "$CP4D_WSL_ACTION" ]] && gitops_deprovision_cp4d_service_help "CP4D_WSL_ACTION is not set"
-  [[ -z "$CP4D_WATSON_MACHINE_LEARNING_ACTION" ]] && gitops_deprovision_cp4d_service_help "CP4D_WATSON_MACHINE_LEARNING_ACTION is not set"
-  [[ -z "$CP4D_SPSS_MODELER_ACTION" ]] && gitops_deprovision_cp4d_service_help "CP4D_SPSS_MODELER_ACTION is not set"
 
   if [[ "$GITHUB_PUSH" == "true" ]]; then
     [[ -z "$GITHUB_HOST" ]] && gitops_deprovision_cp4d_service_help "GITHUB_HOST is not set"


### PR DESCRIPTION
## Problem
If cp4d and predict are not defined, we still invoke deprovision cp4d task and is failing because cp4d actions will be not defined. So making them as optional param