### PR TITLE
[patch] Civil BVT and Mobile pytest new tasks

### DIFF
--- a/image/cli/masfvt/fvt-mobile-testng.yml
+++ b/image/cli/masfvt/fvt-mobile-testng.yml
@@ -14,6 +14,7 @@
     mas_app_channel_manage: "{{ lookup('env', 'MAS_APP_CHANNEL_MANAGE') }}"
     mas_instance_id: "{{ lookup('env', 'MAS_INSTANCE_ID') }}"
     mas_workspace_id: "{{ lookup('env', 'MAS_WORKSPACE_ID') }}"
+    mas_appws_components: "{{ lookup('env', 'MANAGE_COMPONENTS') }}"
 
     # Black and white listing
     fvt_blacklist: "{{ lookup('env', 'FVT_BLACKLIST') }}"
@@ -39,6 +40,7 @@
           - "mas_app_channel_manage ................... {{ mas_app_channel_manage }}"
           - "mas_instance_id .......................... {{ mas_instance_id }}"
           - "mas_workspace_id ......................... {{ mas_workspace_id }}"
+          - "mas_appws_components ..................... {{ mas_appws_components }}"
           - ""
           - "fvt_image_registry ....................... {{ fvt_image_registry }}"
           - "fvt_artifactory_token .................... {{ fvt_artifactory_token }}"

--- a/image/cli/masfvt/templates/mas-fvt-mobile-testng.yml.j2
+++ b/image/cli/masfvt/templates/mas-fvt-mobile-testng.yml.j2
@@ -34,6 +34,8 @@ spec:
       value: "{{ mas_instance_id }}"
     - name: mas_workspace_id
       value: "{{ mas_workspace_id }}"
+    - name: mas_appws_components
+      value: "{{ mas_appws_components }}"
         
     # Digests
     - name: fvt_digest_mobile_pytest

--- a/tekton/src/pipelines/mas-fvt-mobile-testng.yml.j2
+++ b/tekton/src/pipelines/mas-fvt-mobile-testng.yml.j2
@@ -28,6 +28,9 @@ spec:
     - name: mas_workspace_id
       type: string
       default: ""
+    - name: mas_appws_components
+      type: string
+      default: ""
 
     # FVT Configuration
     - name: fvt_image_registry
@@ -45,12 +48,22 @@ spec:
       type: string
       default: ""
   
-      # Image Digests
+    # Image Digests
     - name: fvt_digest_manage
       type: string
       default: ""
 
   tasks:
+
+    # Manage Components Information
+    - name: fvt-component
+      taskRef:
+        kind: Task
+        name: mas-fvt-components
+      params:
+        - name: mas_appws_components
+          value: "$(params.mas_appws_components)"
+
     # 2. Manage FVT - Manage Mobile
     # -------------------------------------------------------------------------
     

--- a/tekton/src/pipelines/taskdefs/fvt-mobile/common/params-pytest.yml.j2
+++ b/tekton/src/pipelines/taskdefs/fvt-mobile/common/params-pytest.yml.j2
@@ -10,5 +10,3 @@
   value: $(params.mas_app_channel_manage)
 - name: input_data_file
   value: "MobilePytestSetup.data"
-- name: enable_perf_debug
-  value: "True"

--- a/tekton/src/pipelines/taskdefs/fvt-mobile/common/taskref-manage.yml.j2
+++ b/tekton/src/pipelines/taskdefs/fvt-mobile/common/taskref-manage.yml.j2
@@ -9,6 +9,9 @@ when:
   - input: "$(params.mas_app_channel_manage)"
     operator: notin
     values: [""]
+  - input: "civil"
+    operator: in
+    values: ["$(tasks.fvt-component.results.component_names[*])"]
 workspaces:
   - name: configs
     workspace: shared-configs

--- a/tekton/src/pipelines/taskdefs/fvt-mobile/pytest/phase1-setup.yml.j2
+++ b/tekton/src/pipelines/taskdefs/fvt-mobile/pytest/phase1-setup.yml.j2
@@ -38,5 +38,25 @@
     {{ lookup('template', 'taskdefs/fvt-mobile/common/params-pytest.yml.j2') | indent(4) }}
     - name: fvt_test_suite
       value: mobile-api-requests
+    - name: enable_perf_debug
+      value: "True"  
+  runAfter:
+    - mobile-setup-pytest
+
+- name: mobile-pytest-asset-image
+  {{ lookup('template', 'taskdefs/fvt-mobile/common/taskref-pytest.yml.j2') | indent(2) }}
+  params:
+    {{ lookup('template', 'taskdefs/fvt-mobile/common/params-pytest.yml.j2') | indent(4) }}
+    - name: fvt_test_suite
+      value: mobile-api-asset-image
+  runAfter:
+    - mobile-setup-pytest
+
+- name: mobile-pytest-download
+  {{ lookup('template', 'taskdefs/fvt-mobile/common/taskref-pytest.yml.j2') | indent(2) }}
+  params:
+    {{ lookup('template', 'taskdefs/fvt-mobile/common/params-pytest.yml.j2') | indent(4) }}
+    - name: fvt_test_suite
+      value: mobile-api-download
   runAfter:
     - mobile-setup-pytest

--- a/tekton/src/pipelines/taskdefs/fvt-mobile/pytest/phase2-apps.yml.j2
+++ b/tekton/src/pipelines/taskdefs/fvt-mobile/pytest/phase2-apps.yml.j2
@@ -6,8 +6,12 @@
     {{ lookup('template', 'taskdefs/fvt-mobile/common/params-pytest.yml.j2') | indent(4) }}
     - name: fvt_test_suite
       value: mobile-api-assetm
+    - name: enable_perf_debug
+      value: "True"
   runAfter:
     - mobile-pytest-requests
+    - mobile-pytest-asset-image
+    - mobile-pytest-download
     
 - name: mobile-pytest-tech
   {{ lookup('template', 'taskdefs/fvt-mobile/common/taskref-pytest.yml.j2') | indent(2) }}
@@ -15,8 +19,12 @@
     {{ lookup('template', 'taskdefs/fvt-mobile/common/params-pytest.yml.j2') | indent(4) }}
     - name: fvt_test_suite
       value: mobile-api-tech
+    - name: enable_perf_debug
+      value: "True"
   runAfter:
     - mobile-pytest-requests
+    - mobile-pytest-asset-image
+    - mobile-pytest-download
 
 - name: mobile-pytest-supervisor
   {{ lookup('template', 'taskdefs/fvt-mobile/common/taskref-pytest.yml.j2') | indent(2) }}
@@ -24,5 +32,9 @@
     {{ lookup('template', 'taskdefs/fvt-mobile/common/params-pytest.yml.j2') | indent(4) }}
     - name: fvt_test_suite
       value: mobile-api-supervisor
+    - name: enable_perf_debug
+      value: "True"
   runAfter:
     - mobile-pytest-requests
+    - mobile-pytest-asset-image
+    - mobile-pytest-download

--- a/tekton/src/pipelines/taskdefs/fvt-mobile/pytest/phase3-apps.yml.j2
+++ b/tekton/src/pipelines/taskdefs/fvt-mobile/pytest/phase3-apps.yml.j2
@@ -4,6 +4,8 @@
     {{ lookup('template', 'taskdefs/fvt-mobile/common/params-pytest.yml.j2') | indent(4) }}
     - name: fvt_test_suite
       value: mobile-api-calibration
+    - name: enable_perf_debug
+      value: "True"
   runAfter:
     - mobile-pytest-assetmanager
     - mobile-pytest-tech
@@ -15,6 +17,8 @@
     {{ lookup('template', 'taskdefs/fvt-mobile/common/params-pytest.yml.j2') | indent(4) }}
     - name: fvt_test_suite
       value: mobile-api-civil-defects
+    - name: enable_perf_debug
+      value: "True"
   runAfter:
     - mobile-pytest-assetmanager
     - mobile-pytest-tech

--- a/tekton/src/pipelines/taskdefs/fvt-mobile/pytest/phase4-apps.yml.j2
+++ b/tekton/src/pipelines/taskdefs/fvt-mobile/pytest/phase4-apps.yml.j2
@@ -4,6 +4,8 @@
     {{ lookup('template', 'taskdefs/fvt-mobile/common/params-pytest.yml.j2') | indent(4) }}
     - name: fvt_test_suite
       value: mobile-api-ic
+    - name: enable_perf_debug
+      value: "True"
   runAfter:
     - mobile-pytest-calibration
     - mobile-pytest-civil-defects
@@ -14,6 +16,8 @@
     {{ lookup('template', 'taskdefs/fvt-mobile/common/params-pytest.yml.j2') | indent(4) }}
     - name: fvt_test_suite
       value: mobile-api-ir
+    - name: enable_perf_debug
+      value: "True"
   runAfter:
     - mobile-pytest-calibration
     - mobile-pytest-civil-defects
@@ -24,6 +28,8 @@
     {{ lookup('template', 'taskdefs/fvt-mobile/common/params-pytest.yml.j2') | indent(4) }}
     - name: fvt_test_suite
       value: mobile-api-it
+    - name: enable_perf_debug
+      value: "True"
   runAfter:
     - mobile-pytest-calibration
     - mobile-pytest-civil-defects

--- a/tekton/src/pipelines/taskdefs/fvt-mobile/pytest/phase5-apps.yml.j2
+++ b/tekton/src/pipelines/taskdefs/fvt-mobile/pytest/phase5-apps.yml.j2
@@ -4,6 +4,8 @@
     {{ lookup('template', 'taskdefs/fvt-mobile/common/params-pytest.yml.j2') | indent(4) }}
     - name: fvt_test_suite
       value: mobile-api-sr
+    - name: enable_perf_debug
+      value: "True"
   runAfter:
     - mobile-pytest-ic
     - mobile-pytest-ir
@@ -15,6 +17,8 @@
     {{ lookup('template', 'taskdefs/fvt-mobile/common/params-pytest.yml.j2') | indent(4) }}
     - name: fvt_test_suite
       value: mobile-api-insp
+    - name: enable_perf_debug
+      value: "True"
   runAfter:
     - mobile-pytest-ic
     - mobile-pytest-ir

--- a/tekton/src/pipelines/taskdefs/fvt-mobile/testng/phase1-setup.yml.j2
+++ b/tekton/src/pipelines/taskdefs/fvt-mobile/testng/phase1-setup.yml.j2
@@ -59,8 +59,6 @@
       value: "MobileSetup4MAS.data"
     - name: output_data_file
       value: "MobileSetup4MAS.data"
-    - name: enable_perf_debug
-      value: "True"
   workspaces:
     - name: configs
       workspace: shared-configs

--- a/tekton/src/pipelines/taskdefs/fvt-mobile/testng/phase1-setup.yml.j2
+++ b/tekton/src/pipelines/taskdefs/fvt-mobile/testng/phase1-setup.yml.j2
@@ -31,6 +31,8 @@
     - input: "$(params.fvt_digest_mobile_pytest)"
       operator: notin
       values: [""]
+  runAfter:
+    - fvt-component
 
 ## Verification for Mobile JSON Schema
 - name: fvt-mob-schema-pre

--- a/tekton/src/pipelines/taskdefs/fvt-mobile/testng/phase4-final.yml.j2
+++ b/tekton/src/pipelines/taskdefs/fvt-mobile/testng/phase4-final.yml.j2
@@ -21,8 +21,6 @@
       value: mobile-api-mobile-schema
     - name: input_data_file
       value: "MobileSetup4MAS.data"
-    - name: enable_perf_debug
-      value: "True"
   workspaces:
     - name: configs
       workspace: shared-configs

--- a/tekton/src/tasks/fvt-launcher/mas-launchfvt-mobile.yml.j2
+++ b/tekton/src/tasks/fvt-launcher/mas-launchfvt-mobile.yml.j2
@@ -89,6 +89,12 @@ spec:
               name: mas-fvt-mobile
               key: MAS_WORKSPACE_ID
               optional: false
+        - name: MANAGE_COMPONENTS
+          valueFrom:
+            secretKeyRef:
+              name: mas-fvt-mobile
+              key: MANAGE_COMPONENTS
+              optional: false
 
         # Digests
         - name: FVT_DIGEST_MOBILE_PYTEST

--- a/tekton/src/tasks/fvt-launcher/mas-launchfvt-mobile.yml.j2
+++ b/tekton/src/tasks/fvt-launcher/mas-launchfvt-mobile.yml.j2
@@ -89,13 +89,6 @@ spec:
               name: mas-fvt-mobile
               key: MAS_WORKSPACE_ID
               optional: false
-        - name: MANAGE_COMPONENTS
-          valueFrom:
-            secretKeyRef:
-              name: mas-fvt-mobile
-              key: MANAGE_COMPONENTS
-              optional: false
-
         # Digests
         - name: FVT_DIGEST_MOBILE_PYTEST
           valueFrom:
@@ -200,6 +193,13 @@ spec:
             secretKeyRef:
               name: mas-fvt-mobile
               key: MAS_WORKSPACE_ID
+              optional: false
+        
+        - name: MANAGE_COMPONENTS
+          valueFrom:
+            secretKeyRef:
+              name: mas-fvt-mobile
+              key: MANAGE_COMPONENTS
               optional: false
 
         # Digests


### PR DESCRIPTION
- Adding new when condition to Civil BVT task so that it is skipped when Civil is not configured in ManageWorkspace
- New Mobile Pytest tasks:
<img width="612" height="577" alt="image" src="https://github.com/user-attachments/assets/401bc774-a78e-438c-a99e-5daf8e2f85cd" />
