### PR TITLE
[patch] Fix build logic for master branch

### DIFF
--- a/image/cli/install/install-ansible-collections.sh
+++ b/image/cli/install/install-ansible-collections.sh
@@ -5,7 +5,7 @@ echo "==========================="
 echo "GitHub reference = ${GITHUB_REF_TYPE}/${GITHUB_REF_NAME}"
 echo "Artifactory = ${ARTIFACTORY_GENERIC_RELEASE_URL}"
 echo "Contents of /tmp/install/:"
-ls /tmp/install/
+ls -l /tmp/install/
 echo ""
 
 # If the local file is present, defer to this
@@ -14,19 +14,19 @@ echo ""
 if [[ -e /tmp/install/ibm-mas_devops.tar.gz ]]; then
     echo "Installing local build of ansible-devops from archive"
     ansible-galaxy collection install /tmp/install/ibm-mas_devops.tar.gz -p $ANSIBLE_COLLECTIONS_PATH
-elif [[ "$GITHUB_REF_NAME" != "master" ]] && [[ "$GITHUB_REF_TYPE" == "branch" ]]; then
+elif [[ "$GITHUB_REF_TYPE" == "branch" ]]; then
     # Download and validate the archive
     BRANCH_TARGET_URL="${ARTIFACTORY_GENERIC_RELEASE_URL}/ibm-mas/ansible-devops/branches/ibm-mas_devops-${GITHUB_REF_NAME}.tar.gz"
     curl -H "Authorization:Bearer $ARTIFACTORY_TOKEN" $BRANCH_TARGET_URL -o /tmp/install/ibm-mas_devops.tar.gz
     tar -tzf /tmp/install/ibm-mas_devops.tar.gz > /dev/null
     if [[ "$?" == "0" ]]; then
-        echo "Installing matching branch build of ansible-devops from Artifactory"
+        echo "Installing matching branch build (${GITHUB_REF_NAME}) of ansible-devops from Artifactory"
         ansible-galaxy collection install /tmp/install/ibm-mas_devops.tar.gz -p $ANSIBLE_COLLECTIONS_PATH
     else
         echo "Installing release build of ansible-devops from Galaxy (branch build)"
         ansible-galaxy collection install ibm.mas_devops
     fi
 else
-    echo "Installing release build of ansible-devops from Galaxy (master/tag build)"
+    echo "Installing release build of ansible-devops from Galaxy (tag build)"
     ansible-galaxy collection install ibm.mas_devops
 fi


### PR DESCRIPTION
When we build the master branch of this repo we want to use the code from the master branch of ansible-devops, currently master is treated as a special case and we pull in the latest release of the ansible collection instead.