### PR TITLE
[patch] Fix tektonDefsWithDigestPath changes introduced in #1805

### DIFF
--- a/python/src/mas/cli/cli.py
+++ b/python/src/mas/cli/cli.py
@@ -242,6 +242,7 @@ class BaseApp(PrintMixin, PromptMixin):
     def createTektonFileWithDigest(self) -> None:
         if path.exists(self.tektonDefsWithDigestPath):
             logger.debug(f"We have already generated {self.tektonDefsWithDigestPath}")
+            self.tektonDefsPath = self.tektonDefsWithDigestPath
         elif isAirgapInstall(self.dynamicClient):
             # We need to modify the tekton definitions to
             imageWithoutDigest = f"quay.io/ibmmas/cli:{self.version}"
@@ -279,7 +280,7 @@ class BaseApp(PrintMixin, PromptMixin):
             with open(self.tektonDefsWithDigestPath, 'w') as file:
                 file.write(tektonDefsWithDigest)
 
-        self.tektonDefsPath = self.tektonDefsWithDigestPath
+            self.tektonDefsPath = self.tektonDefsWithDigestPath
 
     @logMethodCall
     def getCompatibleVersions(self, coreChannel: str, appId: str) -> list:


### PR DESCRIPTION
PR #1805 attempted to fix the scenario where we have already generated the tekton definition file containing digests, however it did not take into account the scenario where we are **not** running in an airgap environment and don't want to use the digest at all.  this update fixes the fix.