### PR TITLE
[patch] Adding keycloak environment variables that are needed for SAML FVTs

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2025-10-20T12:26:06Z",
+  "generated_at": "2025-10-22T12:41:23Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -760,7 +760,7 @@
         "hashed_secret": "d2e2ab0f407e4ee3cf2ab87d61c31b25a74085e5",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 27,
+        "line_number": 32,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/image/cli/masfvt/fvt-core.yml
+++ b/image/cli/masfvt/fvt-core.yml
@@ -63,6 +63,8 @@
           - ""
           - "keycloak_admin_username ..... ********"
           - "keycloak_admin_password ..... ********"
+          - "keycloak_base_url ........... {{ keycloak_base_url }}"
+          - "keycloak_realm_name ......... {{ keycloak_realm_name }}"
 
     - name: "Start FVT-core pipeline"
       kubernetes.core.k8s:

--- a/image/cli/masfvt/fvt-core.yml
+++ b/image/cli/masfvt/fvt-core.yml
@@ -28,6 +28,11 @@
     ldap_user_map: "{{ lookup('env', 'LDAP_USER_MAP') }}"
     ldap_cert_alias: "{{ lookup('env', 'LDAP_CERT_ALIAS') }}"
     ldap_crt: "{{ lookup('env', 'LDAP_CRT') }}"
+    keycloak_admin_username: "{{ lookup('env', 'KEYCLOAK_ADMIN_USERNAME') }}"
+    keycloak_admin_password: "{{ lookup('env', 'KEYCLOAK_ADMIN_PASSWORD') }}"
+    keycloak_base_url: "{{ lookup('env', 'KEYCLOAK_BASE_URL') }}"
+    keycloak_realm_name: "{{ lookup('env', 'KEYCLOAK_REALM_NAME') }}"
+
     # Pipeline Run Info
     devops_build_number: "{{ lookup('env', 'DEVOPS_BUILD_NUMBER') | default('0', True) }}"
     pipelinerun_name: "{{ lookup('env', 'PIPELINERUN_NAME') | default('mas-fvt-core', True) }}-{{ devops_build_number }}"
@@ -55,6 +60,9 @@
           - "ddp_apikey .................. {{ ddp_apikey }}"
           - "partium_username ............ ********"
           - "partium_password ............ ********"
+          - ""
+          - "keycloak_admin_username ..... ********"
+          - "keycloak_admin_password ..... ********"
 
     - name: "Start FVT-core pipeline"
       kubernetes.core.k8s:

--- a/tekton/src/tasks/fvt-launcher/mas-launchfvt-core.yml.j2
+++ b/tekton/src/tasks/fvt-launcher/mas-launchfvt-core.yml.j2
@@ -166,7 +166,30 @@ spec:
               name: mas-fvt-core
               key: LDAP_CRT
               optional: false
-
+        - name: KEYCLOAK_ADMIN_USERNAME
+          valueFrom:
+            secretKeyRef:
+              name: mas-fvt-core
+              key: KEYCLOAK_ADMIN_USERNAME
+              optional: false
+        - name: KEYCLOAK_ADMIN_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: mas-fvt-core
+              key: KEYCLOAK_ADMIN_PASSWORD
+              optional: false
+        - name: KEYCLOAK_BASE_URL
+          valueFrom:
+            secretKeyRef:
+              name: mas-fvt-core
+              key: KEYCLOAK_BASE_URL
+              optional: false
+        - name: KEYCLOAK_REALM_NAME
+          valueFrom:
+            secretKeyRef:
+              name: mas-fvt-core
+              key: KEYCLOAK_REALM_NAME
+              optional: false
     - name: wait-for-pipelinerun
       image: quay.io/ibmmas/cli:latest
       imagePullPolicy: $(params.image_pull_policy)

--- a/tekton/src/tasks/fvt/mas-fvt-core.yml.j2
+++ b/tekton/src/tasks/fvt/mas-fvt-core.yml.j2
@@ -178,6 +178,30 @@ spec:
             name: mas-fvt-core
             key: LDAP_CRT
             optional: false
+      - name: KEYCLOAK_ADMIN_USERNAME
+        valueFrom:
+          secretKeyRef:
+            name: mas-fvt-core
+            key: KEYCLOAK_ADMIN_USERNAME
+            optional: false
+      - name: KEYCLOAK_ADMIN_PASSWORD
+        valueFrom:
+          secretKeyRef:
+            name: mas-fvt-core
+            key: KEYCLOAK_ADMIN_PASSWORD
+            optional: false
+      - name: KEYCLOAK_BASE_URL
+        valueFrom:
+          secretKeyRef:
+            name: mas-fvt-core
+            key: KEYCLOAK_BASE_URL
+            optional: false
+      - name: KEYCLOAK_REALM_NAME
+        valueFrom:
+          secretKeyRef:
+            name: mas-fvt-core
+            key: KEYCLOAK_REALM_NAME
+            optional: false
 
   steps:
     - image: '$(params.fvt_image_registry)/mas-devops/fvt-ibm-mas@$(params.fvt_image_digest)'

--- a/tekton/src/tasks/fvt/mas-fvt-run-suite.yml.j2
+++ b/tekton/src/tasks/fvt/mas-fvt-run-suite.yml.j2
@@ -183,6 +183,30 @@ spec:
             name: mas-fvt-core
             key: PARTIUM_PASSWORD
             optional: true
+      - name: KEYCLOAK_ADMIN_USERNAME
+        valueFrom:
+          secretKeyRef:
+            name: mas-fvt-core
+            key: KEYCLOAK_ADMIN_USERNAME
+            optional: false
+      - name: KEYCLOAK_ADMIN_PASSWORD
+        valueFrom:
+          secretKeyRef:
+            name: mas-fvt-core
+            key: KEYCLOAK_ADMIN_PASSWORD
+            optional: false
+      - name: KEYCLOAK_BASE_URL
+        valueFrom:
+          secretKeyRef:
+            name: mas-fvt-core
+            key: KEYCLOAK_BASE_URL
+            optional: false
+      - name: KEYCLOAK_REALM_NAME
+        valueFrom:
+          secretKeyRef:
+            name: mas-fvt-core
+            key: KEYCLOAK_REALM_NAME
+            optional: false
 # To enable collection of logs and screenshots
       - name: ARTIFACTORY_TOKEN
         valueFrom:


### PR DESCRIPTION
The new keycloak environment variables are needed for SAML UI FVTs, that integrate with Keycloak IDP test server.
All SAML UI tests passed, which means the keycloak variables were available for the tests to use.
<img width="389" height="460" alt="image" src="https://github.com/user-attachments/assets/194cc099-df49-4f9e-bd18-5561e67374cf" />
