### PR TITLE
[patch] add jdbc-connection-url-additional-params to gitops_mas_config

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2025-10-06T11:47:32Z",
+  "generated_at": "2025-10-14T06:43:10Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -390,7 +390,7 @@
         "hashed_secret": "b2817467154949a61f8e9ad31d1eeaf03221cbfa",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 632,
+        "line_number": 636,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -398,7 +398,7 @@
         "hashed_secret": "effb7852555adce89885fb075fb43a77a1e0e77e",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 801,
+        "line_number": 805,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -406,7 +406,7 @@
         "hashed_secret": "2582aea6f911bd00fc04cb25e0ec16d5ead62068",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 803,
+        "line_number": 807,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/image/cli/mascli/functions/gitops_mas_config
+++ b/image/cli/mascli/functions/gitops_mas_config
@@ -59,6 +59,7 @@ JDBC Configuration (required if MAS_CONFIG_TYPE is "jdbc"):
   --jdbc-type ${COLOR_YELLOW}JDBC_TYPE${TEXT_RESET}                           Set to 'incluster-db2' when wanting to use the gitops configured, via gitops-db2u-database, db2u cluster (defaults to incluster-db2)
   --jdbc-instance-name ${COLOR_YELLOW}JDBC_INSTANCE_NAME${TEXT_RESET}         The JDBC instance name to use. Required for all JDBC_TYPE's
   --jdbc-connection-url ${COLOR_YELLOW}JDBC_CONNECTION_URL${TEXT_RESET}       The JDBC connection URL. Required when JDBC_TYPE is not incluster-db2
+  --jdbc-connection-url-additional-params ${COLOR_YELLOW}JDBC_CONNECTION_URL_ADDITIONAL_PARAMS${TEXT_RESET}  Additional parameters for JDBC connection URL
   --jdbc-certificate-file ${COLOR_YELLOW}JDBC_CERTIFICATE_FILE${TEXT_RESET}   Path to file containing CA Certificate for JDBC server. Required when JDBC_TYPE is not incluster-db2
   --jdbc-route ${COLOR_YELLOW}JDBC_ROUTE${TEXT_RESET}                         By default routes are not exposed to public. To expose route, set this to public.
 
@@ -211,6 +212,9 @@ function gitops_mas_config_noninteractive() {
         ;;
       --jdbc-connection-url)
         export JDBC_CONNECTION_URL=$1 && shift
+        ;;
+      --jdbc-connection-url-additional-params)
+        export JDBC_CONNECTION_URL_ADDITIONAL_PARAMS=$1 && shift
         ;;
       --jdbc-certificate-file)
         export JDBC_CERTIFICATE_FILE=$1 && shift

--- a/tekton/src/tasks/gitops/gitops-deprovision-suite-config.yml.j2
+++ b/tekton/src/tasks/gitops/gitops-deprovision-suite-config.yml.j2
@@ -119,7 +119,6 @@ spec:
         --mas-app-id "iot" \
         --dir /tmp/deprovision-suite-config-iotdb \
         --jdbc-type "$JDBC_TYPE_IOT" \
-
         --jdbc-connection-url-additional-params "$JDBC_CONNECTION_URL_ADDITIONAL_PARAMS_IOT" \
         --jdbc-route "$JDBC_ROUTE_IOT" \
         --jdbc-instance-name "$JDBC_INSTANCE_NAME_IOT" \

--- a/tekton/src/tasks/gitops/gitops-deprovision-suite-config.yml.j2
+++ b/tekton/src/tasks/gitops/gitops-deprovision-suite-config.yml.j2
@@ -119,7 +119,7 @@ spec:
         --mas-app-id "iot" \
         --dir /tmp/deprovision-suite-config-iotdb \
         --jdbc-type "$JDBC_TYPE_IOT" \
-        --jdbc_connection_url_additional_params "$JDBC_CONNECTION_URL_ADDITIONAL_PARAMS_IOT" \
+        --jdbc-connection-url-additional-params "$JDBC_CONNECTION_URL_ADDITIONAL_PARAMS_IOT" \
         --jdbc-route "$JDBC_ROUTE_IOT" \
         --jdbc-instance-name "$JDBC_INSTANCE_NAME_IOT" \
         || exit 1

--- a/tekton/src/tasks/gitops/gitops-deprovision-suite-config.yml.j2
+++ b/tekton/src/tasks/gitops/gitops-deprovision-suite-config.yml.j2
@@ -119,6 +119,7 @@ spec:
         --mas-app-id "iot" \
         --dir /tmp/deprovision-suite-config-iotdb \
         --jdbc-type "$JDBC_TYPE_IOT" \
+
         --jdbc-connection-url-additional-params "$JDBC_CONNECTION_URL_ADDITIONAL_PARAMS_IOT" \
         --jdbc-route "$JDBC_ROUTE_IOT" \
         --jdbc-instance-name "$JDBC_INSTANCE_NAME_IOT" \


### PR DESCRIPTION
Description:
Deprovision pipeline was failing as jdbc-connection-url-additional-params was not available in gitops_mas_config, So added it.

Test Result: 
Verified by deprovisiong a instance on noble7.
pipeline : https://cloud.ibm.com/devops/pipelines/tekton/39587f23-e891-42a3-ad41-da50d48e6693/runs/686aa387-eeab-4607-b57e-4ae92b4017e4/pipeline-launcher-task/launch?env_id=ibm:yp:us-south&view=logs

Related PR:
https://github.ibm.com/maximoappsuite/saas-tekton/pull/164