### PR TITLE
[patch] add cluster verification in must-gather

### DIFF
--- a/image/cli/usr/bin/gather
+++ b/image/cli/usr/bin/gather
@@ -2,6 +2,26 @@
 
 # https://github.com/openshift/enhancements/blob/89bbe226db20573f8f489eacb558a9f011072737/enhancements/oc/must-gather.md#must-gather-images
 
+# Check if the user is logged into an OpenShift cluster
+function check_cluster_connection() {
+  echo "Checking connection to OpenShift cluster..."
+  if ! oc whoami &>/dev/null; then
+    echo -e "\033[1;31mERROR: Not logged into an OpenShift cluster.\033[0m"
+    echo -e "\033[1;31mThe must-gather command requires an active connection to an OpenShift cluster.\033[0m"
+    echo -e "\033[1;33mPlease login using one of the following methods:\033[0m"
+    echo "  1. oc login --token=<token> --server=<server>"
+    echo "  2. oc login -u <username> -p <password> --server=<server>"
+    echo "  3. Use KUBECONFIG environment variable pointing to a valid config file"
+    echo ""
+    echo "For more information, see the documentation at: https://docs.openshift.com/container-platform/latest/cli_reference/openshift_cli/getting-started-cli.html"
+    exit 1
+  fi
+  echo "Successfully connected to OpenShift cluster."
+}
+
+# Check if the user is logged into an OpenShift cluster before running the must-gather
+check_cluster_connection
+
 # Creating a directory named /must-gather will change the default output directory from /tmp/must-gather to /must-gather, which is
 # the directory that the oc must-gather command expects to collect the must-gather files from
 mkdir -p /must-gather


### PR DESCRIPTION
[Provide a warning if MAS CLI must-gather is running without being logged into a cluster](https://github.com/ibm-mas/cli/issues/1542)

Modified the script as per the conditions. Currently, when a MAS CLI must-gather is run without logging into a OpenShift cluster, the must-gather will still execute and attempt to collect data. The collection logs will be full of messages like this:

error: Missing or incomplete configuration info.  Please point to an existing, complete config file:

  1. Via the command-line flag --kubeconfig
  2. Via the KUBECONFIG environment variable
  3. In your home directory as ~/.kube/config
While to someone experienced with OpenShift this may be an obvious sign the must-gather did not collect the data properly, it is not immediately apparent to those with less exposure to OpenShift. It would be beneficial if the must-gather script itself would provide a warning message to the end user that the must-gather did not execute properly due to not being logged in to a cluster instead.

Attaching snippets with & without the oc login

<img width="3456" height="382" alt="Screenshot 2025-08-13 at 10 22 13 PM" src="https://github.com/user-attachments/assets/2f255fba-69a4-45a5-bc5c-593945d079a0" />
<img width="3456" height="2120" alt="Screenshot 2025-08-13 at 10 26 19 PM" src="https://github.com/user-attachments/assets/9ea89e40-5397-4da0-8e7a-3e7a5e12a7e5" />


