### PR TITLE
[DOC Update] Update v9-250731-amd64.md

### DIFF
--- a/docs/catalogs/v9-250731-amd64.md
+++ b/docs/catalogs/v9-250731-amd64.md
@@ -35,6 +35,7 @@ Reminder
 Known Issues
 -------------------------------------------------------------------------------
 - Customers using Maximo Assist v8.7 or v8.8 should not update and must instead contact IBM Support for guidance regarding the removal of IBM Watson Discovery and upgrading to Maximo Assist v9.0
+- "mas update" pipeline automation will fail if --mongodb-v7-upgrade option is not included. Command to run update - "mas update --catalog v9-250731-amd64 --mongodb-v7-upgrade"
 
 
 Manual Installation


### PR DESCRIPTION
Its a known issue and if we run mas update without the option --mongodb-v7-upgrade, it will fail. Hence documented it on release known issues.