### PR TITLE
[patch] Remove params for defunct redhat-operators-mirror application for gitops

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "build/bin/config/oscap/ssg-rhel9-ds.xml|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2025-10-24T15:33:48Z",
+  "generated_at": "2025-10-30T11:01:08Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -242,7 +242,7 @@
         "hashed_secret": "b2817467154949a61f8e9ad31d1eeaf03221cbfa",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 514,
+        "line_number": 494,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/image/cli/mascli/functions/gitops_cluster
+++ b/image/cli/mascli/functions/gitops_cluster
@@ -37,12 +37,6 @@ Operator Catalog (Optional):
 Redhat Cert Manager (Optional):
       --install-redhat-cert-manager ${COLOR_YELLOW}INSTALL_REDHAT_CERT_MANAGER${TEXT_RESET}                                      Install RedHat Cert Manager (default to true)  
       --redhat-cert-manager-install-plan ${COLOR_YELLOW}REDHAT_CERT_MANAGER_INSTALL_PLAN${TEXT_RESET}                            Set Redhat Cert manager subscription install plan approval ('Automatic' or 'Manual'. Default is 'Automatic')
-      --redhat-cert-manager-catalog-source ${COLOR_YELLOW}REDHAT_CERT_MANAGER_CATALOG_SOURCE${TEXT_RESET}                        Set Redhat Cert manager catalog source. Only required for mirroring.
-      --redhat_cert_manager_catalog_source_namespace ${COLOR_YELLOW}REDHAT_CERT_MANAGER_CATALOG_SOURCE_NAMESPACE${TEXT_RESET}    Set Redhat Cert manager catalog source namespace.  Only required for mirroring.
-
-Redhat Operators Catalog Mirror (Optional):
-      --redhat_operators_mirror_catalog_version ${COLOR_YELLOW}REDHAT_OPERATORS_MIRROR_CATALOG_VERSION${TEXT_RESET}              Set Redhat Operators Mirror Catalog Version. Only required for mirroring.
-      --redhat-operators-mirror-catalog-image ${COLOR_YELLOW}REDHAT_OPERATORS_MIRROR_CATALOG_IMAGE${TEXT_RESET}                  Set Redhat Operators Mirror Catalog Image. Only required for mirroring.
 
 IBM CIS Cert Manager:
       --dns-provider ${COLOR_YELLOW}DNS_PROVIDER${TEXT_RESET}                         DNS Provider, Currently supported CIS (Akamai support inprogress)
@@ -203,20 +197,6 @@ function gitops_cluster_noninteractive() {
         ;;
       --redhat-cert-manager-install-plan)
         export REDHAT_CERT_MANAGER_INSTALL_PLAN=$1 && shift
-        ;;
-      --redhat-cert-manager-catalog-source) 
-        export REDHAT_CERT_MANAGER_CATALOG_SOURCE=$1 && shift
-        ;;
-      --redhat-cert-manager-catalog-source-namespace)
-        export REDHAT_CERT_MANAGER_CATALOG_SOURCE_NAMESPACE=$1 && shift
-        ;;
-
-      # Redhat Operators Mirror Catalog
-      --redhat-operators-mirror-catalog-version)
-        export REDHAT_OPERATORS_MIRROR_CATALOG_VERSION=$1 && shift
-        ;;
-      --redhat-operators-mirror-catalog-image)
-        export REDHAT_OPERATORS_MIRROR_CATALOG_IMAGE=$1 && shift
         ;;
 
       # MAS CLI
@@ -527,19 +507,8 @@ function gitops_cluster() {
   echo_reset_dim "Install RedHat Cert Manager .................................................. ${COLOR_MAGENTA}${INSTALL_REDHAT_CERT_MANAGER}"
   if [[ "$INSTALL_REDHAT_CERT_MANAGER" == "true" ]]; then
     echo_reset_dim "Redhat Certificate Manager Subscription Install Plan Approval ................ ${COLOR_MAGENTA}${REDHAT_CERT_MANAGER_INSTALL_PLAN}"
-    echo_reset_dim "Redhat Certificate Manager Catalog Source .................................... ${COLOR_MAGENTA}${REDHAT_CERT_MANAGER_CATALOG_SOURCE}"
-    echo_reset_dim "Redhat Certificate Manager Catalog Source namespace .......................... ${COLOR_MAGENTA}${REDHAT_CERT_MANAGER_CATALOG_SOURCE_NAMESPACE}"
   fi
   reset_colors
-
-  if [[ -n "$REDHAT_OPERATORS_MIRROR_CATALOG_IMAGE" ]]; then
-    echo "${TEXT_DIM}"
-    echo_h2 "RedHat Operators Mirror Catalog" "    "
-    echo_reset_dim "RedHat Operators Mirror Catalog Version ................................. ${COLOR_MAGENTA}${REDHAT_OPERATORS_MIRROR_CATALOG_VERSION}"
-    echo_reset_dim "RedHat Operators Mirror Catalog Image ................................... ${COLOR_MAGENTA}${REDHAT_OPERATORS_MIRROR_CATALOG_IMAGE}"
-    reset_colors
-  fi
-
 
   echo "${TEXT_DIM}"
   echo_h2 "Cluster Promotion" "    "
@@ -785,11 +754,6 @@ function gitops_cluster() {
   if [[ "$INSTALL_REDHAT_CERT_MANAGER" == "true" ]]; then
     echo "- Redhat Cert Manager"
     jinjanate_commmon $CLI_DIR/templates/gitops/appset-configs/cluster/phase1/redhat-cert-manager.yaml.j2 ${GITOPS_CLUSTER_DIR}/redhat-cert-manager.yaml
-  fi
-
-  if [[ -n "$REDHAT_OPERATORS_MIRROR_CATALOG_IMAGE" ]]; then
-    echo "- RedHat Opertors Mirror Catalog"
-    jinjanate_commmon $CLI_DIR/templates/gitops/appset-configs/cluster/phase1/redhat-operators-mirror-catalog.yaml.j2 ${GITOPS_CLUSTER_DIR}/redhat-operators-mirror-catalog.yaml
   fi
 
   if [[ "$INSTALL_SELENIUM_GRID" == "true" ]]; then

--- a/image/cli/mascli/templates/gitops/appset-configs/cluster/phase1/redhat-cert-manager.yaml.j2
+++ b/image/cli/mascli/templates/gitops/appset-configs/cluster/phase1/redhat-cert-manager.yaml.j2
@@ -4,9 +4,3 @@ redhat_cert_manager:
    run_sync_hooks: true
    channel: stable-v1
    redhat_cert_manager_install_plan: "{{ REDHAT_CERT_MANAGER_INSTALL_PLAN }}"
-{%- if REDHAT_CERT_MANAGER_CATALOG_SOURCE is defined and REDHAT_CERT_MANAGER_CATALOG_SOURCE !='' %}
-   catalog_source: "{{ REDHAT_CERT_MANAGER_CATALOG_SOURCE }}"
-{%- endif %}
-{%- if REDHAT_CERT_MANAGER_CATALOG_SOURCE_NAMESPACE is defined and REDHAT_CERT_MANAGER_CATALOG_SOURCE_NAMESPACE !='' %}
-   catalog_source_namespace: "{{ REDHAT_CERT_MANAGER_CATALOG_SOURCE_NAMESPACE }}"
-{%- endif %}

--- a/image/cli/mascli/templates/gitops/appset-configs/cluster/phase1/redhat-operators-mirror-catalog.yaml.j2
+++ b/image/cli/mascli/templates/gitops/appset-configs/cluster/phase1/redhat-operators-mirror-catalog.yaml.j2
@@ -1,5 +1,0 @@
-merge-key: "{{ ACCOUNT_ID }}/{{ CLUSTER_ID }}"
-
-redhat_operators_mirror_catalog:
-   catalog_version: "{{ REDHAT_OPERATORS_MIRROR_CATALOG_VERSION }}"
-   catalog_image: "{{ REDHAT_OPERATORS_MIRROR_CATALOG_IMAGE }}"


### PR DESCRIPTION
The redhat-operators-mirror catalog is unnecessary and so has been removed to avoid confusion.
This PR removes the associated (optional) params from the CLI. Nothing is using these params to removing them will not break anything (and why this change does not need to be major).

# Testing

Verified that gitops-cluster command works as before.

