### PR TITLE
[patch] fix mas-instance pipeline license creation steps in gitops

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2025-10-06T11:47:32Z",
+  "generated_at": "2025-10-13T21:40:09Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -380,7 +380,7 @@
         "hashed_secret": "b2817467154949a61f8e9ad31d1eeaf03221cbfa",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 133,
+        "line_number": 132,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/image/cli/mascli/functions/gitops_license
+++ b/image/cli/mascli/functions/gitops_license
@@ -90,7 +90,7 @@ function gitops_license_noninteractive() {
 
   [[ -z "$ACCOUNT_ID" ]] && gitops_license_help "ACCOUNT_ID is not set"
   [[ -z "$LICENSE_FILE" ]] && gitops_license_help "LICENSE_FILE is not set"
-  [[ -z "$ICN" ]] && gitops_license_help "ICN is not set"
+  ( [[ ! -z "$SAAS_SUB_ID" ]] && [[ -z "$ICN" ]] ) && gitops_license_help "ICN is not set"
 
 }
 

--- a/image/cli/mascli/functions/gitops_license
+++ b/image/cli/mascli/functions/gitops_license
@@ -91,7 +91,7 @@ function gitops_license_noninteractive() {
   [[ -z "$ACCOUNT_ID" ]] && gitops_license_help "ACCOUNT_ID is not set"
   [[ -z "$LICENSE_FILE" ]] && gitops_license_help "LICENSE_FILE is not set"
 
-  ([[ ! -z "$ICN" ]] && [[ -z "$SAAS_SUB_ID" ]]) && gitops_license_help "When ICN is set, SAAS_SUB_ID must also be set"
+  [[ ! -z "$ICN" ]] && gitops_license_help "ICN is not set"
 
 }
 
@@ -141,7 +141,7 @@ function gitops_license() {
   AVP_TYPE=aws
   sm_login
 
-  if [ ! -z "$ICN" ]; then
+  if [ ! -z "$SAAS_SUB_ID" ]; then
      export SECRET_NAME_LICENSE_FILE=${ACCOUNT_ID}${SECRETS_KEY_SEPARATOR}${ICN}${SECRETS_KEY_SEPARATOR}${SAAS_SUB_ID}${SECRETS_KEY_SEPARATOR}license
      TAGS="[{\"Key\": \"source\", \"Value\": \"gitops_license\"}, {\"Key\": \"account\", \"Value\": \"${ACCOUNT_ID}\"}, {\"Key\": \"subscription_id\", \"Value\": \"${SAAS_SUB_ID}\"}]"
   else

--- a/image/cli/mascli/functions/gitops_license
+++ b/image/cli/mascli/functions/gitops_license
@@ -90,8 +90,7 @@ function gitops_license_noninteractive() {
 
   [[ -z "$ACCOUNT_ID" ]] && gitops_license_help "ACCOUNT_ID is not set"
   [[ -z "$LICENSE_FILE" ]] && gitops_license_help "LICENSE_FILE is not set"
-
-  [[ ! -z "$ICN" ]] && gitops_license_help "ICN is not set"
+  [[ -z "$ICN" ]] && gitops_license_help "ICN is not set"
 
 }
 

--- a/tekton/src/pipelines/gitops/gitops-mas-instance.yml.j2
+++ b/tekton/src/pipelines/gitops/gitops-mas-instance.yml.j2
@@ -210,6 +210,10 @@ spec:
       type: string
     - name: sls_license_icn
       type: string
+      default: ""
+    - name: sls_subscription_id
+      type: string
+      default: ""
 
     # oidc parameters
     # ------------------------------------------------------------------------- 
@@ -281,6 +285,10 @@ spec:
           value: $(params.mas_instance_id)
         - name: avp_aws_secret_region
           value: $(params.avp_aws_secret_region)
+        - name: sls_license_icn
+          value: $(params.sls_license_icn)
+        - name: sls_subscription_id
+          value: $(params.sls_subscription_id)
       workspaces:
         - name: shared-entitlement
           workspace: shared-entitlement
@@ -311,8 +319,10 @@ spec:
           value: $(params.sls_license_customer_name)
         - name: country
           value: $(params.sls_license_country)
-        - name: icn
+        - name: sls_license_icn
           value: $(params.sls_license_icn)
+        - name: sls_subscription_id
+          value: $(params.sls_subscription_id)
       taskRef:
         kind: Task
         name: gitops-license-generator

--- a/tekton/src/tasks/gitops/gitops-license-generator.yml.j2
+++ b/tekton/src/tasks/gitops/gitops-license-generator.yml.j2
@@ -73,6 +73,7 @@ spec:
           mas gitops-license \
             -a ${ACCOUNT} \
             -c ${CLUSTER_NAME} \
+            -i ${ICN} \
             -m ${MAS_INSTANCE_ID} \
             --license-file /tmp/authorized_entitlement_saas.lic
           exit $?


### PR DESCRIPTION
## Issue
[MASCORE-8792](https://jsw.ibm.com/browse/mascore-8792)


## Description
The mas-instance pipeline is failing with "[User error] Validation failed for pipelinerun gitops-mas-instance-chglicense with error invalid input params for task gitops-license: missing values for these params which have no default values: [sls_license_icn sls_subscription_id]"

Update the instance pipeline to ensure missing parameters are present and handled correctly. 

## Test Results
4 Tests were conducted
1) Provision of standalone license service using specified license file.
<img width="1072" height="1175" alt="image" src="https://github.com/user-attachments/assets/f1c1494f-c6f4-440f-92f0-e9f2e224f74b" />
2) Provision of standalone license service with license generated by the pipeline
<img width="1302" height="1077" alt="image" src="https://github.com/user-attachments/assets/e8d98d8a-d024-4eaf-b4fa-64f370506c56" />
3) Provision/Update of existing mas instance with generated license file
<img width="1257" height="1139" alt="image" src="https://github.com/user-attachments/assets/6b6065cf-bffa-40a7-ab79-fa52c3b0f566" />
4) Provision/Update of existing mas instance with generated license file
<img width="1331" height="1281" alt="image" src="https://github.com/user-attachments/assets/b7508869-3895-4d7f-a1d0-2483c425bec2" />

## Backporting
Not Required

## Related Pull Requests
[SaaS-Task PR 20 ]((https://github.ibm.com/maximoappsuite/saas-task/pull/20)
[SaaS-Tekton PR 163]https://github.ibm.com/maximoappsuite/saas-tekton/pull/163)

<hr/>

### :warning: Notes for Reviewers
* Ensure you have understood the [guidelines](https://pages.github.ibm.com/maximoappsuite/playbook/tools/github/#guidelines) before proceeding with a review.
* Ensure all sections in the PR template are appropriately completed.