### PR TITLE
[patch] get catalog data from python-devops while update

### DIFF
--- a/python/src/mas/cli/update/app.py
+++ b/python/src/mas/cli/update/app.py
@@ -19,7 +19,7 @@ from openshift.dynamic.exceptions import NotFoundError, ResourceNotFoundError
 
 from ..cli import BaseApp
 from .argParser import updateArgParser
-
+from mas.devops.data import getCatalog
 from mas.devops.ocp import createNamespace, getConsoleURL, getClusterVersion, isClusterVersionInRange
 from mas.devops.mas import listMasInstances, listAiServiceInstances, getCurrentCatalog
 from mas.devops.tekton import preparePipelinesNamespace, installOpenShiftPipelines, updateTektonDefinitions, launchUpdatePipeline
@@ -267,6 +267,8 @@ class UpdateApp(BaseApp):
     def validateCatalog(self) -> None:
         # Check supported OCP versions
         ocpVersion = getClusterVersion(self.dynamicClient)
+        # Load the catalog information
+        self.chosenCatalog = getCatalog(self.getParam("mas_catalog_version"))
         supportedReleases = self.chosenCatalog.get("ocp_compatibility", [])
         if len(supportedReleases) > 0 and not isClusterVersionInRange(ocpVersion, supportedReleases):
             self.fatalError(f"IBM Maximo Operator Catalog {self.getParam('mas_catalog_version')} is not compatible with OpenShift v{ocpVersion}.  Compatible OpenShift releases are {supportedReleases}")


### PR DESCRIPTION
fixing error: https://github.com/ibm-mas/cli/pull/1905

Tested 
```
[ibmmas/cli:17.0.0-pre.update-251127]mascli$ mas update --catalog v9-251127-amd64 --mongodb-v8-upgrade  --no-confirm
IBM Maximo Application Suite Update Manager (v17.0.0-pre.update-251127)
Powered by https://github.com/ibm-mas/ansible-devops/ and https://tekton.dev/

IBM Maximo Application Suite Admin CLI v17.0.0-pre.update-251127
Powered by https://github.com/ibm-mas/ansible-devops/ and https://tekton.dev/


1) Review Installed Catalog
The currently installed Maximo Operator Catalog is IBM Maximo Operators (v9-251030-amd64)
 icr.io/cpopen/ibm-maximo-operator-catalog:v9-251030-amd64

2) Review MAS Instances
The following MAS instances are installed on the target cluster and will be affected by the catalog update:
- fvtday2 v9.0.16

3) Review AI Service Instances
No AI Service instances were detected on the cluster (AIServiceApp.aiservice.ibm.com/v1 API is not available)

4) Dependency Update Checks
✅️ IBM Watson Discovery is not installed
✅️ IBM Watson Openscale is not installed
✅️ IBM Certificate-Manager is not installed
✅️ Grafana Operator v4 is not installed
✅️ MongoDb CE will be updated from 7.0.23 to 8.0.13

Dependency Update Notice
MongoDB Community Edition is currently running version 7.0.23 and will be updated to 8.0.13
It is recommended that you backup your MongoDB instance before proceeding:
  https://www.ibm.com/docs/en/mas-cd/continuous-delivery?topic=suite-backing-up-mongodb-maximo-application

✅️ 2 Db2uClusters (db2u.databases.ibm.com/v1) in namespace 'db2u' will be updated
✅️ 1 Kafkas (kafka.strimzi.io/v1beta2) in namespace 'strimzi' will be updated
✅️ IBM Cloud Pak for Data (ibm-cpd) is already installed at version 5.1.3


5) Review Settings
Connected to:
 - https://console-openshift-console.apps.day2-91-747.cp.fyre.ibm.com

5.1) IBM Maximo Operator Catalog
  Installed Catalog ....................... v9-251030-amd64
  Updated Catalog ......................... v9-251127-amd64

5.2) Supported Dependency Updates
  IBM Db2 ................................. All Db2uCluster instances in db2u
  MongoDb CE .............................. All MongoDbCommunity instances in mongoce
  Apache Kafka ............................ All Kafka instances in strimzi
  IBM Cloud Pak for Data .................. No action required

5.3) Required Migrations
  IBM Certificate-Manager ................. No action required
  Grafana v4 Operator ..................... No action required

6) Launch Update
✅️ OpenShift Pipelines Operator is installed and ready to use
✅️ Namespace is ready (mas-pipelines)
 ⠋ Installing latest Tekton definitions (v17.0.0-pre.update-251127)

```