### PR TITLE
[patch] Updates gitops-cli to allow redhat certmanager to be bypassed + docdb changes

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2025-09-24T12:31:45Z",
+  "generated_at": "2025-09-29T09:39:41Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -202,7 +202,7 @@
         "hashed_secret": "b2817467154949a61f8e9ad31d1eeaf03221cbfa",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 505,
+        "line_number": 510,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -338,7 +338,7 @@
         "hashed_secret": "effb7852555adce89885fb075fb43a77a1e0e77e",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 797,
+        "line_number": 806,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -346,7 +346,7 @@
         "hashed_secret": "2582aea6f911bd00fc04cb25e0ec16d5ead62068",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 799,
+        "line_number": 808,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/image/cli/mascli/functions/gitops_cluster
+++ b/image/cli/mascli/functions/gitops_cluster
@@ -35,6 +35,7 @@ Operator Catalog (Optional):
       --catalog-action ${COLOR_YELLOW}MAS_CATALOG_ACTION${TEXT_RESET}     Action to take for IBM Maximo Operator Catalog ('install', 'update' or 'none'. Default is 'install')
 
 Redhat Cert Manager (Optional):
+      --install-redhat-cert-manager ${COLOR_YELLOW}INSTALL_REDHAT_CERT_MANAGER${TEXT_RESET}                                      Install RedHat Cert Manager (default to true)  
       --redhat-cert-manager-install-plan ${COLOR_YELLOW}REDHAT_CERT_MANAGER_INSTALL_PLAN${TEXT_RESET}                            Set Redhat Cert manager subscription install plan approval ('Automatic' or 'Manual'. Default is 'Automatic')
       --redhat-cert-manager-catalog-source ${COLOR_YELLOW}REDHAT_CERT_MANAGER_CATALOG_SOURCE${TEXT_RESET}                        Set Redhat Cert manager catalog source. Only required for mirroring.
       --redhat_cert_manager_catalog_source_namespace ${COLOR_YELLOW}REDHAT_CERT_MANAGER_CATALOG_SOURCE_NAMESPACE${TEXT_RESET}    Set Redhat Cert manager catalog source namespace.  Only required for mirroring.
@@ -131,6 +132,7 @@ function gitops_cluster_noninteractive() {
   export ICR_USERNAME=cp
   export REGION_ID=${REGION_ID:-${SM_AWS_REGION}}
   export REDHAT_CERT_MANAGER_INSTALL_PLAN=${REDHAT_CERT_MANAGER_INSTALL_PLAN:-"Automatic"}
+  export INSTALL_REDHAT_CERT_MANAGER=${INSTALL_REDHAT_CERT_MANAGER:-"true"}
 
   # Target the local (to ArgoCD) cluster
   export CLUSTER_URL=${CLUSTER_URL:-"https://kubernetes.default.svc"}
@@ -196,6 +198,9 @@ function gitops_cluster_noninteractive() {
         ;;
 
       # Redhat Cert Manager
+      --install-redhat-cert-manager)
+        export INSTALL_REDHAT_CERT_MANAGER=true
+        ;;
       --redhat-cert-manager-install-plan)
         export REDHAT_CERT_MANAGER_INSTALL_PLAN=$1 && shift
         ;;
@@ -515,9 +520,12 @@ function gitops_cluster() {
 
   echo "${TEXT_DIM}"
   echo_h2 "Redhat Certificate Manager" "    "
-  echo_reset_dim "Redhat Certificate Manager Subscription Install Plan Approval ................ ${COLOR_MAGENTA}${REDHAT_CERT_MANAGER_INSTALL_PLAN}"
-  echo_reset_dim "Redhat Certificate Manager Catalog Source .................................... ${COLOR_MAGENTA}${REDHAT_CERT_MANAGER_CATALOG_SOURCE}"
-  echo_reset_dim "Redhat Certificate Manager Catalog Source namespace .......................... ${COLOR_MAGENTA}${REDHAT_CERT_MANAGER_CATALOG_SOURCE_NAMESPACE}"
+  echo_reset_dim "Install RedHat Cert Manager .................................................. ${COLOR_MAGENTA}${INSTALL_REDHAT_CERT_MANAGER}"
+  if [[ "$INSTALL_REDHAT_CERT_MANAGER" == "true" ]]; then
+    echo_reset_dim "Redhat Certificate Manager Subscription Install Plan Approval ................ ${COLOR_MAGENTA}${REDHAT_CERT_MANAGER_INSTALL_PLAN}"
+    echo_reset_dim "Redhat Certificate Manager Catalog Source .................................... ${COLOR_MAGENTA}${REDHAT_CERT_MANAGER_CATALOG_SOURCE}"
+    echo_reset_dim "Redhat Certificate Manager Catalog Source namespace .......................... ${COLOR_MAGENTA}${REDHAT_CERT_MANAGER_CATALOG_SOURCE_NAMESPACE}"
+  fi
   reset_colors
 
   if [[ -n "$REDHAT_OPERATORS_MIRROR_CATALOG_IMAGE" ]]; then
@@ -770,10 +778,12 @@ function gitops_cluster() {
   echo "- IBM Operator Catalog"
   jinjanate_commmon $CLI_DIR/templates/gitops/appset-configs/cluster/phase1/ibm-operator-catalog.yaml.j2 ${GITOPS_CLUSTER_DIR}/ibm-operator-catalog.yaml
 
-  echo "- Redhat Cert Manager"
-  jinjanate_commmon $CLI_DIR/templates/gitops/appset-configs/cluster/phase1/redhat-cert-manager.yaml.j2 ${GITOPS_CLUSTER_DIR}/redhat-cert-manager.yaml
+  if [[ "$INSTALL_REDHAT_CERT_MANAGER" == "true" ]]; then
+    echo "- Redhat Cert Manager"
+    jinjanate_commmon $CLI_DIR/templates/gitops/appset-configs/cluster/phase1/redhat-cert-manager.yaml.j2 ${GITOPS_CLUSTER_DIR}/redhat-cert-manager.yaml
+  fi
 
- if [[ -n "$REDHAT_OPERATORS_MIRROR_CATALOG_IMAGE" ]]; then
+  if [[ -n "$REDHAT_OPERATORS_MIRROR_CATALOG_IMAGE" ]]; then
     echo "- RedHat Opertors Mirror Catalog"
     jinjanate_commmon $CLI_DIR/templates/gitops/appset-configs/cluster/phase1/redhat-operators-mirror-catalog.yaml.j2 ${GITOPS_CLUSTER_DIR}/redhat-operators-mirror-catalog.yaml
   fi

--- a/image/cli/mascli/functions/gitops_mas_config
+++ b/image/cli/mascli/functions/gitops_mas_config
@@ -687,7 +687,7 @@ function gitops_mas_config() {
         DOCDB_FEDERAL_ACCESS_KEY=$(jq -r .access_key_id $DOCDB_FEDERAL_INSTANCE_SECRET_FILE)
         if [[ -n ${DOCDB_FEDERAL_ACCESS_KEY} ]]; then
           export DOCDB_AUTHMECHANISM="MONGODB-AWS"
-          export DOCDB_CONFIGDB="$$external"
+          export DOCDB_CONFIGDB='$$external'
         fi
       fi
 

--- a/image/cli/mascli/functions/gitops_mas_config
+++ b/image/cli/mascli/functions/gitops_mas_config
@@ -680,6 +680,15 @@ function gitops_mas_config() {
         #enforce validation set to false for instance level check
         sm_verify_secret_exists ${ACCOUNT_ID}${SECRETS_KEY_SEPERATOR}${CLUSTER_ID}${SECRETS_KEY_SEPERATOR}${MAS_INSTANCE_ID}${SECRETS_KEY_SEPERATOR}mongo "username,password" false
         sm_get_secret_file ${ACCOUNT_ID}${SECRETS_KEY_SEPERATOR}${CLUSTER_ID}${SECRETS_KEY_SEPERATOR}${MAS_INSTANCE_ID}${SECRETS_KEY_SEPERATOR}mongo $MONGO_SECRET_FILE
+
+        #For AWS Docdb in govcloud set the corect authmechanism and configdb
+        export DOCDB_FEDERAL_INSTANCE_SECRET_FILE=$TEMP_DIR/docdb-federal-instance-secret.json
+        sm_get_secret_file ${ACCOUNT_ID}${SECRETS_KEY_SEPERATOR}${CLUSTER_ID}${SECRETS_KEY_SEPERATOR}${MAS_INSTANCE_ID}${SECRETS_KEY_SEPERATOR}docdb $DOCDB_FEDERAL_INSTANCE_SECRET_FILE
+        DOCDB_FEDERAL_ACCESS_KEY=$(jq -r .access_key_id $DOCDB_FEDERAL_INSTANCE_SECRET_FILE)
+        if [[ -n ${DOCDB_FEDERAL_ACCESS_KEY} ]]; then
+          export DOCDB_AUTHMECHANISM="MONGODB-AWS"
+          export DOCDB_CONFIGDB="$$external"
+        fi
       fi
 
       jq -r .info $MONGO_SECRET_FILE > $ADDITIONAL_JINJA_PARAMS_FILE

--- a/image/cli/mascli/functions/gitops_suite
+++ b/image/cli/mascli/functions/gitops_suite
@@ -662,7 +662,7 @@ function gitops_suite() {
     INSTANCE_MONGO_PASSWORD=$(jq -r .secret_access_key $DOCDB_FEDERAL_INSTANCE_SECRET_FILE)
     echo "gitops_suite : DOCDB_FEDERAL_ACCESS_KEY=${DOCDB_FEDERAL_ACCESS_KEY:0:8}<snip> is available in the docdb secret"
     export DOCDB_AUTHMECHANISM="MONGODB-AWS"
-    export DOCDB_CONFIGDB="$$external"
+    export DOCDB_CONFIGDB='$$external'
   fi
 
   ESCAPED_INFO=${UNESCAPED_MONGO_INFO//\"/\\\"}

--- a/image/cli/mascli/functions/gitops_suite
+++ b/image/cli/mascli/functions/gitops_suite
@@ -652,7 +652,18 @@ function gitops_suite() {
   INSTANCE_MONGO_PASSWORD=$(jq -r .password $MONGO_INSTANCE_SECRET_FILE)
 
   # Setting mongo instance secret with info field copied from the cluster level secret, 
-  # Instance username and password will be created in presync hook 
+  # Instance username and password will be created in presync hook unless it is already set in the docdb secret created in federal env, this is due to the
+  # presync hook not running in a federal env due to the userid requirements.
+  export DOCDB_FEDERAL_INSTANCE_SECRET_FILE=$TEMP_DIR/docdb-federal-instance-secret.json
+  sm_get_secret_file ${ACCOUNT_ID}${SECRETS_KEY_SEPERATOR}${CLUSTER_ID}${SECRETS_KEY_SEPERATOR}${MAS_INSTANCE_ID}${SECRETS_KEY_SEPERATOR}docdb $DOCDB_FEDERAL_INSTANCE_SECRET_FILE
+  DOCDB_FEDERAL_ACCESS_KEY=$(jq -r .access_key_id $DOCDB_FEDERAL_INSTANCE_SECRET_FILE)
+  if [[ -n ${DOCDB_FEDERAL_ACCESS_KEY} ]]; then
+    INSTANCE_MONGO_USERNAME=$(jq -r .access_key_id $DOCDB_FEDERAL_INSTANCE_SECRET_FILE)
+    INSTANCE_MONGO_PASSWORD=$(jq -r .secret_access_key $DOCDB_FEDERAL_INSTANCE_SECRET_FILE)
+    echo "gitops_suite : DOCDB_FEDERAL_ACCESS_KEY=${DOCDB_FEDERAL_ACCESS_KEY:0:8}<snip> is available in the docdb secret"
+    export DOCDB_AUTHMECHANISM="MONGODB-AWS"
+    export DOCDB_CONFIGDB="$$external"
+  fi
 
   ESCAPED_INFO=${UNESCAPED_MONGO_INFO//\"/\\\"}
   ESCAPED_INFO=${ESCAPED_INFO//$'\n'/\\n}

--- a/image/cli/mascli/functions/gitops_suite_license_service
+++ b/image/cli/mascli/functions/gitops_suite_license_service
@@ -343,7 +343,18 @@ function gitops_suite_license_service() {
   INSTANCE_MONGO_PASSWORD=$(jq -r .password $MONGO_INSTANCE_SECRET_FILE)
 
   # Setting mongo instance secret with info field copied from the cluster level secret, 
-  # Instance username and password will be created in presync hook 
+  # Instance username and password will be created in presync hook unless it is already set in the docdb secret created in federal env, this is due to the
+  # presync hook not running in a federal env due to the userid requirements.
+  export DOCDB_FEDERAL_INSTANCE_SECRET_FILE=$TEMP_DIR/docdb-federal-instance-secret.json
+  sm_get_secret_file ${ACCOUNT_ID}${SECRETS_KEY_SEPERATOR}${ICN}${SECRETS_KEY_SEPERATOR}${SAAS_SUB_ID}${SECRETS_KEY_SEPERATOR}docdb $DOCDB_FEDERAL_INSTANCE_SECRET_FILE
+  DOCDB_FEDERAL_ACCESS_KEY=$(jq -r .access_key_id $DOCDB_FEDERAL_INSTANCE_SECRET_FILE)
+  if [[ -n ${DOCDB_FEDERAL_ACCESS_KEY} ]]; then
+    INSTANCE_MONGO_USERNAME=$(jq -r .access_key_id $DOCDB_FEDERAL_INSTANCE_SECRET_FILE)
+    INSTANCE_MONGO_PASSWORD=$(jq -r .secret_access_key $DOCDB_FEDERAL_INSTANCE_SECRET_FILE)
+    echo "gitops_suite : DOCDB_FEDERAL_ACCESS_KEY=${DOCDB_FEDERAL_ACCESS_KEY:0:8}<snip> is available in the docdb secret"
+    export DOCDB_AUTHMECHANISM="MONGODB-AWS"
+    export DOCDB_CONFIGDB="$$external"
+  fi
 
   ESCAPED_INFO=${UNESCAPED_MONGO_INFO//\"/\\\"}
   ESCAPED_INFO=${ESCAPED_INFO//$'\n'/\\n}

--- a/image/cli/mascli/functions/gitops_suite_license_service
+++ b/image/cli/mascli/functions/gitops_suite_license_service
@@ -353,7 +353,7 @@ function gitops_suite_license_service() {
     INSTANCE_MONGO_PASSWORD=$(jq -r .secret_access_key $DOCDB_FEDERAL_INSTANCE_SECRET_FILE)
     echo "gitops_suite : DOCDB_FEDERAL_ACCESS_KEY=${DOCDB_FEDERAL_ACCESS_KEY:0:8}<snip> is available in the docdb secret"
     export DOCDB_AUTHMECHANISM="MONGODB-AWS"
-    export DOCDB_CONFIGDB="$$external"
+    export DOCDB_CONFIGDB='$$external'
   fi
 
   ESCAPED_INFO=${UNESCAPED_MONGO_INFO//\"/\\\"}

--- a/image/cli/mascli/templates/gitops/appset-configs/cluster/instance/configs/ibm-mas-mongo-config.yaml.j2
+++ b/image/cli/mascli/templates/gitops/appset-configs/cluster/instance/configs/ibm-mas-mongo-config.yaml.j2
@@ -16,8 +16,8 @@ config:
     - host: {{ mongo_host.host }}
       port: {{ mongo_host.port }}
     {%- endfor %}
-  configDb: admin
-  authMechanism: DEFAULT
+  authMechanism: {{ DOCDB_AUTHMECAHNISM | default("DEFAULT") }}
+  configDb: {{ DOCDB_CONFIGDB | default{"admin"} }}
   {%- if config.retryWrites is sameas false %}
   retryWrites: false
   {%- endif %}

--- a/image/cli/mascli/templates/gitops/appset-configs/cluster/instance/configs/ibm-mas-mongo-config.yaml.j2
+++ b/image/cli/mascli/templates/gitops/appset-configs/cluster/instance/configs/ibm-mas-mongo-config.yaml.j2
@@ -17,7 +17,7 @@ config:
       port: {{ mongo_host.port }}
     {%- endfor %}
   authMechanism: {{ DOCDB_AUTHMECAHNISM | default("DEFAULT") }}
-  configDb: {{ DOCDB_CONFIGDB | default{"admin"} }}
+  configDb: {{ DOCDB_CONFIGDB | default("admin") }}
   {%- if config.retryWrites is sameas false %}
   retryWrites: false
   {%- endif %}

--- a/image/cli/mascli/templates/gitops/appset-configs/cluster/instance/configs/ibm-mas-mongo-config.yaml.j2
+++ b/image/cli/mascli/templates/gitops/appset-configs/cluster/instance/configs/ibm-mas-mongo-config.yaml.j2
@@ -16,7 +16,7 @@ config:
     - host: {{ mongo_host.host }}
       port: {{ mongo_host.port }}
     {%- endfor %}
-  authMechanism: {{ DOCDB_AUTHMECAHNISM | default("DEFAULT") }}
+  authMechanism: {{ DOCDB_AUTHMECHANISM | default("DEFAULT") }}
   configDb: {{ DOCDB_CONFIGDB | default("admin") }}
   {%- if config.retryWrites is sameas false %}
   retryWrites: false

--- a/image/cli/mascli/templates/gitops/appset-configs/cluster/instance/ibm-sls.yaml.j2
+++ b/image/cli/mascli/templates/gitops/appset-configs/cluster/instance/ibm-sls.yaml.j2
@@ -21,8 +21,8 @@ ibm_sls:
   sls_install_plan: {{ SLS_INSTALL_PLAN }}
   run_sync_hooks: true
   mongo_spec:
-    authMechanism: DEFAULT
-    configDb: admin
+    authMechanism: {{ DOCDB_AUTHMECAHNISM | default("DEFAULT") }}
+    configDb: {{ DOCDB_CONFIGDB | default{"admin"} }}
     secretName: sls-mongo-credentials
 {%- if config.retryWrites is sameas false %}
     retryWrites: false

--- a/image/cli/mascli/templates/gitops/appset-configs/cluster/instance/ibm-sls.yaml.j2
+++ b/image/cli/mascli/templates/gitops/appset-configs/cluster/instance/ibm-sls.yaml.j2
@@ -22,7 +22,7 @@ ibm_sls:
   run_sync_hooks: true
   mongo_spec:
     authMechanism: {{ DOCDB_AUTHMECAHNISM | default("DEFAULT") }}
-    configDb: {{ DOCDB_CONFIGDB | default{"admin"} }}
+    configDb: {{ DOCDB_CONFIGDB | default("admin") }}
     secretName: sls-mongo-credentials
 {%- if config.retryWrites is sameas false %}
     retryWrites: false

--- a/image/cli/mascli/templates/gitops/appset-configs/cluster/instance/ibm-sls.yaml.j2
+++ b/image/cli/mascli/templates/gitops/appset-configs/cluster/instance/ibm-sls.yaml.j2
@@ -21,7 +21,7 @@ ibm_sls:
   sls_install_plan: {{ SLS_INSTALL_PLAN }}
   run_sync_hooks: true
   mongo_spec:
-    authMechanism: {{ DOCDB_AUTHMECAHNISM | default("DEFAULT") }}
+    authMechanism: {{ DOCDB_AUTHMECHANISM | default("DEFAULT") }}
     configDb: {{ DOCDB_CONFIGDB | default("admin") }}
     secretName: sls-mongo-credentials
 {%- if config.retryWrites is sameas false %}

--- a/image/cli/mascli/templates/gitops/appset-configs/cluster/sls/ibm-sls.yaml.j2
+++ b/image/cli/mascli/templates/gitops/appset-configs/cluster/sls/ibm-sls.yaml.j2
@@ -36,7 +36,7 @@ ibm_sls_standalone:
   sls_install_plan: {{ SLS_INSTALL_PLAN }}
   run_sync_hooks: true
   mongo_spec:
-    authMechanism: {{ DOCDB_AUTHMECAHNISM | default("DEFAULT") }}
+    authMechanism: {{ DOCDB_AUTHMECHANISM | default("DEFAULT") }}
     configDb: {{ DOCDB_CONFIGDB | default("admin") }}
     secretName: sls-mongo-credentials
 {%- if config.retryWrites is sameas false %}

--- a/image/cli/mascli/templates/gitops/appset-configs/cluster/sls/ibm-sls.yaml.j2
+++ b/image/cli/mascli/templates/gitops/appset-configs/cluster/sls/ibm-sls.yaml.j2
@@ -37,7 +37,7 @@ ibm_sls_standalone:
   run_sync_hooks: true
   mongo_spec:
     authMechanism: {{ DOCDB_AUTHMECAHNISM | default("DEFAULT") }}
-    configDb: {{ DOCDB_CONFIGDB | default{"admin"} }}
+    configDb: {{ DOCDB_CONFIGDB | default("admin") }}
     secretName: sls-mongo-credentials
 {%- if config.retryWrites is sameas false %}
     retryWrites: false

--- a/image/cli/mascli/templates/gitops/appset-configs/cluster/sls/ibm-sls.yaml.j2
+++ b/image/cli/mascli/templates/gitops/appset-configs/cluster/sls/ibm-sls.yaml.j2
@@ -36,8 +36,8 @@ ibm_sls_standalone:
   sls_install_plan: {{ SLS_INSTALL_PLAN }}
   run_sync_hooks: true
   mongo_spec:
-    authMechanism: DEFAULT
-    configDb: admin
+    authMechanism: {{ DOCDB_AUTHMECAHNISM | default("DEFAULT") }}
+    configDb: {{ DOCDB_CONFIGDB | default{"admin"} }}
     secretName: sls-mongo-credentials
 {%- if config.retryWrites is sameas false %}
     retryWrites: false


### PR DESCRIPTION
Adds changes to allow the redhat cert manager to be skipped (as we install if via MCSP).

Also adds the changes based on the federal docdb requirements where the user is created before hand rather than in the presync hook. If that docdb entry in SM is present then we set the mongo username/password using that accesskey and secret. We also set the configDB and auth mechanism when in this mode.

Tested in mas-pp-8.