### PR TITLE
[patch] Add missing parameter aiservice_watsonx_full to pipeline configuration for gitops

### DIFF
--- a/tekton/src/tasks/gitops/gitops-aiservice-tenant.yml.j2
+++ b/tekton/src/tasks/gitops/gitops-aiservice-tenant.yml.j2
@@ -51,8 +51,6 @@ spec:
       type: string
     - name: aiservice_watsonxai_ca_crt
       type: string
-    - name: aiservice_watsonx_full
-      type: string
     - name: aiservice_watsonxai_instance_id
       type: string
     - name: aiservice_watsonxai_version
@@ -130,6 +128,8 @@ spec:
         value: $(params.aiservice_sls_subscription_id)
       - name: AISERVICE_WATSONXAI_URL
         value: $(params.aiservice_watsonxai_url)
+      - name: AISERVICE_WATSONX_FULL
+        value: $(params.aiservice_watsonxai_full)
       - name: AISERVICE_WATSONXAI_CA_CRT
         value: $(params.aiservice_watsonxai_ca_crt)
       - name: AISERVICE_WATSONXAI_INSTANCE_ID


### PR DESCRIPTION
## Issue
https://jsw.ibm.com/browse/MASCORE-10981

## Description
[User error] Validation failed for pipelinerun gitops-aiservice-tenant-pipeline-t02 with error invalid input params for task gitops-aiservice-tenant: missing values for these params which have no default values: [aiservice_watsonx_full]

Added the missing parameter `aiservice_watsonx_full` to the pipeline configuration for the `gitops-aiservice-tenant` task. 
 
**Why:** The pipeline was failing due to missing mandatory parameters without default values.  
because of this commit :-  https://github.com/ibm-mas/cli/commit/8356a66af907145aa5959f215b4d73d6c161df88#diff-5f1fb7c6bc120a031c08555e679489f8f99e3ccd64e23946d15cca727b353c88L127

**Impact:** This change ensures successful pipeline execution by providing the required input values, improving reliability and preventing deployment failures.

---

## Test Results
- Verified pipeline execution after the fix by running `gitops-aiservice-tenant-pipeline-t02`.  
- Pipeline completed successfully without validation errors.  
- No additional automated tests were required as this is a configuration fix.

---

## Backporting
No backporting required for this change.

---

## Related Pull Requests
None.
