### PR TITLE
[patch] Fix manage deployment lua syntax error for gitops

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,15 +2,15 @@ default_language_version:
     python: python
 repos:
   - repo: https://github.com/hhatto/autopep8
-    rev: v2.3.1
+    rev: v2.3.2
     hooks:
     -   id: autopep8
   - repo: https://github.com/PyCQA/flake8
-    rev: 7.1.1
+    rev: 7.3.0
     hooks:
       - id: flake8
   - repo: https://github.com/ibm/detect-secrets
-    rev: 0.13.1+ibm.62.dss
+    rev: 0.13.1+ibm.64.dss
     hooks:
       - id: detect-secrets
         args: [--baseline, .secrets.baseline, --use-all-plugins, --fail-on-unaudited]

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,8 +3,7 @@
     "files": "^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2025-10-14T06:43:10Z",
-
+  "generated_at": "2025-10-20T12:26:06Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -857,7 +856,7 @@
       }
     ]
   },
-  "version": "0.13.1+ibm.62.dss",
+  "version": "0.13.1+ibm.64.dss",
   "word_list": {
     "file": null,
     "hash": null

--- a/image/cli/mascli/templates/gitops/bootstrap/argocd.yaml
+++ b/image/cli/mascli/templates/gitops/bootstrap/argocd.yaml
@@ -420,6 +420,7 @@ spec:
                 hs.status = "Healthy"
                 hs.message = "Bundle and DB both Ready"
                 return hs
+              end
             end
           end
           hs.status = "Progressing"

--- a/image/cli/mascli/templates/gitops/bootstrap/argocd.yaml
+++ b/image/cli/mascli/templates/gitops/bootstrap/argocd.yaml
@@ -1,4 +1,9 @@
 ---
+# !!! IMPORTANT !!!
+# Any changes to the healthchecks defined in this file (i.e. anything under spec.extraConfig.resource\.customizations)
+# must be synced to https://github.ibm.com/automation-paas-cd-pipeline/mas-extensions
+# Consult the README in that repo for instructions.
+
 apiVersion: argoproj.io/v1beta1
 kind: ArgoCD
 metadata:


### PR DESCRIPTION
Noticed a syntax error in our ArgoCD custom health check for the ManageDeployment CR.

Also added a note to remind developers to keep health checks in sync with mas-extensions.

Also updates pre-commit hook versions (resolves detect-secrets failure in build pipeline)