### PR TITLE
[patch] Improve the MAS quick summary report with Manage to MAS communication results

### DIFF
--- a/docs/commands/must-gather.md
+++ b/docs/commands/must-gather.md
@@ -193,6 +193,12 @@ mas must-gather -d /mnt/home/must-gather --no-ocp --no-dependencies --no-sls --m
 mas must-gather -d /mnt/home/must-gather --no-ocp --no-dependencies --no-sls --mas-instance-ids "inst2" --mas-app-ids "core,manage"
 ```
 
+**Generate MAS quick summary report for specific MAS instance:**  By default, must-gather includes a MAS quick summary report in the `mas-quick-summary` folder, providing compiled information to help identify common issues in the environment. When used with the flags `--summary-only`, `--no-ocp`, `--no-dependencies`, `--no-sls`, and `--mas-instance-ids` to target a specific namespace or MAS application, must-gather focuses the collection for faster execution while still including the MAS quick summary.
+
+```bash
+mas must-gather -d /mnt/home/must-gather --summary-only --no-ocp --no-dependencies --no-sls --mas-instance-ids "inst1" --mas-app-ids "core"
+```
+
 ### Execute the Must-Gather in non-interactive mode
 ```bash
 docker run --rm -v /~:/mnt/home:z quay.io/ibmmas/cli /bin/bash -c "oc login --token=sha256~XFnSk...fc8U --server=https://api.<openshift domain>:6443/ --insecure-skip-tls-verify; mas must-gather -d /mnt/home/must-gather"

--- a/docs/commands/must-gather.md
+++ b/docs/commands/must-gather.md
@@ -26,6 +26,7 @@ Usage
 - `--no-ocp` Disable must-gather for the OCP cluster itself
 - `--no-dependencies` Disable must-gather for in-cluster dependencies (Db2, Cloud Pak for Data, Cloud Pak Foundational Services, Mongo)
 - `--no-sls` Disable must-gather for IBM Suite License Service
+- `--no-mas-quick-summary` Disable MAS quick summary reports (per MAS instance reports with information on MAS version, environment info, available IDPs, pod status, MAS-Manage connection, licensing info, etc)
 
 ### Additional Collectors:
 - `--extra-namespaces` Enable must-gather in custom namespaces (comma-seperated list)
@@ -41,6 +42,9 @@ Content
 ```
 /must-gather/
 ├── 20230423-204411
+│   ├── mas-quick-summary
+│   │   ├── inst1.txt
+│   │   └── inst2.txt
 │   ├── reconcile-logs
 │   │   └── mas-inst1-core
 │   │   |   ├── Suite

--- a/image/cli/mascli/must-gather/mg-quick-summary-mas
+++ b/image/cli/mascli/must-gather/mg-quick-summary-mas
@@ -107,6 +107,7 @@ echo  🧩 Manage Application Details >> ${OUTPUT_FILE} 2> /dev/null
 echo  ============================= >> ${OUTPUT_FILE} 2> /dev/null
 echo "" >> ${OUTPUT_FILE} 2> /dev/null
 
+declare -A CR_JSON_MAP
 # Now extract the contents of the CRs of all installed APPs (Manage CR will be used many times in this script)
 echo "# Activated applications" >> ${OUTPUT_FILE} 2> /dev/null
 echo "Apps activated:" >> ${OUTPUT_FILE} 2> /dev/null
@@ -124,12 +125,12 @@ do
     echo "- $APP_ID" >> ${OUTPUT_FILE} 2> /dev/null
   fi
   # Store app CR json for future reference in this script (specially Manage CR)
-  APP_ID_UPPERCASE="${APP_ID^^}"
-  eval "${APP_ID_UPPERCASE}_CR_JSON='$CR_CONTENT'"
+  CR_JSON_MAP["${APP_ID}"]="$CR_CONTENT"
 done
 echo "" >> ${OUTPUT_FILE} 2> /dev/null
 
 # Steps below are only applicable if Manage is installed
+MANAGE_CR_JSON="${CR_JSON_MAP["manage"]}"
 if [[ "$MANAGE_CR_JSON" != "" ]]; then
 
   echo "# Manage App Version" >> ${OUTPUT_FILE} 2> /dev/null

--- a/image/cli/mascli/must-gather/mg-quick-summary-mas
+++ b/image/cli/mascli/must-gather/mg-quick-summary-mas
@@ -211,7 +211,7 @@ if [[ "$MANAGE_CR_JSON" != "" ]]; then
           fi
         else
           echo "Manage endpoint access from MAS internalapi: failed" >> ${OUTPUT_FILE} 2> /dev/null
-          echo "Details: Could not get a response from Manage /ping endpoint. " >> ${OUTPUT_FILE} 2> /dev/null
+          echo "Details: Could not get a response from Manage /ping endpoint." >> ${OUTPUT_FILE} 2> /dev/null
         fi
       else
         echo "Manage endpoint access from MAS internalapi: failed" >> ${OUTPUT_FILE} 2> /dev/null
@@ -238,7 +238,7 @@ if [[ "$MANAGE_CR_JSON" != "" ]]; then
           fi
         else
           echo "Manage endpoint access from MAS coreapi: failed" >> ${OUTPUT_FILE} 2> /dev/null
-          echo "Details: Could not get a response from Manage /ping endpoint. " >> ${OUTPUT_FILE} 2> /dev/null
+          echo "Details: Could not get a response from Manage /ping endpoint." >> ${OUTPUT_FILE} 2> /dev/null
         fi
       else
         echo "Manage endpoint access from MAS coreapi: failed" >> ${OUTPUT_FILE} 2> /dev/null
@@ -286,7 +286,7 @@ if [[ "$MANAGE_CR_JSON" != "" ]]; then
         fi
       else
         echo "MAS internalapi endpoint access from Manage: failed" >> ${OUTPUT_FILE} 2> /dev/null
-        echo "Details: Could not get a response from Manage /v1/authservice/systeminfo endpoint. " >> ${OUTPUT_FILE} 2> /dev/null
+        echo "Details: Could not get a response from Manage /v1/authservice/systeminfo endpoint." >> ${OUTPUT_FILE} 2> /dev/null
       fi
     else
       echo "MAS internalapi endpoint access from Manage: failed" >> ${OUTPUT_FILE} 2> /dev/null
@@ -322,7 +322,7 @@ if [[ "$MANAGE_CR_JSON" != "" ]]; then
           fi
         else
           echo "MAS internalapi endpoint access from Manage: failed" >> ${OUTPUT_FILE} 2> /dev/null
-          echo "Details: Could not get a response from Manage /v1/idps endpoint. " >> ${OUTPUT_FILE} 2> /dev/null
+          echo "Details: Could not get a response from Manage /v1/idps endpoint." >> ${OUTPUT_FILE} 2> /dev/null
         fi
       else
         echo "MAS internalapi endpoint access from Manage: failed" >> ${OUTPUT_FILE} 2> /dev/null

--- a/image/cli/mascli/must-gather/mg-quick-summary-mas
+++ b/image/cli/mascli/must-gather/mg-quick-summary-mas
@@ -82,7 +82,7 @@ echo "" >> ${OUTPUT_FILE} 2> /dev/null
 
 # Create a temporary file with the output of oc get pods command to avoid having to run that command many times
 TEMP_PODS_LIST_FILE_PATH=/tmp/coreservicespods.txt
-oc get pods -n mas-${INSTANCE_ID}-core -o custom-columns="NAME:.metadata.name,STATUS:.status.phase" --no-headers >> $TEMP_PODS_LIST_FILE_PATH 2> /dev/null || true
+oc get pods -n mas-${INSTANCE_ID}-core -o json | jq -r '.items[] | . as $pod | $pod.status.containerStatuses[] | [$pod.metadata.name, (.state | keys[0]), (if .state.waiting? then .state.waiting.reason else "" end)] | @tsv' >> $TEMP_PODS_LIST_FILE_PATH 2> /dev/null || true
 echo "# Core services" >> ${OUTPUT_FILE} 2> /dev/null
 echo "Coreapi pods running states: " >> ${OUTPUT_FILE} 2> /dev/null
 cat $TEMP_PODS_LIST_FILE_PATH | grep "^.*-coreapi-" >> ${OUTPUT_FILE} 2> /dev/null || true
@@ -158,7 +158,7 @@ if [[ "$MANAGE_CR_JSON" != "" ]]; then
   if [[ "$WORKSPACE_ID" != "null" ]]; then
     # Create a temporary file with the output of oc get pods command to avoid having to run that command many times
     TEMP_PODS_LIST_FILE_PATH=/tmp/managepods.txt
-    oc get pods -n mas-${INSTANCE_ID}-manage -o custom-columns="NAME:.metadata.name,STATUS:.status.phase" --no-headers >> $TEMP_PODS_LIST_FILE_PATH 2> /dev/null || true
+    oc get pods -n mas-${INSTANCE_ID}-manage -o json | jq -r '.items[] | . as $pod | $pod.status.containerStatuses[] | [$pod.metadata.name, (.state | keys[0]), (if .state.waiting? then .state.waiting.reason else "" end)] | @tsv' >> $TEMP_PODS_LIST_FILE_PATH 2> /dev/null || true
     echo "# Manage Pods" >> ${OUTPUT_FILE} 2> /dev/null
     # Manage usersyncagent pod running state
     echo "Manage usersyncagent pod running state:" >> ${OUTPUT_FILE} 2> /dev/null

--- a/image/cli/mascli/must-gather/mg-quick-summary-mas
+++ b/image/cli/mascli/must-gather/mg-quick-summary-mas
@@ -256,7 +256,7 @@ if [[ "$MANAGE_CR_JSON" != "" ]]; then
       SYSTEM_INFO_RESPONSE=$((oc exec -n mas-$INSTANCE_ID-manage "$MANAGE_BUNDLE_POD_NAME" -- curl -vs -X GET "https://internalapi.mas-$INSTANCE_ID-core.svc/v1/authservice/systeminfo" --cert /etc/pki/tls/certs/internal-manage-tls/tls.crt --key /etc/pki/tls/certs/internal-manage-tls/tls.key --cacert /etc/pki/tls/certs/internal-manage-tls/ca.crt) 2>/dev/null || echo "")
       if [[ "$SYSTEM_INFO_RESPONSE" != "" ]]; then
         if echo "$SYSTEM_INFO_RESPONSE" | jq empty 2>/dev/null; then
-          echo "MAS internalapi endpoint access from Manage pod: successful" >> ${OUTPUT_FILE} 2> /dev/null
+          echo "MAS internalapi endpoint access from Manage: successful" >> ${OUTPUT_FILE} 2> /dev/null
           echo "" >> ${OUTPUT_FILE} 2> /dev/null
           echo  =========================== >> ${OUTPUT_FILE} 2> /dev/null
           echo  🔐 Identity Provider Status >> ${OUTPUT_FILE} 2> /dev/null

--- a/image/cli/mascli/must-gather/mg-quick-summary-mas
+++ b/image/cli/mascli/must-gather/mg-quick-summary-mas
@@ -323,7 +323,7 @@ if [[ "$MANAGE_CR_JSON" != "" ]]; then
           fi
         else
           echo "MAS internalapi endpoint access from Manage: failed" >> ${OUTPUT_FILE} 2> /dev/null
-          echo "Details: Could not get a response from Manage /v1/idps endpoint." >> ${OUTPUT_FILE} 2> /dev/null
+          echo "Details: Could not get a response from MAS /v1/idps endpoint." >> ${OUTPUT_FILE} 2> /dev/null
         fi
       else
         echo "MAS internalapi endpoint access from Manage: failed" >> ${OUTPUT_FILE} 2> /dev/null
@@ -349,17 +349,27 @@ else
 
     echo "# Installed IDPs" >> ${OUTPUT_FILE} 2> /dev/null
     INTERNALAPI_POD_NAME=$(oc get pods -n mas-${INSTANCE_ID}-core --no-headers -o custom-columns=":metadata.name" | grep "^${INSTANCE_ID}-internalapi-" | head -n 1)
-    IDPS_API_RESPONSE=$((oc exec -n mas-${INSTANCE_ID}-core "$INTERNALAPI_POD_NAME" -- curl -s -X GET --header 'Content-Type: application/json'  https://internalapi.mas-${INSTANCE_ID}-core.svc/v1/idps --cert /etc/pki/tls/certs/mascore-cert/tls.crt --key /etc/pki/tls/certs/mascore-cert/tls.key --cacert /etc/pki/tls/certs/mascore-cert/ca.crt) 2>/dev/null || echo "")
-    
-    echo "Installed IDPs:" >> ${OUTPUT_FILE} 2> /dev/null
-    if echo "$IDPS_API_RESPONSE" | jq empty 2>/dev/null; then
-      echo "$IDPS_API_RESPONSE" | jq -r '.[] | "\(.name): status \"\(.status)\", isEnabled \(.isEnabled), isDefault \(.isDefault)"' >> ${OUTPUT_FILE} 2> /dev/null
+    if [[ "$INTERNALAPI_POD_NAME" != "" ]]; then
+      IDPS_API_RESPONSE=$((oc exec -n mas-${INSTANCE_ID}-core "$INTERNALAPI_POD_NAME" -- curl -s -X GET --header 'Content-Type: application/json'  https://internalapi.mas-${INSTANCE_ID}-core.svc/v1/idps --cert /etc/pki/tls/certs/mascore-cert/tls.crt --key /etc/pki/tls/certs/mascore-cert/tls.key --cacert /etc/pki/tls/certs/mascore-cert/ca.crt) 2>/dev/null || echo "")
+      if [[ "$IDPS_API_RESPONSE" != "" ]]; then
+        echo "Installed IDPs:" >> ${OUTPUT_FILE} 2> /dev/null
+        if echo "$IDPS_API_RESPONSE" | jq empty 2>/dev/null; then
+          echo "$IDPS_API_RESPONSE" | jq -r '.[] | "\(.name): status \"\(.status)\", isEnabled \(.isEnabled), isDefault \(.isDefault)"' >> ${OUTPUT_FILE} 2> /dev/null
+        else
+          echo "Could not retrieve identity provider status." >> ${OUTPUT_FILE} 2> /dev/null
+          echo "Invalid JSON response: $IDPS_API_RESPONSE" >> ${OUTPUT_FILE} 2> /dev/null
+        fi
+      else
+        echo "Could not retrieve identity provider status." >> ${OUTPUT_FILE} 2> /dev/null
+        echo "Details: Could not get a response from MAS /v1/idps endpoint." >> ${OUTPUT_FILE} 2> /dev/null
+      fi
     else
-      echo "Invalid JSON response: $IDPS_API_RESPONSE" >> ${OUTPUT_FILE} 2> /dev/null
+      echo "Could not retrieve identity provider status." >> ${OUTPUT_FILE} 2> /dev/null
+      echo "Details: Internalapi pod could not be found." >> ${OUTPUT_FILE} 2> /dev/null
     fi
     echo "" >> ${OUTPUT_FILE} 2> /dev/null
   else
-    echo "Skipping identity provider check. MAS 8.10 is installed, /v1/idps API is not available." >> ${OUTPUT_FILE} 2> /dev/null
+    echo "Skipping identity provider check. MAS 8.10 is installed, MAS /v1/idps API is not available." >> ${OUTPUT_FILE} 2> /dev/null
     echo "" >> ${OUTPUT_FILE} 2> /dev/null
   fi
 

--- a/image/cli/mascli/must-gather/mg-quick-summary-mas
+++ b/image/cli/mascli/must-gather/mg-quick-summary-mas
@@ -181,9 +181,9 @@ if [[ "$MANAGE_CR_JSON" != "" ]]; then
   echo $MANAGE_POD_TEMPLATES >> ${OUTPUT_FILE} 2> /dev/null
   echo "" >> ${OUTPUT_FILE} 2> /dev/null
 
-  echo  =========================== >> ${OUTPUT_FILE} 2> /dev/null
-  echo  📡 MAS-Manage Communication >> ${OUTPUT_FILE} 2> /dev/null
-  echo  =========================== >> ${OUTPUT_FILE} 2> /dev/null
+  echo  ========================================== >> ${OUTPUT_FILE} 2> /dev/null
+  echo  📡 MAS-Manage and Manage-MAS Communication >> ${OUTPUT_FILE} 2> /dev/null
+  echo  ========================================== >> ${OUTPUT_FILE} 2> /dev/null
   echo "" >> ${OUTPUT_FILE} 2> /dev/null
 
   # If Manage is installed and we are in 9.1 All Manage to MAS and MAS to Manage tests can be performed
@@ -248,76 +248,90 @@ if [[ "$MANAGE_CR_JSON" != "" ]]; then
     fi
 
     # If Manage is installed but and we are in 9.1, request the /v1/authservice/systeminfo internal API from Manage pod
-    echo  =========================== >> ${OUTPUT_FILE} 2> /dev/null
-    echo  🔐 Identity Provider Status >> ${OUTPUT_FILE} 2> /dev/null
-    echo  =========================== >> ${OUTPUT_FILE} 2> /dev/null
-    echo "" >> ${OUTPUT_FILE} 2> /dev/null
-
     # Get the name of the Manage pod to be used for checking the connection between Manage and MAS 
+    echo "# MAS internalapi endpoint access from Manage" >> ${OUTPUT_FILE} 2> /dev/null
     MANAGE_BUNDLE_POD_NAME=$(oc get pods -n mas-$INSTANCE_ID-manage -o json | jq -r --arg appTypeName "$MANAGE_BUNDLE_NAME" '.items[] | select(.metadata.labels["mas.ibm.com/appTypeName"] == $appTypeName) | .metadata.name' | head -n 1 2>/dev/null || echo "")
     if [[ "$MANAGE_BUNDLE_POD_NAME" != "" ]]; then
       # Call the /systeminfo API in MAS from the Manage pod
       SYSTEM_INFO_RESPONSE=$((oc exec -n mas-$INSTANCE_ID-manage "$MANAGE_BUNDLE_POD_NAME" -- curl -vs -X GET "https://internalapi.mas-$INSTANCE_ID-core.svc/v1/authservice/systeminfo" --cert /etc/pki/tls/certs/internal-manage-tls/tls.crt --key /etc/pki/tls/certs/internal-manage-tls/tls.key --cacert /etc/pki/tls/certs/internal-manage-tls/ca.crt) 2>/dev/null || echo "")
-      if echo "$SYSTEM_INFO_RESPONSE" | jq empty 2>/dev/null; then
-        echo "# Identity Provider Status" >> ${OUTPUT_FILE} 2> /dev/null
-        echo "Identity Provider Status:" >> ${OUTPUT_FILE} 2> /dev/null
-        echo "$SYSTEM_INFO_RESPONSE" | jq -r '.availableIdps[] | "\(.name): status \"\(.status)\", isEnabled \(.isEnabled), isDefault \(.isDefault)"' >> ${OUTPUT_FILE} 2> /dev/null
-        echo "" >> ${OUTPUT_FILE} 2> /dev/null
-        echo "# Environment setup" >> ${OUTPUT_FILE} 2> /dev/null
-        echo "Environment setup:" >> ${OUTPUT_FILE} 2> /dev/null
-        echo "$SYSTEM_INFO_RESPONSE" | jq -r '.envSetup | "domain: \(.domain)\nisSaaS: \(.isSaaS)\nsuperUserId: \(.superUserId)"' >> ${OUTPUT_FILE} 2> /dev/null
-        echo "" >> ${OUTPUT_FILE} 2> /dev/null
+      if [[ "$SYSTEM_INFO_RESPONSE" != "" ]]; then
+        if echo "$SYSTEM_INFO_RESPONSE" | jq empty 2>/dev/null; then
+          echo "MAS internalapi endpoint access from Manage pod: successful" >> ${OUTPUT_FILE} 2> /dev/null
+          echo "" >> ${OUTPUT_FILE} 2> /dev/null
+          echo  =========================== >> ${OUTPUT_FILE} 2> /dev/null
+          echo  🔐 Identity Provider Status >> ${OUTPUT_FILE} 2> /dev/null
+          echo  =========================== >> ${OUTPUT_FILE} 2> /dev/null
+          echo "" >> ${OUTPUT_FILE} 2> /dev/null
+          echo "# Identity Provider Status" >> ${OUTPUT_FILE} 2> /dev/null
+          echo "Identity Provider Status:" >> ${OUTPUT_FILE} 2> /dev/null
+          echo "$SYSTEM_INFO_RESPONSE" | jq -r '.availableIdps[] | "\(.name): status \"\(.status)\", isEnabled \(.isEnabled), isDefault \(.isDefault)"' >> ${OUTPUT_FILE} 2> /dev/null
+          echo "" >> ${OUTPUT_FILE} 2> /dev/null
+          echo "# Environment setup" >> ${OUTPUT_FILE} 2> /dev/null
+          echo "Environment setup:" >> ${OUTPUT_FILE} 2> /dev/null
+          echo "$SYSTEM_INFO_RESPONSE" | jq -r '.envSetup | "domain: \(.domain)\nisSaaS: \(.isSaaS)\nsuperUserId: \(.superUserId)"' >> ${OUTPUT_FILE} 2> /dev/null
+          echo "" >> ${OUTPUT_FILE} 2> /dev/null
 
-        echo  ======================== >> ${OUTPUT_FILE} 2> /dev/null
-        echo  📜 Licensing Information >> ${OUTPUT_FILE} 2> /dev/null
-        echo  ======================== >> ${OUTPUT_FILE} 2> /dev/null
-        echo "" >> ${OUTPUT_FILE} 2> /dev/null
+          echo  ======================== >> ${OUTPUT_FILE} 2> /dev/null
+          echo  📜 Licensing Information >> ${OUTPUT_FILE} 2> /dev/null
+          echo  ======================== >> ${OUTPUT_FILE} 2> /dev/null
+          echo "" >> ${OUTPUT_FILE} 2> /dev/null
 
-        echo "# Licensing Products and Token Costs" >> ${OUTPUT_FILE} 2> /dev/null
-        echo "Licensing Products:" >> ${OUTPUT_FILE} 2> /dev/null
-        echo "$SYSTEM_INFO_RESPONSE" | jq -r '.licensingProducts[] | "\(.productId): \(.tokenCost) \(.tokenId)"' >> ${OUTPUT_FILE} 2> /dev/null
-        echo "" >> ${OUTPUT_FILE} 2> /dev/null
+          echo "# Licensing Products and Token Costs" >> ${OUTPUT_FILE} 2> /dev/null
+          echo "Licensing Products:" >> ${OUTPUT_FILE} 2> /dev/null
+          echo "$SYSTEM_INFO_RESPONSE" | jq -r '.licensingProducts[] | "\(.productId): \(.tokenCost) \(.tokenId)"' >> ${OUTPUT_FILE} 2> /dev/null
+          echo "" >> ${OUTPUT_FILE} 2> /dev/null
+        else
+          echo "MAS internalapi endpoint access from Manage: failed" >> ${OUTPUT_FILE} 2> /dev/null
+          echo "Details: Invalid JSON response: $SYSTEM_INFO_RESPONSE" >> ${OUTPUT_FILE} 2> /dev/null
+        fi
       else
-        echo "Invalid JSON response: $SYSTEM_INFO_RESPONSE" >> ${OUTPUT_FILE} 2> /dev/null
+        echo "MAS internalapi endpoint access from Manage: failed" >> ${OUTPUT_FILE} 2> /dev/null
+        echo "Details: Could not get a response from Manage /v1/authservice/systeminfo endpoint. " >> ${OUTPUT_FILE} 2> /dev/null
       fi
-      echo "" >> ${OUTPUT_FILE} 2> /dev/null
     else
-      echo "Manage pod could not be found for bundle $MANAGE_BUNDLE_NAME. MAS system info could not be retrieved. " >> ${OUTPUT_FILE} 2> /dev/null
-      echo "" >> ${OUTPUT_FILE} 2> /dev/null
+      echo "MAS internalapi endpoint access from Manage: failed" >> ${OUTPUT_FILE} 2> /dev/null
+      echo "Details: Manage pod could not be found for bundle $MANAGE_BUNDLE_NAME." >> ${OUTPUT_FILE} 2> /dev/null
     fi
-
+    echo "" >> ${OUTPUT_FILE} 2> /dev/null
   else
     # If Manage is installed but we are in 8.11 or 9.0, only Manage to MAS communication test is performed
     # Request the /v1/idps MAS endpoint instead of the /v1/authservice/systeminfo from Manage pod
-    echo "Skipping MAS to Manage communication test. Installed MAS version is below 9.1, so /v1/authservice/systeminfo API is not available." >> ${OUTPUT_FILE} 2> /dev/null
+    echo "Skipping MAS to Manage communication test. Installed MAS version is below 9.1, so /maximo/api/ping API is not available in Manage." >> ${OUTPUT_FILE} 2> /dev/null
     echo "" >> ${OUTPUT_FILE} 2> /dev/null
     if [[ "$IS_AFTER_MAS811" == "true" ]]; then
-      echo  =========================== >> ${OUTPUT_FILE} 2> /dev/null
-      echo  🔐 Identity Provider Status >> ${OUTPUT_FILE} 2> /dev/null
-      echo  =========================== >> ${OUTPUT_FILE} 2> /dev/null
-      echo "" >> ${OUTPUT_FILE} 2> /dev/null
-
+      echo "# MAS internalapi endpoint access from Manage" >> ${OUTPUT_FILE} 2> /dev/null
       # Get the name of the Manage pod to be used for checking the connection between Manage and MAS 
       MANAGE_BUNDLE_POD_NAME=$(oc get pods -n mas-$INSTANCE_ID-manage -o json | jq -r --arg appTypeName "$MANAGE_BUNDLE_NAME" '.items[] | select(.metadata.labels["mas.ibm.com/appTypeName"] == $appTypeName) | .metadata.name' | head -n 1 2>/dev/null || echo "")
       if [[ "$MANAGE_BUNDLE_POD_NAME" != "" ]]; then
-        echo "# Installed IDPs" >> ${OUTPUT_FILE} 2> /dev/null
         # Call the /idps API in MAS from the Manage pod
         IDPS_API_RESPONSE=$((oc exec -n mas-$INSTANCE_ID-manage "$MANAGE_BUNDLE_POD_NAME" -- curl -vs -X GET "https://internalapi.mas-$INSTANCE_ID-core.svc/v1/idps" --cert /etc/pki/tls/certs/internal-manage-tls/tls.crt --key /etc/pki/tls/certs/internal-manage-tls/tls.key --cacert /etc/pki/tls/certs/internal-manage-tls/ca.crt) 2>/dev/null || echo "")
-        echo "Installed IDPs:" >> ${OUTPUT_FILE} 2> /dev/null
-        if echo "$IDPS_API_RESPONSE" | jq empty 2>/dev/null; then
-          echo "$IDPS_API_RESPONSE" | jq -r '.[] | "\(.name): status \"\(.status)\", isEnabled \(.isEnabled), isDefault \(.isDefault)"' >> ${OUTPUT_FILE} 2> /dev/null
+        if [[ "$IDPS_API_RESPONSE" != "" ]]; then
+          if echo "$IDPS_API_RESPONSE" | jq empty 2>/dev/null; then
+            echo "MAS internalapi endpoint access from Manage: successful" >> ${OUTPUT_FILE} 2> /dev/null
+            echo "" >> ${OUTPUT_FILE} 2> /dev/null
+            echo  =========================== >> ${OUTPUT_FILE} 2> /dev/null
+            echo  🔐 Identity Provider Status >> ${OUTPUT_FILE} 2> /dev/null
+            echo  =========================== >> ${OUTPUT_FILE} 2> /dev/null
+            echo "" >> ${OUTPUT_FILE} 2> /dev/null
+            echo "# Installed IDPs" >> ${OUTPUT_FILE} 2> /dev/null
+            echo "Installed IDPs:" >> ${OUTPUT_FILE} 2> /dev/null
+            echo "$IDPS_API_RESPONSE" | jq -r '.[] | "\(.name): status \"\(.status)\", isEnabled \(.isEnabled), isDefault \(.isDefault)"' >> ${OUTPUT_FILE} 2> /dev/null
+          else
+            echo "MAS internalapi endpoint access from Manage: failed" >> ${OUTPUT_FILE} 2> /dev/null
+            echo "Details: Invalid JSON response: $IDPS_API_RESPONSE" >> ${OUTPUT_FILE} 2> /dev/null
+          fi
         else
-          echo "Invalid JSON response: $IDPS_API_RESPONSE" >> ${OUTPUT_FILE} 2> /dev/null
+          echo "MAS internalapi endpoint access from Manage: failed" >> ${OUTPUT_FILE} 2> /dev/null
+          echo "Details: Could not get a response from Manage /v1/idps endpoint. " >> ${OUTPUT_FILE} 2> /dev/null
         fi
-        echo "" >> ${OUTPUT_FILE} 2> /dev/null
       else
-        echo "Manage pod could not be found for bundle $MANAGE_BUNDLE_NAME." >> ${OUTPUT_FILE} 2> /dev/null
-        echo "" >> ${OUTPUT_FILE} 2> /dev/null
+        echo "MAS internalapi endpoint access from Manage: failed" >> ${OUTPUT_FILE} 2> /dev/null
+        echo "Details: Manage pod could not be found for bundle $MANAGE_BUNDLE_NAME." >> ${OUTPUT_FILE} 2> /dev/null
       fi
     else
-      echo "Skipping MAS to Manage and Manage to MAS communication tests. MAS 8.10 is installed, so /v1/idps API is not available in MAS and /v1/authservice/systeminfo API is not avaliable in Manage." >> ${OUTPUT_FILE} 2> /dev/null
-      echo "" >> ${OUTPUT_FILE} 2> /dev/null
+      echo "Skipping Manage to MAS communication tests. MAS 8.10 is installed, so /v1/idps API is not available in MAS." >> ${OUTPUT_FILE} 2> /dev/null
     fi
+    echo "" >> ${OUTPUT_FILE} 2> /dev/null
   fi
 
 else

--- a/image/cli/mascli/must-gather/mg-quick-summary-mas
+++ b/image/cli/mascli/must-gather/mg-quick-summary-mas
@@ -268,7 +268,7 @@ if [[ "$MANAGE_CR_JSON" != "" ]]; then
           echo "" >> ${OUTPUT_FILE} 2> /dev/null
           echo "# Environment setup" >> ${OUTPUT_FILE} 2> /dev/null
           echo "Environment setup:" >> ${OUTPUT_FILE} 2> /dev/null
-          echo "$SYSTEM_INFO_RESPONSE" | jq -r '.envSetup | "domain: \(.domain)\nisSaaS: \(.isSaaS)\nsuperUserId: \(.superUserId)"' >> ${OUTPUT_FILE} 2> /dev/null
+          echo "$SYSTEM_INFO_RESPONSE" | jq -r '.envSetup | "domain: \(.domain)\nisSaaS: \(.isSaaS)"' >> ${OUTPUT_FILE} 2> /dev/null
           echo "" >> ${OUTPUT_FILE} 2> /dev/null
 
           echo  ======================== >> ${OUTPUT_FILE} 2> /dev/null


### PR DESCRIPTION
- Adding `MAS internalapi endpoint access from Manage: failed/successful` to the MAS quick summary report and also including the details in case of failure in the Manage-MAS connection test.
- Improving error handling when requesting APIs inside pods with oc exec commands.
- Retrieving pod status from `status.containerStatuses` instead of `status.phase`, as `status.phase` does not catch container errors like `ImagePullBackOff`.
- Replaced `eval` with associative array approach when storing application CRs in environment variables, since eval could fail sometimes, with certain characters in the CR.
- Updating must-gather documentation to include the generated folder for the quick summary, an extra example of running the must-gather command and the new flag to skip the quick summary generation.
- Removing superuser username from the report.

Example of MAS-to-Manage and Manage-to-MAS communication report:
```
==========================================
📡 MAS-Manage and Manage-MAS Communication
==========================================

# Manage endpoint access from MAS internalapi
Manage endpoint access from MAS internalapi: failed
Details: Could not get a response from Manage /ping endpoint.

# Manage endpoint access from MAS coreapi
Manage endpoint access from MAS coreapi: successful

# MAS internalapi endpoint access from Manage
MAS internalapi endpoint access from Manage: successful
```

Example of error handling when an oc exec command fails:
```
===========================
🔐 Identity Provider Status
===========================

# Installed IDPs
Could not retrieve identity provider status.
Details: Could not get a response from MAS /v1/idps endpoint.
```

Example of pod health check when containers are not actually running (even though status.phase says they are Running):
```
==============================
📦 Pod Health and Status Check
==============================

# Core services
Coreapi pods running states: 
idp90x-coreapi-7d784484c-bkfxs	waiting	ImagePullBackOff
idp90x-coreapi-7d784484c-czv7w	waiting	ImagePullBackOff
idp90x-coreapi-7d784484c-qd7gj	waiting	ImagePullBackOff

Internalapi pod running state: 
idp90x-internalapi-68c8855f7b-2wgqz	waiting	ImagePullBackOff

Usersync-coordinator pod running state: 
idp90x-usersync-coordinator-576c7cb5c9-bn82f	waiting	PodInitializing

Scimsync running state: 
idp90x-default-scimsync-6bd55b6bc4-xl28p	waiting	ImagePullBackOff

Scimsync-agent pods running states: 
idp90x-default-scim-cronjob-29333918-4q72l	terminated	
idp90x-default-scim-cronjob-29333922-bqm92	terminated	
idp90x-default-scim-cronjob-29333928-mzd55	terminated	
idp90x-default-scim-cronjob-29333932-l24t4	terminated	
idp90x-default-scim-cronjob-29333936-mlbg5	terminated	
idp90x-default-scim-cronjob-29333942-7pkl8	running	
```