### PR TITLE
Support --skip-aws-secret-creation and AWS Session Tokens

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2025-09-18T11:33:38Z",
+  "generated_at": "2025-09-23T12:28:50Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -202,7 +202,7 @@
         "hashed_secret": "b2817467154949a61f8e9ad31d1eeaf03221cbfa",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 480,
+        "line_number": 484,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -424,7 +424,7 @@
         "hashed_secret": "effb7852555adce89885fb075fb43a77a1e0e77e",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 725,
+        "line_number": 728,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/image/cli/mascli/functions/gitops_cluster
+++ b/image/cli/mascli/functions/gitops_cluster
@@ -16,10 +16,11 @@ Basic Configuration (Required):
       --custom-labels ${COLOR_YELLOW}CUSTOM_LABELS${TEXT_RESET}    Custom Labels definition in dict format
 
 AWS Secrets Manager Configuration (Required):
-      --sm-aws-secret-region ${COLOR_YELLOW}SM_AWS_REGION${TEXT_RESET}          Region of the AWS Secrets Manager to use
-      --sm-aws-access-key ${COLOR_YELLOW}SM_AWS_ACCESS_KEY_ID${TEXT_RESET}      Your AWS Access Key ID
-      --sm-aws-secret-key ${COLOR_YELLOW}SM_AWS_SECRET_ACCESS_KEY${TEXT_RESET}  Your AWS Secret Key
-      --secrets-path ${COLOR_YELLOW}SECRETS_PATH${TEXT_RESET}                   Secrets Manager path
+      --sm-aws-secret-region ${COLOR_YELLOW}SM_AWS_REGION${TEXT_RESET}                Region of the AWS Secrets Manager to use
+      --sm-aws-access-key ${COLOR_YELLOW}SM_AWS_ACCESS_KEY_ID${TEXT_RESET}            Your AWS Access Key ID
+      --sm-aws-secret-key ${COLOR_YELLOW}SM_AWS_SECRET_ACCESS_KEY${TEXT_RESET}        Your AWS Secret Key
+      --secrets-path ${COLOR_YELLOW}SECRETS_PATH${TEXT_RESET}                         Secrets Manager path
+      --skip-aws-secret-creation ${COLOR_YELLOW}SKIP_AWS_SECRET_CREATION${TEXT_RESET} If set, cluster AWS secret will be verified but not created. For use when cluster AWS secret is managed by some other configuration mechanism (e.g. Terraform).
 
 IBM Container Registry Entitlement (Required):
       --icr-username ${COLOR_YELLOW}ICR_USERNAME${TEXT_RESET}  Username to authenticate with IBM Container Registry (defaults to 'cp')
@@ -163,6 +164,9 @@ function gitops_cluster_noninteractive() {
         ;;
       --secrets-path)
         export SECRETS_PATH=$1 && shift
+        ;;
+      --skip-aws-secret-creation)
+        export SKIP_AWS_SECRET_CREATION=true
         ;;
 
       # IBM Container Registry Entitlement
@@ -475,10 +479,11 @@ function gitops_cluster() {
 
   echo "${TEXT_DIM}"
   echo_h2 "AWS Secrets Manager" "    "
-  echo_reset_dim "Region ......................... ${COLOR_MAGENTA}${SM_AWS_REGION}"
-  echo_reset_dim "Secret Key ..................... ${COLOR_MAGENTA}${SM_AWS_ACCESS_KEY_ID:0:4}<snip>"
-  echo_reset_dim "Access Key ..................... ${COLOR_MAGENTA}${SM_AWS_SECRET_ACCESS_KEY:0:4}<snip>"
-  echo_reset_dim "Secrets Path ................... ${COLOR_MAGENTA}${SECRETS_PATH}"
+  echo_reset_dim "Region ................................. ${COLOR_MAGENTA}${SM_AWS_REGION}"
+  echo_reset_dim "Secret Key ............................. ${COLOR_MAGENTA}${SM_AWS_ACCESS_KEY_ID:0:4}<snip>"
+  echo_reset_dim "Access Key ............................. ${COLOR_MAGENTA}${SM_AWS_SECRET_ACCESS_KEY:0:4}<snip>"
+  echo_reset_dim "Secrets Path ........................... ${COLOR_MAGENTA}${SECRETS_PATH}"
+  echo_reset_dim "Skip creation of cluster AWS secret? ... ${COLOR_MAGENTA}${SKIP_AWS_SECRET_CREATION}"
   reset_colors
 
   echo "${TEXT_DIM}"
@@ -702,11 +707,16 @@ function gitops_cluster() {
   rm -rf ${GITOPS_CLUSTER_DIR}/ibm-entitlement-with-artifactory.json
 
 
-  echo "- Generate AWS secret"
   # This is used by some of the ArgoCD sync hooks to make updates to AWS SM from within the cluster
   export SECRET_NAME_AWS=${ACCOUNT_ID}${SM_DELIM}${CLUSTER_ID}${SM_DELIM}aws
-  TAGS="[{\"Key\": \"source\", \"Value\": \"gitops_cluster\"}, {\"Key\": \"account\", \"Value\": \"${ACCOUNT_ID}\"}, {\"Key\": \"cluster\", \"Value\": \"${CLUSTER_ID}\"}]"
-  sm_update_secret $SECRET_NAME_AWS "{\"sm_aws_access_key_id\": \"${SM_AWS_ACCESS_KEY_ID}\", \"sm_aws_secret_access_key\": \"${SM_AWS_SECRET_ACCESS_KEY}\"}" "${TAGS}"
+  if [[ "$SKIP_AWS_SECRET_CREATION" == "true" ]]; then
+    echo "- Verify AWS secret"
+    sm_verify_secret_exists $SECRET_NAME_AWS "sm_aws_access_key_id,sm_aws_secret_access_key"
+  else
+    echo "- Generate AWS secret"
+    TAGS="[{\"Key\": \"source\", \"Value\": \"gitops_cluster\"}, {\"Key\": \"account\", \"Value\": \"${ACCOUNT_ID}\"}, {\"Key\": \"cluster\", \"Value\": \"${CLUSTER_ID}\"}]"
+    sm_update_secret $SECRET_NAME_AWS "{\"sm_aws_access_key_id\": \"${SM_AWS_ACCESS_KEY_ID}\", \"sm_aws_secret_access_key\": \"${SM_AWS_SECRET_ACCESS_KEY}\"}" "${TAGS}"
+  fi
 
 
   # Generate ArgoApps

--- a/image/cli/mascli/functions/gitops_utils
+++ b/image/cli/mascli/functions/gitops_utils
@@ -12,6 +12,9 @@ function sm_login() {
     echo "Logging into AWS SecretsManager ..."
     aws configure set aws_access_key_id $SM_AWS_ACCESS_KEY_ID
     aws configure set aws_secret_access_key $SM_AWS_SECRET_ACCESS_KEY
+    if [[ -n "${SM_AWS_SESSION_TOKEN}" ]]; then
+      aws configure set aws_session_token "${SM_AWS_SESSION_TOKEN}"
+    fi
     aws configure set default.region $SM_AWS_REGION
     export AWS_REGION=$SM_AWS_REGION
     aws configure list


### PR DESCRIPTION
If `--skip-aws-secret-creation` is set, `gitops_cluster` will only verify the cluster AWS secret instead of attempting to create it from the supplied AWS credentials.

This is intended for use where some external tool (e.g. Terraform) is responsible for maintaining the cluster AWS secret.

If `--skip-aws-secret-creation` is set, the AWS credentials will be solely used by the CLI for interacting with AWS SM. Since it makes sense for users to provide their ephemeral AWS session tokens for this purpose (unlike for the AWS cluster secret which needs to be long-lived), this PR also adds support for the (optional) `SM_AWS_SESSION_TOKEN` env var in `sm_login`.

These changes are intended to be used primarily by the new mas-saas-gitops-cli Python wrapper.