### PR TITLE
[patch] Add missing param

### DIFF
--- a/tekton/src/params/install-aiservice.yml.j2
+++ b/tekton/src/params/install-aiservice.yml.j2
@@ -195,6 +195,11 @@
   description: S3/Minio storage template bucket for IBM Maximo AI Service
   default: ""
 
+- name: aiservice_odh_model_deployment_type
+  type: string
+  description: Model deployment type for ODH. Must be one of; [raw, serverless]
+  default: "raw"
+
 - name: minio_root_user
   type: string
   description: root user for minio


### PR DESCRIPTION
Add missing `aiservice_odh_model_deployment_type` in install-aiservice pipeline.

Evidences:
[cli_test.log](https://github.com/user-attachments/files/22040423/cli_test.log)
<img width="1419" height="624" alt="Screenshot 2025-08-29 at 12 44 03 PM" src="https://github.com/user-attachments/assets/b5094537-8b86-49ad-b3dc-e1c4a35a8f22" />
<img width="1441" height="536" alt="Screenshot 2025-08-29 at 12 43 53 PM" src="https://github.com/user-attachments/assets/45e90349-151b-47a5-b873-bbab76639775" />
<img width="1425" height="643" alt="Screenshot 2025-08-29 at 12 43 47 PM" src="https://github.com/user-attachments/assets/a42e9837-1871-4a7f-aeda-a43394fbb7dc" />
<img width="2746" height="1322" alt="Screenshot 2025-08-29 at 12 39 57 PM" src="https://github.com/user-attachments/assets/21b1c8f7-0e74-44f2-9348-36fc9892addb" />
