### PR TITLE
[minor] Update SLS secrets prefix to include AISERVICE_INSTANCE_ID and TENANT_ID for gitops

### DIFF
--- a/image/cli/mascli/functions/gitops_aiservice_tenant
+++ b/image/cli/mascli/functions/gitops_aiservice_tenant
@@ -394,8 +394,9 @@ function gitops_aiservice_tenant() {
   export SECRET_KEY_DROCFG_REGISTRATION_KEY=${SECRETS_PREFIX}droai#drocfg_registration_key
 
   # sls
-  export SECRET_KEY_SLSCFG_REGISTRATION_KEY=${SECRETS_PREFIX}sls#slscfg_registration_key
-  export SECRET_KEY_SLSCFG_CA_B64ENC=${SECRETS_PREFIX}sls#slscfg_ca_b64enc
+  SLS_SECRETS_PREFIX="${ACCOUNT_ID}${SECRETS_KEY_SEPERATOR}${CLUSTER_ID}${SECRETS_KEY_SEPERATOR}${AISERVICE_INSTANCE_ID}${SECRETS_KEY_SEPERATOR}${TENANT_ID}${SECRETS_KEY_SEPERATOR}"
+  export SECRET_KEY_SLSCFG_REGISTRATION_KEY=${SLS_SECRETS_PREFIX}sls#slscfg_registration_key
+  export SECRET_KEY_SLSCFG_CA_B64ENC=${SLS_SECRETS_PREFIX}sls#slscfg_ca_b64enc
 
   export SECRET_KEY_RSL_ORG_ID=${SECRETS_PREFIX}rsl#rsl_org_id
   export SECRET_KEY_RSL_TOKEN=${SECRETS_PREFIX}rsl#rsl_token
@@ -415,7 +416,7 @@ function gitops_aiservice_tenant() {
 
   sm_verify_secret_exists ${SECRETS_PREFIX}ibm_entitlement "image_pull_secret_b64,entitlement_key"
   sm_verify_secret_exists ${SECRETS_PREFIX}droai "drocfg_registration_key,drocfg_ca_b64enc"
-  sm_verify_secret_exists ${SECRETS_PREFIX}sls "slscfg_registration_key,slscfg_ca_b64enc"
+  sm_verify_secret_exists ${SLS_SECRETS_PREFIX}sls "slscfg_registration_key,slscfg_ca_b64enc"
   sm_verify_secret_exists ${SECRETS_PREFIX}rsl "rsl_org_id,rsl_token"
   sm_verify_secret_exists ${SECRETS_PREFIX}watsonx "watsonxai_apikey,watsonxai_project_id"
   


### PR DESCRIPTION
## Issue
https://jsw.ibm.com/browse/MASCORE-10981

## Description
This PR addresses the issue where the PipelineRun was missing required parameters for the Watsonx AI service related variables .

Why: Without these parameters, the pipeline cannot execute successfully.

Impact: Adds the necessary configuration to ensure all required parameters are passed during PipelineRun execution.

## Test Results

Verified that the updated pipeline configuration includes:

aiservice_watsonxai_instance_id
aiservice_watsonxai_version
aiservice_watsonxai_username
aiservice_watsonxai_ca_crt
aiservice_watsonxai_full
aiservice_watsonxai_verify


Successfully triggered a PipelineRun after changes; execution completed without missing parameter errors.
Logs confirm all parameters were injected correctly.



## Related Pull Requests

https://github.com/ibm-mas/cli/pull/1926

