### PR TITLE
[patch] Fix FVT Secret Reference for IoT

### DIFF
--- a/tekton/src/tasks/fvt-launcher/mas-launchfvt-iot.yml.j2
+++ b/tekton/src/tasks/fvt-launcher/mas-launchfvt-iot.yml.j2
@@ -89,7 +89,7 @@ spec:
         - name: IVT_DIGEST_CORE
           valueFrom:
             secretKeyRef:
-              name: mas-fvt-assist
+              name: mas-fvt-iot
               key: IVT_DIGEST_CORE
               optional: false
 


### PR DESCRIPTION
### Issue

fvt-launcher for IoT used fvt-secret for Assist, which as expected caused failure when Assist is not being installed
- launchfvt-iot pod end's up failing due to `CreateContainerConfigError` - `Error: secret "mas-fvt-assist" not found`

([Discussion](https://ibm-watson-iot.slack.com/archives/C031Q7W21FZ/p1754902797568759))

### Fix

Specify fvt-secret for IoT to be used instead of Assist's