### PR TITLE
[patch] Fix uninstall & catalog validation

### DIFF
--- a/python/src/mas/cli/install/app.py
+++ b/python/src/mas/cli/install/app.py
@@ -83,9 +83,9 @@ class InstallApp(BaseApp, InstallSettingsMixin, InstallSummarizerMixin, ConfigGe
     def validateCatalogSource(self):
         # Check supported OCP versions
         ocpVersion = getClusterVersion(self.dynamicClient)
-        supportedReleases = self.chosenCatalog.get("ocp_compatibility", None)
-        if supportedReleases is not None and not isClusterVersionInRange(ocpVersion, supportedReleases):
-            self.fatalError(f"IBM Maximo Operator Catalog {self.getParam('mas_catalog_version')} is not compatible with OpenShift v{ocpVersion}.  Compatible OpenShift releases are {', '.join(supportedReleases)}")
+        supportedReleases = self.chosenCatalog.get("ocp_compatibility", [])
+        if len(supportedReleases) > 0 and not isClusterVersionInRange(ocpVersion, supportedReleases):
+            self.fatalError(f"IBM Maximo Operator Catalog {self.getParam('mas_catalog_version')} is not compatible with OpenShift v{ocpVersion}.  Compatible OpenShift releases are {supportedReleases}")
 
         # Compare with any existing installed catalog
         catalogsAPI = self.dynamicClient.resources.get(api_version="operators.coreos.com/v1alpha1", kind="CatalogSource")

--- a/python/src/mas/cli/uninstall/app.py
+++ b/python/src/mas/cli/uninstall/app.py
@@ -42,7 +42,6 @@ class UninstallApp(BaseApp):
         if args.uninstall_all_deps:
             uninstallGrafana = True
             uninstallIBMCatalog = True
-            uninstallCommonServices = True
             uninstallCertManager = True
             uninstallDRO = True
             uninstallMongoDb = True
@@ -50,7 +49,6 @@ class UninstallApp(BaseApp):
         else:
             uninstallGrafana = args.uninstall_grafana
             uninstallIBMCatalog = args.uninstall_ibm_catalog
-            uninstallCommonServices = args.uninstall_common_services
             uninstallCertManager = args.uninstall_cert_manager
             uninstallDRO = args.uninstall_dro
             uninstallMongoDb = args.uninstall_mongodb
@@ -97,7 +95,6 @@ class UninstallApp(BaseApp):
                 # If you choose to uninstall Cert-Manager, everything will be uninstalled
                 uninstallGrafana = True
                 uninstallIBMCatalog = True
-                uninstallCommonServices = True
                 uninstallDRO = True
                 uninstallMongoDb = True
                 uninstallSLS = True
@@ -115,11 +112,9 @@ class UninstallApp(BaseApp):
                 uninstallIBMCatalog = self.yesOrNo("Uninstall IBM operator Catalog")
                 if uninstallIBMCatalog:
                     # If you choose to uninstall IBM Operator Catalog, everything from the catalog will be uninstalled
-                    uninstallCommonServices = True
                     uninstallDRO = True
                     uninstallSLS = True
                 else:
-                    uninstallCommonServices = self.yesOrNo("Uninstall IBM Common Services")
                     uninstallDRO = self.yesOrNo("Uninstall IBM Data Reporter Operator")
 
         else:
@@ -148,7 +143,6 @@ class UninstallApp(BaseApp):
         self.printSummary("Uninstall Cert-Manager", f"{uninstallCertManager} ({certManagerProvider})")
         self.printSummary("Uninstall Grafana", uninstallGrafana)
         self.printSummary("Uninstall IBM Operator Catalog", uninstallIBMCatalog)
-        self.printSummary("Uninstall IBM Common Services", uninstallCommonServices)
         self.printSummary("Uninstall DRO", uninstallDRO)
         self.printSummary("Uninstall MongoDb", uninstallMongoDb)
         self.printSummary("Uninstall SLS", uninstallSLS)
@@ -184,7 +178,7 @@ class UninstallApp(BaseApp):
                     instanceId=instanceId,
                     uninstallCertManager=uninstallCertManager,
                     uninstallGrafana=uninstallGrafana,
-                    uninstallCatalog=uninstallCommonServices,
+                    uninstallCatalog=uninstallIBMCatalog,
                     uninstallDRO=uninstallDRO,
                     uninstallMongoDb=uninstallMongoDb,
                     uninstallSLS=uninstallSLS,

--- a/python/src/mas/cli/update/app.py
+++ b/python/src/mas/cli/update/app.py
@@ -267,9 +267,9 @@ class UpdateApp(BaseApp):
     def validateCatalog(self) -> None:
         # Check supported OCP versions
         ocpVersion = getClusterVersion(self.dynamicClient)
-        supportedReleases = self.chosenCatalog.get("ocp_compatibility", None)
-        if supportedReleases is not None and not isClusterVersionInRange(ocpVersion, supportedReleases):
-            self.fatalError(f"IBM Maximo Operator Catalog {self.getParam('mas_catalog_version')} is not compatible with OpenShift v{ocpVersion}.  Compatible OpenShift releases are {', '.join(supportedReleases)}")
+        supportedReleases = self.chosenCatalog.get("ocp_compatibility", [])
+        if len(supportedReleases) > 0 and not isClusterVersionInRange(ocpVersion, supportedReleases):
+            self.fatalError(f"IBM Maximo Operator Catalog {self.getParam('mas_catalog_version')} is not compatible with OpenShift v{ocpVersion}.  Compatible OpenShift releases are {supportedReleases}")
 
         if self.installedCatalogId is not None and self.installedCatalogId > self.getParam("mas_catalog_version"):
             self.fatalError(f"Selected catalog is older than the currently installed catalog.  Unable to update catalog from {self.installedCatalogId} to {self.getParam('mas_catalog_version')}")


### PR DESCRIPTION
A couple of fixes:
- The long deprecated IBM Common Services namespace should have been removed from uninstall scope in previous update
- The uninstall of the Operator Catalog was being assigned via the wrong variable, which could result in unintentional removal of the catalog in certain circumstances