### PR TITLE
[patch] Change reference for WATSONX_FULL with watsonx_on_prem

### DIFF
--- a/tekton/src/tasks/gitops/gitops-aiservice-tenant.yml.j2
+++ b/tekton/src/tasks/gitops/gitops-aiservice-tenant.yml.j2
@@ -129,7 +129,7 @@ spec:
       - name: AISERVICE_WATSONXAI_URL
         value: $(params.aiservice_watsonxai_url)
       - name: AISERVICE_WATSONX_FULL
-        value: $(params.aiservice_watsonxai_full)
+        value: $(params.aiservice_watsonxai_on_prem)
       - name: AISERVICE_WATSONXAI_CA_CRT
         value: $(params.aiservice_watsonxai_ca_crt)
       - name: AISERVICE_WATSONXAI_INSTANCE_ID


### PR DESCRIPTION
workaround for failing gitops pipeline as in gitops functions we are using the term WATSONX_FULL ( not WATSONX_ON_PREM ) so env remain same but it referred from watsonx_on_prem