### PR TITLE
[patch] update SLS tekton pipeline to support license file

### DIFF
--- a/tekton/src/pipelines/gitops/gitops-suite-license-service.yml.j2
+++ b/tekton/src/pipelines/gitops/gitops-suite-license-service.yml.j2
@@ -6,6 +6,8 @@ metadata:
 spec:
   workspaces:
     - name: shared-entitlement
+    - name: shared-gitops-configs
+    - name: configs
   description: MAS provision Suite License Service for customer subscription
   params:
     - name: cluster_name
@@ -85,6 +87,10 @@ spec:
       type: string
       default: ""
 
+    - name: authorized_entitlement_saas_encoded
+      type: string
+      default: ""
+
     - name: mas_slscfg_pod_template_yaml
       type: string
       default: ""
@@ -125,7 +131,9 @@ spec:
           value: $(params.sls_license_icn)
         - name: sls_subscription_id
           value: $(params.sls_subscription_id)
-        
+
+        - name: authorized_entitlement_saas_encoded
+          value: $(params.authorized_entitlement_saas_encoded)
       workspaces:
         - name: shared-entitlement
           workspace: shared-entitlement
@@ -133,8 +141,8 @@ spec:
         kind: Task
         name: gitops-license
       when:
-        - input: "$(params.sls_subscription_id)"
-          operator: in
+        - input: "$(params.authorized_entitlement_saas_encoded)"
+          operator: notin
           values: [""]
 
     - name: gitops-license-generator
@@ -162,12 +170,14 @@ spec:
           value: $(params.sls_license_icn)
         - name: sls_subscription_id
           value: $(params.sls_subscription_id)
+        - name: authorized_entitlement_saas_encoded
+          value: $(params.authorized_entitlement_saas_encoded)  
       taskRef:
         kind: Task
         name: gitops-license-generator
       when:
-        - input: "$(params.sls_subscription_id)"
-          operator: notin
+        - input: "$(params.authorized_entitlement_saas_encoded)"
+          operator: in
           values: [""]
 
     # 2. 
@@ -223,6 +233,8 @@ spec:
           value: $(params.sls_license_icn)
         - name: sls_subscription_id
           value: $(params.sls_subscription_id)
+        - name: mas_slscfg_pod_template_yaml
+          value: $(params.mas_slscfg_pod_template_yaml)
 
       taskRef:
         kind: Task
@@ -230,3 +242,7 @@ spec:
       workspaces:
         - name: shared-entitlement
           workspace: shared-entitlement
+        - name: configs
+          workspace: configs
+        - name: shared-gitops-configs
+          workspace: shared-gitops-configs

--- a/tekton/src/tasks/gitops/gitops-sls.yml.j2
+++ b/tekton/src/tasks/gitops/gitops-sls.yml.j2
@@ -48,6 +48,8 @@ spec:
       type: string
     - name: github_ssh
       type: string
+    - name: mas_slscfg_pod_template_yaml
+      type: string
 
   stepTemplate:
     name: gitops-sls
@@ -95,6 +97,8 @@ spec:
         value: $(params.git_commit_msg)
       - name: GIT_SSH
         value: $(params.github_ssh)
+      - name: POD_TEMPLATE
+        value: $(params.mas_slscfg_pod_template_yaml)
 
     envFrom:
       - configMapRef:
@@ -124,4 +128,6 @@ spec:
       image: quay.io/ibmmas/cli:latest
   workspaces:
     - name: shared-entitlement
+    - name: configs
+    - name: shared-gitops-configs
 


### PR DESCRIPTION
## Issue
[MASCORE-8792](https://jsw.ibm.com/browse/mascore-8792)

## Description
This change enables the standalone sls pipeline to support specification of license file.  Before this pipeline would not run the git-license step of the pipeline because of a bug in both condition of the step and missing values required for completion of this step. 

## Test Results
1. Tested pipeline to run with license file included. 
<img width="1140" height="721" alt="image" src="https://github.com/user-attachments/assets/1dc65fff-9354-4b33-a205-b9ba493044a7" />

2. Tested pipeline with run with license info specified.
<img width="1137" height="483" alt="image" src="https://github.com/user-attachments/assets/7a57b9c6-187d-4ba7-9000-e4ec42fb145a" />

## Related Pull Requests
[SaaS Tekton PR 161](https://github.ibm.com/maximoappsuite/saas-tekton/pull/161)

<hr/>

### :warning: Notes for Reviewers
* Ensure you have understood the [guidelines](https://pages.github.ibm.com/maximoappsuite/playbook/tools/github/#guidelines) before proceeding with a review.
* Ensure all sections in the PR template are appropriately completed.