### PR TITLE
[patch] Updating fips and ipv6 arguments for provision_fyre

### DIFF
--- a/image/cli/mascli/functions/provision_fyre
+++ b/image/cli/mascli/functions/provision_fyre
@@ -101,10 +101,10 @@ function provision_fyre_noninteractive() {
 
       # Cluster Definition - optional
       --enable-fips)
-        OCP_FIPS_ENABLED=true && shift
+        OCP_FIPS_ENABLED=true
         ;;
       --enable-ipv6)
-        ENABLE_IPV6=true && shift
+        ENABLE_IPV6=true
         ;;
 
       # Worker configuration


### PR DESCRIPTION
https://jsw.ibm.com/browse/MASCORE-10802

The --enable-fips and --enable-ipv6 options can't be used together due to the incorrect shift