### PR TITLE
[minor] Add Turbonomic integration to OCP provision functions

### DIFF
--- a/.github/workflows/build-cli.yml
+++ b/.github/workflows/build-cli.yml
@@ -174,23 +174,7 @@ jobs:
           $GITHUB_WORKSPACE/build/bin/initbuild.sh
           source $GITHUB_WORKSPACE/build/bin/.functions.sh
 
-      # 2. Download Ansible collection from Artifactory
-      # -------------------------------------------------------------------------------------------
-      - name: Download Ansible collection from Artifactory
-        id: download-ansible
-        if: contains(fromJson('["push", "workflow_dispatch", "repository_dispatch"]'), github.event_name)
-        env:
-          ARTIFACTORY_GENERIC_RELEASE_URL: ${{ secrets.ARTIFACTORY_GENERIC_RELEASE_URL }}
-          ARTIFACTORY_TOKEN: ${{ secrets.ARTIFACTORY_TOKEN }}
-        run: |
-          if [[ -e $GITHUB_WORKSPACE/image/cli/install/ibm-mas_devops.tar.gz ]]; then
-            echo "Found a local Ansible collection to be used in $GITHUB_WORKSPACE/image/cli/install/ibm-mas_devops.tar.gz! Skip download from Artifactory..."
-          else
-            echo "Downloading from ***/ibm-mas/ansible-devops/latest/ibm-mas_devops-latest.tar.gz"
-            wget --header="Authorization:Bearer $ARTIFACTORY_TOKEN" $ARTIFACTORY_GENERIC_RELEASE_URL/ibm-mas/ansible-devops/latest/ibm-mas_devops-latest.tar.gz -O $GITHUB_WORKSPACE/image/cli/install/ibm-mas_devops.tar.gz
-          fi
-
-      # 3. Download Built Artifacts
+      # 2. Download Built Artifacts
       # -------------------------------------------------------------------------------------------
       - name: Download the tekton file built in the other job
         id: download-tekton
@@ -206,7 +190,7 @@ jobs:
           name: mas_cli.tar.gz
           path: ${{ github.workspace }}/image/cli/install/
 
-      # 4. CLI Container Images
+      # 3. CLI Container Images
       # -------------------------------------------------------------------------------------------
       - name: Build the container image
         id: docker-build
@@ -254,23 +238,7 @@ jobs:
           $GITHUB_WORKSPACE/build/bin/initbuild.sh
           source $GITHUB_WORKSPACE/build/bin/.functions.sh
 
-      # 2. Download Ansible collection from Artifactory
-      # -------------------------------------------------------------------------------------------
-      - name: Download Ansible collection from Artifactory
-        id: download-ansible
-        if: contains(fromJson('["push", "workflow_dispatch", "repository_dispatch"]'), github.event_name)
-        env:
-          ARTIFACTORY_GENERIC_RELEASE_URL: ${{ secrets.ARTIFACTORY_GENERIC_RELEASE_URL }}
-          ARTIFACTORY_TOKEN: ${{ secrets.ARTIFACTORY_TOKEN }}
-        run: |
-          if [[ -e $GITHUB_WORKSPACE/image/cli/install/ibm-mas_devops.tar.gz ]]; then
-            echo "Found a local Ansible collection to be used in $GITHUB_WORKSPACE/image/cli/install/ibm-mas_devops.tar.gz! Skip download from Artifactory..."
-          else
-            echo "Downloading from ***/ibm-mas/ansible-devops/latest/ibm-mas_devops-latest.tar.gz"
-            wget --header="Authorization:Bearer $ARTIFACTORY_TOKEN" $ARTIFACTORY_GENERIC_RELEASE_URL/ibm-mas/ansible-devops/latest/ibm-mas_devops-latest.tar.gz -O $GITHUB_WORKSPACE/image/cli/install/ibm-mas_devops.tar.gz
-          fi
-
-      # 3. Download Built Artifacts
+      # 2. Download Built Artifacts
       # -------------------------------------------------------------------------------------------
       - name: Download the tekton file built in the other job
         id: download-tekton
@@ -286,7 +254,7 @@ jobs:
           name: mas_cli.tar.gz
           path: ${{ github.workspace }}/image/cli/install/
 
-      # 4. CLI Container Images
+      # 3. CLI Container Images
       # -------------------------------------------------------------------------------------------
       - name: Build the container image
         id: docker-build
@@ -333,23 +301,7 @@ jobs:
           $GITHUB_WORKSPACE/build/bin/initbuild.sh
           source $GITHUB_WORKSPACE/build/bin/.functions.sh
 
-      # 2. Download Ansible collection from Artifactory
-      # -------------------------------------------------------------------------------------------
-      - name: Download Ansible collection from Artifactory
-        id: download-ansible
-        if: contains(fromJson('["push", "workflow_dispatch", "repository_dispatch"]'), github.event_name)
-        env:
-          ARTIFACTORY_GENERIC_RELEASE_URL: ${{ secrets.ARTIFACTORY_GENERIC_RELEASE_URL }}
-          ARTIFACTORY_TOKEN: ${{ secrets.ARTIFACTORY_TOKEN }}
-        run: |
-          if [[ -e $GITHUB_WORKSPACE/image/cli/install/ibm-mas_devops.tar.gz ]]; then
-            echo "Found a local Ansible collection to be used in $GITHUB_WORKSPACE/image/cli/install/ibm-mas_devops.tar.gz! Skip download from Artifactory..."
-          else
-            echo "Downloading from ***/ibm-mas/ansible-devops/latest/ibm-mas_devops-latest.tar.gz"
-            wget --header="Authorization:Bearer $ARTIFACTORY_TOKEN" $ARTIFACTORY_GENERIC_RELEASE_URL/ibm-mas/ansible-devops/latest/ibm-mas_devops-latest.tar.gz -O $GITHUB_WORKSPACE/image/cli/install/ibm-mas_devops.tar.gz
-          fi
-
-      # 3. Download Built Artifacts
+      # 2. Download Built Artifacts
       # -------------------------------------------------------------------------------------------
       - name: Download the tekton file built in the other job
         id: download-tekton
@@ -365,7 +317,7 @@ jobs:
           name: mas_cli.tar.gz
           path: ${{ github.workspace }}/image/cli/install/
 
-      # 4. CLI Container Images
+      # 3. CLI Container Images
       # -------------------------------------------------------------------------------------------
       - name: Build the container image
         id: docker-build
@@ -412,23 +364,7 @@ jobs:
           $GITHUB_WORKSPACE/build/bin/initbuild.sh
           source $GITHUB_WORKSPACE/build/bin/.functions.sh
 
-      # 2. Download Ansible collection from Artifactory
-      # -------------------------------------------------------------------------------------------
-      - name: Download Ansible collection from Artifactory
-        id: download-ansible
-        if: contains(fromJson('["push", "workflow_dispatch", "repository_dispatch"]'), github.event_name)
-        env:
-          ARTIFACTORY_GENERIC_RELEASE_URL: ${{ secrets.ARTIFACTORY_GENERIC_RELEASE_URL }}
-          ARTIFACTORY_TOKEN: ${{ secrets.ARTIFACTORY_TOKEN }}
-        run: |
-          if [[ -e $GITHUB_WORKSPACE/image/cli/install/ibm-mas_devops.tar.gz ]]; then
-            echo "Found a local Ansible collection to be used in $GITHUB_WORKSPACE/image/cli/install/ibm-mas_devops.tar.gz! Skip download from Artifactory..."
-          else
-            echo "Downloading from ***/ibm-mas/ansible-devops/latest/ibm-mas_devops-latest.tar.gz"
-            wget --header="Authorization:Bearer $ARTIFACTORY_TOKEN" $ARTIFACTORY_GENERIC_RELEASE_URL/ibm-mas/ansible-devops/latest/ibm-mas_devops-latest.tar.gz -O $GITHUB_WORKSPACE/image/cli/install/ibm-mas_devops.tar.gz
-          fi
-
-      # 3. Download Built Artifacts
+      # 2. Download Built Artifacts
       # -------------------------------------------------------------------------------------------
       - name: Download the tekton file built in the other job
         id: download-tekton
@@ -444,7 +380,7 @@ jobs:
           name: mas_cli.tar.gz
           path: ${{ github.workspace }}/image/cli/install/
 
-      # 4. CLI Container Images
+      # 3. CLI Container Images
       # -------------------------------------------------------------------------------------------
       - name: Build the container image
         id: docker-build
@@ -474,7 +410,7 @@ jobs:
       - build-amd64-container
       - build-s390x-container
       - build-arm64-container
-      - build-ppc64le-container 
+      - build-ppc64le-container
     if: ${{ !contains(github.event.head_commit.message, '[doc]') }}
     steps:
       - name: Checkout

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "build/bin/config/oscap/ssg-rhel9-ds.xml|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2025-11-03T10:05:27Z",
+  "generated_at": "2025-11-03T17:22:33Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -232,7 +232,7 @@
         "hashed_secret": "b2817467154949a61f8e9ad31d1eeaf03221cbfa",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 139,
+        "line_number": 145,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "build/bin/config/oscap/ssg-rhel9-ds.xml|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2025-10-30T11:01:08Z",
+  "generated_at": "2025-11-03T10:05:27Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -493,26 +493,6 @@
         "is_secret": false,
         "is_verified": false,
         "line_number": 728,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
-    "image/cli/mascli/functions/provision_fyre": [
-      {
-        "hashed_secret": "2582aea6f911bd00fc04cb25e0ec16d5ead62068",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 346,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
-    "image/cli/mascli/functions/provision_roks": [
-      {
-        "hashed_secret": "e62334bcf07206e5aacba407fb29c1b85540d61f",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 219,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/build/bin/docker-build.sh
+++ b/build/bin/docker-build.sh
@@ -62,6 +62,8 @@ echo "VERSION_LABEL .... $DOCKER_TAG"
 echo "RELEASE_LABEL .... $GITHUB_RUN_ID"
 echo "VCS_REF .......... $GITHUB_SHA"
 echo "VCS_URL .......... https://github.com/$GITHUB_REPOSITORY"
+echo "GITHUB_REF_TYPE .. $GITHUB_REF_TYPE"
+echo "GITHUB_REF_NAME .. $GITHUB_REF_NAME"
 
 install_buildx
 
@@ -81,10 +83,10 @@ docker buildx build --progress plain \
   --build-arg RELEASE_LABEL=$GITHUB_RUN_ID \
   --build-arg VCS_REF=$GITHUB_SHA \
   --build-arg VCS_URL=https://github.com/$GITHUB_REPOSITORY \
-  --secret id=ARTIFACTORY_TOKEN,env=ARTIFACTORY_TOKEN \
-  --secret id=ARTIFACTORY_GENERIC_RELEASE_URL,env=ARTIFACTORY_GENERIC_RELEASE_URL \
-  --secret id=GITHUB_REF_NAME,env=GITHUB_REF_NAME \
-  --secret id=GITHUB_REF_TYPE,env=GITHUB_REF_TYPE \
+  --secret id=ARTIFACTORY_TOKEN \
+  --secret id=ARTIFACTORY_GENERIC_RELEASE_URL \
+  --secret id=GITHUB_REF_NAME \
+  --secret id=GITHUB_REF_TYPE \
   -t $LOCAL_TAG $EXTRA_PARAMS -f $DOCKERFILE $BUILDPATH || exit 1
 
 # 5. Generate OSCAP(Security Content Automation Protocol) report

--- a/build/bin/docker-build.sh
+++ b/build/bin/docker-build.sh
@@ -81,6 +81,10 @@ docker buildx build --progress plain \
   --build-arg RELEASE_LABEL=$GITHUB_RUN_ID \
   --build-arg VCS_REF=$GITHUB_SHA \
   --build-arg VCS_URL=https://github.com/$GITHUB_REPOSITORY \
+  --secret id=ARTIFACTORY_TOKEN,env=ARTIFACTORY_TOKEN \
+  --secret id=ARTIFACTORY_GENERIC_RELEASE_URL,env=ARTIFACTORY_GENERIC_RELEASE_URL \
+  --secret id=GITHUB_REF_NAME,env=GITHUB_REF_NAME \
+  --secret id=GITHUB_REF_TYPE,env=GITHUB_REF_TYPE \
   -t $LOCAL_TAG $EXTRA_PARAMS -f $DOCKERFILE $BUILDPATH || exit 1
 
 # 5. Generate OSCAP(Security Content Automation Protocol) report
@@ -101,8 +105,8 @@ if [[ "$TARGET_PLATFORM" == "amd64" ]]; then
       sudo $DIR/oscap-docker.sh $REPOSITORY:$DOCKER_TAG-$TARGET_PLATFORM xccdf eval --report $OSCAP_DIR/$image_name-report.html --results $OSCAP_DIR/$image_name-results.xml --profile stig $CONFIG_DIR/oscap/${SCAP_DATA_STREAM}.xml
     fi
     sudo oscap xccdf generate fix --fix-type bash --output $OSCAP_DIR/$image_name-remediation.sh --result-id xccdf_org.open-scap_testresult_xccdf_org.ssgproject.content_profile_stig $OSCAP_DIR/$image_name-results.xml
-    
-    # Upload the results to Artifactory    
+
+    # Upload the results to Artifactory
     artifactory_upload $OSCAP_DIR/$image_name-report.html $ARTIFACTORY_GENERIC_RELEASE_URL/ibm-mas/$image_name/$DOCKER_TAG/$image_name-report.html
     artifactory_upload $OSCAP_DIR/$image_name-results.xml $ARTIFACTORY_GENERIC_RELEASE_URL/ibm-mas/$image_name/$DOCKER_TAG/$image_name-results.xml
   fi

--- a/image/cli/Dockerfile
+++ b/image/cli/Dockerfile
@@ -29,7 +29,6 @@ ENV ANSIBLE_COLLECTIONS_PATH=/opt/app-root/lib64/python3.9/site-packages/ansible
 # 4. Install Ansible collections
 # 5. Disable ibmcloud cli's new version check
 # 6. Set file permissions to be developer (hack) friendly
-RUN ls /tmp/install
 COPY install /tmp/install
 RUN umask 0002 && \
     ls /tmp/install && \

--- a/image/cli/Dockerfile
+++ b/image/cli/Dockerfile
@@ -29,6 +29,7 @@ ENV ANSIBLE_COLLECTIONS_PATH=/opt/app-root/lib64/python3.9/site-packages/ansible
 # 4. Install Ansible collections
 # 5. Disable ibmcloud cli's new version check
 # 6. Set file permissions to be developer (hack) friendly
+RUN ls /tmp/install
 COPY install /tmp/install
 RUN umask 0002 && \
     ls /tmp/install && \

--- a/image/cli/Dockerfile
+++ b/image/cli/Dockerfile
@@ -4,6 +4,12 @@ ARG VERSION_LABEL
 # Auto-expire the image in quay.io after 3 weeks
 LABEL quay.expires-after=3w
 
+# Set up Artifactory secrets
+RUN --mount=type=secret,id=ARTIFACTORY_TOKEN,env=ARTIFACTORY_TOKEN
+RUN --mount=type=secret,id=ARTIFACTORY_GENERIC_RELEASE_URL,env=ARTIFACTORY_GENERIC_RELEASE_URL
+RUN --mount=type=secret,id=GITHUB_REF_NAME,env=GITHUB_REF_NAME
+RUN --mount=type=secret,id=GITHUB_REF_TYPE,env=GITHUB_REF_TYPE
+
 # 1. Copy basics
 COPY app-root/src/ /opt/app-root/src/
 COPY mascli/ /mascli/

--- a/image/cli/Dockerfile
+++ b/image/cli/Dockerfile
@@ -4,7 +4,7 @@ ARG VERSION_LABEL
 # Auto-expire the image in quay.io after 3 weeks
 LABEL quay.expires-after=3w
 
-# Set up Artifactory secrets
+# Secrets for install-ansible-collections.sh
 RUN --mount=type=secret,id=ARTIFACTORY_TOKEN,env=ARTIFACTORY_TOKEN
 RUN --mount=type=secret,id=ARTIFACTORY_GENERIC_RELEASE_URL,env=ARTIFACTORY_GENERIC_RELEASE_URL
 RUN --mount=type=secret,id=GITHUB_REF_NAME,env=GITHUB_REF_NAME

--- a/image/cli/Dockerfile
+++ b/image/cli/Dockerfile
@@ -4,12 +4,6 @@ ARG VERSION_LABEL
 # Auto-expire the image in quay.io after 3 weeks
 LABEL quay.expires-after=3w
 
-# Secrets for install-ansible-collections.sh
-RUN --mount=type=secret,id=ARTIFACTORY_TOKEN,env=ARTIFACTORY_TOKEN
-RUN --mount=type=secret,id=ARTIFACTORY_GENERIC_RELEASE_URL,env=ARTIFACTORY_GENERIC_RELEASE_URL
-RUN --mount=type=secret,id=GITHUB_REF_NAME,env=GITHUB_REF_NAME
-RUN --mount=type=secret,id=GITHUB_REF_TYPE,env=GITHUB_REF_TYPE
-
 # 1. Copy basics
 COPY app-root/src/ /opt/app-root/src/
 COPY mascli/ /mascli/
@@ -30,7 +24,11 @@ ENV ANSIBLE_COLLECTIONS_PATH=/opt/app-root/lib64/python3.9/site-packages/ansible
 # 5. Disable ibmcloud cli's new version check
 # 6. Set file permissions to be developer (hack) friendly
 COPY install /tmp/install
-RUN umask 0002 && \
+RUN --mount=type=secret,id=ARTIFACTORY_TOKEN,env=ARTIFACTORY_TOKEN \
+    --mount=type=secret,id=ARTIFACTORY_GENERIC_RELEASE_URL,env=ARTIFACTORY_GENERIC_RELEASE_URL \
+    --mount=type=secret,id=GITHUB_REF_NAME,env=GITHUB_REF_NAME \
+    --mount=type=secret,id=GITHUB_REF_TYPE,env=GITHUB_REF_TYPE \
+    umask 0002 && \
     ls /tmp/install && \
     bash /tmp/install/install-python-packages.sh && \
     bash /tmp/install/install-ansible-collections.sh && \

--- a/image/cli/app-root/src/ansible.cfg
+++ b/image/cli/app-root/src/ansible.cfg
@@ -5,7 +5,8 @@ library = /opt/ansible/library
 
 # Enable junit result file generation
 callbacks_enabled = junit
-stdout_callback = yaml
+stdout_callback = default
+result_format=yaml
 
 # Verbosity: 0 (low) - 7 (high)
 verbosity = 1

--- a/image/cli/install/install-ansible-collections.sh
+++ b/image/cli/install/install-ansible-collections.sh
@@ -19,6 +19,7 @@ elif [[ "$GITHUB_REF_NAME" != "master" ]] && [[ "$GITHUB_REF_TYPE" == "branch" ]
     curl -H "Authorization:Bearer $ARTIFACTORY_TOKEN" $BRANCH_TARGET_URL -o /tmp/install/ibm-mas_devops.tar.gz
     if [[ "$?" == "0" ]]; then
         echo "Installing matching branch build of ansible-devops from Artifactory"
+        tar -tzf /tmp/install/ibm-mas_devops.tar.gz
         ansible-galaxy collection install /tmp/install/ibm-mas_devops.tar.gz -p $ANSIBLE_COLLECTIONS_PATH
     else
         echo "Installing release build of ansible-devops from Galaxy (branch build)"

--- a/image/cli/install/install-ansible-collections.sh
+++ b/image/cli/install/install-ansible-collections.sh
@@ -1,6 +1,22 @@
 #!/bin/bash
 
-if [[ -e /tmp/install/ibm-mas_devops.tar.gz ]]
-then ansible-galaxy collection install /tmp/install/ibm-mas_devops.tar.gz -p $ANSIBLE_COLLECTIONS_PATH
-else ansible-galaxy collection install ibm.mas_devops
+# If the local file is present, defer to this
+# Otherwise, check for a matching branch name in Artifactory
+# Otherwise, install the most recent version from Galaxy
+if [[ -e /tmp/install/ibm-mas_devops.tar.gz ]]; then
+    echo "Installing local build of ansible-devops from archive"
+    ansible-galaxy collection install /tmp/install/ibm-mas_devops.tar.gz -p $ANSIBLE_COLLECTIONS_PATH
+elif [[ "$GITHUB_REF_NAME" != "master" ]] && [[ "$GITHUB_REF_TYPE" == "branch" ]]
+    BRANCH_TARGET_URL="${ARTIFACTORY_GENERIC_RELEASE_URL}/ansible-devops/branches/ibm-mas_devops-${GITHUB_REF_NAME}.tar.gz"
+    curl -H "Authorization:Bearer $ARTIFACTORY_TOKEN" $BRANCH_TARGET_URL -o /tmp/install/ibm-mas_devops.tar.gz
+    if [[ "$?" == "0" ]]; then
+        echo "Installing matching branch build of ansible-devops from Artifactory"
+        ansible-galaxy collection install /tmp/install/ibm-mas_devops.tar.gz -p $ANSIBLE_COLLECTIONS_PATH
+    else
+        echo "Installing release build of ansible-devops from Galaxy"
+        ansible-galaxy collection install ibm.mas_devops
+    fi
+else
+    echo "Installing release build of ansible-devops from Galaxy"
+    ansible-galaxy collection install ibm.mas_devops
 fi

--- a/image/cli/install/install-ansible-collections.sh
+++ b/image/cli/install/install-ansible-collections.sh
@@ -15,11 +15,12 @@ if [[ -e /tmp/install/ibm-mas_devops.tar.gz ]]; then
     echo "Installing local build of ansible-devops from archive"
     ansible-galaxy collection install /tmp/install/ibm-mas_devops.tar.gz -p $ANSIBLE_COLLECTIONS_PATH
 elif [[ "$GITHUB_REF_NAME" != "master" ]] && [[ "$GITHUB_REF_TYPE" == "branch" ]]; then
-    BRANCH_TARGET_URL="${ARTIFACTORY_GENERIC_RELEASE_URL}/ansible-devops/branches/ibm-mas_devops-${GITHUB_REF_NAME}.tar.gz"
+    # Download and validate the archive
+    BRANCH_TARGET_URL="${ARTIFACTORY_GENERIC_RELEASE_URL}/ibm-mas/ansible-devops/branches/ibm-mas_devops-${GITHUB_REF_NAME}.tar.gz"
     curl -H "Authorization:Bearer $ARTIFACTORY_TOKEN" $BRANCH_TARGET_URL -o /tmp/install/ibm-mas_devops.tar.gz
+    tar -tzf /tmp/install/ibm-mas_devops.tar.gz
     if [[ "$?" == "0" ]]; then
         echo "Installing matching branch build of ansible-devops from Artifactory"
-        tar -tzf /tmp/install/ibm-mas_devops.tar.gz
         ansible-galaxy collection install /tmp/install/ibm-mas_devops.tar.gz -p $ANSIBLE_COLLECTIONS_PATH
     else
         echo "Installing release build of ansible-devops from Galaxy (branch build)"

--- a/image/cli/install/install-ansible-collections.sh
+++ b/image/cli/install/install-ansible-collections.sh
@@ -6,7 +6,7 @@
 if [[ -e /tmp/install/ibm-mas_devops.tar.gz ]]; then
     echo "Installing local build of ansible-devops from archive"
     ansible-galaxy collection install /tmp/install/ibm-mas_devops.tar.gz -p $ANSIBLE_COLLECTIONS_PATH
-elif [[ "$GITHUB_REF_NAME" != "master" ]] && [[ "$GITHUB_REF_TYPE" == "branch" ]]
+elif [[ "$GITHUB_REF_NAME" != "master" ]] && [[ "$GITHUB_REF_TYPE" == "branch" ]]; then
     BRANCH_TARGET_URL="${ARTIFACTORY_GENERIC_RELEASE_URL}/ansible-devops/branches/ibm-mas_devops-${GITHUB_REF_NAME}.tar.gz"
     curl -H "Authorization:Bearer $ARTIFACTORY_TOKEN" $BRANCH_TARGET_URL -o /tmp/install/ibm-mas_devops.tar.gz
     if [[ "$?" == "0" ]]; then

--- a/image/cli/install/install-ansible-collections.sh
+++ b/image/cli/install/install-ansible-collections.sh
@@ -2,6 +2,8 @@
 
 echo "Install Ansible Collections"
 echo "==========================="
+echo "GitHub reference = ${GITHUB_REF_TYPE}/${GITHUB_REF_NAME}"
+echo "Artifactory = ${ARTIFACTORY_GENERIC_RELEASE_URL}"
 echo "Contents of /tmp/install/:"
 ls /tmp/install/
 echo ""
@@ -19,10 +21,10 @@ elif [[ "$GITHUB_REF_NAME" != "master" ]] && [[ "$GITHUB_REF_TYPE" == "branch" ]
         echo "Installing matching branch build of ansible-devops from Artifactory"
         ansible-galaxy collection install /tmp/install/ibm-mas_devops.tar.gz -p $ANSIBLE_COLLECTIONS_PATH
     else
-        echo "Installing release build of ansible-devops from Galaxy"
+        echo "Installing release build of ansible-devops from Galaxy (branch build)"
         ansible-galaxy collection install ibm.mas_devops
     fi
 else
-    echo "Installing release build of ansible-devops from Galaxy"
+    echo "Installing release build of ansible-devops from Galaxy (master/tag build)"
     ansible-galaxy collection install ibm.mas_devops
 fi

--- a/image/cli/install/install-ansible-collections.sh
+++ b/image/cli/install/install-ansible-collections.sh
@@ -1,5 +1,11 @@
 #!/bin/bash
 
+echo "Install Ansible Collections"
+echo "==========================="
+echo "Contents of /tmp/install/:"
+ls /tmp/install/
+echo ""
+
 # If the local file is present, defer to this
 # Otherwise, check for a matching branch name in Artifactory
 # Otherwise, install the most recent version from Galaxy

--- a/image/cli/install/install-ansible-collections.sh
+++ b/image/cli/install/install-ansible-collections.sh
@@ -18,7 +18,7 @@ elif [[ "$GITHUB_REF_NAME" != "master" ]] && [[ "$GITHUB_REF_TYPE" == "branch" ]
     # Download and validate the archive
     BRANCH_TARGET_URL="${ARTIFACTORY_GENERIC_RELEASE_URL}/ibm-mas/ansible-devops/branches/ibm-mas_devops-${GITHUB_REF_NAME}.tar.gz"
     curl -H "Authorization:Bearer $ARTIFACTORY_TOKEN" $BRANCH_TARGET_URL -o /tmp/install/ibm-mas_devops.tar.gz
-    tar -tzf /tmp/install/ibm-mas_devops.tar.gz
+    tar -tzf /tmp/install/ibm-mas_devops.tar.gz > /dev/null
     if [[ "$?" == "0" ]]; then
         echo "Installing matching branch build of ansible-devops from Artifactory"
         ansible-galaxy collection install /tmp/install/ibm-mas_devops.tar.gz -p $ANSIBLE_COLLECTIONS_PATH

--- a/image/cli/mascli/functions/provision_fyre
+++ b/image/cli/mascli/functions/provision_fyre
@@ -40,6 +40,13 @@ Storage Provisioner Configuration:
       --storage ${COLOR_YELLOW}OCP_STORAGE_PROVIDER${TEXT_RESET}                         Choose optional storage provider (nfs, odf, or longhorn)
       --nfs-image-registry-size ${COLOR_YELLOW}FYRE_NFS_IMAGE_REGISTRY_SIZE${TEXT_RESET}  Defines the image registry storage size when configured to use NFS (default 100gb). The size allocated cannot be superior of storage available in the Fyre Infrastructure node.
 
+Turbonomic Integration:
+      --turbonomic-name ${COLOR_YELLOW}TURBONOMIC_TARGET_NAME${TEXT_RESET}   Name of the cluster in Turbonomic
+      --turbonomic-url ${COLOR_YELLOW}TURBONOMIC_SERVER_URL${TEXT_RESET}   Turbonomic server URL
+      --turbonomic-version ${COLOR_YELLOW}TURBONOMIC_SERVER_VERSION${TEXT_RESET}   Turbonomic server version
+      --turbonomic-username ${COLOR_YELLOW}TURBONOMIC_USERNAME${TEXT_RESET}   Turbonomic username
+      --turbonomic-password ${COLOR_YELLOW}TURBONOMIC_PASSWORD${TEXT_RESET}   Turbonomic password
+
 Other Commands:
       --no-confirm        Provision the cluster without prompting for confirmation
   -h, --help              Show this help message
@@ -125,6 +132,23 @@ function provision_fyre_noninteractive() {
         ;;
       --nfs-image-registry-size)
         IMAGE_REGISTRY_STORAGE_SIZE=$1 && shift
+        ;;
+
+      # Turbonomic
+      --turbonomic-name)
+        TURBONOMIC_TARGET_NAME=$1 && shift
+        ;;
+      --turbonomic-url)
+        TURBONOMIC_SERVER_URL=$1 && shift
+        ;;
+      --turbonomic-version)
+        TURBONOMIC_SERVER_VERSION=$1 && shift
+        ;;
+      --turbonomic-username)
+        TURBONOMIC_USERNAME=$1 && shift
+        ;;
+      --turbonomic-password)
+        TURBONOMIC_PASSWORD=$1 && shift
         ;;
 
       # Other options
@@ -324,6 +348,7 @@ function provision_fyre() {
   export OCP_VERSION
   export CLUSTER_PLATFORM
   export FYRE_CLUSTER_DESCRIPTION
+  export FYRE_CLUSTER_SIZE
   export FYRE_SITE
 
   export FYRE_WORKER_COUNT
@@ -333,23 +358,29 @@ function provision_fyre() {
   export OCP_FIPS_ENABLED
   export ENABLE_IPV6
 
-  export FYRE_CLUSTER_SIZE
-
   export OCP_STORAGE_PROVIDER
+
+  export TURBONOMIC_TARGET_NAME
+  export TURBONOMIC_SERVER_URL
+  export TURBONOMIC_SERVER_VERSION
+  export TURBONOMIC_USERNAME
+  export TURBONOMIC_PASSWORD
 
   echo
   reset_colors
   echo_h2 "Review Settings"
+
   echo "${TEXT_DIM}"
   echo_h2 "FYRE Authentication" "    "
   echo_reset_dim "Username .................. ${COLOR_MAGENTA}${FYRE_USERNAME}"
-  echo_reset_dim "API Key ................... ${COLOR_MAGENTA}${FYRE_APIKEY:0:8}<snip>"
+
   reset_colors
   echo "${TEXT_DIM}"
   echo_h2 "FYRE Accounting" "    "
   echo_reset_dim "Product Group ID .......... ${COLOR_MAGENTA}${FYRE_PRODUCT_ID}"
   echo_reset_dim "Quota Type ................ ${COLOR_MAGENTA}${FYRE_QUOTA_TYPE}"
   echo_reset_dim "Site ...................... ${COLOR_MAGENTA}${FYRE_SITE}"
+
   reset_colors
   echo "${TEXT_DIM}"
   echo_h2 "Cluster Configuration" "    "
@@ -373,6 +404,15 @@ function provision_fyre() {
   echo "${TEXT_DIM}"
   echo_h2 "Storage" "    "
   echo_reset_dim "Storage Provider ............ ${COLOR_MAGENTA}${OCP_STORAGE_PROVIDER}"
+
+  if [[ "${TURBONOMIC_NAME}" != "" ]]; then
+    reset_colors
+    echo "${TEXT_DIM}"
+    echo_h2 "Turbonomic Integration" "    "
+    echo_reset_dim "Cluster Name ................ ${COLOR_MAGENTA}${TURBONOMIC_NAME}"
+    echo_reset_dim "Server URL .................. ${COLOR_MAGENTA}${TURBONOMIC_SERVER_URL}"
+    echo_reset_dim "Server Version .............. ${COLOR_MAGENTA}${TURBONOMIC_SERVER_VERSION}"
+  fi
 
   echo
   reset_colors

--- a/image/cli/mascli/functions/provision_fyre
+++ b/image/cli/mascli/functions/provision_fyre
@@ -38,14 +38,14 @@ Worker Node Configuration (Optional, only takes effect when quota-type is set to
 
 Storage Provisioner Configuration:
       --storage ${COLOR_YELLOW}OCP_STORAGE_PROVIDER${TEXT_RESET}                         Choose optional storage provider (nfs, odf, or longhorn)
-      --nfs-image-registry-size ${COLOR_YELLOW}FYRE_NFS_IMAGE_REGISTRY_SIZE${TEXT_RESET}  Defines the image registry storage size when configured to use NFS (default 100gb). The size allocated cannot be superior of storage available in the Fyre Infrastructure node.
+      --nfs-image-registry-size ${COLOR_YELLOW}FYRE_NFS_IMAGE_REGISTRY_SIZE${TEXT_RESET} Defines the image registry storage size when configured to use NFS (default 100gb). The size allocated cannot be superior of storage available in the Fyre Infrastructure node.
 
 Turbonomic Integration:
-      --turbonomic-name ${COLOR_YELLOW}TURBONOMIC_TARGET_NAME${TEXT_RESET}   Name of the cluster in Turbonomic
-      --turbonomic-url ${COLOR_YELLOW}TURBONOMIC_SERVER_URL${TEXT_RESET}   Turbonomic server URL
-      --turbonomic-version ${COLOR_YELLOW}TURBONOMIC_SERVER_VERSION${TEXT_RESET}   Turbonomic server version
-      --turbonomic-username ${COLOR_YELLOW}TURBONOMIC_USERNAME${TEXT_RESET}   Turbonomic username
-      --turbonomic-password ${COLOR_YELLOW}TURBONOMIC_PASSWORD${TEXT_RESET}   Turbonomic password
+      --turbonomic-name ${COLOR_YELLOW}TURBONOMIC_TARGET_NAME${TEXT_RESET}               Target name in Turbonomic
+      --turbonomic-url ${COLOR_YELLOW}TURBONOMIC_SERVER_URL${TEXT_RESET}                 Turbonomic server URL
+      --turbonomic-version ${COLOR_YELLOW}TURBONOMIC_SERVER_VERSION${TEXT_RESET}         Turbonomic server version
+      --turbonomic-username ${COLOR_YELLOW}TURBONOMIC_USERNAME${TEXT_RESET}              Turbonomic username
+      --turbonomic-password ${COLOR_YELLOW}TURBONOMIC_PASSWORD${TEXT_RESET}              Turbonomic password
 
 Other Commands:
       --no-confirm        Provision the cluster without prompting for confirmation
@@ -321,8 +321,8 @@ function provision_fyre_interactive() {
   echo
   echo_h2 "Turbonomic Integration:"
   echo "Leave name empty if you do not want to enable Turbonomic integration in this cluster"
-  prompt_for_input "Turbonomic Name" TURBONOMIC_NAME
-  if [[ "$TURBONOMIC_NAME" != "" ]]; then
+  prompt_for_input "Turbonomic Name" TURBONOMIC_TARGET_NAME
+  if [[ "$TURBONOMIC_TARGET_NAME" != "" ]]; then
     prompt_for_input "Server URL" TURBONOMIC_SERVER_URL
     prompt_for_input "Server Version" TURBONOMIC_SERVER_VERSION
     prompt_for_input "Username" TURBONOMIC_USERNAME
@@ -417,11 +417,11 @@ function provision_fyre() {
   echo_h2 "Storage" "    "
   echo_reset_dim "Storage Provider ............ ${COLOR_MAGENTA}${OCP_STORAGE_PROVIDER}"
 
-  if [[ "${TURBONOMIC_NAME}" != "" ]]; then
+  if [[ "${TURBONOMIC_TARGET_NAME}" != "" ]]; then
     reset_colors
     echo "${TEXT_DIM}"
     echo_h2 "Turbonomic Integration" "    "
-    echo_reset_dim "Cluster Name ................ ${COLOR_MAGENTA}${TURBONOMIC_NAME}"
+    echo_reset_dim "Target Name ................. ${COLOR_MAGENTA}${TURBONOMIC_TARGET_NAME}"
     echo_reset_dim "Server URL .................. ${COLOR_MAGENTA}${TURBONOMIC_SERVER_URL}"
     echo_reset_dim "Server Version .............. ${COLOR_MAGENTA}${TURBONOMIC_SERVER_VERSION}"
   fi

--- a/image/cli/mascli/functions/provision_fyre
+++ b/image/cli/mascli/functions/provision_fyre
@@ -193,11 +193,11 @@ function provision_fyre_interactive() {
     prompt_for_confirm_default_yes "Re-use saved authentication details for user '$FYRE_USERNAME'?" REUSE_FYRE_AUTH
     if [[ "$REUSE_FYRE_AUTH" == "false" ]]; then
       prompt_for_input "Fyre Username" FYRE_USERNAME
-      prompt_for_input "Fyre API Key" FYRE_APIKEY
+      prompt_for_secret "Fyre API Key" FYRE_APIKEY
     fi
   else
     prompt_for_input "Fyre Username" FYRE_USERNAME
-    prompt_for_input "Fyre API Key" FYRE_APIKEY
+    prompt_for_secret "Fyre API Key" FYRE_APIKEY
   fi
 
   if [[ ! -z "$1" ]]; then
@@ -301,7 +301,7 @@ function provision_fyre_interactive() {
   fi
 
   echo
-  echo "Storage Provider:"
+  echo_h2 "Storage Provider:"
   echo "  1. None"
   echo "  2. Longhorn"
   echo "  3. NFS"
@@ -317,6 +317,18 @@ function provision_fyre_interactive() {
   elif [[ "$OCP_STORAGE_PROVIDER_SELECTION" == "4" ]]; then
     OCP_STORAGE_PROVIDER="odf"
   fi
+
+  echo
+  echo_h2 "Turbonomic Integration:"
+  echo "Leave name empty if you do not want to enable Turbonomic integration in this cluster"
+  prompt_for_input "Turbonomic Name" TURBONOMIC_NAME
+  if [[ "$TURBONOMIC_NAME" != "" ]]; then
+    prompt_for_input "Server URL" TURBONOMIC_SERVER_URL
+    prompt_for_input "Server Version" TURBONOMIC_SERVER_VERSION
+    prompt_for_input "Username" TURBONOMIC_USERNAME
+    prompt_for_secret "Password" TURBONOMIC_PASSWORD
+  fi
+
 }
 
 function provision_fyre() {

--- a/image/cli/mascli/functions/provision_fyre
+++ b/image/cli/mascli/functions/provision_fyre
@@ -271,9 +271,9 @@ function provision_fyre_interactive() {
   prompt_for_confirm "Use Product Group Quota?" USE_PRODUCT_GROUP_QUOTA
   if [[ "$USE_PRODUCT_GROUP_QUOTA" == "true" ]]; then
     FYRE_QUOTA_TYPE="product_group"
-    prompt_for_number "Number of Worker Nodes" FYRE_WORKER_COUNT "2"
+    prompt_for_number "Number of Worker Nodes" FYRE_WORKER_COUNT "3"
     prompt_for_number "Worker Node CPU (max 16)" FYRE_WORKER_CPU "8"
-    prompt_for_number "Worker Node Memory (max 64)" FYRE_WORKER_MEMORY "32"
+    prompt_for_number "Worker Node Memory (max 64)" FYRE_WORKER_MEMORY "16"
     prompt_for_input "Worker Additional Disk Sizes (GB, comma-seperated list)" FYRE_WORKER_ADDITIONAL_DISKS
     prompt_for_confirm "Enable FIPS? " OCP_FIPS_ENABLED
     prompt_for_confirm "Enable IPV6? " ENABLE_IPV6

--- a/image/cli/mascli/functions/provision_roks
+++ b/image/cli/mascli/functions/provision_roks
@@ -211,7 +211,7 @@ function provision_roks_interactive() {
   fi
 
   echo
-  echo "Storage Provider:"
+  echo_h2 "Storage Provider:"
   echo "  1. IBMCloud"
   echo "  2. Longhorn"
   prompt_for_input "Select the storage provider to setup" OCP_STORAGE_PROVIDER_SELECTION "1"
@@ -220,6 +220,17 @@ function provision_roks_interactive() {
     OCP_STORAGE_PROVIDER=""
   elif [[ "$OCP_STORAGE_PROVIDER_SELECTION" == "2" ]]; then
     OCP_STORAGE_PROVIDER="longhorn"
+  fi
+
+  echo
+  echo_h2 "Turbonomic Integration:"
+  echo "Leave name empty if you do not want to enable Turbonomic integration in this cluster"
+  prompt_for_input "Turbonomic Name" TURBONOMIC_NAME
+  if [[ "$TURBONOMIC_NAME" != "" ]]; then
+    prompt_for_input "Server URL" TURBONOMIC_SERVER_URL
+    prompt_for_input "Server Version" TURBONOMIC_SERVER_VERSION
+    prompt_for_input "Username" TURBONOMIC_USERNAME
+    prompt_for_secret "Password" TURBONOMIC_PASSWORD
   fi
 
   export UPGRADE_IMAGE_REGISTRY_STORAGE=false

--- a/image/cli/mascli/functions/provision_roks
+++ b/image/cli/mascli/functions/provision_roks
@@ -26,6 +26,16 @@ GPU Support (Optional):
       --gpu-worker-count ${COLOR_YELLOW}GPU_WORKERS${TEXT_RESET}            Number of GPU worker nodes to provision
       --gpu-workerpool-name ${COLOR_YELLOW}GPU_WORKERPOOL_NAME${TEXT_RESET} Name of the GPU workerpool
 
+Storage Provisioner Configuration:
+      --storage ${COLOR_YELLOW}OCP_STORAGE_PROVIDER${TEXT_RESET}            Choose optional storage provider (longhorn)
+
+Turbonomic Integration:
+      --turbonomic-name ${COLOR_YELLOW}TURBONOMIC_TARGET_NAME${TEXT_RESET}   Name of the cluster in Turbonomic
+      --turbonomic-url ${COLOR_YELLOW}TURBONOMIC_SERVER_URL${TEXT_RESET}   Turbonomic server URL
+      --turbonomic-version ${COLOR_YELLOW}TURBONOMIC_SERVER_VERSION${TEXT_RESET}   Turbonomic server version
+      --turbonomic-username ${COLOR_YELLOW}TURBONOMIC_USERNAME${TEXT_RESET}   Turbonomic username
+      --turbonomic-password ${COLOR_YELLOW}TURBONOMIC_PASSWORD${TEXT_RESET}   Turbonomic password
+
 Other Commands:
       --no-confirm                              Provision the cluster without prompting for confirmation
   -h, --help                                    Show this help message
@@ -68,9 +78,33 @@ function provision_roks_noninteractive() {
         OCP_PROVISION_GPU=true
         GPU_WORKERPOOL_NAME=$1 && shift
         ;;
+
+      # Storage Configuration
+      --storage)
+        OCP_STORAGE_PROVIDER=$1 && shift
+        ;;
       --upgrade-registry-storage)
         UPGRADE_IMAGE_REGISTRY_STORAGE=true
         ;;
+
+      # Turbonomic
+      --turbonomic-name)
+        TURBONOMIC_TARGET_NAME=$1 && shift
+        ;;
+      --turbonomic-url)
+        TURBONOMIC_SERVER_URL=$1 && shift
+        ;;
+      --turbonomic-version)
+        TURBONOMIC_SERVER_VERSION=$1 && shift
+        ;;
+      --turbonomic-username)
+        TURBONOMIC_USERNAME=$1 && shift
+        ;;
+      --turbonomic-password)
+        TURBONOMIC_PASSWORD=$1 && shift
+        ;;
+
+      # Other options
       --no-confirm)
         NO_CONFIRM=true
         ;;
@@ -123,12 +157,12 @@ function provision_roks_interactive() {
 
   echo
   echo "OCP Version:"
-  echo "  1. 4.19 (MAS 8.10-9.2)"
-  echo "  2. 4.18 (MAS 8.10-9.1)"
-  echo "  3. 4.17 (MAS 8.10-9.1)"
-  echo "  4. 4.16 (MAS 8.10-9.1)"
-  echo "  5. 4.15 (MAS 8.10-9.1)"
-  echo "  6. 4.14 (MAS 8.10-9.1)"
+  echo "  1. 4.19"
+  echo "  2. 4.18"
+  echo "  3. 4.17"
+  echo "  4. 4.16"
+  echo "  5. 4.15"
+  echo "  6. 4.14"
   prompt_for_input "Select Version" OCP_VERSION_SELECTION "1"
 
   case $OCP_VERSION_SELECTION in
@@ -176,6 +210,18 @@ function provision_roks_interactive() {
     prompt_for_input "GPU Worker Pool Name" GPU_WORKERPOOL_NAME "gpu" && export GPU_WORKERPOOL_NAME
   fi
 
+  echo
+  echo "Storage Provider:"
+  echo "  1. IBMCloud"
+  echo "  2. Longhorn"
+  prompt_for_input "Select the storage provider to setup" OCP_STORAGE_PROVIDER_SELECTION "1"
+
+  if [[ "$OCP_STORAGE_PROVIDER_SELECTION" == "1" ]]; then
+    OCP_STORAGE_PROVIDER=""
+  elif [[ "$OCP_STORAGE_PROVIDER_SELECTION" == "2" ]]; then
+    OCP_STORAGE_PROVIDER="longhorn"
+  fi
+
   export UPGRADE_IMAGE_REGISTRY_STORAGE=false
   echo ""
   echo_h2 "Upgrade Image Registry Capacity"
@@ -211,19 +257,29 @@ function provision_roks() {
   export GPU_WORKERPOOL_NAME
   export UPGRADE_IMAGE_REGISTRY_STORAGE
 
+  export OCP_STORAGE_PROVIDER
+
+  export TURBONOMIC_TARGET_NAME
+  export TURBONOMIC_SERVER_URL
+  export TURBONOMIC_SERVER_VERSION
+  export TURBONOMIC_USERNAME
+  export TURBONOMIC_PASSWORD
+
 
   echo ""
   echo_h2 "Review Settings"
+
   echo "${TEXT_DIM}"
   echo_h2 "IBMCloud Authentication" "    "
-  echo_reset_dim "IBMCloud API Key .......... ${IBMCLOUD_APIKEY:0:8}..."
   echo_reset_dim "IBMCloud Resource Group ... $IBMCLOUD_RESOURCEGROUP"
+
   reset_colors
   echo "${TEXT_DIM}"
   echo_h2 "Cluster Configuration" "    "
   echo_reset_dim "Cluster Name .............. $CLUSTER_NAME"
   echo_reset_dim "OCP Version ............... $OCP_VERSION"
   echo_reset_dim "Upgrade Registry Storage .. ${UPGRADE_IMAGE_REGISTRY_STORAGE:-false}"
+
   reset_colors
   echo "${TEXT_DIM}"
   echo_h2 "Worker Configuration" "    "
@@ -234,6 +290,24 @@ function provision_roks() {
   if [[ $OCP_PROVISION_GPU == "true" ]]; then
     echo_reset_dim "GPU Worker Pool Size ...... $GPU_WORKERS"
     echo_reset_dim "GPU Worker Pool Name ...... $GPU_WORKERPOOL_NAME"
+  fi
+
+  reset_colors
+  echo "${TEXT_DIM}"
+  echo_h2 "Storage" "    "
+  if [[ "${OCP_STORAGE_PROVIDER}" == "" ]]; then
+    echo_reset_dim "Storage Provider ............ ${COLOR_MAGENTA}IBMCloud"
+  else
+    echo_reset_dim "Storage Provider ............ ${COLOR_MAGENTA}${OCP_STORAGE_PROVIDER}"
+  fi
+
+  if [[ "${TURBONOMIC_NAME}" != "" ]]; then
+    reset_colors
+    echo "${TEXT_DIM}"
+    echo_h2 "Turbonomic Integration" "    "
+    echo_reset_dim "Cluster Name ................ ${COLOR_MAGENTA}${TURBONOMIC_NAME}"
+    echo_reset_dim "Server URL .................. ${COLOR_MAGENTA}${TURBONOMIC_SERVER_URL}"
+    echo_reset_dim "Server Version .............. ${COLOR_MAGENTA}${TURBONOMIC_SERVER_VERSION}"
   fi
 
   echo

--- a/image/cli/mascli/functions/provision_roks
+++ b/image/cli/mascli/functions/provision_roks
@@ -30,11 +30,11 @@ Storage Provisioner Configuration:
       --storage ${COLOR_YELLOW}OCP_STORAGE_PROVIDER${TEXT_RESET}            Choose optional storage provider (longhorn)
 
 Turbonomic Integration:
-      --turbonomic-name ${COLOR_YELLOW}TURBONOMIC_TARGET_NAME${TEXT_RESET}   Name of the cluster in Turbonomic
-      --turbonomic-url ${COLOR_YELLOW}TURBONOMIC_SERVER_URL${TEXT_RESET}   Turbonomic server URL
-      --turbonomic-version ${COLOR_YELLOW}TURBONOMIC_SERVER_VERSION${TEXT_RESET}   Turbonomic server version
-      --turbonomic-username ${COLOR_YELLOW}TURBONOMIC_USERNAME${TEXT_RESET}   Turbonomic username
-      --turbonomic-password ${COLOR_YELLOW}TURBONOMIC_PASSWORD${TEXT_RESET}   Turbonomic password
+      --turbonomic-name ${COLOR_YELLOW}TURBONOMIC_TARGET_NAME${TEXT_RESET}               Target name in Turbonomic
+      --turbonomic-url ${COLOR_YELLOW}TURBONOMIC_SERVER_URL${TEXT_RESET}                 Turbonomic server URL
+      --turbonomic-version ${COLOR_YELLOW}TURBONOMIC_SERVER_VERSION${TEXT_RESET}         Turbonomic server version
+      --turbonomic-username ${COLOR_YELLOW}TURBONOMIC_USERNAME${TEXT_RESET}              Turbonomic username
+      --turbonomic-password ${COLOR_YELLOW}TURBONOMIC_PASSWORD${TEXT_RESET}              Turbonomic password
 
 Other Commands:
       --no-confirm                              Provision the cluster without prompting for confirmation
@@ -225,8 +225,8 @@ function provision_roks_interactive() {
   echo
   echo_h2 "Turbonomic Integration:"
   echo "Leave name empty if you do not want to enable Turbonomic integration in this cluster"
-  prompt_for_input "Turbonomic Name" TURBONOMIC_NAME
-  if [[ "$TURBONOMIC_NAME" != "" ]]; then
+  prompt_for_input "Turbonomic Name" TURBONOMIC_TARGET_NAME
+  if [[ "$TURBONOMIC_TARGET_NAME" != "" ]]; then
     prompt_for_input "Server URL" TURBONOMIC_SERVER_URL
     prompt_for_input "Server Version" TURBONOMIC_SERVER_VERSION
     prompt_for_input "Username" TURBONOMIC_USERNAME
@@ -312,11 +312,11 @@ function provision_roks() {
     echo_reset_dim "Storage Provider ............ ${COLOR_MAGENTA}${OCP_STORAGE_PROVIDER}"
   fi
 
-  if [[ "${TURBONOMIC_NAME}" != "" ]]; then
+  if [[ "${TURBONOMIC_TARGET_NAME}" != "" ]]; then
     reset_colors
     echo "${TEXT_DIM}"
     echo_h2 "Turbonomic Integration" "    "
-    echo_reset_dim "Cluster Name ................ ${COLOR_MAGENTA}${TURBONOMIC_NAME}"
+    echo_reset_dim "Target Name ................. ${COLOR_MAGENTA}${TURBONOMIC_TARGET_NAME}"
     echo_reset_dim "Server URL .................. ${COLOR_MAGENTA}${TURBONOMIC_SERVER_URL}"
     echo_reset_dim "Server Version .............. ${COLOR_MAGENTA}${TURBONOMIC_SERVER_VERSION}"
   fi


### PR DESCRIPTION
## Turbonomic Integration with OCP Provision
Shift Turbonomic configuration into cluster provisioning (for now it also remained in install pipeline, but in a future update we will remove it from the install pipeline)

## Build Update
Also, updates the build to better support development builds of ibm-mas/ansible-devops.  It's long been an annoyance having to package local builds of ansible-devops and python-devops into the CLI to combine the three repos; the first steps to solve this are about to be delivered:

**Before:**
* If you don't do anything, your cli container will build using the master branch of ansible-devops
* If you copy a tgz into the `/install` folder it will be used instead of the master build of ansible-devops (usually done by running `make ansible-devops`)

**After:**
* If someone has copied a local tgz into the usual location it will be used exactly as it is today
* If you don't do anything, your cli container will attempt to build using aa matching branch of ansible-devops (if your cli branch is called `issue5601` we will try to install the latest build frm the `issue5601` branch of ansible-devops)
* If there is no matching branch build in the ansible collection, then we will install the master version as we do today

**TLDR; use the same branch name in ansible-devops and cli, and the cli build will automatically use your build of ansible-devops -- no more running `make ansible-devops` and committing the generated tgz file into the repo.**

## Ansible Yaml Output Fix
Update to the ansible config file to deal with the removal of the deprecated yaml callback plugin we have been using.

```
Using /opt/app-root/src/ansible.cfg as config file
[WARNING]: No inventory was parsed, only implicit localhost is available
[WARNING]: provided hosts list is empty, only localhost is available. Note that the implicit localhost does not match 'all'
running playbook inside collection ibm.mas_devops
[WARNING]: Collection kubernetes.core does not support Ansible version 2.15.13
[WARNING]: Collection community.general does not support Ansible version 2.15.13
ERROR! [DEPRECATED]: community.general.yaml has been removed. The plugin has been superseded by the option `result_format=yaml` in callback plugin ansible.builtin.default from ansible-core 2.13 onwards. This feature was removed from community.general in version 12.0.0. Please update your playbooks.
```

See also:
- https://github.com/ibm-mas/ansible-devops/pull/1966