### PR TITLE
[patch] Support image mirror repo config

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -202,7 +202,7 @@
         "hashed_secret": "b2817467154949a61f8e9ad31d1eeaf03221cbfa",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 484,
+        "line_number": 500,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2025-09-24T12:20:41Z",
+  "generated_at": "2025-09-24T12:31:45Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2025-09-23T14:19:04Z",
+  "generated_at": "2025-09-24T12:20:41Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -202,7 +202,7 @@
         "hashed_secret": "b2817467154949a61f8e9ad31d1eeaf03221cbfa",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 500,
+        "line_number": 505,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2025-09-23T12:28:50Z",
+  "generated_at": "2025-09-23T14:19:04Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -495,6 +495,16 @@
         "is_secret": false,
         "is_verified": false,
         "line_number": 12,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "image/cli/mascli/templates/gitops/appset-configs/cluster/image-mirroring.yaml.j2": [
+      {
+        "hashed_secret": "fee2d55ad9a49a95fc89abe8f414dad66704ebfd",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 7,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/image/cli/mascli/functions/gitops_cluster
+++ b/image/cli/mascli/functions/gitops_cluster
@@ -111,7 +111,7 @@ Image Repository Mirror
       --image-repo-mirror          ${COLOR_YELLOW}IMAGE_REPO_MIRROR${TEXT_RESET}                 Setup an image repository mirror. Image pulls by digest from icr.io and cp.icr.io  will be redirected by OCP to a repository of your choosing (via an IDMS).
       --image-repo-mirror-host     ${COLOR_YELLOW}IMAGE_REPO_MIRROR_HOST${TEXT_RESET}            Host of image repository to direct pulls from icr.io and cp.icr.io to. E.g. ECR 012345678910.dkr.ecr.us-east-1.amazonaws.com
       --image-repo-mirror-prefix   ${COLOR_YELLOW}IMAGE_REPO_MIRROR_PREFIX${TEXT_RESET}          Prefix that will be added to the paths of any images referenced in the image repository mirror. E.g. "250701" will result in a pull of icr.io/myimage being redirected to IMAGE_REPO_MIRROR_HOST/250701/myimage.
-      
+
 Other Commands:
   -h, --help                              Show this help message
 EOM
@@ -648,7 +648,7 @@ function gitops_cluster() {
   export SECRET_NAME_LOG_FORWARDER_DLC_CA_BUNDLE=${ACCOUNT_ID}${SM_DELIM}dlc_cert
   export SECRET_KEY_LOG_FORWARDER_DLC_CA_BUNDLE=${SECRET_NAME_LOG_FORWARDER_DLC_CA_BUNDLE}#ca_bundle
 
-  export SECRET_NAME_AWS_ECR=${ACCOUNT_ID}${SM_DELIM}${CLUSTER_ID}${SM_DELIM}/aws_ecr
+  export SECRET_NAME_AWS_ECR=${ACCOUNT_ID}${SM_DELIM}${CLUSTER_ID}${SM_DELIM}aws_ecr
   export SECRET_KEY_AWS_ECR_ACCESS_KEY_ID=${SECRET_NAME_AWS_ECR}#ecr_aws_access_key_id
   export SECRET_KEY_AWS_ECR_ACCESS_KEY_SECRET=${SECRET_NAME_AWS_ECR}#ecr_aws_secret_access_key
 

--- a/image/cli/mascli/functions/gitops_cluster
+++ b/image/cli/mascli/functions/gitops_cluster
@@ -603,6 +603,13 @@ function gitops_cluster() {
   echo_reset_dim "Install the Instana Agent Operator ........... ${COLOR_MAGENTA}${INSTANA_AGENT_OPERATOR_INSTALL}"
   reset_colors
 
+  if [[ -n "$MAS_CLI_IMAGE_REPO" ]]; then
+    echo "${TEXT_DIM}"
+    echo_h2 "MAS CLI Image" "    "
+    echo_reset_dim "MAS CLI Image repo ........... ${COLOR_MAGENTA}${MAS_CLI_IMAGE_REPO}"
+    reset_colors
+  fi
+
   if [[ "$IMAGE_REPO_MIRROR" == "true" ]]; then
     echo "${TEXT_DIM}"
     echo_h2 "Image Repository Mirror" "    "

--- a/image/cli/mascli/functions/gitops_cluster
+++ b/image/cli/mascli/functions/gitops_cluster
@@ -107,6 +107,11 @@ Instana Agent Operator (Optional):
 MAS CLI Image (Optional):
       --mas-cli-image-repo ${COLOR_YELLOW}MAS_CLI_IMAGE_REPO{TEXT_RESET}               The repo that holds the MAS CLI image to be pulled in ArgoCD. Only needed if using a mirror registry, and not quay.io
 
+Image Repository Mirror
+      --image-repo-mirror          ${COLOR_YELLOW}IMAGE_REPO_MIRROR${TEXT_RESET}                 Setup an image repository mirror. Image pulls by digest from icr.io and cp.icr.io  will be redirected by OCP to a repository of your choosing (via an IDMS).
+      --image-repo-mirror-host     ${COLOR_YELLOW}IMAGE_REPO_MIRROR_HOST${TEXT_RESET}            Host of image repository to direct pulls from icr.io and cp.icr.io to. E.g. ECR 012345678910.dkr.ecr.us-east-1.amazonaws.com
+      --image-repo-mirror-prefix   ${COLOR_YELLOW}IMAGE_REPO_MIRROR_PREFIX${TEXT_RESET}          Prefix that will be added to the paths of any images referenced in the image repository mirror. E.g. "250701" will result in a pull of icr.io/myimage being redirected to IMAGE_REPO_MIRROR_HOST/250701/myimage.
+      
 Other Commands:
   -h, --help                              Show this help message
 EOM

--- a/image/cli/mascli/functions/gitops_cluster
+++ b/image/cli/mascli/functions/gitops_cluster
@@ -354,6 +354,17 @@ function gitops_cluster_noninteractive() {
         export INSTANA_AGENT_OPERATOR_INSTALL=true
         ;;
 
+      # Image repository mirror
+      --image-repo-mirror)
+        export IMAGE_REPO_MIRROR=true
+        ;;
+      --image-repo-mirror-host)
+        export IMAGE_REPO_MIRROR_HOST=$1 && shift
+        ;;
+      --image-repo-mirror-prefix)
+        export IMAGE_REPO_MIRROR_PREFIX=$1 && shift
+        ;;
+
       # Other Commands
       -h|--help)
         gitops_cluster_help
@@ -414,6 +425,11 @@ function gitops_cluster_noninteractive() {
 
   if [[ "$CLUSTER_LOGGING_OPERATOR_SETUP_LOG_FORWARDING" == "true" ]]; then
     [[ -z "$CLUSTER_LOGGING_OPERATOR_DLC_CA_BUNDLE_FILE" ]] && gitops_cluster_help "CLUSTER_LOGGING_OPERATOR_DLC_CA_BUNDLE_FILE is not set"
+  fi
+
+  if [[ "$IMAGE_REPO_MIRROR" == "true" ]]; then
+    [[ -z "$IMAGE_REPO_MIRROR_HOST" ]] && gitops_cluster_help "IMAGE_REPO_MIRROR_HOST is not set"
+    [[ -z "$IMAGE_REPO_MIRROR_PREFIX" ]] && gitops_cluster_help "IMAGE_REPO_MIRROR_PREFIX is not set"
   fi
 }
 
@@ -507,6 +523,7 @@ function gitops_cluster() {
     reset_colors
   fi
 
+
   echo "${TEXT_DIM}"
   echo_h2 "Cluster Promotion" "    "
   echo_reset_dim "Cluster Promotion   ............. ${COLOR_MAGENTA}${CLUSTER_PROMOTION}"
@@ -581,10 +598,11 @@ function gitops_cluster() {
   echo_reset_dim "Install the Instana Agent Operator ........... ${COLOR_MAGENTA}${INSTANA_AGENT_OPERATOR_INSTALL}"
   reset_colors
 
-  if [[ -n "$MAS_CLI_IMAGE_REPO" ]]; then
+  if [[ "$IMAGE_REPO_MIRROR" == "true" ]]; then
     echo "${TEXT_DIM}"
-    echo_h2 "MAS CLI Image" "    "
-    echo_reset_dim "MAS CLI Image repo ........... ${COLOR_MAGENTA}${MAS_CLI_IMAGE_REPO}"
+    echo_h2 "Image Repository Mirror" "    "
+    echo_reset_dim "Repository Host ........... ${COLOR_MAGENTA}${IMAGE_REPO_MIRROR_HOST}"
+    echo_reset_dim "Repository Prefix ......... ${COLOR_MAGENTA}${IMAGE_REPO_MIRROR_PREFIX}"
     reset_colors
   fi
 
@@ -625,6 +643,11 @@ function gitops_cluster() {
   export SECRET_NAME_LOG_FORWARDER_DLC_CA_BUNDLE=${ACCOUNT_ID}${SM_DELIM}dlc_cert
   export SECRET_KEY_LOG_FORWARDER_DLC_CA_BUNDLE=${SECRET_NAME_LOG_FORWARDER_DLC_CA_BUNDLE}#ca_bundle
 
+  export SECRET_NAME_AWS_ECR=${ACCOUNT_ID}${SM_DELIM}${CLUSTER_ID}${SM_DELIM}/aws_ecr
+  export SECRET_KEY_AWS_ECR_ACCESS_KEY_ID=${SECRET_NAME_AWS_ECR}#ecr_aws_access_key_id
+  export SECRET_KEY_AWS_ECR_ACCESS_KEY_SECRET=${SECRET_NAME_AWS_ECR}#ecr_aws_secret_access_key
+
+
   if [ -n "$DEVOPS_MONGO_URI" ];then
     echo "- Update DEVOPS_MONGO_URI secret"
     TAGS="[{\"Key\": \"source\", \"Value\": \"gitops_cluster\"}, {\"Key\": \"account\", \"Value\": \"${ACCOUNT_ID}\"}, {\"Key\": \"cluster\", \"Value\": \"${CLUSTER_ID}\"}]"
@@ -654,6 +677,11 @@ function gitops_cluster() {
     TAGS="[{\"Key\": \"source\", \"Value\": \"gitops_cluster\"}, {\"Key\": \"account\", \"Value\": \"${ACCOUNT_ID}\"}, {\"Key\": \"cluster\", \"Value\": \"${CLUSTER_ID}\"}]"
     sm_update_secret $SECRET_NAME_INSTANA "{\"key\": \"${INSTANA_KEY}\"}" "${TAGS}"
   fi
+
+  if [[ "$IMAGE_REPO_MIRROR" == "true" ]]; then
+    sm_verify_secret_exists $SECRET_NAME_AWS_ECR "ecr_aws_access_key_id,ecr_aws_secret_access_key"
+  fi
+
 
   if [ -z $GIT_SSH ]; then
     export GIT_SSH="false"
@@ -799,6 +827,13 @@ function gitops_cluster() {
     sm_verify_secret_exists $SECRET_NAME_INSTANA "key"
     jinjanate_commmon $CLI_DIR/templates/gitops/appset-configs/cluster/instana-agent-operator.yaml.j2 ${GITOPS_CLUSTER_DIR}/instana-agent-operator.yaml
   fi
+
+
+  if [[ "$IMAGE_REPO_MIRROR" == "true" ]]; then
+    echo "- Image Repository Mirror"
+    jinjanate_commmon $CLI_DIR/templates/gitops/appset-configs/cluster/image-mirroring.yaml.j2 ${GITOPS_CLUSTER_DIR}/image-mirroring.yaml
+  fi
+
 
   # Commit and push to github target repo
   # ---------------------------------------------------------------------------

--- a/image/cli/mascli/templates/gitops/appset-configs/cluster/image-mirroring.yaml.j2
+++ b/image/cli/mascli/templates/gitops/appset-configs/cluster/image-mirroring.yaml.j2
@@ -1,0 +1,7 @@
+merge-key: "{{ ACCOUNT_ID }}/{{ CLUSTER_ID }}"
+
+image_mirroring:
+  ecr_host: {{ IMAGE_REPO_MIRROR_HOST }}
+  repo_path_prefix: {{ IMAGE_REPO_MIRROR_PREFIX }}
+  aws_access_key_id: "<path:{{ SECRETS_PATH }}:{{ SECRET_KEY_AWS_ECR_ACCESS_KEY_ID }}>"
+  aws_secret_access_key: "<path:{{ SECRETS_PATH }}:{{ SECRET_KEY_AWS_ECR_ACCESS_KEY_SECRET }}>"


### PR DESCRIPTION
If optional `--image-repo-mirror` options are specified:
- verify `<acc>/<cluster>/aws_ecr` secret is present and correct
- generate `image-mirroring.yaml` ArgoCD config YAML


Tested via saas-gitops-cli in associated internal PR.