### PR TITLE
[doc] Update index.md to reflect OCP EUS1 support dates

### DIFF
--- a/docs/catalogs/index.md
+++ b/docs/catalogs/index.md
@@ -10,6 +10,7 @@ The MAS CLI maintains a rolling window of approximately four months worth of sup
 
 
 ### Catalog Directory
+Note: The Red Hat Extended Update Support Add-on Term 1 offering is included with the OCP subscription that comes with a MAS license. In the case of EUS denoted OCP releases, the support dates stated below refer to the EUS1 end dates.  For more details on the OCP support lifecycle see: https://access.redhat.com/support/policy/updates/openshift 
 
 <cds-tabs trigger-content="Select an item" value="2025">
   <cds-tab id="tab-2025" target="panel-2025" value="2025">2025 Catalogs</cds-tab>
@@ -42,7 +43,7 @@ The MAS CLI maintains a rolling window of approximately four months worth of sup
           <td style="font-style: italic">TBD</td>
           <td style="font-style: italic">7.0 - 8.0 (TBC)</td>
           <td style="font-style: italic">N/A</td>
-          <td style="font-style: italic">OCP 4.18 EOS August 25, 2026</td>
+          <td style="font-style: italic">OCP 4.18 EOS February 25, 2027</td>
         </tr>
         <tr>
           <td style="font-style: italic">v9-251127</td>
@@ -53,7 +54,7 @@ The MAS CLI maintains a rolling window of approximately four months worth of sup
           <td style="font-style: italic">TBD</td>
           <td style="font-style: italic">7.0 - 8.0 (TBC)</td>
           <td style="font-style: italic">N/A</td>
-          <td style="font-style: italic">OCP 4.18 EOS August 25, 2026</td>
+          <td style="font-style: italic">OCP 4.18 EOS February 25, 2027</td>
         </tr>
         <tr>
           <td style="font-style: italic">v9-251030</td>
@@ -64,7 +65,7 @@ The MAS CLI maintains a rolling window of approximately four months worth of sup
           <td style="font-style: italic">TBD</td>
           <td style="font-style: italic">7.0 - 8.0 (TBC)</td>
           <td style="font-style: italic">N/A</td>
-          <td style="font-style: italic">OCP 4.18 EOS August 25, 2026</td>
+          <td style="font-style: italic">OCP 4.18 EOS February 25, 2027</td>
         </tr>
         <tr>
           <td>v9-250902</td>
@@ -75,7 +76,7 @@ The MAS CLI maintains a rolling window of approximately four months worth of sup
           <td>5.1.3</td>
           <td>6.0 - 7.0</td>
           <td>latest</td>
-          <td>OCP 4.18 EOS August 25, 2026</td>
+          <td>OCP 4.18 EOS February 25, 2027</td>
         </tr>
         <tr>
           <td>v9-250828</td>
@@ -86,7 +87,7 @@ The MAS CLI maintains a rolling window of approximately four months worth of sup
           <td>5.1.3</td>
           <td>6.0 - 7.0</td>
           <td>latest</td>
-          <td>OCP 4.18 EOS August 25, 2026</td>
+          <td>OCP 4.18 EOS February 25, 2027</td>
         </tr>
         <tr>
           <td>v9-250731</td>
@@ -97,7 +98,7 @@ The MAS CLI maintains a rolling window of approximately four months worth of sup
           <td>5.1.3</td>
           <td>6.0 - 7.0</td>
           <td>latest</td>
-          <td>OCP 4.18 EOS August 25, 2026</td>
+          <td>OCP 4.18 EOS February 25, 2027</td>
         </tr>
         <tr>
           <td>v9-250624</td>
@@ -108,7 +109,7 @@ The MAS CLI maintains a rolling window of approximately four months worth of sup
           <td>5.1.3</td>
           <td>6.0 - 7.0</td>
           <td>13.26.0</td>
-          <td>OCP 4.18 EOS August 25, 2026</td>
+          <td>OCP 4.18 EOS February 25, 2027</td>
         </tr>
         <tr>
           <td>v9-250501</td>
@@ -119,7 +120,7 @@ The MAS CLI maintains a rolling window of approximately four months worth of sup
           <td>5.0.0</td>
           <td>6.0 - 7.0</td>
           <td>13.20.0</td>
-          <td>OCP 4.16 EOS December 27, 2025</td>
+          <td>OCP 4.16 EOS June 27, 2026</td>
         </tr>
         <tr>
           <td>v9-250403</td>
@@ -130,7 +131,7 @@ The MAS CLI maintains a rolling window of approximately four months worth of sup
           <td>5.0.0</td>
           <td>6.0 - 7.0</td>
           <td>13.15.0</td>
-          <td>OCP 4.16 EOS December 27, 2025</td>
+          <td>OCP 4.16 EOS June 27, 2026</td>
         </tr>
         <tr>
           <td>v9-250306</td>
@@ -141,7 +142,7 @@ The MAS CLI maintains a rolling window of approximately four months worth of sup
           <td>5.0.0</td>
           <td>6.0 - 7.0</td>
           <td>13.10.0</td>
-          <td>OCP 4.16 EOS December 27, 2025</td>
+          <td>OCP 4.16 EOS June 27, 2026</td>
         </tr>
         <tr>
           <td>v9-250206</td>
@@ -152,7 +153,7 @@ The MAS CLI maintains a rolling window of approximately four months worth of sup
           <td>5.0.0</td>
           <td>6.0 - 7.0</td>
           <td>13.3.0</td>
-          <td>OCP 4.16 EOS December 27, 2025</td>
+          <td>OCP 4.16 EOS June 27, 2026</td>
         </tr>
         <tr>
           <td>v9-250109</td>
@@ -163,7 +164,7 @@ The MAS CLI maintains a rolling window of approximately four months worth of sup
           <td>5.0.0</td>
           <td>6.0 - 7.0</td>
           <td>13.0.0</td>
-          <td>OCP 4.16 EOS December 27, 2025</td>
+          <td>OCP 4.16 EOS June 27, 2026</td>
         </tr>
       </tbody>
     </table>
@@ -187,7 +188,7 @@ The MAS CLI maintains a rolling window of approximately four months worth of sup
     <td>5.0.0</td>
     <td>6.0 - 7.0</td>
     <td>11.12.0</td>
-    <td>OCP 4.16 EOS December 27, 2025</td>
+    <td>OCP 4.16 EOS June 27, 2026</td>
     </tr>
     <tr>
     <td><a href="v9-241107-amd64/">v9-241107-amd64</a>, <a href="v9-241107-s390x/">v9-241107-s390x</a></td>
@@ -227,7 +228,7 @@ The MAS CLI maintains a rolling window of approximately four months worth of sup
     <td>4.8.0</td>
     <td>5.0 - 7.0</td>
     <td>10.9.2</td>
-    <td>OCP 4.14 EOS May 1, 2025</td>
+    <td>OCP 4.14 EOS October 31, 2025</td>
     </tr>
     <tr>
     <td><a href="v8-240528-amd64/">v8-240528-amd64</a></td>
@@ -235,7 +236,7 @@ The MAS CLI maintains a rolling window of approximately four months worth of sup
     <td>4.6.6</td>
     <td>5.0 - 7.0</td>
     <td>10.8.1</td>
-    <td>OCP 4.14 EOS May 1, 2025</td>
+    <td>OCP 4.14 EOS October 31, 2025</td>
     </tr>
     <tr>
     <td><a href="v8-240430-amd64/">v8-240430-amd64</a></td>
@@ -243,7 +244,7 @@ The MAS CLI maintains a rolling window of approximately four months worth of sup
     <td>4.6.6</td>
     <td>5.0 - 7.0</td>
     <td>9.4.0</td>
-    <td>OCP 4.14 EOS May 1, 2025</td>
+    <td>OCP 4.14 EOS October 31, 2025</td>
     </tr>
     <tr>
     <td><a href="v8-240405-amd64/">v8-240405-amd64</a></td>
@@ -251,7 +252,7 @@ The MAS CLI maintains a rolling window of approximately four months worth of sup
     <td>4.6.6</td>
     <td>5.0 - 7.0</td>
     <td>9.4.0</td>
-    <td>OCP 4.14 EOS May 1, 2025</td>
+    <td>OCP 4.14 EOS October 31, 2025</td>
     </tr>
     <tr>
     <td><a href="v8-240326-amd64/">v8-240326-amd64</a></td>
@@ -259,7 +260,7 @@ The MAS CLI maintains a rolling window of approximately four months worth of sup
     <td>4.6.6</td>
     <td>5.0 - 7.0</td>
     <td>9.4.0</td>
-    <td>OCP 4.14 EOS May 1, 2025</td>
+    <td>OCP 4.14 EOS October 31, 2025</td>
     </tr>
     <tr>
     <td><a href="v8-240227-amd64/">v8-240227-amd64</a></td>
@@ -267,7 +268,7 @@ The MAS CLI maintains a rolling window of approximately four months worth of sup
     <td>4.6.6</td>
     <td>5.0 - 7.0</td>
     <td>8.2.2</td>
-    <td>OCP 4.12 EOS July 17, 2024</td>
+    <td>OCP 4.12 EOS January 17, 2025</td>
     </tr>
     <tr>
     <td><a href="v8-240130-amd64/">v8-240130-amd64</a></td>
@@ -275,7 +276,7 @@ The MAS CLI maintains a rolling window of approximately four months worth of sup
     <td>4.6.6</td>
     <td>5.0 - 7.0</td>
     <td>8.2.2</td>
-    <td>OCP 4.12 EOS July 17, 2024</td>
+    <td>OCP 4.12 EOS January 17, 2025</td>
     </tr>
     </tbody>
     </table>
@@ -295,61 +296,61 @@ The MAS CLI maintains a rolling window of approximately four months worth of sup
     <td><a href="v8-231228-amd64/">v8-231228-amd64</a></td>
     <td>4.11 - 4.12</td>
     <td>8.2.2</td>
-    <td>OCP 4.12 EOS July 17, 2024</td>
+    <td>OCP 4.12 EOS January 17, 2025</td>
     </tr>
     <tr>
     <td><a href="v8-231128-amd64/">v8-231128-amd64</a></td>
     <td>4.11 - 4.12</td>
     <td>8.2.2</td>
-    <td>OCP 4.12 EOS July 17, 2024</td>
+    <td>OCP 4.12 EOS January 17, 2025</td>
     </tr>
     <tr>
     <td><a href="v8-231031-amd64/">v8-231031-amd64</a></td>
     <td>4.11 - 4.12</td>
     <td>7.12.1</td>
-    <td>OCP 4.12 EOS July 17, 2024</td>
+    <td>OCP 4.12 EOS January 17, 2025</td>
     </tr>
     <tr>
     <td><a href="v8-231004-amd64/">v8-231004-amd64</a></td>
     <td>4.11 - 4.12</td>
     <td>7.12.1</td>
-    <td>OCP 4.12 EOS July 17, 2024</td>
+    <td>OCP 4.12 EOS January 17, 2025</td>
     </tr>
     <tr>
     <td><a href="v8-230926-amd64/">v8-230926-amd64</a></td>
     <td>4.11 - 4.12</td>
     <td>7.12.1</td>
-    <td>OCP 4.12 EOS July 17, 2024</td>
+    <td>OCP 4.12 EOS January 17, 2025</td>
     </tr>
     <tr>
     <td><a href="v8-230829-amd64/">v8-230829-amd64</a></td>
     <td>4.10 - 4.12</td>
     <td>7.12.1</td>
-    <td>OCP 4.12 EOS July 17, 2024</td>
+    <td>OCP 4.12 EOS January 17, 2025</td>
     </tr>
     <tr>
     <td><a href="v8-230725-amd64/">v8-230725-amd64</a></td>
     <td>4.10 - 4.12</td>
     <td>7.12.1</td>
-    <td>OCP 4.12 EOS July 17, 2024</td>
+    <td>OCP 4.12 EOS January 17, 2025</td>
     </tr>
     <tr>
     <td><a href="v8-230721-amd64/">v8-230721-amd64</a></td>
     <td>4.10 - 4.12</td>
     <td>7.12.1</td>
-    <td>OCP 4.12 EOS July 17, 2024</td>
+    <td>OCP 4.12 EOS January 17, 2025</td>
     </tr>
     <tr>
     <td><a href="v8-230627-amd64/">v8-230627-amd64</a></td>
     <td>4.10 - 4.12</td>
     <td>5.5.0</td>
-    <td>OCP 4.12 EOS July 17, 2024</td>
+    <td>OCP 4.12 EOS January 17, 2025</td>
     </tr>
     <tr>
     <td><a href="v8-230616-amd64/">v8-230616-amd64</a></td>
     <td>4.10 - 4.12</td>
     <td>5.5.0</td>
-    <td>OCP 4.12 EOS July 17, 2024</td>
+    <td>OCP 4.12 EOS January 17, 2025</td>
     </tr>
     <tr>
     <td><a href="v8-230526-amd64/">v8-230526-amd64</a></td>


### PR DESCRIPTION
Updated OCP support dates to reflect the inclusion of RH EUS Term1 in the MAS license. Added a clarifying note on RH EUS Term1 support to the Catalog Directory section