### PR TITLE
[minor] Support for jdbc additional connection url for incluster-db2 type for manage, facilities in gitops

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "build/bin/config/oscap/ssg-rhel9-ds.xml|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2025-11-06T16:17:33Z",
+  "generated_at": "2025-11-25T14:39:57Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"

--- a/tekton/src/pipelines/gitops/gitops-mas-apps.yml.j2
+++ b/tekton/src/pipelines/gitops/gitops-mas-apps.yml.j2
@@ -74,6 +74,8 @@ spec:
 
     - name: jdbc_type_manage
       type: string
+    - name: jdbc_connection_url_additional_params_manage
+      type: string
     - name: jdbc_instance_name_manage
       type: string
     - name: jdbc_connection_url_manage
@@ -93,6 +95,8 @@ spec:
       default: "false"
 
     - name: jdbc_type_facilities
+      type: string
+    - name: jdbc_connection_url_additional_params_facilities
       type: string
     - name: jdbc_instance_name_facilities
       type: string
@@ -1163,6 +1167,8 @@ spec:
           value: $(params.mas_workspace_id)
         - name: jdbc_type
           value: $(params.jdbc_type_manage)
+        - name: jdbc_connection_url_additional_params
+          value: $(params.jdbc_connection_url_additional_params_manage)
         - name: jdbc_instance_name
           value: $(params.jdbc_instance_name_manage)
         - name: jdbc_connection_url
@@ -1462,6 +1468,8 @@ spec:
           value: $(params.mas_workspace_id)
         - name: jdbc_type
           value: $(params.jdbc_type_facilities)
+        - name: jdbc_connection_url_additional_params
+          value: $(params.jdbc_connection_url_additional_params_facilities)
         - name: jdbc_instance_name
           value: $(params.jdbc_instance_name_facilities)
         - name: jdbc_connection_url

--- a/tekton/src/tasks/gitops/gitops-jdbc-config.yml.j2
+++ b/tekton/src/tasks/gitops/gitops-jdbc-config.yml.j2
@@ -36,6 +36,9 @@ spec:
     - name: jdbc_type
       type: string
       default: incluster-db2
+    - name: jdbc_connection_url_additional_params
+      type: string
+      default: ""
     - name: jdbc_instance_name
       type: string
     - name: jdbc_connection_url
@@ -80,6 +83,8 @@ spec:
         value: $(params.mas_workspace_id)
       - name: JDBC_TYPE
         value: $(params.jdbc_type)
+      - name: JDBC_CONNECTION_URL_ADDITIONAL_PARAMS
+        value: $(params.jdbc_connection_url_additional_params)
       - name: JDBC_INSTANCE_NAME
         value: $(params.jdbc_instance_name)
       - name: JDBC_CONNECTION_URL


### PR DESCRIPTION
## Issue

https://jsw.ibm.com/browse/MASCORE-10456

## Description

* For jdbc incluster-db2 db2-type only, allow for an optional config `jdbc_connection_url_additional_params.

**Why:**

* Required **jdbc_connection_url_additional_params** for manage and facilities.

**Impact:**

* it will  include this additional parameter in case of jdbc : incluster-db2 db2-type only, jdbc_connection_url_additional_params .

## Test Results

* After pipeline execution, the system generates valid gitops-envs:

##MANAGE

**gitops-envs :**
(https://github.ibm.com/maximoappsuite/gitops-envs/blob/master/fyre-noble4-dev/noble4/sls01/ibm-mas-suite-configs.yaml#L182)

**Pipeline Run:**
(https://cloud.ibm.com/devops/pipelines/tekton/8bb11078-2a03-43b2-9d30-df3ea17af143/runs/2e0b7216-04bc-4010-9ca1-830e2fa9f03d/gitops-jdbc-config-manage?env_id=ibm:yp:us-south&view=params)

##FACILITIES

**gitops-envs :**
(https://github.ibm.com/maximoappsuite/gitops-envs/blob/master/fyre-noble4-dev/noble4/sls01/ibm-mas-suite-configs.yaml#L145)

**Pipeline Run:**
(https://cloud.ibm.com/devops/pipelines/tekton/8bb11078-2a03-43b2-9d30-df3ea17af143/runs/c8fc5f8e-62a2-44c0-b5e2-ca982c1052d4/gitops-jdbc-config-facilities?env_id=ibm:yp:us-south&view=logs)




