### PR TITLE
[doc] update catalog Overview in catalogs/v9-250828-amd64.md

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -35,6 +35,7 @@ nav:
       - "configtool-oidc": commands/configtool-oidc.md
   - "Operator Catalogs":
       - "Overview": catalogs/index.md
+      - "Aug 28 2025": catalogs/v9-250828-amd64.md
       - "Jul 31 2025": catalogs/v9-250731-amd64.md
       - "Jun 24 2025": catalogs/v9-250624-amd64.md
       - "May 01 2025": catalogs/v9-250501-amd64.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -39,7 +39,6 @@ nav:
       - "Jul 31 2025": catalogs/v9-250731-amd64.md
       - "Jun 24 2025": catalogs/v9-250624-amd64.md
       - "May 01 2025": catalogs/v9-250501-amd64.md
-      - "Apr 03 2025": catalogs/v9-250403-amd64.md
   - "Reference":
       - "Dependencies": reference/dependencies.md
       - "Topology": reference/topology.md


### PR DESCRIPTION
Updated the catalog overview in catalogs/v9-250828-amd64.md to reflect changes for the August release.
This revision ensures the documentation is accurate and aligned with the latest updates.
The catalog now maintains four entries; older entries have been moved to preserve clarity and relevance.