### PR TITLE
[patch] Implementation of Pipeline and CLI for Standalone SLS Server 

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -320,7 +320,7 @@
         "hashed_secret": "b2817467154949a61f8e9ad31d1eeaf03221cbfa",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 112,
+        "line_number": 136,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -405,6 +405,16 @@
         "is_secret": false,
         "is_verified": false,
         "line_number": 140,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "image/cli/mascli/functions/gitops_suite_license_service": [
+      {
+        "hashed_secret": "b2817467154949a61f8e9ad31d1eeaf03221cbfa",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 245,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -653,6 +663,16 @@
         "is_secret": false,
         "is_verified": false,
         "line_number": 16,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "image/cli/mascli/templates/gitops/appset-configs/cluster/sls/ibm-sls.yaml.j2": [
+      {
+        "hashed_secret": "fee2d55ad9a49a95fc89abe8f414dad66704ebfd",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 32,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2025-09-03T13:58:29Z",
+  "generated_at": "2025-09-05T14:14:46Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -320,7 +320,7 @@
         "hashed_secret": "b2817467154949a61f8e9ad31d1eeaf03221cbfa",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 136,
+        "line_number": 133,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -414,7 +414,7 @@
         "hashed_secret": "b2817467154949a61f8e9ad31d1eeaf03221cbfa",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 245,
+        "line_number": 239,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/image/cli/mascli/functions/gitops_deprovision_suite_license_service
+++ b/image/cli/mascli/functions/gitops_deprovision_suite_license_service
@@ -1,0 +1,234 @@
+#!/usr/bin/env bash
+
+function gitops_deprovision_suite_license_service_help() {
+  [[ -n "$1" ]] && echo_warning "$1"
+  reset_colors
+  cat << EOM
+Usage:
+  mas gitops-deprovision-suite-license-service [options]
+Where ${COLOR_YELLOW}specified${TEXT_RESET} each option may also be defined by setting the appropriate environment variable.
+When no options are specified on the command line, interactive-mode will be enabled by default.
+
+
+Basic Configuration: 
+  -d, --dir ${COLOR_YELLOW}GITOPS_WORKING_DIR${TEXT_RESET}           Directory for GitOps repository
+  -a, --account-id ${COLOR_YELLOW}ACCOUNT_ID${TEXT_RESET}            Account name that the cluster belongs to
+  -i  --ibm-customer-number ${COLOR_YELLOW}ICN${TEXT_RESET}          IBM Customer Number
+  -s  --subscription-id ${COLOR_YELLOW}SAAS_SUB_ID${TEXT_RESET}      Customer subscription id
+
+AWS Secrets Manager Configuration (Required):
+      --sm-aws-secret-region ${COLOR_YELLOW}SM_AWS_REGION${TEXT_RESET}          Region of the AWS Secrets Manager to use
+      --sm-aws-access-key ${COLOR_YELLOW}SM_AWS_ACCESS_KEY_ID${TEXT_RESET}      Your AWS Access Key ID
+      --sm-aws-secret-key ${COLOR_YELLOW}SM_AWS_SECRET_ACCESS_KEY${TEXT_RESET}  Your AWS Secret Key
+      --secrets-path ${COLOR_YELLOW}SECRETS_PATH${TEXT_RESET}                   Secrets Manager path
+
+Automatic GitHub Push:
+  -P, --github-push ${COLOR_YELLOW}GITHUB_PUSH${TEXT_RESET}        Enable automatic push to GitHub
+  -H, --github-host ${COLOR_YELLOW}GITHUB_HOST${TEXT_RESET}        GitHub Hostname for your GitOps repository
+  -O, --github-org  ${COLOR_YELLOW}GITHUB_ORG${TEXT_RESET}         Github org for your GitOps repository
+  -R, --github-repo ${COLOR_YELLOW}GITHUB_REPO${TEXT_RESET}        Github repo for your GitOps repository
+  -B, --git-branch ${COLOR_YELLOW}GIT_BRANCH${TEXT_RESET}          Git branch to commit to of your GitOps repository
+  -M, --git-commit-msg ${COLOR_YELLOW}GIT_COMMIT_MSG${TEXT_RESET}  Git commit message to use when committing to of your GitOps repository
+  -S , --github-ssh  ${COLOR_YELLOW}GIT_SSH${TEXT_RESET}           Git ssh key path
+
+Other Commands:
+  -h, --help                                      Show this help message
+EOM
+  [[ -n "$1" ]] && exit 1 || exit 0
+}
+
+function gitops_deprovision_suite_license_service_noninteractive() {
+  # TODO: Remember to change the defaults to suite public before release!
+  GITOPS_WORKING_DIR=$PWD/working-dir
+  SECRETS_KEY_SEPARATOR="/"
+
+  GIT_COMMIT_MSG="gitops-deprovision-cluster commit"
+
+  export REGION=${REGION:-${SM_AWS_REGION}}
+
+  while [[ $# -gt 0 ]]
+  do
+    key="$1"
+    shift
+    case $key in
+      # GitOps Configuration
+      -d|--dir)
+        export GITOPS_WORKING_DIR=$1 && shift
+        ;;
+      -a|--account-id)
+        export ACCOUNT_ID=$1 && shift
+        ;;
+      -i|--ibm-customer-number)
+        export ICN=$1 && shift
+        ;;
+      -s|--subscription-id)
+        export SAAS_SUB_ID=$1 && shift
+        ;;
+
+      # Secrets Manager
+      --secrets-path)
+        export SECRETS_PATH=$1 && shift
+        ;;
+      --secrets-key-seperator)
+        export SECRETS_KEY_SEPARATOR=$1 && shift
+        ;;
+
+      # Automatic GitHub Push
+      -P|--github-push)
+        export GITHUB_PUSH=true
+        ;;
+      -H|--github-host)
+        export GITHUB_HOST=$1 && shift
+        ;;
+      -O|--github-org)
+        export GITHUB_ORG=$1 && shift
+        ;;
+      -R|--github-repo)
+        export GITHUB_REPO=$1 && shift
+        ;;
+      -B|--git-branch)
+        export GIT_BRANCH=$1 && shift
+        ;;
+      -M|--git-commit-msg)
+        export GIT_COMMIT_MSG=$1 && shift
+        ;;
+      
+      -S|--github-ssh)
+        export GIT_SSH=$1 && shift
+        ;;
+
+
+      # Other Commands
+      -h|--help)
+        gitops_deprovision_suite_license_service_help
+        ;;
+      *)
+        # unknown option
+        echo -e "${COLOR_RED}Usage Error: Unsupported option \"${key}\"${COLOR_RESET}\n"
+        gitops_deprovision_suite_license_service_help "Usage Error: Unsupported option \"${key}\" "
+        exit 1
+        ;;
+    esac
+  done
+
+  [[ -z "$ACCOUNT_ID" ]] && gitops_deprovision_suite_license_service_help "ACCOUNT_ID is not set"
+  [[ -z "$ICN" ]] && gitops_deprovision_suite_license_service_help "ICN is not set"
+  [[ -z "$SAAS_SUB_ID" ]] && gitops_deprovision_suite_license_service_help "SAAS_SUB_ID is not set"
+
+  if [[ "$GITHUB_PUSH" == "true" ]]; then
+    [[ -z "$GITHUB_HOST" ]] && gitops_deprovision_suite_license_service_help "GITHUB_HOST is not set"
+    [[ -z "$GITHUB_ORG" ]] && gitops_deprovision_suite_license_service_help "GITHUB_ORG is not set"
+    [[ -z "$GITHUB_REPO" ]] && gitops_deprovision_suite_license_service_help "GITHUB_REPO is not set"
+    [[ -z "$GIT_BRANCH" ]] && gitops_deprovision_suite_license_service_help "GIT_BRANCH is not set"
+  fi
+
+}
+
+function gitops_deprovision_suite_license_service() {
+  # Take the first parameter off (it will be create-gitops)
+  shift
+  if [[ $# -gt 0 ]]; then
+    gitops_deprovision_suite_license_service_noninteractive "$@"
+  else
+    echo "Not supported yet"
+    exit 1
+    gitops_deprovision_suite_license_service_interactive
+  fi
+
+  # catch errors
+  set -o pipefail
+  trap 'echo "[ERROR] Error occurred at $BASH_SOURCE, line $LINENO, exited with $?"; exit 1' ERR
+
+  mkdir -p ${GITOPS_WORKING_DIR}
+
+  GITOPS_INSTANCE_DIR=${GITOPS_WORKING_DIR}/${GITHUB_REPO}/${ACCOUNT_ID}/icn/${ICN}/${SAAS_SUB_ID}
+  GITOPS_CUSTOMER_DIR=${GITOPS_WORKING_DIR}/${GITHUB_REPO}/${ACCOUNT_ID}/icn/${ICN}
+
+  echo
+  reset_colors
+  echo_h2 "Review Settings"
+
+  echo "${TEXT_DIM}"
+  echo_h2 "Target" "    "
+  echo_reset_dim "Account ID ............................ ${COLOR_MAGENTA}${ACCOUNT_ID}"
+  echo_reset_dim "IBM Customer Number ................... ${COLOR_MAGENTA}${ICN}"
+  echo_reset_dim "Subscription ID ....................... ${COLOR_MAGENTA}${SAAS_SUB_ID}"
+  reset_colors
+
+  echo "${TEXT_DIM}"
+  if [[ "$GITHUB_PUSH" == "true" ]]; then
+    echo_h2 "GitOps Target" "    "
+    echo_reset_dim "Automatic Push ........................ ${COLOR_GREEN}Enabled"
+    echo_reset_dim "Working Directory ..................... ${COLOR_MAGENTA}${GITOPS_WORKING_DIR}"
+    echo_reset_dim "Host .................................. ${COLOR_MAGENTA}${GITHUB_HOST}"
+    echo_reset_dim "Organization .......................... ${COLOR_MAGENTA}${GITHUB_ORG}"
+    echo_reset_dim "Repository ............................ ${COLOR_MAGENTA}${GITHUB_REPO}"
+    echo_reset_dim "Branch ................................ ${COLOR_MAGENTA}${GIT_BRANCH}"
+  else
+    echo_h2 "GitOps Target" "    "
+    echo_reset_dim "Automatic Push ........................ ${COLOR_RED}Disabled"
+    echo_reset_dim "Working Directory ..................... ${COLOR_MAGENTA}${GITOPS_WORKING_DIR}"
+  fi
+  reset_colors
+
+  echo "${TEXT_DIM}"
+  echo_h2 "Secrets Manager" "    "
+  echo_reset_dim "Secrets Path .......................... ${COLOR_MAGENTA}${SECRETS_PATH}"
+  reset_colors
+
+
+  # Set up secrets
+  # ---------------------------------------------------------------------------
+  echo
+  echo_h2 "Deleting Subscription secret"
+  AVP_TYPE=aws  # Support for IBM will be added later
+  sm_login
+  
+  # Created by gitops_suite_license_service task
+  export SECRET_KEY_LICENSE_FILE=${ACCOUNT_ID}${SECRETS_KEY_SEPARATOR}${ICN}${SECRETS_KEY_SEPARATOR}${SAAS_SUB_ID}${SECRETS_KEY_SEPARATOR}license
+  sm_delete_secret ${SECRET_KEY_LICENSE_FILE}
+
+  if [ -z $GIT_SSH ]; then
+    export GIT_SSH="false"
+  fi
+
+  # Clone github target repo
+  # ---------------------------------------------------------------------------
+  if [ "$GITHUB_PUSH" == "true" ]; then
+    echo
+    echo_h2 "Cloning GitHub repo $GITHUB_ORG $GITHUB_REPO"
+    clone_target_git_repo $GITHUB_HOST $GITHUB_ORG $GITHUB_REPO $GIT_BRANCH $GITOPS_WORKING_DIR $GIT_SSH
+  fi
+  mkdir -p ${GITOPS_INSTANCE_DIR}
+
+
+  # Delete Application config
+  # ---------------------------------------------------------------------------
+  echo
+  echo_h2 "Deleting subscription configuration file"
+
+  if [ -d ${GITOPS_INSTANCE_DIR} ]; then
+    echo "- Delete ibm-sls file and subscription dir"
+    rm -fv ${GITOPS_INSTANCE_DIR}/ibm-sls.yaml
+    rm -rfv ${GITOPS_INSTANCE_DIR}
+  else
+    echo "- SLS Instance ${GITOPS_INSTANCE_DIR} not found"
+  fi
+
+  if [ $(ls -1 ${GITOPS_CUSTOMER_DIR} | wc -l) -eq 0 ]; then
+    echo " - Delete Customer Dir"
+    rm -rfv ${GITOPS_CUSTOMER_DIR}
+  else
+    echo " Subscriptions remain for customer ${ICN} do not remove customer directory"
+  fi
+
+  if [ "$GITHUB_PUSH" == "true" ]; then
+    echo
+    echo_h2 "Commit and push changes to GitHub repo $GITHUB_ORG $GITHUB_REPO"
+    save_to_target_git_repo $GITHUB_HOST $GITHUB_ORG $GITHUB_REPO $GIT_BRANCH "${GITOPS_WORKING_DIR}/${GITHUB_REPO}" "${GIT_COMMIT_MSG}"
+  fi
+
+  if [ "$GITHUB_PUSH" == "true" ]; then
+    remove_git_repo_clone $GITOPS_WORKING_DIR/$GITHUB_REPO
+  fi
+}

--- a/image/cli/mascli/functions/gitops_license
+++ b/image/cli/mascli/functions/gitops_license
@@ -15,6 +15,12 @@ Basic Configuration:
   -m, --mas-instance-id ${COLOR_YELLOW}MAS_INSTANCE_ID${TEXT_RESET}              IBM Suite Maximo Application Suite Instance ID
       --license-file ${COLOR_YELLOW}LICENSE_FILE${TEXT_RESET}                    Path to IBM SLS License File
 
+Standalone License Server Configuration
+  -a, --account-id ${COLOR_YELLOW}ACCOUNT_ID${TEXT_RESET}                        Account name that the cluster belongs to
+  -i, --ibm-customer-number ${COLOR_YELLOW}ICN${TEXT_RESET}                      IBM Customer Number
+  -s, --saas-subscription-id  ${COLOR_YELLOW}ICN${TEXT_RESET}                    SaaS subscription id
+      --license-file ${COLOR_YELLOW}LICENSE_FILE${TEXT_RESET}                    Path to IBM SLS License File
+
 AWS Secrets Manager Configuration:
       --sm-aws-secret-region ${COLOR_YELLOW}SM_AWS_REGION${TEXT_RESET}          Region of the AWS Secrets Manager to use
       --sm-aws-access-key ${COLOR_YELLOW}SM_AWS_ACCESS_KEY_ID${TEXT_RESET}      Your AWS Access Key ID
@@ -27,7 +33,7 @@ EOM
 }
 
 function gitops_license_noninteractive() {
-  SECRETS_KEY_SEPERATOR="/"
+  SECRETS_KEY_SEPARATOR="/"
 
   while [[ $# -gt 0 ]]
   do
@@ -38,11 +44,21 @@ function gitops_license_noninteractive() {
       -c|--cluster-id)
         export CLUSTER_ID=$1 && shift
         ;;
-      -a|--account-id)
-        export ACCOUNT_ID=$1 && shift
-        ;;
       -m|--mas-instance-id)
         export MAS_INSTANCE_ID=$1 && shift
+        ;;
+
+      # Standalone Server configuration
+      -s|--saas-subscription-id)
+        export SAAS_SUB_ID=$1 && shift
+      ;;
+      -i|--ibm-customer-number)
+        export ICN=$1 && shift
+      ;;
+
+      # Common Required parms
+      -a|--account-id)
+        export ACCOUNT_ID=$1 && shift
         ;;
       --license-file)
         export LICENSE_FILE=$1 && shift
@@ -73,9 +89,12 @@ function gitops_license_noninteractive() {
   done
 
   [[ -z "$ACCOUNT_ID" ]] && gitops_license_help "ACCOUNT_ID is not set"
-  [[ -z "$CLUSTER_ID" ]] && gitops_license_help "CLUSTER_ID is not set"
-  [[ -z "$MAS_INSTANCE_ID" ]] && gitops_license_help "MAS_INSTANCE_ID is not set"
   [[ -z "$LICENSE_FILE" ]] && gitops_license_help "LICENSE_FILE is not set"
+
+#  ([[ -z "$ICN" ]] && [[ -z "$MAS_INSTANCE_ID" ]]) && gitops_license_help "One of IBM Customer Number or Cluster ID must be set"
+#  ([[ ! -z "$ICN" ]] && [[ ! -z "$MAS_INSTANCE_ID" ]]) && gitops_license_help "Cannot set both ICN and Instance ID"
+  ([[ ! -z "$ICN" ]] && [[ -z "$SAAS_SUB_ID" ]]) && gitops_license_help "When ICN is set, SAAS_SUB_ID must also be set"
+#  ([[ ! -z "$CLUSTERID" ]] && [[ -z "$MAS_INSTANCE_ID" ]]) && gitops_license_help "When CLUSTERID is set, MAS_INSTANCE_ID must also be set"
 
 }
 
@@ -101,8 +120,13 @@ function gitops_license() {
   echo "${TEXT_DIM}"
   echo_h4 "Target" "    "
   echo_reset_dim "Account ID ..................... ${COLOR_MAGENTA}${ACCOUNT_ID}"
-  echo_reset_dim "Cluster ID ..................... ${COLOR_MAGENTA}${CLUSTER_ID}"
-  echo_reset_dim "MAS Instance ID ................ ${COLOR_MAGENTA}${MAS_INSTANCE_ID}"
+  if [ ! -z "$CLUSTER_ID" ]; then
+     echo_reset_dim "Cluster ID ..................... ${COLOR_MAGENTA}${CLUSTER_ID}"
+     echo_reset_dim "MAS Instance ID ................ ${COLOR_MAGENTA}${MAS_INSTANCE_ID}"  
+  else
+     echo_reset_dim "IBM Customer Number ............ ${COLOR_MAGENTA}${ICN}"
+     echo_reset_dim "SaaS Subscription Id ........... ${COLOR_MAGENTA}${SAAS_SUB_ID}"
+  fi
   reset_colors
 
   echo "${TEXT_DIM}"
@@ -120,7 +144,13 @@ function gitops_license() {
   AVP_TYPE=aws
   sm_login
 
-  export SECRET_NAME_LICENSE_FILE=${ACCOUNT_ID}${SECRETS_KEY_SEPERATOR}${CLUSTER_ID}${SECRETS_KEY_SEPERATOR}${MAS_INSTANCE_ID}${SECRETS_KEY_SEPERATOR}license
+  if [ ! -z "$ICN" ]; then
+     export SECRET_NAME_LICENSE_FILE=${ACCOUNT_ID}${SECRETS_KEY_SEPARATOR}${ICN}${SECRETS_KEY_SEPARATOR}${SAAS_SUB_ID}${SECRETS_KEY_SEPARATOR}license
+     TAGS="[{\"Key\": \"source\", \"Value\": \"gitops_license\"}, {\"Key\": \"account\", \"Value\": \"${ACCOUNT_ID}\"}, {\"Key\": \"subscription_id\", \"Value\": \"${SAAS_SUB_ID}\"}]"
+  else
+     export SECRET_NAME_LICENSE_FILE=${ACCOUNT_ID}${SECRETS_KEY_SEPARATOR}${CLUSTER_ID}${SECRETS_KEY_SEPARATOR}${MAS_INSTANCE_ID}${SECRETS_KEY_SEPARATOR}license
+     TAGS="[{\"Key\": \"source\", \"Value\": \"gitops_license\"}, {\"Key\": \"account\", \"Value\": \"${ACCOUNT_ID}\"}, {\"Key\": \"cluster\", \"Value\": \"${CLUSTER_ID}\"}]"
+  fi
 
   UNESCAPED_LICENSE="$(cat $LICENSE_FILE)"
   ESCAPED_LICENSE=${UNESCAPED_LICENSE//\\/\\\\}
@@ -129,7 +159,6 @@ function gitops_license() {
   ESCAPED_LICENSE=${ESCAPED_LICENSE//$'\t'/\\t}
   ESCAPED_LICENSE=${ESCAPED_LICENSE//$'\r'/''}
 
-  TAGS="[{\"Key\": \"source\", \"Value\": \"gitops_license\"}, {\"Key\": \"account\", \"Value\": \"${ACCOUNT_ID}\"}, {\"Key\": \"cluster\", \"Value\": \"${CLUSTER_ID}\"}]"
   sm_update_secret $SECRET_NAME_LICENSE_FILE "{\"license_file\": \"$ESCAPED_LICENSE\"}" "${TAGS}"
 
 }

--- a/image/cli/mascli/functions/gitops_license
+++ b/image/cli/mascli/functions/gitops_license
@@ -91,10 +91,7 @@ function gitops_license_noninteractive() {
   [[ -z "$ACCOUNT_ID" ]] && gitops_license_help "ACCOUNT_ID is not set"
   [[ -z "$LICENSE_FILE" ]] && gitops_license_help "LICENSE_FILE is not set"
 
-#  ([[ -z "$ICN" ]] && [[ -z "$MAS_INSTANCE_ID" ]]) && gitops_license_help "One of IBM Customer Number or Cluster ID must be set"
-#  ([[ ! -z "$ICN" ]] && [[ ! -z "$MAS_INSTANCE_ID" ]]) && gitops_license_help "Cannot set both ICN and Instance ID"
   ([[ ! -z "$ICN" ]] && [[ -z "$SAAS_SUB_ID" ]]) && gitops_license_help "When ICN is set, SAAS_SUB_ID must also be set"
-#  ([[ ! -z "$CLUSTERID" ]] && [[ -z "$MAS_INSTANCE_ID" ]]) && gitops_license_help "When CLUSTERID is set, MAS_INSTANCE_ID must also be set"
 
 }
 

--- a/image/cli/mascli/functions/gitops_suite_license_service
+++ b/image/cli/mascli/functions/gitops_suite_license_service
@@ -214,12 +214,6 @@ function gitops_suite_license_service() {
   # catch errors
   set -o pipefail
   trap 'echo "[ERROR] Error occurred at $BASH_SOURCE, line $LINENO, exited with $?"; exit 1' ERR
-
-#  if [ "$GITHUB_PUSH" == "true" ]; then
-#    echo
-#    echo_h2 "Cloning GitHub repo $GITHUB_ORG $GITHUB_REPO"
-#    clone_target_git_repo $GITHUB_HOST $GITHUB_ORG $GITHUB_REPO $GIT_BRANCH $GITOPS_WORKING_DIR $GIT_SSH
-#  fi
   
   mkdir -p ${GITOPS_WORKING_DIR}
   GITOPS_INSTANCE_DIR=${GITOPS_WORKING_DIR}/${GITHUB_REPO}/${ACCOUNT_ID}/icn/${ICN}/${SAAS_SUB_ID}

--- a/image/cli/mascli/functions/gitops_suite_license_service
+++ b/image/cli/mascli/functions/gitops_suite_license_service
@@ -1,0 +1,407 @@
+#!/usr/bin/env bash
+
+function gitops_suite_license_service_help() {
+  [[ -n "$1" ]] && echo_warning "$1"
+  reset_colors
+  cat << EOM
+Usage:
+  mas gitops_suite_license_service [options]
+Where ${COLOR_YELLOW}specified${TEXT_RESET} each option may also be defined by setting the appropriate environment variable.
+When no options are specified on the command line, interactive-mode will be enabled by default.
+
+Basic Configuration:
+  -d, --dir ${COLOR_YELLOW}GITOPS_WORKING_DIR${TEXT_RESET}           Directory for GitOps repository
+  -a, --account-id ${COLOR_YELLOW}ACCOUNT_ID${TEXT_RESET}            Account name that the cluster belongs to
+  -c, --cluster-id ${COLOR_YELLOW}CLUSTER_ID${TEXT_RESET}            Cluster ID
+      --custom-labels ${COLOR_YELLOW}CUSTOM_LABELS${TEXT_RESET}      Custom Labels definition in dict format
+  -i  --ibm-customer-number ${COLOR_YELLOW}ICN${TEXT_RESET}          IBM Customer Number
+  -s  --subscription-id ${COLOR_YELLOW}SAAS_SUB_ID${TEXT_RESET}      Customer subscription id
+      --domain ${COLOR_YELLOW}SLS_DOMAIN${TEXT_RESET}                Domain for SLS to create route
+
+AWS Secrets Manager Configuration (Required):
+      --sm-aws-secret-region ${COLOR_YELLOW}SM_AWS_REGION${TEXT_RESET}          Region of the AWS Secrets Manager to use
+      --sm-aws-access-key ${COLOR_YELLOW}SM_AWS_ACCESS_KEY_ID${TEXT_RESET}      Your AWS Access Key ID
+      --sm-aws-secret-key ${COLOR_YELLOW}SM_AWS_SECRET_ACCESS_KEY${TEXT_RESET}  Your AWS Secret Key
+      --secrets-path ${COLOR_YELLOW}SECRETS_PATH${TEXT_RESET}                   Secrets Manager path
+
+MongoDb Provider Selection (Required):
+      --mongo-provider ${COLOR_YELLOW}MONGODB_PROVIDER${TEXT_RESET}  The mongodb provider to install ('aws' or 'yaml')
+
+IBM Suite License Service:
+      --sls-channel ${COLOR_YELLOW}SLS_CHANNEL${TEXT_RESET}  IBM Suite License Service Subscription Channel
+      --sls-install-plan ${COLOR_YELLOW}SLS_INSTALL_PLAN${TEXT_RESET}  IBM Suite License Service Subscription Install Plan ('Automatic' or 'Manual'. Default is 'Automatic')
+      --domain
+
+Target Cluster (Optional):
+      --cluster-url ${COLOR_YELLOW}CLUSTER_URL${TEXT_RESET}       Set to target a remote Kubernetes cluster (defaults to 'https://kubernetes.default.svc')
+
+Automatic GitHub Push:
+  -P, --github-push ${COLOR_YELLOW}GITHUB_PUSH${TEXT_RESET}        Enable automatic push to GitHub
+  -H, --github-host ${COLOR_YELLOW}GITHUB_HOST${TEXT_RESET}        GitHub Hostname for your GitOps repository
+  -O, --github-org  ${COLOR_YELLOW}GITHUB_ORG${TEXT_RESET}         Github org for your GitOps repository
+  -R, --github-repo ${COLOR_YELLOW}GITHUB_REPO${TEXT_RESET}        Github repo for your GitOps repository
+  -B, --git-branch ${COLOR_YELLOW}GIT_BRANCH${TEXT_RESET}          Git branch to commit to of your GitOps repository
+  -M, --git-commit-msg ${COLOR_YELLOW}GIT_COMMIT_MSG${TEXT_RESET}  Git commit message to use when committing to of your GitOps repository
+  -S , --github-ssh  ${COLOR_YELLOW}GIT_SSH${TEXT_RESET}           Git ssh key path
+
+Other Commands:
+  -h, --help                                      Show this help message
+EOM
+  [[ -n "$1" ]] && exit 1 || exit 0
+}
+
+function gitops_suite_license_service_noninteractive() {
+  # Set defaults
+  GITOPS_WORKING_DIR=$PWD/working-dir
+  SECRETS_KEY_SEPARATOR="/"
+
+  GIT_COMMIT_MSG="gitops-suite-license-service commit"
+
+  export REGION_ID=${REGION_ID:-${SM_AWS_REGION}}
+
+  export SLS_INSTALL_PLAN=${SLS_INSTALL_PLAN:-"Automatic"}
+  
+  # Target the local (to ArgoCD) cluster
+  export CLUSTER_URL=${CLUSTER_URL:-"https://kubernetes.default.svc"}
+
+  # Target IBM Container Registry by default
+  export ICR_CP=${ICR_CP:-"cp.icr.io/cp"}
+  export ICR_CP_OPEN=${ICR_CP_OPEN:-"icr.io/cpopen"}
+        
+  while [[ $# -gt 0 ]]
+  do
+    key="$1"
+    shift
+    case $key in
+      # GitOps Configuration
+      -d|--dir)
+        export GITOPS_WORKING_DIR=$1 && shift
+        ;;
+      -a|--account-id)
+        export ACCOUNT_ID=$1 && shift
+        ;;
+      -c|--cluster-id)
+        export CLUSTER_ID=$1 && shift
+        ;;
+      -i|--ibm-customer-number)
+        export ICN=$1 && shift
+        ;;
+      -s|--subscription-id)
+        export SAAS_SUB_ID=$1 && shift
+        ;;
+      --custom-labels)
+        export CUSTOM_LABELS=$1 && shift
+        ;;
+      --domain)
+        export SLS_DOMAIN=$1 && shift
+        ;;
+
+      # AWS Secrets Manager Configuration
+      --sm-aws-secret-region)
+        export SM_AWS_REGION=$1
+        export REGION_ID=$1
+        shift
+        ;;
+      --sm-aws-access-key)
+        export SM_AWS_ACCESS_KEY_ID=$1 && shift
+        ;;
+      --sm-aws-secret-key)
+        export SM_AWS_SECRET_ACCESS_KEY=$1 && shift
+        ;;
+      --secrets-path)
+        export SECRETS_PATH=$1 && shift
+        ;;
+
+      # cert manager
+      --cert-manager-namespace)
+        export CERT_MANAGER_NAMESPACE=$1 && shift
+        ;;
+
+      # MongoDb Provider Selection
+      --mongo-provider)
+        export MONGODB_PROVIDER=$1 && shift
+        ;;
+
+      # AWS MongoDb provider
+      --user-action)
+        export USER_ACTION=$1 && shift
+        ;;
+
+      # SLS
+      --sls-channel)
+        export SLS_CHANNEL=$1 && shift
+        ;;
+      --sls-install-plan)
+        export SLS_INSTALL_PLAN=$1 && shift
+        ;;
+
+      # Target Cluster (Optional)
+      --cluster-url)
+        export CLUSTER_URL=$1 && shift
+        ;;
+
+      # Automatic GitHub Push
+      -P|--github-push)
+        export GITHUB_PUSH=true
+        ;;
+      -H|--github-host)
+        export GITHUB_HOST=$1 && shift
+        ;;
+      -O|--github-org)
+        export GITHUB_ORG=$1 && shift
+        ;;
+      -R|--github-repo)
+        export GITHUB_REPO=$1 && shift
+        ;;
+      -B|--git-branch)
+        export GIT_BRANCH=$1 && shift
+        ;;
+      -M|--git-commit-msg)
+        export GIT_COMMIT_MSG=$1 && shift
+        ;;
+      -S|--github-ssh)
+        export GIT_SSH=$1 && shift
+        ;;
+
+      # Other Commands
+      -h|--help)
+        gitops_suite_help
+        ;;
+      *)
+        # unknown option
+        gitops_suite_license_service_help "Usage Error: Unsupported option \"${key}\" "
+        ;;
+      esac
+  done
+
+  [[ -z "$ACCOUNT_ID" ]] && gitops_suite_license_service_help "ACCOUNT_ID is not set"
+  [[ -z "$CLUSTER_ID" ]] && gitops_suite_license_service_help "CLUSTER_ID is not set"
+  [[ -z "$REGION_ID" && -z "$SM_AWS_REGION" ]] && gitops_suite_license_service_help "REGION_ID or SM_AWS_REGION is not set"
+  [[ -z "$CLUSTER_URL" ]] && gitops_suite_license_service_help "CLUSTER_URL is not set"
+  [[ -z "$MONGODB_PROVIDER" ]] && gitops_suite_license_service_help "MONGODB_PROVIDER is not set"
+  [[ -z "$ICN" ]] && gitops_suite_license_service_help "IBM Customer ID must be set."
+  [[ -z "$SAAS_SUB_ID" ]] && gitops_suite_license_service_help "SaaS Subscription ID must be set."
+
+  if [ $MONGODB_PROVIDER == 'aws' ]; then
+    [[ -z "$USER_ACTION" ]] && gitops_suite_help "USER_ACTION is not set"
+    [[ -z "$MAS_INSTANCE_ID" ]] && gitops_suite_help "MAS_INSTANCE_ID is not set"
+    if [ -z $SM_AWS_ACCESS_KEY_ID ] || [ -z $SM_AWS_SECRET_ACCESS_KEY ] || [ -z $SM_AWS_REGION ]; then
+      echo 'Missing required params for AWS mongo provider, make sure to provide --aws-access-key, --aws-secret-key, --aws-region'
+      exit 1
+    fi
+  fi
+
+  if [[ "$GITHUB_PUSH" == "true" ]]; then
+    [[ -z "$GITHUB_HOST" ]] && gitops_suite_help "GITHUB_HOST is not set"
+    [[ -z "$GITHUB_ORG" ]] && gitops_suite_help "GITHUB_ORG is not set"
+    [[ -z "$GITHUB_REPO" ]] && gitops_suite_help "GITHUB_REPO is not set"
+    [[ -z "$GIT_BRANCH" ]] && gitops_suite_help "GIT_BRANCH is not set"
+  fi
+
+}
+
+function gitops_suite_license_service() {
+  # Take the first parameter off (it will be create-gitops)
+  shift
+  if [[ $# -gt 0 ]]; then
+    gitops_suite_license_service_noninteractive "$@"
+  else
+    echo "Not supported yet"
+    exit 1
+    gitops_suite_license_service_interactive
+  fi
+
+  # catch errors
+  set -o pipefail
+  trap 'echo "[ERROR] Error occurred at $BASH_SOURCE, line $LINENO, exited with $?"; exit 1' ERR
+
+#  if [ "$GITHUB_PUSH" == "true" ]; then
+#    echo
+#    echo_h2 "Cloning GitHub repo $GITHUB_ORG $GITHUB_REPO"
+#    clone_target_git_repo $GITHUB_HOST $GITHUB_ORG $GITHUB_REPO $GIT_BRANCH $GITOPS_WORKING_DIR $GIT_SSH
+#  fi
+  
+  mkdir -p ${GITOPS_WORKING_DIR}
+  GITOPS_INSTANCE_DIR=${GITOPS_WORKING_DIR}/${GITHUB_REPO}/${ACCOUNT_ID}/icn/${ICN}/${SAAS_SUB_ID}
+
+  echo
+  reset_colors
+  echo_h2 "Review Settings"
+
+  echo "${TEXT_DIM}"
+  echo_h4 "Target" "    "
+  echo_reset_dim "Account ID ..................... ${COLOR_MAGENTA}${ACCOUNT_ID}"
+  echo_reset_dim "Cluster ID ..................... ${COLOR_MAGENTA}${CLUSTER_ID}"
+  echo_reset_dim "Cluster URL .................... ${COLOR_MAGENTA}${CLUSTER_URL}"
+  echo_reset_dim "Customer Number ................ ${COLOR_MAGENTA}${ICN}"
+  echo_reset_dim "Subscription ID ................ ${COLOR_MAGENTA}${SAAS_SUB_ID}"
+  echo_reset_dim "SLS Service Config Directory ... ${COLOR_MAGENTA}${GITOPS_INSTANCE_DIR}"
+  reset_colors
+
+  echo "${TEXT_DIM}"
+  echo_h4 "AWS Secrets Manager" "    "
+  echo_reset_dim "Region ......................... ${COLOR_MAGENTA}${SM_AWS_REGION}"
+  echo_reset_dim "Secret Key ..................... ${COLOR_MAGENTA}${SM_AWS_ACCESS_KEY_ID:0:4}<snip>"
+  echo_reset_dim "Access Key ..................... ${COLOR_MAGENTA}${SM_AWS_SECRET_ACCESS_KEY:0:4}<snip>"
+  echo_reset_dim "Secrets Path ................... ${COLOR_MAGENTA}${SECRETS_PATH}"
+  reset_colors
+
+  echo "${TEXT_DIM}"
+  echo_h4 "Mongo" "    "
+  echo_reset_dim "Mongo Provider  ................ ${COLOR_MAGENTA}${MONGODB_PROVIDER}"
+  reset_colors
+
+  echo "${TEXT_DIM}"
+  echo_h4 "IBM Suite License Service" "    "
+  echo_reset_dim "Subscription Channel ........... ${COLOR_MAGENTA}${SLS_CHANNEL}"
+  echo_reset_dim "Subscription Install Plan ...... ${COLOR_MAGENTA}${SLS_INSTALL_PLAN}"
+  reset_colors
+
+  echo "${TEXT_DIM}"
+  if [[ "$GITHUB_PUSH" == "true" ]]; then
+    echo_h4 "GitOps Target" "    "
+    echo_reset_dim "Automatic Push ................. ${COLOR_GREEN}Enabled"
+    echo_reset_dim "Working Directory .............. ${COLOR_MAGENTA}${GITOPS_WORKING_DIR}"
+    echo_reset_dim "Host ........................... ${COLOR_MAGENTA}${GITHUB_HOST}"
+    echo_reset_dim "Organization ................... ${COLOR_MAGENTA}${GITHUB_ORG}"
+    echo_reset_dim "Repository ..................... ${COLOR_MAGENTA}${GITHUB_REPO}"
+    echo_reset_dim "Branch ......................... ${COLOR_MAGENTA}${GIT_BRANCH}"
+  else
+    echo_h4 "GitOps Target" "    "
+    echo_reset_dim "Automatic Push ................. ${COLOR_RED}Disabled"
+    echo_reset_dim "Working Directory .............. ${COLOR_MAGENTA}${GITOPS_WORKING_DIR}"
+  fi
+  reset_colors
+
+  # Set up Suite secrets
+  # ---------------------------------------------------------------------------
+  echo
+  echo_h2 "Configuring Suite License Service secrets"
+  AVP_TYPE=aws
+  sm_login
+
+
+  # Define cluster-level secrets used
+  # ---------------------------------------------------------------------------
+  # Note that this cluster-level secret is set up by gitops-cluster
+  export SECRET_KEY_IBM_ENTITLEMENT=${ACCOUNT_ID}${SECRETS_KEY_SEPARATOR}${CLUSTER_ID}${SECRETS_KEY_SEPARATOR}ibm_entitlement#image_pull_secret_b64
+  
+  # The AWS secret is established by the gitops_cluster step
+  export SECRET_NAME_AWS_ACCESS=${ACCOUNT_ID}${SECRETS_KEY_SEPARATOR}${CLUSTER_ID}${SECRETS_KEY_SEPARATOR}aws
+  export SECRET_KEY_AWS_ACCESS_KEY_ID=${SECRET_NAME_AWS_ACCESS}#sm_aws_access_key_id
+  export SECRET_KEY_AWS_SECRET_ACCESS_KEY=${SECRET_NAME_AWS_ACCESS}#sm_aws_secret_access_key
+  
+  # Instance-level secrets to use
+  # ---------------------------------------------------------------------------
+  # Note that these instance-level secrets are set up by gitops-license
+  export SECRET_KEY_LICENSE_FILE=${ACCOUNT_ID}${SECRETS_KEY_SEPARATOR}${ICN}${SECRETS_KEY_SEPARATOR}${SAAS_SUB_ID}${SECRETS_KEY_SEPARATOR}license#license_file
+
+
+  # Get the cluster-level secrets used
+  # ---------------------------------------------------------------------------
+  # Note that this cluster-level secret is set up by gitops-mongo
+  export SECRET_NAME_MASTER_MONGO=${ACCOUNT_ID}${SECRETS_KEY_SEPARATOR}${CLUSTER_ID}${SECRETS_KEY_SEPARATOR}mongo
+  export SECRET_NAME_CIS=${ACCOUNT_ID}${SECRETS_KEY_SEPARATOR}${CLUSTER_ID}${SECRETS_KEY_SEPARATOR}cis
+
+  export SECRET_KEY_DOCDB_HOST=${SECRET_NAME_MASTER_MONGO}#docdb_host
+  export SECRET_KEY_DOCDB_PORT=${SECRET_NAME_MASTER_MONGO}#docdb_port
+  export SECRET_KEY_DOCDB_MASTER_USERNAME=${SECRET_NAME_MASTER_MONGO}#username
+  export SECRET_KEY_DOCDB_MASTER_PASSWORD=${SECRET_NAME_MASTER_MONGO}#password
+  export SECRET_KEY_DOCDB_MASTER_INFO=${SECRET_NAME_MASTER_MONGO}#info
+
+  CURRENT_DIR=$PWD
+  TEMP_DIR=$CURRENT_DIR/tmp-suite
+  rm -rf TEMP_DIR
+  mkdir -p $TEMP_DIR
+
+  # by default yaml. pass aws, in case if configuring with DocDB
+  export MONGODB_PROVIDER=${MONGODB_PROVIDER:-"yaml"}
+
+  export MONGO_SECRET_FILE=$TEMP_DIR/mongo-secret.json
+  export MONGO_CONFIG_FILE=$TEMP_DIR/mongo-info.yaml
+
+  sm_verify_secret_exists ${ACCOUNT_ID}${SECRETS_KEY_SEPARATOR}${CLUSTER_ID}${SECRETS_KEY_SEPARATOR}mongo "username,password,info"
+  sm_get_secret_file ${ACCOUNT_ID}${SECRETS_KEY_SEPARATOR}${CLUSTER_ID}${SECRETS_KEY_SEPARATOR}mongo $MONGO_SECRET_FILE
+
+  jq -r .info $MONGO_SECRET_FILE > $MONGO_CONFIG_FILE
+  MASTER_MONGO_USERNAME=$(jq -r .username $MONGO_SECRET_FILE)
+  MASTER_MONGO_PASSWORD=$(jq -r .password $MONGO_SECRET_FILE)
+  UNESCAPED_MONGO_INFO=$(jq -r .info $MONGO_SECRET_FILE)
+
+
+  # Instance-level secrets to use
+  # ---------------------------------------------------------------------------
+  # Note that these instance-level secrets are set up by gitops-license
+  export SECRET_NAME_LICENSE_FILE=${ACCOUNT_ID}${SECRETS_KEY_SEPARATOR}${ICN}${SECRETS_KEY_SEPARATOR}${SAAS_SUB_ID}${SECRETS_KEY_SEPARATOR}license#license_file
+
+
+  # Instance-level secrets to create
+  # ---------------------------------------------------------------------------
+  export SECRET_NAME_MONGO=${ACCOUNT_ID}${SECRETS_KEY_SEPARATOR}${ICN}${SECRETS_KEY_SEPARATOR}${SAAS_SUB_ID}${SECRETS_KEY_SEPARATOR}mongo
+  export SECRET_KEY_MONGO_USERNAME=${SECRET_NAME_MONGO}#username
+  export SECRET_KEY_MONGO_PASSWORD=${SECRET_NAME_MONGO}#password
+  export SECRET_KEY_MONGO_INFO=${SECRET_NAME_MONGO}#info
+
+  
+  export MONGO_INSTANCE_SECRET_FILE=$TEMP_DIR/mongo-instance-secret.json
+  sm_get_secret_file ${ACCOUNT_ID}${SECRETS_KEY_SEPARATOR}${ICN}${SECRETS_KEY_SEPARATOR}${SAAS_SUB_ID}${SECRETS_KEY_SEPARATOR}mongo $MONGO_INSTANCE_SECRET_FILE
+  INSTANCE_MONGO_USERNAME=$(jq -r .username $MONGO_INSTANCE_SECRET_FILE)
+  INSTANCE_MONGO_PASSWORD=$(jq -r .password $MONGO_INSTANCE_SECRET_FILE)
+
+  # Setting mongo instance secret with info field copied from the cluster level secret, 
+  # Instance username and password will be created in presync hook 
+
+  ESCAPED_INFO=${UNESCAPED_MONGO_INFO//\"/\\\"}
+  ESCAPED_INFO=${ESCAPED_INFO//$'\n'/\\n}
+  TAGS="[{\"Key\": \"source\", \"Value\": \"gitops_suite\"}, {\"Key\": \"account\", \"Value\": \"${ACCOUNT_ID}\"}, {\"Key\": \"cluster\", \"Value\": \"${CLUSTER_ID}\"}]"
+  sm_update_secret $SECRET_NAME_MONGO "{\"info\": \"$ESCAPED_INFO\", \"username\": \"$INSTANCE_MONGO_USERNAME\", \"password\": \"$INSTANCE_MONGO_PASSWORD\"}" "${TAGS}"
+  
+
+  if [ -z $GIT_SSH ]; then
+    export GIT_SSH="false"
+  fi
+
+
+  # Set and Validate App Names
+  # ---------------------------------------------------------------------------
+  CLUSTER_ROOT_APP="cluster.${CLUSTER_ID}"
+  SLS_APP_NAME="sls.${ICN}.${SAAS_SUB_ID}"
+
+  validate_app_name "${CLUSTER_ROOT_APP}"
+  validate_app_name "${SLS_APP_NAME}"
+
+
+  # Clone github target repo
+  # ---------------------------------------------------------------------------
+  if [ "$GITHUB_PUSH" == "true" ]; then
+    echo
+    echo_h2 "Cloning GitHub repo $GITHUB_ORG $GITHUB_REPO"
+    clone_target_git_repo $GITHUB_HOST $GITHUB_ORG $GITHUB_REPO $GIT_BRANCH $GITOPS_WORKING_DIR $GIT_SSH
+  fi
+  mkdir -p ${GITOPS_INSTANCE_DIR}
+
+  
+  # FIX THIS => SLS POD TEMPLATES?
+  # ---------------------------------------------------------------------------
+
+
+  # Generate ArgoApps
+  # ---------------------------------------------------------------------------
+  echo
+  echo_h2 "Generating Argo Project and Applications"
+
+  echo "- IBM Suite License Service"
+  jinjanate --quiet --undefined --import-env='' $CLI_DIR/templates/gitops/appset-configs/cluster/sls/ibm-sls.yaml.j2 $MONGO_CONFIG_FILE -o ${GITOPS_INSTANCE_DIR}/ibm-sls.yaml
+
+
+  # Commit and push to github target repo
+  # ---------------------------------------------------------------------------
+  if [ "$GITHUB_PUSH" == "true" ]; then
+
+    echo
+    echo_h2 "Commit and push changes to GitHub repo $GITHUB_ORG $GITHUB_REPO"
+    save_to_target_git_repo $GITHUB_HOST $GITHUB_ORG $GITHUB_REPO $GIT_BRANCH "${GITOPS_WORKING_DIR}/${GITHUB_REPO}" "${GIT_COMMIT_MSG}"
+    remove_git_repo_clone $GITOPS_WORKING_DIR/$GITHUB_REPO
+  fi
+
+}

--- a/image/cli/mascli/mas
+++ b/image/cli/mascli/mas
@@ -79,6 +79,7 @@ mkdir -p $CONFIG_DIR
 . $CLI_DIR/functions/gitops_process_mongo_user
 . $CLI_DIR/functions/gitops_aws_infrastructure
 . $CLI_DIR/functions/gitops_rosa
+. $CLI_DIR/functions/gitops_suite_license_service
 . $CLI_DIR/functions/gitops_deprovision_rosa
 . $CLI_DIR/functions/gitops_deprovision_cluster
 . $CLI_DIR/functions/gitops_deprovision_cp4d
@@ -86,6 +87,7 @@ mkdir -p $CONFIG_DIR
 . $CLI_DIR/functions/gitops_deprovision_mongo
 . $CLI_DIR/functions/gitops_deprovision_efs
 . $CLI_DIR/functions/gitops_deprovision_kafka
+. $CLI_DIR/functions/gitops_deprovision_suite_license_service
 . $CLI_DIR/functions/gitops_mas_fvt_preparer
 . $CLI_DIR/functions/gitops_deprovision_db2u_database
 . $CLI_DIR/functions/gitops_nvidia_gpu
@@ -475,6 +477,14 @@ case $1 in
     gitops_deprovision_kafka "$@"
     ;;
 
+  gitops-deprovision-suite-license-service)
+    echo "${TEXT_UNDERLINE}IBM Maximo Application Suite GitOps Manager (v${VERSION})${TEXT_RESET}"
+    echo "Powered by ${COLOR_CYAN}${TEXT_UNDERLINE}https://github.com/ibm-mas/gitops/${TEXT_RESET}"
+    echo
+    reset_colors
+    gitops_deprovision_suite_license_service "$@"
+    ;;
+
   gitops-efs)
     echo "${TEXT_UNDERLINE}IBM Maximo Application Suite GitOps Manager (v${VERSION})${TEXT_RESET}"
     echo "Powered by ${COLOR_CYAN}${TEXT_UNDERLINE}https://github.com/ibm-mas/gitops/${TEXT_RESET}"
@@ -613,6 +623,14 @@ case $1 in
     echo
     reset_colors
     gitops_deprovision_cp4d_service "$@"
+  ;;
+
+  gitops-suite-license-service)
+    echo "${TEXT_UNDERLINE}IBM Maximo Application Suite GitOps Manager (v${VERSION})${TEXT_RESET}"
+    echo "Powered by ${COLOR_CYAN}${TEXT_UNDERLINE}https://github.com/ibm-mas/gitops/${TEXT_RESET}"
+    echo
+    reset_colors
+    gitops_suite_license_service "$@"
     ;;
 
   *)

--- a/image/cli/mascli/templates/gitops/appset-configs/cluster/sls/configs/ibm-mas-sls-config.yaml.j2
+++ b/image/cli/mascli/templates/gitops/appset-configs/cluster/sls/configs/ibm-mas-sls-config.yaml.j2
@@ -1,0 +1,19 @@
+mas_config_name: "{{ MAS_CONFIG_NAME }}"
+mas_config_chart: ibm-mas-sls-config
+mas_config_scope: {{ MAS_CONFIG_SCOPE }}
+mas_workspace_id: {{ MAS_WORKSPACE_ID }}
+mas_application_id: {{ MAS_APP_ID }}
+mas_config_kind: "slscfgs"
+mas_config_api_version: "config.mas.ibm.com"
+use_postdelete_hooks: {{ USE_POSTDELETE_HOOKS }}
+
+{% if MAS_SLSCFG_POD_TEMPLATE is defined and MAS_SLSCFG_POD_TEMPLATE !='' %}
+mas_slscfg_pod_templates:
+  {{ MAS_SLSCFG_POD_TEMPLATE | indent(2) }}
+{% endif %}
+
+registration_key: <path:{{ SECRETS_PATH }}:{{ SECRET_KEY_SLS_REGISTRATION_KEY }}>
+url: "https://sls.mas-{{ MAS_INSTANCE_ID }}-sls.svc"
+ca:
+  crt: |
+    <path:{{ SECRETS_PATH }}:{{ SECRET_KEY_SLS_CA_B64 }} | base64decode>

--- a/image/cli/mascli/templates/gitops/appset-configs/cluster/sls/ibm-sls.yaml.j2
+++ b/image/cli/mascli/templates/gitops/appset-configs/cluster/sls/ibm-sls.yaml.j2
@@ -1,0 +1,67 @@
+
+account:
+  id: {{ ACCOUNT_ID }}
+
+cluster:
+  id: {{ CLUSTER_ID }}
+  url: {{ CLUSTER_URL }}
+region:
+  id: {{ REGION_ID }}
+
+sm:
+  aws_access_key_id: "<path:{{ SECRETS_PATH }}:{{ ACCOUNT_ID }}/{{ CLUSTER_ID }}/aws#sm_aws_access_key_id>"
+  aws_secret_access_key: "<path:{{ SECRETS_PATH }}:{{ ACCOUNT_ID }}/{{ CLUSTER_ID }}/aws#sm_aws_secret_access_key>"
+
+ibm_sls_standalone:
+  sls_channel: {{ SLS_CHANNEL }}
+  sls_entitlement_file: <path:{{ SECRETS_PATH }}:{{ SECRET_KEY_LICENSE_FILE }}>
+  ibm_entitlement_key: <path:{{ SECRETS_PATH }}:{{ SECRET_KEY_IBM_ENTITLEMENT }}>
+  sls_domain: {{ SLS_DOMAIN }}
+  ibm_customer_number: "{{ ICN }}"
+  subscription_id: "{{ SAAS_SUB_ID }}"
+
+  # aws docdb
+  mongodb_provider: "{{ MONGODB_PROVIDER }}"
+  user_action: "{{ USER_ACTION }}"
+  docdb_host: "<path:{{ SECRETS_PATH }}:{{ SECRET_KEY_DOCDB_HOST }}>"
+  docdb_port: "<path:{{ SECRETS_PATH }}:{{ SECRET_KEY_DOCDB_PORT }}>"
+  docdb_master_username: "<path:{{ SECRETS_PATH }}:{{ SECRET_KEY_DOCDB_MASTER_USERNAME }}>"
+  docdb_master_password: "<path:{{ SECRETS_PATH }}:{{ SECRET_KEY_DOCDB_MASTER_PASSWORD }}>"
+  docdb_master_info: "<path:{{ SECRETS_PATH }}:{{ SECRET_KEY_DOCDB_MASTER_INFO }}>"
+  sls_mongo_username: "<path:{{ SECRETS_PATH }}:{{ SECRET_KEY_MONGO_USERNAME }}>"
+  sls_mongo_password: "<path:{{ SECRETS_PATH }}:{{ SECRET_KEY_MONGO_PASSWORD }}>"
+
+  sls_mongo_secret_name: sls-mongo-credentials
+  icr_cp_open: {{ ICR_CP_OPEN }}
+  sls_install_plan: {{ SLS_INSTALL_PLAN }}
+  run_sync_hooks: true
+  mongo_spec:
+    authMechanism: DEFAULT
+    configDb: admin
+    secretName: sls-mongo-credentials
+{%- if config.retryWrites is sameas false %}
+    retryWrites: false
+{%- endif %}
+    nodes:
+{%- for mongo_host in config.hosts %}
+      - host: {{ mongo_host.host }}
+        port: {{ mongo_host.port }}
+{%- endfor %}
+    certificates:
+{%- if config.certificate %}
+{%- for mongo_certificate in config.certificate %}
+      - alias: {{ mongo_certificate.alias }}
+        crt: |
+          {% filter indent(width=10) -%}
+          {{ mongo_certificate.crt }}
+          {%- endfilter %}
+{%- endfor %}
+{%- elif certificates %}
+{%- for mongo_certificate in certificates %}
+      - alias: {{ mongo_certificate.alias }}
+        crt: |
+          {% filter indent(width=10) -%}
+          {{ mongo_certificate.crt }}
+          {%- endfilter %}
+{%- endfor -%}
+{%- endif -%}

--- a/tekton/generate-tekton-pipelines.yml
+++ b/tekton/generate-tekton-pipelines.yml
@@ -93,6 +93,8 @@
         - gitops-mas-initiator
         - gitops-mas-aibroker
         - gitops-mas-aibroker-tenant
+        - gitops-suite-license-service
+        - deprovision-suite-license-service
 
     # 4. Generate Gitops Pipelines with waits
     # -------------------------------------------------------------------------

--- a/tekton/generate-tekton-tasks.yml
+++ b/tekton/generate-tekton-tasks.yml
@@ -195,6 +195,7 @@
         - gitops-deprovision-app-config
         - gitops-deprovision-app-install
         - gitops-deprovision-cluster
+        - gitops-deprovision-customer-subscription
         - gitops-deprovision-cos
         - gitops-deprovision-cp4d
         - gitops-deprovision-cp4d-service
@@ -226,6 +227,7 @@
         - gitops-nvidia-gpu
         - gitops-process-mongo-user
         - gitops-rosa
+        - gitops-sls
         - gitops-suite-app-install
         - gitops-suite-app-config
         - gitops-suite-certs

--- a/tekton/src/pipelines/gitops/deprovision-suite-license-service.yml.j2
+++ b/tekton/src/pipelines/gitops/deprovision-suite-license-service.yml.j2
@@ -1,0 +1,64 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: gitops-deprovision-suite-license-service
+spec:
+  description: Deprovision customer subscription
+  workspaces:
+    - name: shared-entitlement
+  params:
+
+    - name: sls_license_icn
+      type: string
+    - name: sls_license_subscription_id
+      type: string
+    - name: account
+      type: string
+    - name: git_branch
+      type: string
+    - name: github_org
+      type: string
+    - name: github_repo
+      type: string
+    - name: github_host
+      type: string
+    - name: github_user
+      type: string
+    - name: git_commit_msg
+      type: string
+    - name: secrets_path
+      type: string
+    - name: avp_aws_secret_region
+      type: string
+
+  tasks:
+    - name: gitops-deprovision-customer-subscription
+      params:
+        - name: sls_license_icn
+          value: $(params.sls_license_icn)
+        - name: sls_license_subscription_id
+          value: $(params.sls_license_subscription_id)
+        - name: account
+          value: $(params.account)
+        - name: git_branch
+          value: $(params.git_branch)
+        - name: github_org
+          value: $(params.github_org)
+        - name: github_repo
+          value: $(params.github_repo)
+        - name: github_host
+          value: $(params.github_host)
+        - name: git_commit_msg
+          value: $(params.git_commit_msg)
+        - name: secrets_path
+          value: $(params.secrets_path)
+        - name: avp_aws_secret_region
+          value: $(params.avp_aws_secret_region)
+
+      taskRef:
+        kind: Task
+        name: gitops-deprovision-customer-subscription
+      workspaces:
+        - name: shared-entitlement
+          workspace: shared-entitlement

--- a/tekton/src/pipelines/gitops/deprovision-suite-license-service.yml.j2
+++ b/tekton/src/pipelines/gitops/deprovision-suite-license-service.yml.j2
@@ -4,7 +4,7 @@ kind: Pipeline
 metadata:
   name: gitops-deprovision-suite-license-service
 spec:
-  description: Deprovision customer subscription
+  description: MAS deprovision Suite License Service for customer subscription
   workspaces:
     - name: shared-entitlement
   params:

--- a/tekton/src/pipelines/gitops/gitops-suite-license-service.yml.j2
+++ b/tekton/src/pipelines/gitops/gitops-suite-license-service.yml.j2
@@ -1,0 +1,234 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: gitops-suite-license-service
+spec:
+  workspaces:
+    - name: shared-entitlement
+  description: MAS GitOps Suite License Service
+  params:
+    - name: cluster_name
+      type: string
+    - name: account
+      type: string
+    - name: secrets_path
+      type: string
+    - name: avp_aws_secret_region
+      type: string
+    # 1. Gitops git Parameters
+    # -------------------------------------------------------------------------
+    # Gitops Git Parameters
+    # ------------------------------------------------------------------------- 
+    - name: github_push
+      type: string
+      default: "False"
+      description: Whether to push changes to github or not. True or False
+    - name: git_branch
+      type: string
+      description: The git branch to push too
+      default: ""
+    - name: github_org
+      type: string
+      description: The git org to push too
+      default: ""
+    - name: github_repo
+      type: string
+      description: The git repo to push too
+      default: ""
+    - name: github_host
+      type: string
+      description: The git host to push too
+      default: ""
+    - name: github_pat
+      type: string
+      description: The git personal access token to use on the commit
+      default: ""
+    - name: git_commit_msg
+      type: string
+      description: The git commit message to use in the push
+      default: ""
+    - name: github_url
+      type: string
+    - name: github_ssh
+      type: string
+      default: ""
+
+    - name: mas_instance_id
+      type: string
+      default: ""
+
+    - name: mongo_provider
+      type: string
+      default: aws
+    - name: sls_channel
+      type: string
+
+    - name: sls_install_plan
+      type: string
+      default: "Automatic"
+
+    - name: docdb_user_action
+      type: string
+      default: add
+
+    - name: icr_cp
+      type: string
+    - name: icr_cp_open
+      type: string
+
+    - name: ocp_cluster_domain
+      type: string
+      default: ""
+
+    - name: cluster_url
+      type: string
+      default: ""
+
+    - name: mas_slscfg_pod_template_yaml
+      type: string
+      default: ""
+
+    # gitops-license-generator parameters
+    # ------------------------------------------------------------------------- 
+    - name: sls_license_expiry_date
+      type: string
+    - name: sls_license_app_points
+      type: string
+    - name: sls_license_customer_name
+      type: string
+    - name: sls_license_country
+      type: string
+    - name: sls_license_icn
+      type: string
+      default: ""
+    - name: sls_subscription_id
+      type: string
+      default: ""
+
+  tasks:
+
+    # 1. License Entitlement
+    # -------------------------------------------------------------------------
+    - name: gitops-license
+      params:
+        - name: cluster_name
+          value: $(params.cluster_name)
+        - name: account
+          value: $(params.account)
+        - name: mas_instance_id
+          value: $(params.mas_instance_id)
+        - name: avp_aws_secret_region
+          value: $(params.avp_aws_secret_region)
+        
+        - name: sls_license_icn
+          value: $(params.sls_license_icn)
+        - name: sls_subscription_id
+          value: $(params.sls_subscription_id)
+        
+      workspaces:
+        - name: shared-entitlement
+          workspace: shared-entitlement
+      taskRef:
+        kind: Task
+        name: gitops-license
+      when:
+        - input: "$(params.sls_subscription_id)"
+          operator: in
+          values: [""]
+
+    - name: gitops-license-generator
+      runAfter:
+        - gitops-license
+      params:
+        - name: cluster_name
+          value: $(params.cluster_name)
+        - name: account
+          value: $(params.account)
+        - name: mas_instance_id
+          value: $(params.mas_instance_id)
+        - name: avp_aws_secret_region
+          value: $(params.avp_aws_secret_region)
+
+        - name: expiry_date
+          value: $(params.sls_license_expiry_date)
+        - name: app_points
+          value: $(params.sls_license_app_points)
+        - name: customer_name
+          value: $(params.sls_license_customer_name)
+        - name: country
+          value: $(params.sls_license_country)
+        - name: sls_license_icn
+          value: $(params.sls_license_icn)
+        - name: sls_subscription_id
+          value: $(params.sls_subscription_id)
+      taskRef:
+        kind: Task
+        name: gitops-license-generator
+      when:
+        - input: "$(params.sls_subscription_id)"
+          operator: notin
+          values: [""]
+
+    # 2. 
+    # -------------------------------------------------------------------------
+    - name: gitops-sls
+      runAfter:        
+        - gitops-license-generator
+      params:
+        - name: cluster_name
+          value: $(params.cluster_name)
+        - name: account
+          value: $(params.account)
+        - name: secrets_path
+          value: $(params.secrets_path)
+        - name: mas_instance_id
+          value: $(params.mas_instance_id)
+        - name: mongo_provider
+          value: $(params.mongo_provider)
+        - name: user_action
+          value: $(params.docdb_user_action)
+
+        - name: github_push
+          value: $(params.github_push)
+        - name: git_branch
+          value: $(params.git_branch)
+        - name: github_org
+          value: $(params.github_org)
+        - name: github_repo
+          value: $(params.github_repo)
+        - name: github_host
+          value: $(params.github_host)
+        - name: git_commit_msg
+          value: $(params.git_commit_msg)
+        - name: github_ssh
+          value: $(params.github_ssh)
+
+        - name: avp_aws_secret_region
+          value: $(params.avp_aws_secret_region)
+
+        - name: sls_channel
+          value: $(params.sls_channel)
+        - name: sls_install_plan
+          value: $(params.sls_install_plan)
+        - name: icr_cp
+          value: $(params.icr_cp)
+        - name: icr_cp_open
+          value: $(params.icr_cp_open)
+
+        - name: cluster_url
+          value: $(params.cluster_url)
+        - name: ocp_cluster_domain
+          value: $(params.ocp_cluster_domain)
+
+        - name: sls_license_icn
+          value: $(params.sls_license_icn)
+        - name: sls_subscription_id
+          value: $(params.sls_subscription_id)
+
+      taskRef:
+        kind: Task
+        name: gitops-sls
+      workspaces:
+        - name: shared-entitlement
+          workspace: shared-entitlement

--- a/tekton/src/pipelines/gitops/gitops-suite-license-service.yml.j2
+++ b/tekton/src/pipelines/gitops/gitops-suite-license-service.yml.j2
@@ -6,7 +6,7 @@ metadata:
 spec:
   workspaces:
     - name: shared-entitlement
-  description: MAS GitOps Suite License Service
+  description: MAS provision Suite License Service for customer subscription
   params:
     - name: cluster_name
       type: string

--- a/tekton/src/tasks/gitops/gitops-deprovision-customer-subscription.yml.j2
+++ b/tekton/src/tasks/gitops/gitops-deprovision-customer-subscription.yml.j2
@@ -1,0 +1,82 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: gitops-deprovision-customer-subscription
+spec:
+  params:
+    - name: sls_license_icn
+      type: string
+    - name: sls_license_subscription_id
+      type: string
+    - name: account
+      type: string
+    - name: secrets_path
+      type: string
+    - name: git_branch
+      type: string
+    - name: github_org
+      type: string
+    - name: github_repo
+      type: string
+    - name: github_host
+      type: string
+    - name: git_commit_msg
+      type: string
+    - name: avp_aws_secret_region
+      type: string
+  stepTemplate:
+    name: gitops-deprovision-customer-subscription
+    env:
+      - name: ACCOUNT
+        value: $(params.account)
+      - name: ICN
+        value: $(params.sls_license_icn)
+      - name: SAAS_SUB_ID
+        value: $(params.sls_license_subscription_id)
+      - name: GIT_BRANCH
+        value: $(params.git_branch)
+      - name: GITHUB_ORG
+        value: $(params.github_org)
+      - name: GITHUB_HOST
+        value: $(params.github_host)
+      - name: GITHUB_REPO
+        value: $(params.github_repo)
+      - name: GIT_COMMIT_MSG
+        value: $(params.git_commit_msg)
+      - name: SM_AWS_REGION
+        value: $(params.avp_aws_secret_region)
+      - name: SECRET_PATH
+        value: $(params.secrets_path)
+    envFrom:
+      - configMapRef:
+          name: environment-properties
+          optional: true
+      - secretRef:
+          name: secure-properties
+  steps:
+    - args:
+      - |-
+        git config --global user.name "MAS Automation"
+        git config --global user.email "mas_automation@email.com"
+        git config --global user.password $GITHUB_PAT
+
+        mkdir -p /tmp/deprovision-customer-subscription
+        mas gitops-deprovision-suite-license-service -a $ACCOUNT -i ${ICN} -s ${SAAS_SUB_ID} \
+        --dir /tmp/deprovision-suite-license-service \
+        --github-push \
+        --github-host $GITHUB_HOST \
+        --github-org  $GITHUB_ORG \
+        --github-repo $GITHUB_REPO \
+        --git-branch $GIT_BRANCH \
+        --secrets-path $SECRET_PATH
+
+        exit $?
+      command:
+        - /bin/sh
+        - -c
+      name: gitops-deprovision-customer-subscription
+      imagePullPolicy: IfNotPresent
+      image: quay.io/ibmmas/cli:latest
+  workspaces:
+    - name: shared-entitlement

--- a/tekton/src/tasks/gitops/gitops-license-generator.yml.j2
+++ b/tekton/src/tasks/gitops/gitops-license-generator.yml.j2
@@ -22,7 +22,9 @@ spec:
       type: string
     - name: country
       type: string
-    - name: icn
+    - name: sls_license_icn
+      type: string
+    - name: sls_subscription_id
       type: string
   stepTemplate:
     name: gitops-license-generator
@@ -45,7 +47,9 @@ spec:
       - name: COUNTRY
         value: $(params.country)
       - name: ICN
-        value: $(params.icn)
+        value: $(params.sls_license_icn)
+      - name: SAAS_SUB_ID
+        value: $(params.sls_subscription_id)
     envFrom:
       - configMapRef:
           name: environment-properties
@@ -55,13 +59,24 @@ spec:
   steps:
     - args:
       - |-
-        ansible-playbook ibm.mas_saas.generate_saas_license_file || exit 1
-
-        mas gitops-license \
-          -a $ACCOUNT \
-          -c $CLUSTER_NAME \
-          -m $MAS_INSTANCE_ID \
-          --license-file /tmp/authorized_entitlement_saas.lic
+        if [[ -z "${MAS_INSTANCE_ID}" ]]; then
+          MAS_INSTANCE_ID=${SAAS_SUB_ID}
+          ansible-playbook ibm.mas_saas.generate_saas_license_file || exit 1
+          mas gitops-license \
+            -a ${ACCOUNT} \
+            -i ${ICN} \
+            -s ${SAAS_SUB_ID} \
+            --license-file /tmp/authorized_entitlement_saas.lic
+          exit $?
+        else
+          ansible-playbook ibm.mas_saas.generate_saas_license_file || exit 1
+          mas gitops-license \
+            -a ${ACCOUNT} \
+            -c ${CLUSTER_NAME} \
+            -m ${MAS_INSTANCE_ID} \
+            --license-file /tmp/authorized_entitlement_saas.lic
+          exit $?
+        fi
 
         exit $?
       command:

--- a/tekton/src/tasks/gitops/gitops-license.yml.j2
+++ b/tekton/src/tasks/gitops/gitops-license.yml.j2
@@ -13,6 +13,11 @@ spec:
       type: string
     - name: avp_aws_secret_region
       type: string
+    
+    - name: sls_license_icn
+      type: string
+    - name: sls_subscription_id
+      type: string
   stepTemplate:
     name: gitops-license
     env:
@@ -24,6 +29,10 @@ spec:
         value: $(params.mas_instance_id)
       - name: SM_AWS_REGION
         value: $(params.avp_aws_secret_region)
+      - name: ICN
+        value: $(params.sls_license_icn)
+      - name: SAAS_SUB_ID
+        value: $(params.sls_subscription_id)
     envFrom:
       - configMapRef:
           name: environment-properties
@@ -34,10 +43,16 @@ spec:
     - args:
       - |-
 
-        mas gitops-license -a $ACCOUNT -c $CLUSTER_NAME -m $MAS_INSTANCE_ID \
-        --license-file /workspace/shared-entitlement/entitlement.lic
+        if [[ -z "${MAS_INSTANCE_ID}" ]]; then
+          mas gitops-license -a $ACCOUNT -i $ICN -s $SAAS_SUB_ID \
+          --license-file /workspace/shared-entitlement/entitlement.lic
+          exit $?
+        else
+          mas gitops-license -a $ACCOUNT -c $CLUSTER_NAME -m $MAS_INSTANCE_ID \
+          --license-file /workspace/shared-entitlement/entitlement.lic
+          exit $?
+        fi
 
-        exit $?
       command:
         - /bin/sh
         - -c

--- a/tekton/src/tasks/gitops/gitops-sls.yml.j2
+++ b/tekton/src/tasks/gitops/gitops-sls.yml.j2
@@ -1,0 +1,127 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: gitops-sls
+spec:
+  params:
+    - name: cluster_name
+      type: string
+    - name: account
+      type: string
+    - name: cluster_url
+      type: string
+    - name: mas_instance_id
+      type: string
+    - name: avp_aws_secret_region
+      type: string
+    - name: sls_license_icn
+      type: string
+    - name: sls_subscription_id
+      type: string
+    - name: sls_install_plan
+      type: string
+    - name: sls_channel
+      type: string
+    - name: ocp_cluster_domain
+      type: string
+    - name: secrets_path
+      type: string
+    - name: mongo_provider
+      type: string
+    - name: icr_cp
+      type: string
+    - name: icr_cp_open
+      type: string
+
+    - name: github_push
+      type: string
+    - name: git_branch
+      type: string
+    - name: github_org
+      type: string
+    - name: github_repo
+      type: string
+    - name: github_host
+      type: string
+    - name: git_commit_msg
+      type: string
+    - name: github_ssh
+      type: string
+
+  stepTemplate:
+    name: gitops-sls
+    env:
+      - name: CLUSTER_NAME
+        value: $(params.cluster_name)
+      - name: ACCOUNT
+        value: $(params.account)
+      - name: CLUSTER_URL
+        value: $(params.cluster_url)
+      - name: MAS_INSTANCE_ID
+        value: $(params.mas_instance_id)
+      - name: SM_AWS_REGION
+        value: $(params.avp_aws_secret_region)
+      - name: ICN
+        value: $(params.sls_license_icn)
+      - name: SAAS_SUB_ID
+        value: $(params.sls_subscription_id)
+      - name: MONGODB_PROVIDER
+        value: $(params.mongo_provider)
+      - name: SLS_CHANNEL
+        value: $(params.sls_channel)
+      - name: SLS_INSTALL_PLAN
+        value: $(params.sls_install_plan)
+      - name: SLS_DOMAIN
+        value: $(params.ocp_cluster_domain)
+      - name: SECRETS_PATH
+        value: $(params.secrets_path)
+      - name: ICR_CP
+        value: $(params.icr_cp)
+      - name: ICR_CP_OPEN
+        value: $(params.icr_cp_open)
+
+      - name: GITHUB_PUSH
+        value: $(params.github_push)
+      - name: GIT_BRANCH
+        value: $(params.git_branch)
+      - name: GITHUB_ORG
+        value: $(params.github_org)
+      - name: GITHUB_REPO
+        value: $(params.github_repo)
+      - name: GITHUB_HOST
+        value: $(params.github_host)
+      - name: GIT_COMMIT_MSG
+        value: $(params.git_commit_msg)
+      - name: GIT_SSH
+        value: $(params.github_ssh)
+
+    envFrom:
+      - configMapRef:
+          name: environment-properties
+          optional: true
+      - secretRef:
+          name: secure-properties
+  steps:
+    - args:
+      - |-
+
+        git config --global user.name "MAS Automation"
+        git config --global user.email "you@example.com"
+        git config --global user.password $GITHUB_PAT
+
+        WORKING_DIR=/tmp
+
+        mas gitops-suite-license-service -d $WORKING_DIR -a $ACCOUNT -c $CLUSTER_NAME --ibm-customer-number ${ICN} --subscription-id ${SAAS_SUB_ID} \
+        --secrets-path "${SECRETS_PATH}" --domain ${SLS_DOMAIN} --sls-channel ${SLS_CHANNEL} --sls-install-plan ${SLS_INSTALL_PLAN}  --cluster-url ${CLUSTER_URL}
+        
+        sleep 3000
+      command:
+        - /bin/sh
+        - -c
+      name: gitops-sls
+      imagePullPolicy: Always
+      image: quay.io/ibmmas/cli:latest
+  workspaces:
+    - name: shared-entitlement
+


### PR DESCRIPTION
**Implementation for MASCORE-5475 - Gitops Pipeline to Deploy Stand Alone SLS Server**
**Additions**
Defined 2 new Tekton pipelines and required tasks and CLI invocations
- gitops-suite-license-service - creates account/icn/customer number/subscription id/ibm-sls.yaml (i.e. aws-dev/icn/0x1/abc1234/ibm-sls.yaml), secrets that contain license associated with the subscription.
   - update of gitops-license and gitops-license-generator tekton tasks to support both existing task execution for MAS (no change) or new proces
   -  addition of new task gitops-sls that will create new license secret and ibm-sls.yaml file in account/icn/customer id/subscription id (i.e. aws-dev/icn/0x1/abc1234/ibm-sls.yaml
- gitops-deprovision-suite-license-service - deletes existing SLS instance in gitops, deletes secrets manager secrets associated with the SLS instance
   - new task to support deprovision by removal of secrets from secrets manager and any gitops files in account/icn/customer id/subscription id (i.e. aws-dev/icn/0x1/abc1234) directory.
  
**Testing Completed**
- creation of subscription
<img width="1197" height="703" alt="image" src="https://github.com/user-attachments/assets/561c49a1-c1bb-410e-8b88-c61a44fb69df" />

- removal of existing subscription
<img width="1179" height="702" alt="image" src="https://github.com/user-attachments/assets/a15fec82-76b9-43d2-9175-ee39984bd83f" />

- creation of multiple new subscriptions
   - See gitops repo PR
 
** Related Pull Requests **
- [Provision Standalone SLS Server](https://github.com/ibm-mas/gitops/pull/339)
