### PR TITLE
[doc] update image-mirroring doc to include mref

### DIFF
--- a/docs/guides/image-mirroring.md
+++ b/docs/guides/image-mirroring.md
@@ -145,7 +145,7 @@ docker run -ti --rm -v $LOCAL_DIR:/mnt/registry quay.io/ibmmas/cli:@@CLI_LATEST_
   -m direct -d /mnt/registry/apps \
   -H $REGISTRY_HOST -P $REGISTRY_PORT -u $REGISTRY_USERNAME -p $REGISTRY_PASSWORD \
   -c @@MAS_LATEST_CATALOG@@ -C @@MAS_LATEST_CHANNEL@@ \
-  --mirror-assist --mirror-iot --mirror-manage --mirror-icd --mirror-monitor --mirror-optimizer --mirror-predict --mirror-visualinspection \
+  --mirror-assist --mirror-iot --mirror-manage --mirror-icd --mirror-monitor --mirror-optimizer --mirror-predict --mirror-visualinspection --mirror-facilities \
   --ibm-entitlement $IBM_ENTITLEMENT_KEY
 ```
 
@@ -157,7 +157,7 @@ docker run -ti --rm -v $LOCAL_DIR:/mnt/registry quay.io/ibmmas/cli:@@CLI_LATEST_
   -m to-filesystem -d /mnt/registry/apps \
   -H $REGISTRY_HOST -P $REGISTRY_PORT -u $REGISTRY_USERNAME -p $REGISTRY_PASSWORD \
   -c @@MAS_LATEST_CATALOG@@ -C @@MAS_LATEST_CHANNEL@@ \
-  --mirror-assist --mirror-iot --mirror-manage --mirror-icd --mirror-monitor --mirror-optimizer --mirror-predict --mirror-visualinspection \
+  --mirror-assist --mirror-iot --mirror-manage --mirror-icd --mirror-monitor --mirror-optimizer --mirror-predict --mirror-visualinspection --mirror-facilities \
   --ibm-entitlement $IBM_ENTITLEMENT_KEY
 ```
 
@@ -169,7 +169,7 @@ docker run -ti --rm -v $LOCAL_DIR:/mnt/registry quay.io/ibmmas/cli:@@CLI_LATEST_
   -m from-filesystem -d /mnt/registry/apps \
   -H $REGISTRY_HOST -P $REGISTRY_PORT -u $REGISTRY_USERNAME -p $REGISTRY_PASSWORD \
   -c @@MAS_LATEST_CATALOG@@ -C @@MAS_LATEST_CHANNEL@@ \
-  --mirror-assist --mirror-iot --mirror-manage --mirror-icd --mirror-monitor --mirror-optimizer --mirror-predict --mirror-visualinspection
+  --mirror-assist --mirror-iot --mirror-manage --mirror-icd --mirror-monitor --mirror-optimizer --mirror-predict --mirror-visualinspection --mirror-facilities
 ```
 
   </div>
@@ -181,7 +181,7 @@ docker run -ti --rm -v $LOCAL_DIR:/mnt/registry $REGISTRY_HOST:$REGISTRY_PORT/ib
   -m from-filesystem -d /mnt/registry/apps \
   -H $REGISTRY_HOST -P $REGISTRY_PORT -u $REGISTRY_USERNAME -p $REGISTRY_PASSWORD \
   -c @@MAS_LATEST_CATALOG@@ -C @@MAS_LATEST_CHANNEL@@ \
-  --mirror-assist --mirror-iot --mirror-manage --mirror-icd --mirror-monitor --mirror-optimizer --mirror-predict --mirror-visualinspection
+  --mirror-assist --mirror-iot --mirror-manage --mirror-icd --mirror-monitor --mirror-optimizer --mirror-predict --mirror-visualinspection --mirror-facilities
 ```
 
   </div>
@@ -314,18 +314,19 @@ Storage Requirements
 -------------------------------------------------------------------------------
 As of MAS 8.10 (June 2023) the total capacity requirement to mirror content from the IBM Maximo Operator Catalog is approximately **484G**, the following table can be used to determine the approximate storage requirement for your mirrored content based on what content you need to mirror:
 
-| Maximo Application Suite        | Command Flag                | Size    |
-| ------------------------------- | --------------------------- | ------- |
-| Maximo Operator Catalog         | `--mirror-catalog`          | 50M     |
-| Maximo Application Suite Core   | `--mirror-core`             | 4G      |
-| Maximo Assist                   | `--mirror-assist`           | 5G      |
-| Maximo IoT                      | `--mirror-iot`              | 9G      |
-| Maximo Manage                   | `--mirror-manage`           | 8G      |
-| Maximo Monitor                  | `--mirror-monitor`          | 17G     |
-| Maximo Optimizer                | `--mirror-optimizer`        | 3G      |
-| Maximo Predict                  | `--mirror-predict`          | 6G      |
-| Maximo Visual Inspection        | `--mirror-visualinspection` | 40G     |
-| **Total**                       |                             | **92G** |
+| Maximo Application Suite         | Command Flag                | Size    |
+| -------------------------------- | --------------------------- | ------- |
+| Maximo Operator Catalog          | `--mirror-catalog`          | 50M     |
+| Maximo Application Suite Core    | `--mirror-core`             | 4G      |
+| Maximo Assist                    | `--mirror-assist`           | 5G      |
+| Maximo IoT                       | `--mirror-iot`              | 9G      |
+| Maximo Manage                    | `--mirror-manage`           | 8G      |
+| Maximo Monitor                   | `--mirror-monitor`          | 17G     |
+| Maximo Optimizer                 | `--mirror-optimizer`        | 3G      |
+| Maximo Predict                   | `--mirror-predict`          | 6G      |
+| Maximo Visual Inspection         | `--mirror-visualinspection` | 40G     |
+| Maximo Real Estate and Facilities| `--mirror-facilities`.      | TBD     |
+| **Total**                        |                             | **92G** |
 
 | IBM Cloud Pak for Data       | Command Flag                | Size     |
 | ---------------------------- | --------------------------- | -------- |


### PR DESCRIPTION
Added mirror flag for Maximo Real Estate and Facilities in the image-mirroring docs