### PR TITLE
[minor] Add support for configuring EFS CSI driver via ArgoCD

### DIFF
--- a/image/cli/mascli/functions/gitops_efs_csi_driver
+++ b/image/cli/mascli/functions/gitops_efs_csi_driver
@@ -136,7 +136,6 @@ function gitops_efs_csi_driver() {
   echo_reset_dim "Cluster Config Directory ....... ${COLOR_MAGENTA}${GITOPS_CLUSTER_DIR}"
   reset_colors
 
-=
   echo "${TEXT_DIM}"
   if [[ "$GITHUB_PUSH" == "true" ]]; then
     echo_h2 "GitOps Target" "    "

--- a/image/cli/mascli/functions/gitops_efs_csi_driver
+++ b/image/cli/mascli/functions/gitops_efs_csi_driver
@@ -1,0 +1,208 @@
+#!/usr/bin/env bash
+
+function gitops_efs_csi_driver_help() {
+  [[ -n "$1" ]] && echo_warning "$1"
+  reset_colors
+  cat << EOM
+Usage:
+  mas gitops_efs_csi_driver [options]
+Where ${COLOR_YELLOW}specified${TEXT_RESET} each option may also be defined by setting the appropriate environment variable.
+When no options are specified on the command line, interactive-mode will be enabled by default.
+
+Basic Configuration:
+  -d, --dir ${COLOR_YELLOW}GITOPS_WORKING_DIR${TEXT_RESET}         Directory for GitOps repository
+  -a, --account-id ${COLOR_YELLOW}ACCOUNT_ID${TEXT_RESET}          Account name that the cluster belongs to
+  -c, --cluster-id ${COLOR_YELLOW}CLUSTER_ID${TEXT_RESET}          Cluster ID
+
+  --efs-csi-driver-role-arn ${COLOR_YELLOW}EFS_CSI_DRIVER_ROLE_ARN${TEXT_RESET}    ARN of the IAM Role to assign to the EFS CSI driver
+
+Automatic GitHub Push (Optional):
+  -P, --github-push ${COLOR_YELLOW}GITHUB_PUSH${TEXT_RESET}        Enable automatic push to GitHub
+  -H, --github-host ${COLOR_YELLOW}GITHUB_HOST${TEXT_RESET}        GitHub Hostname for your GitOps repository
+  -O, --github-org ${COLOR_YELLOW}GITHUB_ORG${TEXT_RESET}          Github org for your GitOps repository
+  -R, --github-repo ${COLOR_YELLOW}GITHUB_REPO${TEXT_RESET}        Github repo for your GitOps repository
+  -S, --github-ssh ${COLOR_YELLOW}GIT_SSH${TEXT_RESET}             Git ssh key path
+  -B, --git-branch ${COLOR_YELLOW}GIT_BRANCH${TEXT_RESET}          Git branch to commit to of your GitOps repository
+  -M, --git-commit-msg ${COLOR_YELLOW}GIT_COMMIT_MSG${TEXT_RESET}  Git commit message to use when committing to of your GitOps repository
+
+Other Commands:
+  -h, --help                                      Show this help message
+EOM
+  [[ -n "$1" ]] && exit 1 || exit 0
+}
+
+function gitops_efs_csi_driver_noninteractive() {
+  GITOPS_WORKING_DIR=$PWD/working-dir
+  SECRETS_KEY_SEPERATOR="/"
+  GIT_COMMIT_MSG="gitops-efs-csi-driver commit"
+
+  while [[ $# -gt 0 ]]
+  do
+    key="$1"
+    shift
+    case $key in
+      # GitOps Configuration
+      -d|--dir)
+        export GITOPS_WORKING_DIR=$1 && shift
+        ;;
+      -a|--account-id)
+        export ACCOUNT_ID=$1 && shift
+        ;;
+      -c|--cluster-id)
+        export CLUSTER_ID=$1 && shift
+        ;;
+
+      --efs-csi-driver-role-arn)
+        export EFS_CSI_DRIVER_ROLE_ARN=$1 && shift
+        ;;
+
+
+      # Automatic GitHub Push
+      -P|--github-push)
+        export GITHUB_PUSH=true
+        ;;
+      -H|--github-host)
+        export GITHUB_HOST=$1 && shift
+        ;;
+      -O|--github-org)
+        export GITHUB_ORG=$1 && shift
+        ;;
+      -R|--github-repo)
+        export GITHUB_REPO=$1 && shift
+        ;;
+      -S|--github-ssh)
+        export GIT_SSH=$1 && shift
+        ;;
+      -B|--git-branch)
+        export GIT_BRANCH=$1 && shift
+        ;;
+      -M|--git-commit-msg)
+        export GIT_COMMIT_MSG=$1 && shift
+        ;;
+
+      # Other Commands
+      -h|--help)
+        gitops_efs_csi_driver_help
+        ;;
+      *)
+        # unknown option
+        gitops_efs_csi_driver_help  "Usage Error: Unsupported option \"${key}\" "
+        ;;
+      esac
+  done
+
+  [[ -z "$GITOPS_WORKING_DIR" ]] && gitops_efs_csi_driver_help "GITOPS_WORKING_DIR is not set"
+  [[ -z "$ACCOUNT_ID" ]] && gitops_efs_csi_driver_help "ACCOUNT_ID is not set"
+  [[ -z "$CLUSTER_ID" ]] && gitops_efs_csi_driver_help "CLUSTER_ID is not set"
+
+  if [[ "$GITHUB_PUSH" == "true" ]]; then
+    [[ -z "$GITHUB_HOST" ]] && gitops_efs_csi_driver_help "GITHUB_HOST is not set"
+    [[ -z "$GITHUB_ORG" ]] && gitops_efs_csi_driver_help "GITHUB_ORG is not set"
+    [[ -z "$GITHUB_REPO" ]] && gitops_efs_csi_driver_help "GITHUB_REPO is not set"
+    [[ -z "$GIT_BRANCH" ]] && gitops_efs_csi_driver_help "GIT_BRANCH is not set"
+  fi
+
+  [[ -z "$EFS_CSI_DRIVER_ROLE_ARN" ]] && gitops_efs_csi_driver_help "EFS_CSI_DRIVER_ROLE_ARN is not set"
+
+}
+
+function gitops_efs_csi_driver() {
+  # Take the first parameter off (it will be create-gitops)
+  shift
+  if [[ $# -gt 0 ]]; then
+    gitops_efs_csi_driver_noninteractive "$@"
+  else
+    echo "Not supported yet"
+    exit 1
+    gitops_efs_csi_driver_interactive
+  fi
+
+  # catch errors
+  set -o pipefail
+  trap 'echo "[ERROR] Error occurred at $BASH_SOURCE, line $LINENO, exited with $?"; exit 1' ERR
+
+  mkdir -p ${GITOPS_WORKING_DIR}
+  GITOPS_CLUSTER_DIR=${GITOPS_WORKING_DIR}/${GITHUB_REPO}/${ACCOUNT_ID}/${CLUSTER_ID}
+
+  echo
+  reset_colors
+  echo_h2 "Review Settings"
+
+  echo "${TEXT_DIM}"
+  echo_h2 "Target" "    "
+  echo_reset_dim "Account ID ..................... ${COLOR_MAGENTA}${ACCOUNT_ID}"
+  echo_reset_dim "Region ID ...................... ${COLOR_MAGENTA}${REGION_ID}"
+  echo_reset_dim "Cluster ID ..................... ${COLOR_MAGENTA}${CLUSTER_ID}"
+  echo_reset_dim "Cluster Config Directory ....... ${COLOR_MAGENTA}${GITOPS_CLUSTER_DIR}"
+  reset_colors
+
+=
+  echo "${TEXT_DIM}"
+  if [[ "$GITHUB_PUSH" == "true" ]]; then
+    echo_h2 "GitOps Target" "    "
+    echo_reset_dim "Automatic Push ........................ ${COLOR_GREEN}Enabled"
+    echo_reset_dim "Working Directory ..................... ${COLOR_MAGENTA}${GITOPS_WORKING_DIR}"
+    echo_reset_dim "Host .................................. ${COLOR_MAGENTA}${GITHUB_HOST}"
+    echo_reset_dim "Organization .......................... ${COLOR_MAGENTA}${GITHUB_ORG}"
+    echo_reset_dim "Repository ............................ ${COLOR_MAGENTA}${GITHUB_REPO}"
+    echo_reset_dim "Branch ................................ ${COLOR_MAGENTA}${GIT_BRANCH}"
+  else
+    echo_h2 "GitOps Target" "    "
+    echo_reset_dim "Automatic Push ........................ ${COLOR_RED}Disabled"
+    echo_reset_dim "Working Directory ..................... ${COLOR_MAGENTA}${GITOPS_WORKING_DIR}"
+  fi
+  reset_colors
+
+  echo "${TEXT_DIM}"
+  echo_h2 "EFS CSI Driver" "    "
+  echo_reset_dim "EFS_CSI_DRIVER_ROLE_ARN  .......................... ${COLOR_MAGENTA}${EFS_CSI_DRIVER_ROLE_ARN}"
+  reset_colors
+
+
+
+  CURRENT_DIR=$PWD
+  TEMP_DIR=$CURRENT_DIR/tmp-efs_csi_driver
+  mkdir -p $TEMP_DIR
+
+  if [ -z $GIT_SSH ]; then
+    export GIT_SSH=false
+  fi
+
+
+  # Set and Validate App Names
+  # ---------------------------------------------------------------------------
+  EFS_CSI_DRIVER_APP_NAME="efs-csi-driver.${CLUSTER_ID}"
+  validate_app_name "${EFS_CSI_DRIVER_APP_NAME}"
+
+
+  # Clone github target repo
+  # ---------------------------------------------------------------------------
+  if [ "$GITHUB_PUSH" == "true" ]; then
+    echo
+    echo_h2 "Cloning GitHub repo $GITHUB_ORG $GITHUB_REPO"
+    clone_target_git_repo $GITHUB_HOST $GITHUB_ORG $GITHUB_REPO $GIT_BRANCH $GITOPS_WORKING_DIR $GIT_SSH
+  fi
+  mkdir -p ${GITOPS_CLUSTER_DIR}
+
+
+  # Generate ArgoApps
+  # ---------------------------------------------------------------------------
+  echo
+  echo_h2 "Generating efs_csi_driver operator Applications"
+  echo "- efs_csi_driver operator"
+
+  echo "Generating efs_csi_driver file ${GITOPS_CLUSTER_DIR}/efs-csi-driver.yaml"
+  jinjanate_commmon $CLI_DIR/templates/gitops/appset-configs/cluster/efs-csi-driver.yaml.j2 ${GITOPS_CLUSTER_DIR}/efs-csi-driver.yaml
+
+  # Commit and push to github target repo
+  # ---------------------------------------------------------------------------
+  if [ "$GITHUB_PUSH" == "true" ]; then
+    echo
+    echo_h2 "Commit and push changes to GitHub repo $GITHUB_ORG $GITHUB_REPO"
+    save_to_target_git_repo $GITHUB_HOST $GITHUB_ORG $GITHUB_REPO $GIT_BRANCH "${GITOPS_WORKING_DIR}/${GITHUB_REPO}" "${GIT_COMMIT_MSG}"
+    remove_git_repo_clone $GITOPS_WORKING_DIR/$GITHUB_REPO
+  fi
+
+  rm -rf $TEMP_DIR
+
+}

--- a/image/cli/mascli/mas
+++ b/image/cli/mascli/mas
@@ -74,6 +74,7 @@ mkdir -p $CONFIG_DIR
 . $CLI_DIR/functions/gitops_deprovision_suite
 . $CLI_DIR/functions/gitops_deprovision_suite_workspace
 . $CLI_DIR/functions/gitops_efs
+. $CLI_DIR/functions/gitops_efs_csi_driver
 . $CLI_DIR/functions/gitops_dro
 . $CLI_DIR/functions/gitops_db2u
 . $CLI_DIR/functions/gitops_db2u_database
@@ -514,6 +515,14 @@ case $1 in
     echo
     reset_colors
     gitops_efs "$@"
+    ;;
+
+  gitops-efs-csi-driver)
+    echo "${TEXT_UNDERLINE}IBM Maximo Application Suite GitOps Manager (v${VERSION})${TEXT_RESET}"
+    echo "Powered by ${COLOR_CYAN}${TEXT_UNDERLINE}https://github.com/ibm-mas/gitops/${TEXT_RESET}"
+    echo
+    reset_colors
+    gitops_efs_csi_driver "$@"
     ;;
 
   gitops-dro)

--- a/image/cli/mascli/templates/gitops/appset-configs/cluster/efs-csi-driver.yaml.j2
+++ b/image/cli/mascli/templates/gitops/appset-configs/cluster/efs-csi-driver.yaml.j2
@@ -1,0 +1,7 @@
+merge-key: "{{ ACCOUNT_ID }}/{{ CLUSTER_ID }}"
+
+efs_csi_driver:
+  catalog_source: redhat-operators
+  catalog_source_namespace: openshift-marketplace
+  channel: stable
+  role_arn: {{ EFS_CSI_DRIVER_ROLE_ARN }}


### PR DESCRIPTION
```
mas gitops-efs-csi-driver --account-id account--cluster-id cluster --efs-csi-driver-role-arn arn:xxx
```

generates the config file used by ArgoCD to configure the EFS CSI driver in a MAS ROSA Cluster, e.g.:
`account/cluster/efs-csi-driver.yaml`:
```
merge-key: "account/cluster"
efs_csi_driver:
  catalog_source: redhat-operators
  catalog_source_namespace: openshift-marketplace
  channel: stable
  role_arn: arn:xxx
```

No plans to call this from the Tekton pipelines at present - will be called from the saas-gitops-cli utility.