### PR TITLE
[patch] Updating mas_install_core commands in documents

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -84,7 +84,7 @@ docker run -ti --rm --pull always quay.io/ibmmas/cli:x.y.z-pre.mybranch
 oc login --token=xxxx --server=https://myocpserver
 export STUFF
 ansible localhost -m include_role -a name=ibm.mas_devops.ocp_verify
-ansible-playbook ibm.mas_devops.oneclick_core
+ansible-playbook ibm.mas_devops.mas_install_core
 mas install
 ```
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -19,7 +19,7 @@ docker run -ti --rm -v ~:/mnt/home --pull always quay.io/ibmmas/cli mas install 
 The container image provides an out of the box environment for managing MAS on OpenShift, with numerous dependencies pre-installed (see [cli-base](https://github.com/ibm-mas/cli-base) for details).  The Maximo Application Suite Ansible Collection is included in these dependencies, so even if you prefer to drive Ansible directly the CLI image can be a useful tool:
 
 ```bash
-docker run -ti --rm -v ~:/mnt/home --pull always quay.io/ibmmas/cli ansible-playbook ibm.mas_devops.oneclick_core
+docker run -ti --rm -v ~:/mnt/home --pull always quay.io/ibmmas/cli ansible-playbook ibm.mas_devops.mas_install_core
 ```
 
 


### PR DESCRIPTION
## Description

Updated the documentation/commands to reflect the latest changes.
#ISSUE-NUMBER https://github.com/ibm-mas/cli/issues/1712

The playbook ibm.mas_devops.oneclick_core has been replaced with ibm.mas_devops.mas_install_core starting from v29 of the Ansible collection, so the commands have been updated accordingly.

  modified:   CONTRIBUTING.md
  modified:   docs/index.md
        

