### PR TITLE
[minor] Add support for standalone SLS service for gitops.

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "build/bin/config/oscap/ssg-rhel9-ds.xml|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2025-11-24T14:35:27Z",
+  "generated_at": "2025-11-25T09:30:13Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -398,7 +398,7 @@
         "hashed_secret": "effb7852555adce89885fb075fb43a77a1e0e77e",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 852,
+        "line_number": 850,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -406,7 +406,7 @@
         "hashed_secret": "2582aea6f911bd00fc04cb25e0ec16d5ead62068",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 854,
+        "line_number": 852,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "build/bin/config/oscap/ssg-rhel9-ds.xml|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2025-11-25T09:30:13Z",
+  "generated_at": "2025-11-25T11:57:16Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -398,7 +398,7 @@
         "hashed_secret": "effb7852555adce89885fb075fb43a77a1e0e77e",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 850,
+        "line_number": 849,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -406,7 +406,7 @@
         "hashed_secret": "2582aea6f911bd00fc04cb25e0ec16d5ead62068",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 852,
+        "line_number": 851,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -444,7 +444,7 @@
         "hashed_secret": "b2817467154949a61f8e9ad31d1eeaf03221cbfa",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 565,
+        "line_number": 570,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -390,7 +390,7 @@
         "hashed_secret": "b2817467154949a61f8e9ad31d1eeaf03221cbfa",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 643,
+        "line_number": 656,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -398,7 +398,7 @@
         "hashed_secret": "effb7852555adce89885fb075fb43a77a1e0e77e",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 823,
+        "line_number": 838,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -406,7 +406,7 @@
         "hashed_secret": "2582aea6f911bd00fc04cb25e0ec16d5ead62068",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 825,
+        "line_number": 840,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "build/bin/config/oscap/ssg-rhel9-ds.xml|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2025-11-18T18:50:10Z",
+  "generated_at": "2025-11-19T07:34:40Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -390,7 +390,7 @@
         "hashed_secret": "b2817467154949a61f8e9ad31d1eeaf03221cbfa",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 649,
+        "line_number": 651,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -398,7 +398,7 @@
         "hashed_secret": "effb7852555adce89885fb075fb43a77a1e0e77e",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 837,
+        "line_number": 839,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -406,7 +406,7 @@
         "hashed_secret": "2582aea6f911bd00fc04cb25e0ec16d5ead62068",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 839,
+        "line_number": 841,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -444,7 +444,7 @@
         "hashed_secret": "b2817467154949a61f8e9ad31d1eeaf03221cbfa",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 560,
+        "line_number": 559,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -690,7 +690,7 @@
         "hashed_secret": "fee2d55ad9a49a95fc89abe8f414dad66704ebfd",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 20,
+        "line_number": 21,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "build/bin/config/oscap/ssg-rhel9-ds.xml|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2025-11-18T17:29:26Z",
+  "generated_at": "2025-11-18T18:50:10Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -210,7 +210,7 @@
       },
       {
         "hashed_secret": "b2817467154949a61f8e9ad31d1eeaf03221cbfa",
-        "is_secret": true,
+        "is_secret": false,
         "is_verified": false,
         "line_number": 312,
         "type": "Secret Keyword",
@@ -220,7 +220,7 @@
     "image/cli/mascli/functions/gitops_aiservice_tenant": [
       {
         "hashed_secret": "b2817467154949a61f8e9ad31d1eeaf03221cbfa",
-        "is_secret": true,
+        "is_secret": false,
         "is_verified": false,
         "line_number": 337,
         "type": "Secret Keyword",
@@ -270,7 +270,7 @@
     "image/cli/mascli/functions/gitops_deprovision_aiservice": [
       {
         "hashed_secret": "b2817467154949a61f8e9ad31d1eeaf03221cbfa",
-        "is_secret": true,
+        "is_secret": false,
         "is_verified": false,
         "line_number": 180,
         "type": "Secret Keyword",
@@ -280,7 +280,7 @@
     "image/cli/mascli/functions/gitops_deprovision_aiservice_tenant": [
       {
         "hashed_secret": "b2817467154949a61f8e9ad31d1eeaf03221cbfa",
-        "is_secret": true,
+        "is_secret": false,
         "is_verified": false,
         "line_number": 182,
         "type": "Secret Keyword",
@@ -390,7 +390,7 @@
         "hashed_secret": "b2817467154949a61f8e9ad31d1eeaf03221cbfa",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 653,
+        "line_number": 649,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -398,7 +398,7 @@
         "hashed_secret": "effb7852555adce89885fb075fb43a77a1e0e77e",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 841,
+        "line_number": 837,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -406,7 +406,7 @@
         "hashed_secret": "2582aea6f911bd00fc04cb25e0ec16d5ead62068",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 843,
+        "line_number": 839,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -630,7 +630,7 @@
     "image/cli/mascli/templates/gitops/appset-configs/cluster/instance/ibm-aiservice-tenant-base.yaml.j2": [
       {
         "hashed_secret": "fee2d55ad9a49a95fc89abe8f414dad66704ebfd",
-        "is_secret": true,
+        "is_secret": false,
         "is_verified": false,
         "line_number": 21,
         "type": "Secret Keyword",
@@ -640,7 +640,7 @@
     "image/cli/mascli/templates/gitops/appset-configs/cluster/instance/ibm-aiservice-tenant.yaml.j2": [
       {
         "hashed_secret": "fee2d55ad9a49a95fc89abe8f414dad66704ebfd",
-        "is_secret": true,
+        "is_secret": false,
         "is_verified": false,
         "line_number": 37,
         "type": "Secret Keyword",
@@ -650,7 +650,7 @@
     "image/cli/mascli/templates/gitops/appset-configs/cluster/instance/ibm-aiservice.yaml.j2": [
       {
         "hashed_secret": "fee2d55ad9a49a95fc89abe8f414dad66704ebfd",
-        "is_secret": true,
+        "is_secret": false,
         "is_verified": false,
         "line_number": 38,
         "type": "Secret Keyword",
@@ -690,7 +690,7 @@
         "hashed_secret": "fee2d55ad9a49a95fc89abe8f414dad66704ebfd",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 21,
+        "line_number": 20,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "build/bin/config/oscap/ssg-rhel9-ds.xml|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2025-11-14T05:55:58Z",
+  "generated_at": "2025-11-14T08:09:29Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -444,7 +444,7 @@
         "hashed_secret": "b2817467154949a61f8e9ad31d1eeaf03221cbfa",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 560,
+        "line_number": 563,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "build/bin/config/oscap/ssg-rhel9-ds.xml|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2025-11-20T17:38:52Z",
+  "generated_at": "2025-11-24T14:35:27Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -390,7 +390,7 @@
         "hashed_secret": "b2817467154949a61f8e9ad31d1eeaf03221cbfa",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 650,
+        "line_number": 664,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -398,7 +398,7 @@
         "hashed_secret": "effb7852555adce89885fb075fb43a77a1e0e77e",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 840,
+        "line_number": 852,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -406,7 +406,7 @@
         "hashed_secret": "2582aea6f911bd00fc04cb25e0ec16d5ead62068",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 842,
+        "line_number": 854,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -444,7 +444,7 @@
         "hashed_secret": "b2817467154949a61f8e9ad31d1eeaf03221cbfa",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 561,
+        "line_number": 565,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "build/bin/config/oscap/ssg-rhel9-ds.xml|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2025-11-06T16:17:33Z",
+  "generated_at": "2025-11-11T08:39:52Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -444,7 +444,7 @@
         "hashed_secret": "b2817467154949a61f8e9ad31d1eeaf03221cbfa",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 545,
+        "line_number": 556,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -690,7 +690,7 @@
         "hashed_secret": "fee2d55ad9a49a95fc89abe8f414dad66704ebfd",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 17,
+        "line_number": 18,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "build/bin/config/oscap/ssg-rhel9-ds.xml|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2025-11-11T08:39:52Z",
+  "generated_at": "2025-11-13T08:04:12Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -390,7 +390,7 @@
         "hashed_secret": "b2817467154949a61f8e9ad31d1eeaf03221cbfa",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 654,
+        "line_number": 658,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -398,7 +398,7 @@
         "hashed_secret": "effb7852555adce89885fb075fb43a77a1e0e77e",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 839,
+        "line_number": 848,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -406,7 +406,7 @@
         "hashed_secret": "2582aea6f911bd00fc04cb25e0ec16d5ead62068",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 841,
+        "line_number": 850,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "build/bin/config/oscap/ssg-rhel9-ds.xml|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2025-11-14T08:09:29Z",
+  "generated_at": "2025-11-18T17:29:26Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -390,7 +390,7 @@
         "hashed_secret": "b2817467154949a61f8e9ad31d1eeaf03221cbfa",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 652,
+        "line_number": 653,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -398,7 +398,7 @@
         "hashed_secret": "effb7852555adce89885fb075fb43a77a1e0e77e",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 842,
+        "line_number": 841,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -406,7 +406,7 @@
         "hashed_secret": "2582aea6f911bd00fc04cb25e0ec16d5ead62068",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 844,
+        "line_number": 843,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -444,7 +444,7 @@
         "hashed_secret": "b2817467154949a61f8e9ad31d1eeaf03221cbfa",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 563,
+        "line_number": 560,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -690,7 +690,7 @@
         "hashed_secret": "fee2d55ad9a49a95fc89abe8f414dad66704ebfd",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 18,
+        "line_number": 21,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "build/bin/config/oscap/ssg-rhel9-ds.xml|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2025-11-19T07:34:40Z",
+  "generated_at": "2025-11-19T09:28:52Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -390,7 +390,7 @@
         "hashed_secret": "b2817467154949a61f8e9ad31d1eeaf03221cbfa",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 651,
+        "line_number": 650,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -398,7 +398,7 @@
         "hashed_secret": "effb7852555adce89885fb075fb43a77a1e0e77e",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 839,
+        "line_number": 838,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -406,7 +406,7 @@
         "hashed_secret": "2582aea6f911bd00fc04cb25e0ec16d5ead62068",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 841,
+        "line_number": 840,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,11 @@
     "files": "build/bin/config/oscap/ssg-rhel9-ds.xml|^.secrets.baseline$",
     "lines": null
   },
+<<<<<<< HEAD
   "generated_at": "2025-11-06T16:17:33Z",
+=======
+  "generated_at": "2025-10-28T09:13:25Z",
+>>>>>>> 2878999703 (update baseline)
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -390,7 +394,7 @@
         "hashed_secret": "b2817467154949a61f8e9ad31d1eeaf03221cbfa",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 656,
+        "line_number": 655,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -398,7 +402,7 @@
         "hashed_secret": "effb7852555adce89885fb075fb43a77a1e0e77e",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 838,
+        "line_number": 837,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -406,7 +410,7 @@
         "hashed_secret": "2582aea6f911bd00fc04cb25e0ec16d5ead62068",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 840,
+        "line_number": 839,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,11 +3,7 @@
     "files": "build/bin/config/oscap/ssg-rhel9-ds.xml|^.secrets.baseline$",
     "lines": null
   },
-<<<<<<< HEAD
   "generated_at": "2025-11-06T16:17:33Z",
-=======
-  "generated_at": "2025-10-28T09:13:25Z",
->>>>>>> 2878999703 (update baseline)
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -394,7 +390,7 @@
         "hashed_secret": "b2817467154949a61f8e9ad31d1eeaf03221cbfa",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 655,
+        "line_number": 654,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -402,7 +398,7 @@
         "hashed_secret": "effb7852555adce89885fb075fb43a77a1e0e77e",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 837,
+        "line_number": 839,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -410,7 +406,7 @@
         "hashed_secret": "2582aea6f911bd00fc04cb25e0ec16d5ead62068",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 839,
+        "line_number": 841,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "build/bin/config/oscap/ssg-rhel9-ds.xml|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2025-11-19T10:52:23Z",
+  "generated_at": "2025-11-20T16:12:22Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -398,7 +398,7 @@
         "hashed_secret": "effb7852555adce89885fb075fb43a77a1e0e77e",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 838,
+        "line_number": 840,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -406,7 +406,7 @@
         "hashed_secret": "2582aea6f911bd00fc04cb25e0ec16d5ead62068",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 840,
+        "line_number": 842,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "build/bin/config/oscap/ssg-rhel9-ds.xml|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2025-11-19T09:28:52Z",
+  "generated_at": "2025-11-19T10:52:23Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -444,7 +444,7 @@
         "hashed_secret": "b2817467154949a61f8e9ad31d1eeaf03221cbfa",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 559,
+        "line_number": 561,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "build/bin/config/oscap/ssg-rhel9-ds.xml|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2025-11-20T16:12:22Z",
+  "generated_at": "2025-11-20T17:38:52Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "build/bin/config/oscap/ssg-rhel9-ds.xml|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2025-11-13T08:04:12Z",
+  "generated_at": "2025-11-14T05:55:58Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -390,7 +390,7 @@
         "hashed_secret": "b2817467154949a61f8e9ad31d1eeaf03221cbfa",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 658,
+        "line_number": 652,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -398,7 +398,7 @@
         "hashed_secret": "effb7852555adce89885fb075fb43a77a1e0e77e",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 848,
+        "line_number": 842,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -406,7 +406,7 @@
         "hashed_secret": "2582aea6f911bd00fc04cb25e0ec16d5ead62068",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 850,
+        "line_number": 844,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -444,7 +444,7 @@
         "hashed_secret": "b2817467154949a61f8e9ad31d1eeaf03221cbfa",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 556,
+        "line_number": 560,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/image/cli/mascli/functions/gitops_mas_config
+++ b/image/cli/mascli/functions/gitops_mas_config
@@ -757,11 +757,10 @@ function gitops_mas_config() {
         export SECRET_NAME_SLS="${ACCOUNT_ID}${SECRETS_KEY_SEPERATOR}${CLUSTER_ID}${SECRETS_KEY_SEPERATOR}${MAS_INSTANCE_ID}${SECRETS_KEY_SEPERATOR}sls"
       else
         export SECRET_NAME_SLS="${ACCOUNT_ID}${SECRETS_KEY_SEPERATOR}${ICN}${SECRETS_KEY_SEPERATOR}${SAAS_SUB_ID}${SECRETS_KEY_SEPERATOR}sls"
-      fi
-       
-        export SECRET_KEY_SLS_URL=${SECRET_NAME_SLS}#sls_url
-        export SECRET_KEY_SLS_REGISTRATION_KEY=${SECRET_NAME_SLS}#registration_key
-        export SECRET_KEY_SLS_CA_B64=${SECRET_NAME_SLS}#ca_b64
+      fi  
+      export SECRET_KEY_SLS_URL=${SECRET_NAME_SLS}#sls_url
+      export SECRET_KEY_SLS_REGISTRATION_KEY=${SECRET_NAME_SLS}#registration_key
+      export SECRET_KEY_SLS_CA_B64=${SECRET_NAME_SLS}#ca_b64
 
       # Set pod template yaml
       # ---------------------------------------------------------------------------

--- a/image/cli/mascli/functions/gitops_mas_config
+++ b/image/cli/mascli/functions/gitops_mas_config
@@ -15,7 +15,7 @@ GitOps Configuration:
   -d, --dir ${COLOR_YELLOW}GITOPS_WORKING_DIR${TEXT_RESET}                     Working directory for GitOps repository
   -a, --account-id ${COLOR_YELLOW}ACCOUNT_ID${TEXT_RESET}                      Account name that the cluster belongs to
   -c, --cluster-id ${COLOR_YELLOW}CLUSTER_ID${TEXT_RESET}                      Cluster ID
-  -s ,--sls-service ${COLOR_YELLOW}STANDALONE_SLS_SERVICE${TEXT_RESET}         SLS service parameter file Path.
+  -s, --sls-service ${COLOR_YELLOW}STANDALONE_SLS_SERVICE${TEXT_RESET}         for ibm internal use only.
   --config-action ${COLOR_YELLOW}CONFIG_ACTION${TEXT_RESET}                    One of upsert|remove.
   --mas-config-type ${COLOR_YELLOW}MAS_CONFIG_TYPE${TEXT_RESET}                One of bas|jdbc|kafka|ldap-default|mongo|objectstorage|sls|smtp
   --mas-config-scope ${COLOR_YELLOW}MAS_CONFIG-SCOPE${TEXT_RESET}              One of system|ws|app|wsapp
@@ -753,14 +753,12 @@ function gitops_mas_config() {
     fi
 
     if [ "${MAS_CONFIG_TYPE}" == "sls" ]; then
-
-    if [ -z "$STANDALONE_SLS_SERVICE" ]; then
+      if [ -z "$STANDALONE_SLS_SERVICE" ]; then
         export SECRET_NAME_SLS="${ACCOUNT_ID}${SECRETS_KEY_SEPERATOR}${CLUSTER_ID}${SECRETS_KEY_SEPERATOR}${MAS_INSTANCE_ID}${SECRETS_KEY_SEPERATOR}sls"
       else
         export SECRET_NAME_SLS="${ACCOUNT_ID}${SECRETS_KEY_SEPERATOR}${ICN}${SECRETS_KEY_SEPERATOR}${SAAS_SUB_ID}${SECRETS_KEY_SEPERATOR}sls"
-    fi
-
-        
+      fi
+       
         export SECRET_KEY_SLS_URL=${SECRET_NAME_SLS}#sls_url
         export SECRET_KEY_SLS_REGISTRATION_KEY=${SECRET_NAME_SLS}#registration_key
         export SECRET_KEY_SLS_CA_B64=${SECRET_NAME_SLS}#ca_b64

--- a/image/cli/mascli/functions/gitops_mas_config
+++ b/image/cli/mascli/functions/gitops_mas_config
@@ -748,6 +748,8 @@ function gitops_mas_config() {
       else
         export SECRET_NAME_SLS=${ACCOUNT_ID}${SECRETS_KEY_SEPERATOR}${CLUSTER_ID}${SECRETS_KEY_SEPERATOR}${MAS_INSTANCE_ID}${SECRETS_KEY_SEPERATOR}sls
       fi
+        
+        export SECRET_KEY_SLS_URL=${SECRET_NAME_SLS}#sls_url
         export SECRET_KEY_SLS_REGISTRATION_KEY=${SECRET_NAME_SLS}#registration_key
         export SECRET_KEY_SLS_CA_B64=${SECRET_NAME_SLS}#ca_b64
 

--- a/image/cli/mascli/functions/gitops_mas_config
+++ b/image/cli/mascli/functions/gitops_mas_config
@@ -333,7 +333,6 @@ function gitops_mas_config_noninteractive() {
   done
 
 
-
   [[ -z "$GITOPS_WORKING_DIR" ]] && gitops_mas_config_help "GITOPS_WORKING_DIR is not set"
   [[ -z "$ACCOUNT_ID" ]] && gitops_mas_config_help "ACCOUNT_ID is not set"
   [[ -z "$REGION_ID" ]] && gitops_mas_config_help "REGION_ID is not set"
@@ -343,7 +342,6 @@ function gitops_mas_config_noninteractive() {
   [[ -z "$ICN" ]] && gitops_mas_config_help "ICN is not set"
 
   
-
   
   [[ -z "$CONFIG_ACTION" ]] && gitops_mas_config_help "CONFIG_ACTION is not set"
   if ! [[ "$CONFIG_ACTION" =~ ^(upsert|remove)$ ]]; then
@@ -746,8 +744,8 @@ function gitops_mas_config() {
     fi
 
     if [ "${MAS_CONFIG_TYPE}" == "sls" ]; then
-     # export SECRET_NAME_SLS=${ACCOUNT_ID}${SECRETS_KEY_SEPERATOR}${CLUSTER_ID}${SECRETS_KEY_SEPERATOR}${MAS_INSTANCE_ID}${SECRETS_KEY_SEPERATOR}sls
-      export SECRET_NAME_SLS=${ACCOUNT_ID}${SECRETS_KEY_SEPARATOR}${ICN}${SECRETS_KEY_SEPARATOR}${SAAS_SUB_ID}${SECRETS_KEY_SEPARATOR}sls
+      #export SECRET_NAME_SLS=${ACCOUNT_ID}${SECRETS_KEY_SEPERATOR}${CLUSTER_ID}${SECRETS_KEY_SEPERATOR}${MAS_INSTANCE_ID}${SECRETS_KEY_SEPERATOR}sls
+      export SECRET_NAME_SLS=${ACCOUNT_ID}${SECRETS_KEY_SEPERATOR}${ICN}${SECRETS_KEY_SEPERATOR}${SAAS_SUB_ID}${SECRETS_KEY_SEPERATOR}sls
       export SECRET_KEY_SLS_REGISTRATION_KEY=${SECRET_NAME_SLS}#registration_key
       export SECRET_KEY_SLS_CA_B64=${SECRET_NAME_SLS}#ca_b64
       

--- a/image/cli/mascli/functions/gitops_mas_config
+++ b/image/cli/mascli/functions/gitops_mas_config
@@ -15,7 +15,7 @@ GitOps Configuration:
   -d, --dir ${COLOR_YELLOW}GITOPS_WORKING_DIR${TEXT_RESET}                     Working directory for GitOps repository
   -a, --account-id ${COLOR_YELLOW}ACCOUNT_ID${TEXT_RESET}                      Account name that the cluster belongs to
   -c, --cluster-id ${COLOR_YELLOW}CLUSTER_ID${TEXT_RESET}                      Cluster ID
-  -s ,--sls-service ${COLOR_YELLOW}STANDALONE_SLS_SERVICE${TEXT_RESET}        STANDALONE_SLS_SERVICE        
+  -s ,--sls-service ${COLOR_YELLOW}STANDALONE_SLS_SERVICE${TEXT_RESET}         SLS service parameter file Path.
   --config-action ${COLOR_YELLOW}CONFIG_ACTION${TEXT_RESET}                    One of upsert|remove.
   --mas-config-type ${COLOR_YELLOW}MAS_CONFIG_TYPE${TEXT_RESET}                One of bas|jdbc|kafka|ldap-default|mongo|objectstorage|sls|smtp
   --mas-config-scope ${COLOR_YELLOW}MAS_CONFIG-SCOPE${TEXT_RESET}              One of system|ws|app|wsapp
@@ -106,6 +106,20 @@ function gitops_mas_config_noninteractive() {
 
   export REGION_ID=${REGION_ID:-${SM_AWS_REGION}}
 
+  if [ ! -z "$STANDALONE_SLS_SERVICE" ]; then
+    CLEAN_PATH=$(echo "$STANDALONE_SLS_SERVICE" | sed 's#<ref:##; s#>##')
+    IFS='/' read -r -a PARTS <<< "$CLEAN_PATH"
+    if [ ${#PARTS[@]} -lt 6 ]; then
+        echo "Error: Invalid SLS service parameter file Path $STANDALONE_SLS_SERVICE format." >&2
+        exit 1
+    fi
+    ICN="${PARTS[3]}"
+    SAAS_SUB_ID="${PARTS[4]}"
+  fi
+  
+  export ICN=${ICN:-""}
+  export SAAS_SUB_ID=${SAAS_SUB_ID:-""}
+
   if [ -z $GIT_SSH ]; then
     export GIT_SSH="false"
   fi
@@ -160,7 +174,7 @@ function gitops_mas_config_noninteractive() {
       # SLS
       # Standalone Server configuration
       -s|--sls-service)
-        export STANDALONE_SLS_SERVICE=$1 shift
+        export STANDALONE_SLS_SERVICE=$1 && shift
       ;;
       --mas-slscfg-pod-template-yaml)
         export MAS_SLSCFG_POD_TEMPLATE_YAML=$1 && shift
@@ -587,7 +601,7 @@ function gitops_mas_config() {
       echo "${TEXT_DIM}"
       echo_reset_dim "SLS URL  ....................... ${COLOR_MAGENTA}https://sls.mas-${MAS_INSTANCE_ID}-sls.svc"
       echo_reset_dim "Pod Template YAML File  ........ ${COLOR_MAGENTA}${MAS_SLSCFG_POD_TEMPLATE_YAML}"
-      echo_reset_dim "sls service  ........ ${COLOR_MAGENTA}${STANDALONE_SLS_SERVICE}"
+      echo_reset_dim "sls service param file path .....${COLOR_MAGENTA}${STANDALONE_SLS_SERVICE}"
 
       if [[ -n "$INTERNAL_CERT_AUTHORITY" ]]; then
         echo_reset_dim "Internal Certificate Authority ...... ${COLOR_MAGENTA}${INTERNAL_CERT_AUTHORITY}"
@@ -738,16 +752,14 @@ function gitops_mas_config() {
       fi
     fi
 
-      if [ "${MAS_CONFIG_TYPE}" == "sls" ]; then
-      if [ ! -z "$STANDALONE_SLS_SERVICE" ]; then
-          CLEAN_PATH=$(echo "$STANDALONE_SLS_SERVICE" | sed 's#<ref:##; s#>##')
-          IFS='/' read -r -a PARTS <<< "$CLEAN_PATH"
-          ICN="${PARTS[3]}"
-          SAAS_SUB_ID="${PARTS[4]}"    
-        export SECRET_NAME_SLS=${ACCOUNT_ID}${SECRETS_KEY_SEPERATOR}${ICN}${SECRETS_KEY_SEPERATOR}${SAAS_SUB_ID}${SECRETS_KEY_SEPERATOR}sls
+    if [ "${MAS_CONFIG_TYPE}" == "sls" ]; then
+
+    if [ -z "$STANDALONE_SLS_SERVICE" ]; then
+        export SECRET_NAME_SLS="${ACCOUNT_ID}${SECRETS_KEY_SEPERATOR}${CLUSTER_ID}${SECRETS_KEY_SEPERATOR}${MAS_INSTANCE_ID}${SECRETS_KEY_SEPERATOR}sls"
       else
-        export SECRET_NAME_SLS=${ACCOUNT_ID}${SECRETS_KEY_SEPERATOR}${CLUSTER_ID}${SECRETS_KEY_SEPERATOR}${MAS_INSTANCE_ID}${SECRETS_KEY_SEPERATOR}sls
-      fi
+        export SECRET_NAME_SLS="${ACCOUNT_ID}${SECRETS_KEY_SEPERATOR}${ICN}${SECRETS_KEY_SEPERATOR}${SAAS_SUB_ID}${SECRETS_KEY_SEPERATOR}sls"
+    fi
+
         
         export SECRET_KEY_SLS_URL=${SECRET_NAME_SLS}#sls_url
         export SECRET_KEY_SLS_REGISTRATION_KEY=${SECRET_NAME_SLS}#registration_key

--- a/image/cli/mascli/functions/gitops_mas_config
+++ b/image/cli/mascli/functions/gitops_mas_config
@@ -338,8 +338,7 @@ function gitops_mas_config_noninteractive() {
   [[ -z "$REGION_ID" ]] && gitops_mas_config_help "REGION_ID is not set"
   [[ -z "$CLUSTER_ID" ]] && gitops_mas_config_help "CLUSTER_ID is not set"
   [[ -z "$MAS_INSTANCE_ID" ]] && gitops_mas_config_help "MAS_INSTANCE_ID is not set"
-  [[ -z "$SAAS_SUB_ID" ]] && gitops_mas_config_help "SAAS_SUB_ID is not set"
-  [[ -z "$ICN" ]] && gitops_mas_config_help "ICN is not set"
+  ( [[ ! -z "$SAAS_SUB_ID" ]] && [[ -z "$ICN" ]] ) && gitops_license_help "ICN is not set"
 
   
   
@@ -743,12 +742,15 @@ function gitops_mas_config() {
       fi
     fi
 
-    if [ "${MAS_CONFIG_TYPE}" == "sls" ]; then
-      #export SECRET_NAME_SLS=${ACCOUNT_ID}${SECRETS_KEY_SEPERATOR}${CLUSTER_ID}${SECRETS_KEY_SEPERATOR}${MAS_INSTANCE_ID}${SECRETS_KEY_SEPERATOR}sls
+
+     if [ "${MAS_CONFIG_TYPE}" == "sls" ]; then
+       if [ ! -z "$SAAS_SUB_ID" ]; then
       export SECRET_NAME_SLS=${ACCOUNT_ID}${SECRETS_KEY_SEPERATOR}${ICN}${SECRETS_KEY_SEPERATOR}${SAAS_SUB_ID}${SECRETS_KEY_SEPERATOR}sls
+      else
+      export SECRET_NAME_SLS=${ACCOUNT_ID}${SECRETS_KEY_SEPERATOR}${CLUSTER_ID}${SECRETS_KEY_SEPERATOR}${MAS_INSTANCE_ID}${SECRETS_KEY_SEPERATOR}sls
+      fi
       export SECRET_KEY_SLS_REGISTRATION_KEY=${SECRET_NAME_SLS}#registration_key
       export SECRET_KEY_SLS_CA_B64=${SECRET_NAME_SLS}#ca_b64
-      
 
       # Set pod template yaml
       # ---------------------------------------------------------------------------

--- a/image/cli/mascli/functions/gitops_mas_config
+++ b/image/cli/mascli/functions/gitops_mas_config
@@ -15,8 +15,6 @@ GitOps Configuration:
   -d, --dir ${COLOR_YELLOW}GITOPS_WORKING_DIR${TEXT_RESET}                     Working directory for GitOps repository
   -a, --account-id ${COLOR_YELLOW}ACCOUNT_ID${TEXT_RESET}                      Account name that the cluster belongs to
   -c, --cluster-id ${COLOR_YELLOW}CLUSTER_ID${TEXT_RESET}                      Cluster ID
-  -i, --ibm-customer-number ${COLOR_YELLOW}ICN${TEXT_RESET}                      IBM Customer Number
-  -s, --saas-subscription-id  ${COLOR_YELLOW}SAAS_SUB_ID${TEXT_RESET}                    SaaS subscription id
   -s ,--sls-sls-service      ${COLOR_YELLOW}STANDALONE_SLS_SERVICE${TEXT_RESET}        STANDALONE_SLS_SERVICE        
   --config-action ${COLOR_YELLOW}CONFIG_ACTION${TEXT_RESET}                    One of upsert|remove.
   --mas-config-type ${COLOR_YELLOW}MAS_CONFIG_TYPE${TEXT_RESET}                One of bas|jdbc|kafka|ldap-default|mongo|objectstorage|sls|smtp
@@ -161,12 +159,6 @@ function gitops_mas_config_noninteractive() {
 
       # SLS
       # Standalone Server configuration
-      -s|--saas-subscription-id)
-        export SAAS_SUB_ID=$1 && shift
-      ;;
-      -i|--ibm-customer-number)
-        export ICN=$1 && shift
-      ;;
       -s|--sls-sls-service)
         export STANDALONE_SLS_SERVICE=$1 shift
       ;;
@@ -342,7 +334,6 @@ function gitops_mas_config_noninteractive() {
   [[ -z "$REGION_ID" ]] && gitops_mas_config_help "REGION_ID is not set"
   [[ -z "$CLUSTER_ID" ]] && gitops_mas_config_help "CLUSTER_ID is not set"
   [[ -z "$MAS_INSTANCE_ID" ]] && gitops_mas_config_help "MAS_INSTANCE_ID is not set"
-  ( [[ ! -z "$SAAS_SUB_ID" ]] && [[ -z "$ICN" ]] ) && gitops_mas_config_help "ICN is not set"
 
   
   
@@ -351,7 +342,7 @@ function gitops_mas_config_noninteractive() {
     gitops_mas_config_help "Invalid CONFIG_ACTION \"${CONFIG_ACTION}\"; must be one of 'upsert' or 'remove'"
   fi
 
-  [[ -z "$MAS_CONFIG_TYPE" ]] && gitops_mas_config_help "MAS_INSTANCE_ID is not set"
+  [[ -z "$MAS_CONFIG_TYPE" ]] && gitops_mas_config_help "MAS_CONFIG_TYPE is not set"
   if ! [[ "$MAS_CONFIG_TYPE" =~ ^(bas|jdbc|kafka|ldap-default|mongo|objectstorage|sls|smtp|watsonstudio)$ ]]; then
     gitops_mas_config_help "Invalid MAS_CONFIG_TYPE \"${MAS_CONFIG_TYPE}\"; must be one of bas|jdbc|kafka|ldap-default|mongo|objectstorage|sls|smtp|watsonstudio"
   fi
@@ -521,6 +512,7 @@ function gitops_mas_config() {
   echo_reset_dim "Cluster ID ..................... ${COLOR_MAGENTA}${CLUSTER_ID}"
   echo_reset_dim "MAS Instance ID ................ ${COLOR_MAGENTA}${MAS_INSTANCE_ID}"
   echo_reset_dim "System Config Directory ........ ${COLOR_MAGENTA}${GITOPS_INSTANCE_DIR}"
+
   reset_colors
 
   echo "${TEXT_DIM}"
@@ -597,6 +589,8 @@ function gitops_mas_config() {
       echo "${TEXT_DIM}"
       echo_reset_dim "SLS URL  ....................... ${COLOR_MAGENTA}https://sls.mas-${MAS_INSTANCE_ID}-sls.svc"
       echo_reset_dim "Pod Template YAML File  ........ ${COLOR_MAGENTA}${MAS_SLSCFG_POD_TEMPLATE_YAML}"
+      echo_reset_dim "sls service  ........ ${COLOR_MAGENTA}${STANDALONE_SLS_SERVICE}"
+
       if [[ -n "$INTERNAL_CERT_AUTHORITY" ]]; then
         echo_reset_dim "Internal Certificate Authority ...... ${COLOR_MAGENTA}${INTERNAL_CERT_AUTHORITY}"
       fi

--- a/image/cli/mascli/functions/gitops_mas_config
+++ b/image/cli/mascli/functions/gitops_mas_config
@@ -328,6 +328,8 @@ function gitops_mas_config_noninteractive() {
       esac
   done
 
+
+
   [[ -z "$GITOPS_WORKING_DIR" ]] && gitops_mas_config_help "GITOPS_WORKING_DIR is not set"
   [[ -z "$ACCOUNT_ID" ]] && gitops_mas_config_help "ACCOUNT_ID is not set"
   [[ -z "$REGION_ID" ]] && gitops_mas_config_help "REGION_ID is not set"

--- a/image/cli/mascli/functions/gitops_mas_config
+++ b/image/cli/mascli/functions/gitops_mas_config
@@ -15,11 +15,13 @@ GitOps Configuration:
   -d, --dir ${COLOR_YELLOW}GITOPS_WORKING_DIR${TEXT_RESET}                     Working directory for GitOps repository
   -a, --account-id ${COLOR_YELLOW}ACCOUNT_ID${TEXT_RESET}                      Account name that the cluster belongs to
   -c, --cluster-id ${COLOR_YELLOW}CLUSTER_ID${TEXT_RESET}                      Cluster ID
+  -i, --ibm-customer-number ${COLOR_YELLOW}ICN${TEXT_RESET}                      IBM Customer Number
+  -s, --saas-subscription-id  ${COLOR_YELLOW}SAAS_SUB_ID${TEXT_RESET}                    SaaS subscription id
   --config-action ${COLOR_YELLOW}CONFIG_ACTION${TEXT_RESET}                    One of upsert|remove.
   --mas-config-type ${COLOR_YELLOW}MAS_CONFIG_TYPE${TEXT_RESET}                One of bas|jdbc|kafka|ldap-default|mongo|objectstorage|sls|smtp
   --mas-config-scope ${COLOR_YELLOW}MAS_CONFIG-SCOPE${TEXT_RESET}              One of system|ws|app|wsapp
   --disable-postdelete-hooks ${COLOR_YELLOW}USE_POSTDELETE_HOOKS${TEXT_RESET}  Unless set (or USE_POSTDELETE_HOOKS exported and set to false), PostDelete hooks will be deployed to ensure config CRs are properly cleaned up by ArgoCD on deletion. !!! PostDelete hooks should never be used when ArgoCD version < 2.10 !!! 
-
+  
 IBM Maximo Application Suite:
   -m, --mas-instance-id ${COLOR_YELLOW}MAS_INSTANCE_ID${TEXT_RESET}         IBM Suite Maximo Application Suite Instance ID
   --mas-app-id ${COLOR_YELLOW}MAS_APP_ID${TEXT_RESET}                       MAS Application scope for this configuration (required if MAS_CONFIG_SCOPE is app or wsapp)     
@@ -36,8 +38,6 @@ Mongo Configuration (required if MAS_CONFIG_TYPE is "mongo"):
   --mongo-provider ${COLOR_YELLOW}MONGODB_PROVIDER${TEXT_RESET}  The mongodb provider to install. One of aws|yaml (defaults to yaml)
 
 SLS Configuration (if MAS_CONFIG_TYPE is "sls"):
-  -i, --ibm-customer-number ${COLOR_YELLOW}ICN${TEXT_RESET}                      IBM Customer Number
-  -s, --saas-subscription-id  ${COLOR_YELLOW}SAAS_SUB_ID${TEXT_RESET}                    SaaS subscription id
   --mas-slscfg-pod-template-yaml ${COLOR_YELLOW}MAS_SLSCFG_POD_TEMPLATE_YAML${TEXT_RESET}               The location of a file containing the POD template
   --internal-cert-authority ${COLOR_YELLOW}INTERNAL_CERT_AUTHORITY${TEXT_RESET}  Internal Certificate Authority to use for provisoning internal certificates
 

--- a/image/cli/mascli/functions/gitops_mas_config
+++ b/image/cli/mascli/functions/gitops_mas_config
@@ -15,7 +15,7 @@ GitOps Configuration:
   -d, --dir ${COLOR_YELLOW}GITOPS_WORKING_DIR${TEXT_RESET}                     Working directory for GitOps repository
   -a, --account-id ${COLOR_YELLOW}ACCOUNT_ID${TEXT_RESET}                      Account name that the cluster belongs to
   -c, --cluster-id ${COLOR_YELLOW}CLUSTER_ID${TEXT_RESET}                      Cluster ID
-  -s ,--sls-sls-service      ${COLOR_YELLOW}STANDALONE_SLS_SERVICE${TEXT_RESET}        STANDALONE_SLS_SERVICE        
+  -s ,--sls-service ${COLOR_YELLOW}STANDALONE_SLS_SERVICE${TEXT_RESET}        STANDALONE_SLS_SERVICE        
   --config-action ${COLOR_YELLOW}CONFIG_ACTION${TEXT_RESET}                    One of upsert|remove.
   --mas-config-type ${COLOR_YELLOW}MAS_CONFIG_TYPE${TEXT_RESET}                One of bas|jdbc|kafka|ldap-default|mongo|objectstorage|sls|smtp
   --mas-config-scope ${COLOR_YELLOW}MAS_CONFIG-SCOPE${TEXT_RESET}              One of system|ws|app|wsapp
@@ -159,7 +159,7 @@ function gitops_mas_config_noninteractive() {
 
       # SLS
       # Standalone Server configuration
-      -s|--sls-sls-service)
+      -s|--sls-service)
         export STANDALONE_SLS_SERVICE=$1 shift
       ;;
       --mas-slscfg-pod-template-yaml)
@@ -513,6 +513,7 @@ function gitops_mas_config() {
   echo_reset_dim "MAS Instance ID ................ ${COLOR_MAGENTA}${MAS_INSTANCE_ID}"
   echo_reset_dim "System Config Directory ........ ${COLOR_MAGENTA}${GITOPS_INSTANCE_DIR}"
 
+
   reset_colors
 
   echo "${TEXT_DIM}"
@@ -740,20 +741,18 @@ function gitops_mas_config() {
       fi
     fi
 
-
-     if [ "${MAS_CONFIG_TYPE}" == "sls" ]; then
-       if [ ! -z "$STANDALONE_SLS_SERVICE" ]; then
-        CLEAN_PATH=$(echo "$STANDALONE_SLS_SERVICE" | sed 's#<ref:##; s#>##')
-        IFS='/' read -r -a PARTS <<< "$CLEAN_PATH"
-        ICN="${PARTS[3]}"
-        SAAS_SUB_ID="${PARTS[4]}"
-        
-      export SECRET_NAME_SLS=${ACCOUNT_ID}${SECRETS_KEY_SEPERATOR}${ICN}${SECRETS_KEY_SEPERATOR}${SAAS_SUB_ID}${SECRETS_KEY_SEPERATOR}sls
+      if [ "${MAS_CONFIG_TYPE}" == "sls" ]; then
+      if [ ! -z "$STANDALONE_SLS_SERVICE" ]; then
+          CLEAN_PATH=$(echo "$STANDALONE_SLS_SERVICE" | sed 's#<ref:##; s#>##')
+          IFS='/' read -r -a PARTS <<< "$CLEAN_PATH"
+          ICN="${PARTS[3]}"
+          SAAS_SUB_ID="${PARTS[4]}"    
+        export SECRET_NAME_SLS=${ACCOUNT_ID}${SECRETS_KEY_SEPERATOR}${ICN}${SECRETS_KEY_SEPERATOR}${SAAS_SUB_ID}${SECRETS_KEY_SEPERATOR}sls
       else
-      export SECRET_NAME_SLS=${ACCOUNT_ID}${SECRETS_KEY_SEPERATOR}${CLUSTER_ID}${SECRETS_KEY_SEPERATOR}${MAS_INSTANCE_ID}${SECRETS_KEY_SEPERATOR}sls
+        export SECRET_NAME_SLS=${ACCOUNT_ID}${SECRETS_KEY_SEPERATOR}${CLUSTER_ID}${SECRETS_KEY_SEPERATOR}${MAS_INSTANCE_ID}${SECRETS_KEY_SEPERATOR}sls
       fi
-      export SECRET_KEY_SLS_REGISTRATION_KEY=${SECRET_NAME_SLS}#registration_key
-      export SECRET_KEY_SLS_CA_B64=${SECRET_NAME_SLS}#ca_b64
+        export SECRET_KEY_SLS_REGISTRATION_KEY=${SECRET_NAME_SLS}#registration_key
+        export SECRET_KEY_SLS_CA_B64=${SECRET_NAME_SLS}#ca_b64
 
       # Set pod template yaml
       # ---------------------------------------------------------------------------

--- a/image/cli/mascli/functions/gitops_mas_config
+++ b/image/cli/mascli/functions/gitops_mas_config
@@ -511,7 +511,6 @@ function gitops_mas_config() {
   echo_reset_dim "Cluster ID ..................... ${COLOR_MAGENTA}${CLUSTER_ID}"
   echo_reset_dim "MAS Instance ID ................ ${COLOR_MAGENTA}${MAS_INSTANCE_ID}"
   echo_reset_dim "System Config Directory ........ ${COLOR_MAGENTA}${GITOPS_INSTANCE_DIR}"
-
   reset_colors
 
   echo "${TEXT_DIM}"

--- a/image/cli/mascli/functions/gitops_mas_config
+++ b/image/cli/mascli/functions/gitops_mas_config
@@ -36,6 +36,8 @@ Mongo Configuration (required if MAS_CONFIG_TYPE is "mongo"):
   --mongo-provider ${COLOR_YELLOW}MONGODB_PROVIDER${TEXT_RESET}  The mongodb provider to install. One of aws|yaml (defaults to yaml)
 
 SLS Configuration (if MAS_CONFIG_TYPE is "sls"):
+  -i, --ibm-customer-number ${COLOR_YELLOW}ICN${TEXT_RESET}                      IBM Customer Number
+  -s, --saas-subscription-id  ${COLOR_YELLOW}SAAS_SUB_ID${TEXT_RESET}                    SaaS subscription id
   --mas-slscfg-pod-template-yaml ${COLOR_YELLOW}MAS_SLSCFG_POD_TEMPLATE_YAML${TEXT_RESET}               The location of a file containing the POD template
   --internal-cert-authority ${COLOR_YELLOW}INTERNAL_CERT_AUTHORITY${TEXT_RESET}  Internal Certificate Authority to use for provisoning internal certificates
 
@@ -157,6 +159,13 @@ function gitops_mas_config_noninteractive() {
         ;;
 
       # SLS
+      # Standalone Server configuration
+      -s|--saas-subscription-id)
+        export SAAS_SUB_ID=$1 && shift
+      ;;
+      -i|--ibm-customer-number)
+        export ICN=$1 && shift
+      ;;
       --mas-slscfg-pod-template-yaml)
         export MAS_SLSCFG_POD_TEMPLATE_YAML=$1 && shift
         ;;
@@ -330,6 +339,11 @@ function gitops_mas_config_noninteractive() {
   [[ -z "$REGION_ID" ]] && gitops_mas_config_help "REGION_ID is not set"
   [[ -z "$CLUSTER_ID" ]] && gitops_mas_config_help "CLUSTER_ID is not set"
   [[ -z "$MAS_INSTANCE_ID" ]] && gitops_mas_config_help "MAS_INSTANCE_ID is not set"
+  [[ -z "$SAAS_SUB_ID" ]] && gitops_mas_config_help "SAAS_SUB_ID is not set"
+  [[ -z "$ICN" ]] && gitops_mas_config_help "ICN is not set"
+
+  
+
   
   [[ -z "$CONFIG_ACTION" ]] && gitops_mas_config_help "CONFIG_ACTION is not set"
   if ! [[ "$CONFIG_ACTION" =~ ^(upsert|remove)$ ]]; then
@@ -732,10 +746,12 @@ function gitops_mas_config() {
     fi
 
     if [ "${MAS_CONFIG_TYPE}" == "sls" ]; then
-      export SECRET_NAME_SLS=${ACCOUNT_ID}${SECRETS_KEY_SEPERATOR}${CLUSTER_ID}${SECRETS_KEY_SEPERATOR}${MAS_INSTANCE_ID}${SECRETS_KEY_SEPERATOR}sls
+     # export SECRET_NAME_SLS=${ACCOUNT_ID}${SECRETS_KEY_SEPERATOR}${CLUSTER_ID}${SECRETS_KEY_SEPERATOR}${MAS_INSTANCE_ID}${SECRETS_KEY_SEPERATOR}sls
+      export SECRET_NAME_SLS=${ACCOUNT_ID}${SECRETS_KEY_SEPARATOR}${ICN}${SECRETS_KEY_SEPARATOR}${SAAS_SUB_ID}${SECRETS_KEY_SEPARATOR}sls
       export SECRET_KEY_SLS_REGISTRATION_KEY=${SECRET_NAME_SLS}#registration_key
       export SECRET_KEY_SLS_CA_B64=${SECRET_NAME_SLS}#ca_b64
       
+
       # Set pod template yaml
       # ---------------------------------------------------------------------------
       if [[ -n "$MAS_SLSCFG_POD_TEMPLATE_YAML" && -s "$MAS_SLSCFG_POD_TEMPLATE_YAML" ]]; then

--- a/image/cli/mascli/functions/gitops_mas_config
+++ b/image/cli/mascli/functions/gitops_mas_config
@@ -17,6 +17,7 @@ GitOps Configuration:
   -c, --cluster-id ${COLOR_YELLOW}CLUSTER_ID${TEXT_RESET}                      Cluster ID
   -i, --ibm-customer-number ${COLOR_YELLOW}ICN${TEXT_RESET}                      IBM Customer Number
   -s, --saas-subscription-id  ${COLOR_YELLOW}SAAS_SUB_ID${TEXT_RESET}                    SaaS subscription id
+  -s ,--sls-sls-service      ${COLOR_YELLOW}STANDALONE_SLS_SERVICE${TEXT_RESET}        STANDALONE_SLS_SERVICE        
   --config-action ${COLOR_YELLOW}CONFIG_ACTION${TEXT_RESET}                    One of upsert|remove.
   --mas-config-type ${COLOR_YELLOW}MAS_CONFIG_TYPE${TEXT_RESET}                One of bas|jdbc|kafka|ldap-default|mongo|objectstorage|sls|smtp
   --mas-config-scope ${COLOR_YELLOW}MAS_CONFIG-SCOPE${TEXT_RESET}              One of system|ws|app|wsapp
@@ -165,6 +166,9 @@ function gitops_mas_config_noninteractive() {
       ;;
       -i|--ibm-customer-number)
         export ICN=$1 && shift
+      ;;
+      -s|--sls-sls-service)
+        export STANDALONE_SLS_SERVICE=$1 shift
       ;;
       --mas-slscfg-pod-template-yaml)
         export MAS_SLSCFG_POD_TEMPLATE_YAML=$1 && shift
@@ -744,7 +748,12 @@ function gitops_mas_config() {
 
 
      if [ "${MAS_CONFIG_TYPE}" == "sls" ]; then
-       if [ ! -z "$SAAS_SUB_ID" ]; then
+       if [ ! -z "$STANDALONE_SLS_SERVICE" ]; then
+        CLEAN_PATH=$(echo "$STANDALONE_SLS_SERVICE" | sed 's#<ref:##; s#>##')
+        IFS='/' read -r -a PARTS <<< "$CLEAN_PATH"
+        ICN="${PARTS[3]}"
+        SAAS_SUB_ID="${PARTS[4]}"
+        
       export SECRET_NAME_SLS=${ACCOUNT_ID}${SECRETS_KEY_SEPERATOR}${ICN}${SECRETS_KEY_SEPERATOR}${SAAS_SUB_ID}${SECRETS_KEY_SEPERATOR}sls
       else
       export SECRET_NAME_SLS=${ACCOUNT_ID}${SECRETS_KEY_SEPERATOR}${CLUSTER_ID}${SECRETS_KEY_SEPERATOR}${MAS_INSTANCE_ID}${SECRETS_KEY_SEPERATOR}sls

--- a/image/cli/mascli/functions/gitops_mas_config
+++ b/image/cli/mascli/functions/gitops_mas_config
@@ -20,7 +20,7 @@ GitOps Configuration:
   --mas-config-type ${COLOR_YELLOW}MAS_CONFIG_TYPE${TEXT_RESET}                One of bas|jdbc|kafka|ldap-default|mongo|objectstorage|sls|smtp
   --mas-config-scope ${COLOR_YELLOW}MAS_CONFIG-SCOPE${TEXT_RESET}              One of system|ws|app|wsapp
   --disable-postdelete-hooks ${COLOR_YELLOW}USE_POSTDELETE_HOOKS${TEXT_RESET}  Unless set (or USE_POSTDELETE_HOOKS exported and set to false), PostDelete hooks will be deployed to ensure config CRs are properly cleaned up by ArgoCD on deletion. !!! PostDelete hooks should never be used when ArgoCD version < 2.10 !!! 
-  
+
 IBM Maximo Application Suite:
   -m, --mas-instance-id ${COLOR_YELLOW}MAS_INSTANCE_ID${TEXT_RESET}         IBM Suite Maximo Application Suite Instance ID
   --mas-app-id ${COLOR_YELLOW}MAS_APP_ID${TEXT_RESET}                       MAS Application scope for this configuration (required if MAS_CONFIG_SCOPE is app or wsapp)     
@@ -328,14 +328,11 @@ function gitops_mas_config_noninteractive() {
       esac
   done
 
-
   [[ -z "$GITOPS_WORKING_DIR" ]] && gitops_mas_config_help "GITOPS_WORKING_DIR is not set"
   [[ -z "$ACCOUNT_ID" ]] && gitops_mas_config_help "ACCOUNT_ID is not set"
   [[ -z "$REGION_ID" ]] && gitops_mas_config_help "REGION_ID is not set"
   [[ -z "$CLUSTER_ID" ]] && gitops_mas_config_help "CLUSTER_ID is not set"
   [[ -z "$MAS_INSTANCE_ID" ]] && gitops_mas_config_help "MAS_INSTANCE_ID is not set"
-
-  
   
   [[ -z "$CONFIG_ACTION" ]] && gitops_mas_config_help "CONFIG_ACTION is not set"
   if ! [[ "$CONFIG_ACTION" =~ ^(upsert|remove)$ ]]; then
@@ -512,7 +509,6 @@ function gitops_mas_config() {
   echo_reset_dim "Cluster ID ..................... ${COLOR_MAGENTA}${CLUSTER_ID}"
   echo_reset_dim "MAS Instance ID ................ ${COLOR_MAGENTA}${MAS_INSTANCE_ID}"
   echo_reset_dim "System Config Directory ........ ${COLOR_MAGENTA}${GITOPS_INSTANCE_DIR}"
-
 
   reset_colors
 

--- a/image/cli/mascli/functions/gitops_mas_config
+++ b/image/cli/mascli/functions/gitops_mas_config
@@ -338,7 +338,7 @@ function gitops_mas_config_noninteractive() {
   [[ -z "$REGION_ID" ]] && gitops_mas_config_help "REGION_ID is not set"
   [[ -z "$CLUSTER_ID" ]] && gitops_mas_config_help "CLUSTER_ID is not set"
   [[ -z "$MAS_INSTANCE_ID" ]] && gitops_mas_config_help "MAS_INSTANCE_ID is not set"
-  ( [[ ! -z "$SAAS_SUB_ID" ]] && [[ -z "$ICN" ]] ) && gitops_license_help "ICN is not set"
+  ( [[ ! -z "$SAAS_SUB_ID" ]] && [[ -z "$ICN" ]] ) && gitops_mas_config_help "ICN is not set"
 
   
   

--- a/image/cli/mascli/functions/gitops_suite
+++ b/image/cli/mascli/functions/gitops_suite
@@ -26,7 +26,7 @@ MongoDb Provider Selection (Required):
       --mongo-provider ${COLOR_YELLOW}MONGODB_PROVIDER${TEXT_RESET}  The mongodb provider to install ('aws' or 'yaml')
 
 IBM Suite License Service:
-  -s ,--sls-service ${COLOR_YELLOW}STANDALONE_SLS_SERVICE${TEXT_RESET}         SLS service parameter file Path.
+  -s, --sls-service ${COLOR_YELLOW}STANDALONE_SLS_SERVICE${TEXT_RESET}         for ibm internal use only.
       --sls-channel ${COLOR_YELLOW}SLS_CHANNEL${TEXT_RESET}  IBM Suite License Service Subscription Channel
       --sls-install-plan ${COLOR_YELLOW}SLS_INSTALL_PLAN${TEXT_RESET}  IBM Suite License Service Subscription Install Plan ('Automatic' or 'Manual'. Default is 'Automatic')
 

--- a/image/cli/mascli/functions/gitops_suite
+++ b/image/cli/mascli/functions/gitops_suite
@@ -209,6 +209,11 @@ function gitops_suite_noninteractive() {
         export SLS_INSTALL_PLAN=$1 && shift
         ;;
 
+      # Standalone Server configuration
+      -s|--sls-service)
+        export STANDALONE_SLS_SERVICE=$1 && shift
+        ;;
+
       # MAS
       --mas-annotations)
         export MAS_ANNOTATIONS=$1 && shift

--- a/image/cli/mascli/functions/gitops_suite
+++ b/image/cli/mascli/functions/gitops_suite
@@ -515,7 +515,9 @@ function gitops_suite() {
   echo_h4 "IBM Suite License Service" "    "
   echo_reset_dim "Subscription Channel ........... ${COLOR_MAGENTA}${SLS_CHANNEL}"
   echo_reset_dim "Subscription Install Plan ...... ${COLOR_MAGENTA}${SLS_INSTALL_PLAN}"
-  echo_reset_dim "ibm customer number  ........ ${COLOR_MAGENTA}${ICN}"
+  echo_reset_dim "Ibm Customer Number  ........ ${COLOR_MAGENTA}${ICN}"
+  echo_reset_dim "Subscription Id   ........ ${COLOR_MAGENTA}${SAAS_SUB_ID}"
+
 
   if [[ -n "$INTERNAL_CERT_AUTHORITY" ]]; then
     echo_reset_dim "Internal Certificate Authority ...... ${COLOR_MAGENTA}${INTERNAL_CERT_AUTHORITY}"

--- a/image/cli/mascli/functions/gitops_suite
+++ b/image/cli/mascli/functions/gitops_suite
@@ -26,7 +26,7 @@ MongoDb Provider Selection (Required):
       --mongo-provider ${COLOR_YELLOW}MONGODB_PROVIDER${TEXT_RESET}  The mongodb provider to install ('aws' or 'yaml')
 
 IBM Suite License Service:
-  -s, --sls-service ${COLOR_YELLOW}STANDALONE_SLS_SERVICE${TEXT_RESET}        STANDALONE_SLS_SERVICE        
+  -s ,--sls-service ${COLOR_YELLOW}STANDALONE_SLS_SERVICE${TEXT_RESET}         SLS service parameter file Path.
       --sls-channel ${COLOR_YELLOW}SLS_CHANNEL${TEXT_RESET}  IBM Suite License Service Subscription Channel
       --sls-install-plan ${COLOR_YELLOW}SLS_INSTALL_PLAN${TEXT_RESET}  IBM Suite License Service Subscription Install Plan ('Automatic' or 'Manual'. Default is 'Automatic')
 
@@ -139,11 +139,15 @@ function gitops_suite_noninteractive() {
   export CERT_MANAGER_NAMESPACE=${CERT_MANAGER_NAMESPACE:-"cert-manager"}
 
   if [ ! -z "$STANDALONE_SLS_SERVICE" ]; then
-        CLEAN_PATH=$(echo "$STANDALONE_SLS_SERVICE" | sed 's#<ref:##; s#>##')
-        IFS='/' read -r -a PARTS <<< "$CLEAN_PATH"
-        ICN="${PARTS[3]}"
-        SAAS_SUB_ID="${PARTS[4]}"
-  fi    
+      CLEAN_PATH=$(echo "$STANDALONE_SLS_SERVICE" | sed 's#<ref:##; s#>##')
+      IFS='/' read -r -a PARTS <<< "$CLEAN_PATH"
+      if [ ${#PARTS[@]} -lt 6 ]; then
+          echo "Error: Invalid SLS service parameter file Path $STANDALONE_SLS_SERVICE format." >&2
+          exit 1
+      fi
+      ICN="${PARTS[3]}"
+      SAAS_SUB_ID="${PARTS[4]}"
+  fi
    
   export ICN=${ICN:-""}
   export SAAS_SUB_ID=${SAAS_SUB_ID:-""}
@@ -515,8 +519,8 @@ function gitops_suite() {
   echo_h4 "IBM Suite License Service" "    "
   echo_reset_dim "Subscription Channel ........... ${COLOR_MAGENTA}${SLS_CHANNEL}"
   echo_reset_dim "Subscription Install Plan ...... ${COLOR_MAGENTA}${SLS_INSTALL_PLAN}"
-  echo_reset_dim "Ibm Customer Number  ........ ${COLOR_MAGENTA}${ICN}"
-  echo_reset_dim "Subscription Id   ........ ${COLOR_MAGENTA}${SAAS_SUB_ID}"
+  echo_reset_dim "Ibm Customer Number  ........... ${COLOR_MAGENTA}${ICN}"
+  echo_reset_dim "Subscription Id   .............. ${COLOR_MAGENTA}${SAAS_SUB_ID}"
 
 
   if [[ -n "$INTERNAL_CERT_AUTHORITY" ]]; then

--- a/image/cli/mascli/functions/gitops_suite
+++ b/image/cli/mascli/functions/gitops_suite
@@ -15,8 +15,6 @@ Basic Configuration:
   -c, --cluster-id ${COLOR_YELLOW}CLUSTER_ID${TEXT_RESET}            Cluster ID
   -m, --mas-instance-id ${COLOR_YELLOW}MAS_INSTANCE_ID${TEXT_RESET}  IBM Suite Maximo Application Suite Instance ID
       --custom-labels ${COLOR_YELLOW}CUSTOM_LABELS${TEXT_RESET}      Custom Labels definition in dict format
-  -i  --ibm-customer-number ${COLOR_YELLOW}ICN${TEXT_RESET}          IBM Customer Number
-
 
 AWS Secrets Manager Configuration (Required):
       --sm-aws-secret-region ${COLOR_YELLOW}SM_AWS_REGION${TEXT_RESET}          Region of the AWS Secrets Manager to use
@@ -28,6 +26,8 @@ MongoDb Provider Selection (Required):
       --mongo-provider ${COLOR_YELLOW}MONGODB_PROVIDER${TEXT_RESET}  The mongodb provider to install ('aws' or 'yaml')
 
 IBM Suite License Service:
+  -s, --sls-sls-service      ${COLOR_YELLOW}STANDALONE_SLS_SERVICE${TEXT_RESET}        STANDALONE_SLS_SERVICE        
+
       --sls-channel ${COLOR_YELLOW}SLS_CHANNEL${TEXT_RESET}  IBM Suite License Service Subscription Channel
       --sls-install-plan ${COLOR_YELLOW}SLS_INSTALL_PLAN${TEXT_RESET}  IBM Suite License Service Subscription Install Plan ('Automatic' or 'Manual'. Default is 'Automatic')
 
@@ -139,9 +139,12 @@ function gitops_suite_noninteractive() {
   # cert-manager namespace, in case redhat default value is cert-manager
   export CERT_MANAGER_NAMESPACE=${CERT_MANAGER_NAMESPACE:-"cert-manager"}
 
-  export ICN=${ICN:-""}
+  if [ ! -z "$STANDALONE_SLS_SERVICE" ]; then
+        CLEAN_PATH=$(echo "$STANDALONE_SLS_SERVICE" | sed 's#<ref:##; s#>##')
+        IFS='/' read -r -a PARTS <<< "$CLEAN_PATH"
+        ICN="${PARTS[3]}"
+  fi    
 
-        
   while [[ $# -gt 0 ]]
   do
     key="$1"
@@ -491,7 +494,6 @@ function gitops_suite() {
   echo_reset_dim "Cluster URL .................... ${COLOR_MAGENTA}${CLUSTER_URL}"
   echo_reset_dim "MAS Instance ID ................ ${COLOR_MAGENTA}${MAS_INSTANCE_ID}"
   echo_reset_dim "Instance Config Directory ...... ${COLOR_MAGENTA}${GITOPS_INSTANCE_DIR}"
-  echo_reset_dim "IBM Customer Number.............${COLOR_MAGENTA}${ICN}"
 
 
   reset_colors
@@ -514,6 +516,8 @@ function gitops_suite() {
   echo_h4 "IBM Suite License Service" "    "
   echo_reset_dim "Subscription Channel ........... ${COLOR_MAGENTA}${SLS_CHANNEL}"
   echo_reset_dim "Subscription Install Plan ...... ${COLOR_MAGENTA}${SLS_INSTALL_PLAN}"
+  echo_reset_dim "ibm customer number  ........ ${COLOR_MAGENTA}${ICN}"
+
   if [[ -n "$INTERNAL_CERT_AUTHORITY" ]]; then
     echo_reset_dim "Internal Certificate Authority ...... ${COLOR_MAGENTA}${INTERNAL_CERT_AUTHORITY}"
   fi
@@ -691,7 +695,7 @@ function gitops_suite() {
   ESCAPED_INFO=${UNESCAPED_MONGO_INFO//\"/\\\"}
   ESCAPED_INFO=${ESCAPED_INFO//$'\n'/\\n}
   TAGS="[{\"Key\": \"source\", \"Value\": \"gitops_suite\"}, {\"Key\": \"account\", \"Value\": \"${ACCOUNT_ID}\"}, {\"Key\": \"cluster\", \"Value\": \"${CLUSTER_ID}\"}]"
-  sm_update_secret $SECRET_NAME_MONGO "{\"info\": \"$ESCAPED_INFO\", \"username\": \"$INSTANCE_MONGO_USERNAME\", \"password\": \"$INSTANCE_MONGO_PASSWORD\"}" "${TAGS}"
+  #sm_update_secret $SECRET_NAME_MONGO "{\"info\": \"$ESCAPED_INFO\", \"username\": \"$INSTANCE_MONGO_USERNAME\", \"password\": \"$INSTANCE_MONGO_PASSWORD\"}" "${TAGS}"
   
 
   if [ -z $GIT_SSH ]; then

--- a/image/cli/mascli/functions/gitops_suite
+++ b/image/cli/mascli/functions/gitops_suite
@@ -27,7 +27,7 @@ MongoDb Provider Selection (Required):
 
 IBM Suite License Service:
   -s, --sls-sls-service      ${COLOR_YELLOW}STANDALONE_SLS_SERVICE${TEXT_RESET}        STANDALONE_SLS_SERVICE        
-
+  -i, --ibm-customer-number     ${COLOR_YELLOW}ICN${TEXT_RESET}                         IBM CUSTOMER NUMBER
       --sls-channel ${COLOR_YELLOW}SLS_CHANNEL${TEXT_RESET}  IBM Suite License Service Subscription Channel
       --sls-install-plan ${COLOR_YELLOW}SLS_INSTALL_PLAN${TEXT_RESET}  IBM Suite License Service Subscription Install Plan ('Automatic' or 'Manual'. Default is 'Automatic')
 
@@ -144,6 +144,9 @@ function gitops_suite_noninteractive() {
         IFS='/' read -r -a PARTS <<< "$CLEAN_PATH"
         ICN="${PARTS[3]}"
   fi    
+   
+  export ICN=${ICN:-""}
+
 
   while [[ $# -gt 0 ]]
   do

--- a/image/cli/mascli/functions/gitops_suite
+++ b/image/cli/mascli/functions/gitops_suite
@@ -698,7 +698,7 @@ function gitops_suite() {
   ESCAPED_INFO=${UNESCAPED_MONGO_INFO//\"/\\\"}
   ESCAPED_INFO=${ESCAPED_INFO//$'\n'/\\n}
   TAGS="[{\"Key\": \"source\", \"Value\": \"gitops_suite\"}, {\"Key\": \"account\", \"Value\": \"${ACCOUNT_ID}\"}, {\"Key\": \"cluster\", \"Value\": \"${CLUSTER_ID}\"}]"
-  #sm_update_secret $SECRET_NAME_MONGO "{\"info\": \"$ESCAPED_INFO\", \"username\": \"$INSTANCE_MONGO_USERNAME\", \"password\": \"$INSTANCE_MONGO_PASSWORD\"}" "${TAGS}"
+  sm_update_secret $SECRET_NAME_MONGO "{\"info\": \"$ESCAPED_INFO\", \"username\": \"$INSTANCE_MONGO_USERNAME\", \"password\": \"$INSTANCE_MONGO_PASSWORD\"}" "${TAGS}"
   
 
   if [ -z $GIT_SSH ]; then

--- a/image/cli/mascli/functions/gitops_suite
+++ b/image/cli/mascli/functions/gitops_suite
@@ -805,5 +805,3 @@ function gitops_suite() {
   rm -rf $TEMP_DIR
 
 }
-
-

--- a/image/cli/mascli/functions/gitops_suite
+++ b/image/cli/mascli/functions/gitops_suite
@@ -137,7 +137,7 @@ function gitops_suite_noninteractive() {
 
   # cert-manager namespace, in case redhat default value is cert-manager
   export CERT_MANAGER_NAMESPACE=${CERT_MANAGER_NAMESPACE:-"cert-manager"}
-
+  
   if [ ! -z "$STANDALONE_SLS_SERVICE" ]; then
         CLEAN_PATH=$(echo "$STANDALONE_SLS_SERVICE" | sed 's#<ref:##; s#>##')
         IFS='/' read -r -a PARTS <<< "$CLEAN_PATH"

--- a/image/cli/mascli/functions/gitops_suite
+++ b/image/cli/mascli/functions/gitops_suite
@@ -137,7 +137,7 @@ function gitops_suite_noninteractive() {
 
   # cert-manager namespace, in case redhat default value is cert-manager
   export CERT_MANAGER_NAMESPACE=${CERT_MANAGER_NAMESPACE:-"cert-manager"}
-  
+
   if [ ! -z "$STANDALONE_SLS_SERVICE" ]; then
         CLEAN_PATH=$(echo "$STANDALONE_SLS_SERVICE" | sed 's#<ref:##; s#>##')
         IFS='/' read -r -a PARTS <<< "$CLEAN_PATH"
@@ -170,6 +170,7 @@ function gitops_suite_noninteractive() {
       --custom-labels)
         export CUSTOM_LABELS=$1 && shift
         ;;
+
       # AWS Secrets Manager Configuration
       --sm-aws-secret-region)
         export SM_AWS_REGION=$1
@@ -494,8 +495,6 @@ function gitops_suite() {
   echo_reset_dim "Cluster URL .................... ${COLOR_MAGENTA}${CLUSTER_URL}"
   echo_reset_dim "MAS Instance ID ................ ${COLOR_MAGENTA}${MAS_INSTANCE_ID}"
   echo_reset_dim "Instance Config Directory ...... ${COLOR_MAGENTA}${GITOPS_INSTANCE_DIR}"
-
-
   reset_colors
 
   echo "${TEXT_DIM}"

--- a/image/cli/mascli/functions/gitops_suite
+++ b/image/cli/mascli/functions/gitops_suite
@@ -15,6 +15,8 @@ Basic Configuration:
   -c, --cluster-id ${COLOR_YELLOW}CLUSTER_ID${TEXT_RESET}            Cluster ID
   -m, --mas-instance-id ${COLOR_YELLOW}MAS_INSTANCE_ID${TEXT_RESET}  IBM Suite Maximo Application Suite Instance ID
       --custom-labels ${COLOR_YELLOW}CUSTOM_LABELS${TEXT_RESET}      Custom Labels definition in dict format
+  -i  --ibm-customer-number ${COLOR_YELLOW}ICN${TEXT_RESET}          IBM Customer Number
+
 
 AWS Secrets Manager Configuration (Required):
       --sm-aws-secret-region ${COLOR_YELLOW}SM_AWS_REGION${TEXT_RESET}          Region of the AWS Secrets Manager to use
@@ -136,6 +138,9 @@ function gitops_suite_noninteractive() {
 
   # cert-manager namespace, in case redhat default value is cert-manager
   export CERT_MANAGER_NAMESPACE=${CERT_MANAGER_NAMESPACE:-"cert-manager"}
+
+  export ICN=${ICN:-""}
+
         
   while [[ $# -gt 0 ]]
   do
@@ -157,6 +162,9 @@ function gitops_suite_noninteractive() {
         ;;
       --custom-labels)
         export CUSTOM_LABELS=$1 && shift
+        ;;
+      -i|--ibm-customer-number)
+        export ICN=$1 && shift
         ;;
 
       # AWS Secrets Manager Configuration
@@ -483,6 +491,9 @@ function gitops_suite() {
   echo_reset_dim "Cluster URL .................... ${COLOR_MAGENTA}${CLUSTER_URL}"
   echo_reset_dim "MAS Instance ID ................ ${COLOR_MAGENTA}${MAS_INSTANCE_ID}"
   echo_reset_dim "Instance Config Directory ...... ${COLOR_MAGENTA}${GITOPS_INSTANCE_DIR}"
+  echo_reset_dim "IBM Customer Number.............${COLOR_MAGENTA}${ICN}"
+
+
   reset_colors
 
   echo "${TEXT_DIM}"

--- a/image/cli/mascli/functions/gitops_suite
+++ b/image/cli/mascli/functions/gitops_suite
@@ -26,8 +26,7 @@ MongoDb Provider Selection (Required):
       --mongo-provider ${COLOR_YELLOW}MONGODB_PROVIDER${TEXT_RESET}  The mongodb provider to install ('aws' or 'yaml')
 
 IBM Suite License Service:
-  -s, --sls-sls-service      ${COLOR_YELLOW}STANDALONE_SLS_SERVICE${TEXT_RESET}        STANDALONE_SLS_SERVICE        
-  -i, --ibm-customer-number     ${COLOR_YELLOW}ICN${TEXT_RESET}                         IBM CUSTOMER NUMBER
+  -s, --sls-service ${COLOR_YELLOW}STANDALONE_SLS_SERVICE${TEXT_RESET}        STANDALONE_SLS_SERVICE        
       --sls-channel ${COLOR_YELLOW}SLS_CHANNEL${TEXT_RESET}  IBM Suite License Service Subscription Channel
       --sls-install-plan ${COLOR_YELLOW}SLS_INSTALL_PLAN${TEXT_RESET}  IBM Suite License Service Subscription Install Plan ('Automatic' or 'Manual'. Default is 'Automatic')
 
@@ -143,9 +142,11 @@ function gitops_suite_noninteractive() {
         CLEAN_PATH=$(echo "$STANDALONE_SLS_SERVICE" | sed 's#<ref:##; s#>##')
         IFS='/' read -r -a PARTS <<< "$CLEAN_PATH"
         ICN="${PARTS[3]}"
+        SAAS_SUB_ID="${PARTS[4]}"
   fi    
    
   export ICN=${ICN:-""}
+  export SAAS_SUB_ID=${SAAS_SUB_ID:-""}
 
 
   while [[ $# -gt 0 ]]
@@ -169,10 +170,6 @@ function gitops_suite_noninteractive() {
       --custom-labels)
         export CUSTOM_LABELS=$1 && shift
         ;;
-      -i|--ibm-customer-number)
-        export ICN=$1 && shift
-        ;;
-
       # AWS Secrets Manager Configuration
       --sm-aws-secret-region)
         export SM_AWS_REGION=$1

--- a/image/cli/mascli/functions/gitops_suite
+++ b/image/cli/mascli/functions/gitops_suite
@@ -805,3 +805,5 @@ function gitops_suite() {
   rm -rf $TEMP_DIR
 
 }
+
+

--- a/image/cli/mascli/templates/gitops/appset-configs/cluster/instance/configs/ibm-mas-sls-config.yaml.j2
+++ b/image/cli/mascli/templates/gitops/appset-configs/cluster/instance/configs/ibm-mas-sls-config.yaml.j2
@@ -13,7 +13,11 @@ mas_slscfg_pod_templates:
 {% endif %}
 
 registration_key: <path:{{ SECRETS_PATH }}:{{ SECRET_KEY_SLS_REGISTRATION_KEY }}>
+{%- if STANDALONE_SLS_SERVICE %}
+url: "<path:{{ SECRETS_PATH }}:{{ SECRET_KEY_SLS_URL }}>"
+{%- else %}
 url: "https://sls.mas-{{ MAS_INSTANCE_ID }}-sls.svc"
+{%- endif %}
 ca:
   crt: |
     <path:{{ SECRETS_PATH }}:{{ SECRET_KEY_SLS_CA_B64 }} | base64decode>

--- a/image/cli/mascli/templates/gitops/appset-configs/cluster/instance/configs/ibm-mas-sls-config.yaml.j2
+++ b/image/cli/mascli/templates/gitops/appset-configs/cluster/instance/configs/ibm-mas-sls-config.yaml.j2
@@ -21,3 +21,4 @@ url: "https://sls.mas-{{ MAS_INSTANCE_ID }}-sls.svc"
 ca:
   crt: |
     <path:{{ SECRETS_PATH }}:{{ SECRET_KEY_SLS_CA_B64 }} | base64decode>
+

--- a/image/cli/mascli/templates/gitops/appset-configs/cluster/instance/configs/ibm-mas-sls-config.yaml.j2
+++ b/image/cli/mascli/templates/gitops/appset-configs/cluster/instance/configs/ibm-mas-sls-config.yaml.j2
@@ -21,4 +21,3 @@ url: "https://sls.mas-{{ MAS_INSTANCE_ID }}-sls.svc"
 ca:
   crt: |
     <path:{{ SECRETS_PATH }}:{{ SECRET_KEY_SLS_CA_B64 }} | base64decode>
-

--- a/image/cli/mascli/templates/gitops/appset-configs/cluster/instance/configs/ibm-mas-sls-config.yaml.j2
+++ b/image/cli/mascli/templates/gitops/appset-configs/cluster/instance/configs/ibm-mas-sls-config.yaml.j2
@@ -14,7 +14,7 @@ mas_slscfg_pod_templates:
 
 registration_key: <path:{{ SECRETS_PATH }}:{{ SECRET_KEY_SLS_REGISTRATION_KEY }}>
 {%- if STANDALONE_SLS_SERVICE %}
-url: "<path:{{ SECRETS_PATH }}:{{ SECRET_KEY_SLS_URL }}>"
+url: <path:{{ SECRETS_PATH }}:{{ SECRET_KEY_SLS_URL }}>
 {%- else %}
 url: "https://sls.mas-{{ MAS_INSTANCE_ID }}-sls.svc"
 {%- endif %}

--- a/image/cli/mascli/templates/gitops/appset-configs/cluster/instance/ibm-sls.yaml.j2
+++ b/image/cli/mascli/templates/gitops/appset-configs/cluster/instance/ibm-sls.yaml.j2
@@ -4,6 +4,7 @@ ibm_sls:
   sls_channel: {{ SLS_CHANNEL }}
   sls_entitlement_file: <path:{{ SECRETS_PATH }}:{{ SECRET_KEY_LICENSE_FILE }}>
   ibm_entitlement_key: <path:{{ SECRETS_PATH }}:{{ SECRET_KEY_IBM_ENTITLEMENT }}>
+  ibm_customer_number: "{{ ICN }}"
 
   # aws docdb
   mongodb_provider: "{{ MONGODB_PROVIDER }}"

--- a/image/cli/mascli/templates/gitops/appset-configs/cluster/instance/ibm-sls.yaml.j2
+++ b/image/cli/mascli/templates/gitops/appset-configs/cluster/instance/ibm-sls.yaml.j2
@@ -1,10 +1,10 @@
 merge-key: "{{ ACCOUNT_ID }}/{{ CLUSTER_ID }}/{{ MAS_INSTANCE_ID }}"
 
 ibm_sls:
+{%- if ICN %}
   ibm_customer_number: "{{ ICN }}"
   subscription_id: "{{ SAAS_SUB_ID }}"
-{% if not ICN %}
-
+{%- else %}
   sls_channel: {{ SLS_CHANNEL }}
   sls_entitlement_file: <path:{{ SECRETS_PATH }}:{{ SECRET_KEY_LICENSE_FILE }}>
   ibm_entitlement_key: <path:{{ SECRETS_PATH }}:{{ SECRET_KEY_IBM_ENTITLEMENT }}>

--- a/image/cli/mascli/templates/gitops/appset-configs/cluster/instance/ibm-sls.yaml.j2
+++ b/image/cli/mascli/templates/gitops/appset-configs/cluster/instance/ibm-sls.yaml.j2
@@ -8,7 +8,6 @@ ibm_sls:
   sls_channel: {{ SLS_CHANNEL }}
   sls_entitlement_file: <path:{{ SECRETS_PATH }}:{{ SECRET_KEY_LICENSE_FILE }}>
   ibm_entitlement_key: <path:{{ SECRETS_PATH }}:{{ SECRET_KEY_IBM_ENTITLEMENT }}>
-  
   # aws docdb
   mongodb_provider: "{{ MONGODB_PROVIDER }}"
   user_action: "{{ USER_ACTION }}"

--- a/image/cli/mascli/templates/gitops/appset-configs/cluster/instance/ibm-sls.yaml.j2
+++ b/image/cli/mascli/templates/gitops/appset-configs/cluster/instance/ibm-sls.yaml.j2
@@ -8,6 +8,7 @@ ibm_sls:
   sls_channel: {{ SLS_CHANNEL }}
   sls_entitlement_file: <path:{{ SECRETS_PATH }}:{{ SECRET_KEY_LICENSE_FILE }}>
   ibm_entitlement_key: <path:{{ SECRETS_PATH }}:{{ SECRET_KEY_IBM_ENTITLEMENT }}>
+  
   # aws docdb
   mongodb_provider: "{{ MONGODB_PROVIDER }}"
   user_action: "{{ USER_ACTION }}"

--- a/image/cli/mascli/templates/gitops/appset-configs/cluster/instance/ibm-sls.yaml.j2
+++ b/image/cli/mascli/templates/gitops/appset-configs/cluster/instance/ibm-sls.yaml.j2
@@ -1,11 +1,14 @@
 merge-key: "{{ ACCOUNT_ID }}/{{ CLUSTER_ID }}/{{ MAS_INSTANCE_ID }}"
 
 ibm_sls:
+  ibm_customer_number: "{{ ICN }}"
+  subscription_id: "{{ SAAS_SUB_ID }}"
+{% if not ICN %}
+
   sls_channel: {{ SLS_CHANNEL }}
   sls_entitlement_file: <path:{{ SECRETS_PATH }}:{{ SECRET_KEY_LICENSE_FILE }}>
   ibm_entitlement_key: <path:{{ SECRETS_PATH }}:{{ SECRET_KEY_IBM_ENTITLEMENT }}>
-  ibm_customer_number: "{{ ICN }}"
-
+  
   # aws docdb
   mongodb_provider: "{{ MONGODB_PROVIDER }}"
   user_action: "{{ USER_ACTION }}"
@@ -53,4 +56,6 @@ ibm_sls:
 {%- endif -%}
 {% if INTERNAL_CERTIFICATE_AUTHORITY is defined and INTERNAL_CERTIFICATE_AUTHORITY != '' %}
   internal_certificate_authority: {{ INTERNAL_CERTIFICATE_AUTHORITY }}
+{% endif %}
+
 {% endif %}

--- a/image/cli/mascli/templates/gitops/appset-configs/cluster/sls/configs/ibm-mas-sls-config.yaml.j2
+++ b/image/cli/mascli/templates/gitops/appset-configs/cluster/sls/configs/ibm-mas-sls-config.yaml.j2
@@ -6,6 +6,8 @@ mas_application_id: {{ MAS_APP_ID }}
 mas_config_kind: "slscfgs"
 mas_config_api_version: "config.mas.ibm.com"
 use_postdelete_hooks: {{ USE_POSTDELETE_HOOKS }}
+ibm_customer_number: {{ ICN }}
+saas_subscription_id: {{ SAAS_SUB_ID }}
 
 {% if MAS_SLSCFG_POD_TEMPLATE is defined and MAS_SLSCFG_POD_TEMPLATE !='' %}
 mas_slscfg_pod_templates:

--- a/image/cli/mascli/templates/gitops/appset-configs/cluster/sls/configs/ibm-mas-sls-config.yaml.j2
+++ b/image/cli/mascli/templates/gitops/appset-configs/cluster/sls/configs/ibm-mas-sls-config.yaml.j2
@@ -6,7 +6,7 @@ mas_application_id: {{ MAS_APP_ID }}
 mas_config_kind: "slscfgs"
 mas_config_api_version: "config.mas.ibm.com"
 use_postdelete_hooks: {{ USE_POSTDELETE_HOOKS }}
-sls_sls_service: "{{ STANDALONE_SLS_SERVICE }}"
+sls_service: "{{ STANDALONE_SLS_SERVICE }}"
 
 {% if MAS_SLSCFG_POD_TEMPLATE is defined and MAS_SLSCFG_POD_TEMPLATE !='' %}
 mas_slscfg_pod_templates:

--- a/image/cli/mascli/templates/gitops/appset-configs/cluster/sls/configs/ibm-mas-sls-config.yaml.j2
+++ b/image/cli/mascli/templates/gitops/appset-configs/cluster/sls/configs/ibm-mas-sls-config.yaml.j2
@@ -6,8 +6,8 @@ mas_application_id: {{ MAS_APP_ID }}
 mas_config_kind: "slscfgs"
 mas_config_api_version: "config.mas.ibm.com"
 use_postdelete_hooks: {{ USE_POSTDELETE_HOOKS }}
-ibm_customer_number: {{ ICN }}
-saas_subscription_id: {{ SAAS_SUB_ID }}
+ibm_customer_number: "{{ ICN }}"
+saas_subscription_id: "{{ SAAS_SUB_ID }}"
 
 {% if MAS_SLSCFG_POD_TEMPLATE is defined and MAS_SLSCFG_POD_TEMPLATE !='' %}
 mas_slscfg_pod_templates:

--- a/image/cli/mascli/templates/gitops/appset-configs/cluster/sls/configs/ibm-mas-sls-config.yaml.j2
+++ b/image/cli/mascli/templates/gitops/appset-configs/cluster/sls/configs/ibm-mas-sls-config.yaml.j2
@@ -6,8 +6,6 @@ mas_application_id: {{ MAS_APP_ID }}
 mas_config_kind: "slscfgs"
 mas_config_api_version: "config.mas.ibm.com"
 use_postdelete_hooks: {{ USE_POSTDELETE_HOOKS }}
-ibm_customer_number: "{{ ICN }}"
-saas_subscription_id: "{{ SAAS_SUB_ID }}"
 sls_sls_service: "{{ STANDALONE_SLS_SERVICE }}"
 
 {% if MAS_SLSCFG_POD_TEMPLATE is defined and MAS_SLSCFG_POD_TEMPLATE !='' %}

--- a/image/cli/mascli/templates/gitops/appset-configs/cluster/sls/configs/ibm-mas-sls-config.yaml.j2
+++ b/image/cli/mascli/templates/gitops/appset-configs/cluster/sls/configs/ibm-mas-sls-config.yaml.j2
@@ -8,6 +8,7 @@ mas_config_api_version: "config.mas.ibm.com"
 use_postdelete_hooks: {{ USE_POSTDELETE_HOOKS }}
 ibm_customer_number: "{{ ICN }}"
 saas_subscription_id: "{{ SAAS_SUB_ID }}"
+sls_sls_service: "{{ STANDALONE_SLS_SERVICE }}"
 
 {% if MAS_SLSCFG_POD_TEMPLATE is defined and MAS_SLSCFG_POD_TEMPLATE !='' %}
 mas_slscfg_pod_templates:

--- a/image/cli/mascli/templates/gitops/appset-configs/cluster/sls/configs/ibm-mas-sls-config.yaml.j2
+++ b/image/cli/mascli/templates/gitops/appset-configs/cluster/sls/configs/ibm-mas-sls-config.yaml.j2
@@ -6,7 +6,6 @@ mas_application_id: {{ MAS_APP_ID }}
 mas_config_kind: "slscfgs"
 mas_config_api_version: "config.mas.ibm.com"
 use_postdelete_hooks: {{ USE_POSTDELETE_HOOKS }}
-sls_service: "{{ STANDALONE_SLS_SERVICE }}"
 
 {% if MAS_SLSCFG_POD_TEMPLATE is defined and MAS_SLSCFG_POD_TEMPLATE !='' %}
 mas_slscfg_pod_templates:

--- a/tekton/src/pipelines/gitops/gitops-mas-instance.yml.j2
+++ b/tekton/src/pipelines/gitops/gitops-mas-instance.yml.j2
@@ -230,6 +230,10 @@ spec:
     - name: additional_vpn
       type: string
 
+   # standalone sls
+    - name : sls_sls_service
+      type : string
+      default: ""
   tasks:
 
     # 0. Per-instance DB2U Operator
@@ -444,8 +448,8 @@ spec:
           value: $(params.additional_vpn)
         - name: extensions
           value: $(params.extensions)
-        - name: sls_license_icn
-          value: $(params.sls_license_icn)
+        - name : sls_sls_service
+          value: $(params.sls_sls_service)
       taskRef:
         kind: Task
         name: gitops-suite
@@ -500,10 +504,8 @@ spec:
           value: $(params.mas_bascfg_pod_template_yaml)
         - name: mas_slscfg_pod_template_yaml
           value: $(params.mas_slscfg_pod_template_yaml)
-        - name: sls_license_icn
-          value: $(params.sls_license_icn)
-        - name: sls_subscription_id
-          value: $(params.sls_subscription_id)
+        - name : sls_sls_service
+          value: $(params.sls_sls_service)
       workspaces:
         - name: configs
           workspace: configs

--- a/tekton/src/pipelines/gitops/gitops-mas-instance.yml.j2
+++ b/tekton/src/pipelines/gitops/gitops-mas-instance.yml.j2
@@ -498,6 +498,10 @@ spec:
           value: $(params.mas_bascfg_pod_template_yaml)
         - name: mas_slscfg_pod_template_yaml
           value: $(params.mas_slscfg_pod_template_yaml)
+        - name: sls_license_icn
+          value: $(params.sls_license_icn)
+        - name: sls_subscription_id
+          value: $(params.sls_subscription_id)
       workspaces:
         - name: configs
           workspace: configs

--- a/tekton/src/pipelines/gitops/gitops-mas-instance.yml.j2
+++ b/tekton/src/pipelines/gitops/gitops-mas-instance.yml.j2
@@ -444,6 +444,8 @@ spec:
           value: $(params.additional_vpn)
         - name: extensions
           value: $(params.extensions)
+        - name: sls_license_icn
+          value: $(params.sls_license_icn)
       taskRef:
         kind: Task
         name: gitops-suite

--- a/tekton/src/pipelines/gitops/gitops-mas-instance.yml.j2
+++ b/tekton/src/pipelines/gitops/gitops-mas-instance.yml.j2
@@ -231,7 +231,7 @@ spec:
       type: string
 
    # standalone sls
-    - name : sls_sls_service
+    - name : sls_service
       type : string
       default: ""
   tasks:
@@ -448,8 +448,8 @@ spec:
           value: $(params.additional_vpn)
         - name: extensions
           value: $(params.extensions)
-        - name : sls_sls_service
-          value: $(params.sls_sls_service)
+        - name : sls_service
+          value: $(params.sls_service)
       taskRef:
         kind: Task
         name: gitops-suite
@@ -504,8 +504,8 @@ spec:
           value: $(params.mas_bascfg_pod_template_yaml)
         - name: mas_slscfg_pod_template_yaml
           value: $(params.mas_slscfg_pod_template_yaml)
-        - name : sls_sls_service
-          value: $(params.sls_sls_service)
+        - name : sls_service
+          value: $(params.sls_service)
       workspaces:
         - name: configs
           workspace: configs

--- a/tekton/src/tasks/gitops/gitops-suite-config.yml.j2
+++ b/tekton/src/tasks/gitops/gitops-suite-config.yml.j2
@@ -47,10 +47,10 @@ spec:
     - name: smtp_config_ca_certificate_file
       type: string
       default: ""
-    - name: ibm_customer_number
+    - name: sls_license_icn
       type: string
       default: ""
-    - name: saas_subscription_id
+    - name: sls_subscription_id
       type: string
       default: ""
   stepTemplate:
@@ -95,9 +95,9 @@ spec:
       - name: SMTP_CONFIG_CA_CERTIFICATE_FILE
         value: $(params.smtp_config_ca_certificate_file)
       - name: ICN
-        value: $(params.ibm_customer_number)
+        value: $(params.sls_license_icn)
       - name: SAAS_SUB_ID
-        value: $(params.saas_subscription_id)
+        value: $(params.sls_subscription_id)
     envFrom:
       - configMapRef:
           name: environment-properties
@@ -142,8 +142,8 @@ spec:
         --github-org "$GITHUB_ORG" \
         --github-repo "$GITHUB_REPO" \
         --git-branch "$GIT_BRANCH" \
-        --ibm-customer-number "$ICN" \
-        --saas-subscription-id "$SAAS_SUB_ID" \
+        --sls_license_icn "$ICN" \
+        --sls_subscription_id "$SAAS_SUB_ID" \
         --config-action upsert \
         --mas-config-scope system \
         --mas-config-type sls \

--- a/tekton/src/tasks/gitops/gitops-suite-config.yml.j2
+++ b/tekton/src/tasks/gitops/gitops-suite-config.yml.j2
@@ -47,10 +47,7 @@ spec:
     - name: smtp_config_ca_certificate_file
       type: string
       default: ""
-    - name: sls_license_icn
-      type: string
-      default: ""
-    - name: sls_subscription_id
+    - name: sls_sls_service
       type: string
       default: ""
   stepTemplate:
@@ -94,10 +91,8 @@ spec:
         value: $(params.mas_bascfg_pod_template_yaml)
       - name: SMTP_CONFIG_CA_CERTIFICATE_FILE
         value: $(params.smtp_config_ca_certificate_file)
-      - name: ICN
-        value: $(params.sls_license_icn)
-      - name: SAAS_SUB_ID
-        value: $(params.sls_subscription_id)
+      - name: STANDALONE_SLS_SERVICE
+        value: $(params.sls_sls_service)
     envFrom:
       - configMapRef:
           name: environment-properties
@@ -142,8 +137,6 @@ spec:
         --github-org "$GITHUB_ORG" \
         --github-repo "$GITHUB_REPO" \
         --git-branch "$GIT_BRANCH" \
-        --ibm-customer-number "$ICN" \
-        --saas-subscription-id "$SAAS_SUB_ID" \
         --config-action upsert \
         --mas-config-scope system \
         --mas-config-type sls \

--- a/tekton/src/tasks/gitops/gitops-suite-config.yml.j2
+++ b/tekton/src/tasks/gitops/gitops-suite-config.yml.j2
@@ -49,8 +49,10 @@ spec:
       default: ""
     - name: ibm_customer_number
       type: string
+      default: ""
     - name: saas_subscription_id
       type: string
+      default: ""
   stepTemplate:
     name: gitops-suite-config
     env:

--- a/tekton/src/tasks/gitops/gitops-suite-config.yml.j2
+++ b/tekton/src/tasks/gitops/gitops-suite-config.yml.j2
@@ -47,7 +47,7 @@ spec:
     - name: smtp_config_ca_certificate_file
       type: string
       default: ""
-    - name: sls_sls_service
+    - name: sls_service
       type: string
       default: ""
   stepTemplate:
@@ -92,7 +92,7 @@ spec:
       - name: SMTP_CONFIG_CA_CERTIFICATE_FILE
         value: $(params.smtp_config_ca_certificate_file)
       - name: STANDALONE_SLS_SERVICE
-        value: $(params.sls_sls_service)
+        value: $(params.sls_service)
     envFrom:
       - configMapRef:
           name: environment-properties

--- a/tekton/src/tasks/gitops/gitops-suite-config.yml.j2
+++ b/tekton/src/tasks/gitops/gitops-suite-config.yml.j2
@@ -47,6 +47,10 @@ spec:
     - name: smtp_config_ca_certificate_file
       type: string
       default: ""
+    - name: ibm_customer_number
+      type: string
+    - name: saas_subscription_id
+      type: string
   stepTemplate:
     name: gitops-suite-config
     env:
@@ -88,6 +92,10 @@ spec:
         value: $(params.mas_bascfg_pod_template_yaml)
       - name: SMTP_CONFIG_CA_CERTIFICATE_FILE
         value: $(params.smtp_config_ca_certificate_file)
+      - name: ICN
+        value: $(params.ibm_customer_number)
+      - name: SAAS_SUB_ID
+        value: $(params.saas_subscription_id)
     envFrom:
       - configMapRef:
           name: environment-properties
@@ -132,6 +140,8 @@ spec:
         --github-org "$GITHUB_ORG" \
         --github-repo "$GITHUB_REPO" \
         --git-branch "$GIT_BRANCH" \
+        --ibm-customer-number "$ICN" \
+        --saas-subscription-id "$SAAS_SUB_ID" \
         --config-action upsert \
         --mas-config-scope system \
         --mas-config-type sls \

--- a/tekton/src/tasks/gitops/gitops-suite-config.yml.j2
+++ b/tekton/src/tasks/gitops/gitops-suite-config.yml.j2
@@ -142,8 +142,8 @@ spec:
         --github-org "$GITHUB_ORG" \
         --github-repo "$GITHUB_REPO" \
         --git-branch "$GIT_BRANCH" \
-        --sls_license_icn "$ICN" \
-        --sls_subscription_id "$SAAS_SUB_ID" \
+        --ibm-customer-number "$ICN" \
+        --saas-subscription-id "$SAAS_SUB_ID" \
         --config-action upsert \
         --mas-config-scope system \
         --mas-config-type sls \

--- a/tekton/src/tasks/gitops/gitops-suite.yml.j2
+++ b/tekton/src/tasks/gitops/gitops-suite.yml.j2
@@ -142,6 +142,9 @@ spec:
     - name: extensions
       type: string
       default: "false"
+    - name: sls_license_icn
+      type: string
+      default: ""
   stepTemplate:
     name: gitops-suite
     env:
@@ -253,6 +256,8 @@ spec:
         value: $(params.is_non_shared_cluster)
       - name: EXTENSIONS
         value: $(params.extensions)
+      - name: ICN
+        value: $(params.sls_license_icn)
 
     envFrom:
       - configMapRef:
@@ -322,6 +327,7 @@ spec:
         --github-org  $GITHUB_ORG \
         --github-repo $GITHUB_REPO \
         --git-branch $GIT_BRANCH \
+        --ibm-customer-number "$ICN" \
         --mas-wipe-mongo-data "$MAS_WIPE_MONGO_DATA" \
 
         exit $?

--- a/tekton/src/tasks/gitops/gitops-suite.yml.j2
+++ b/tekton/src/tasks/gitops/gitops-suite.yml.j2
@@ -142,7 +142,7 @@ spec:
     - name: extensions
       type: string
       default: "false"
-    - name: sls_sls_service
+    - name: sls_service
       type: string
       default: ""
   stepTemplate:
@@ -257,7 +257,7 @@ spec:
       - name: EXTENSIONS
         value: $(params.extensions)
       - name: STANDALONE_SLS_SERVICE
-        value: $(params.sls_sls_service)
+        value: $(params.sls_service)
 
     envFrom:
       - configMapRef:

--- a/tekton/src/tasks/gitops/gitops-suite.yml.j2
+++ b/tekton/src/tasks/gitops/gitops-suite.yml.j2
@@ -142,7 +142,7 @@ spec:
     - name: extensions
       type: string
       default: "false"
-    - name: sls_license_icn
+    - name: sls_sls_service
       type: string
       default: ""
   stepTemplate:
@@ -256,8 +256,8 @@ spec:
         value: $(params.is_non_shared_cluster)
       - name: EXTENSIONS
         value: $(params.extensions)
-      - name: ICN
-        value: $(params.sls_license_icn)
+      - name: STANDALONE_SLS_SERVICE
+        value: $(params.sls_sls_service)
 
     envFrom:
       - configMapRef:
@@ -327,7 +327,6 @@ spec:
         --github-org  $GITHUB_ORG \
         --github-repo $GITHUB_REPO \
         --git-branch $GIT_BRANCH \
-        --ibm-customer-number "$ICN" \
         --mas-wipe-mongo-data "$MAS_WIPE_MONGO_DATA" \
 
         exit $?


### PR DESCRIPTION
## Issue

https://jsw.ibm.com/browse/MASCORE-10255
https://jsw.ibm.com/browse/MASCORE-10462

## Description

* Use the sls_service param to retrieve ibm customer number and subscription id .

**Why:**

* Required to  support standalone sls.

**Impact:**

* Remove unnecessary param from Ibm_sls.yaml and kept only  icn and sub id .
* it will  include the correct URL, Registration key and ca cert from the secret .

## Test Results

* sls installation is  successfully skipped under mascore.
* After pipeline execution, the system generates valid gitops-envs:

**gitops-envs :**
(https://github.ibm.com/maximoappsuite/gitops-envs/blob/master/fyre-noble4-dev/noble4/sls01/ibm-sls.yaml)
(https://github.ibm.com/maximoappsuite/gitops-envs/blob/master/fyre-noble4-dev/noble4/sls01/ibm-mas-suite-configs.yaml#L210)

**Pipeline Run:**
(https://cloud.ibm.com/devops/pipelines/tekton/8445f6a9-217b-4ceb-92e8-d3c25dd9fc22/runs/a638bb18-482f-450a-a45f-261b45f02a3a/gitops-suite?env_id=ibm:yp:us-south&view=logs)
