### PR TITLE
[patch] Always pull latest cli image while deprovisioning rosa

### DIFF
--- a/tekton/src/tasks/gitops/gitops-deprovision-rosa.yml.j2
+++ b/tekton/src/tasks/gitops/gitops-deprovision-rosa.yml.j2
@@ -45,7 +45,7 @@ spec:
         - /bin/sh
         - -c
       name: gitops-deprovision-rosa
-      imagePullPolicy: IfNotPresent
+      imagePullPolicy: Always
       image: quay.io/ibmmas/cli:latest
   workspaces:
     - name: configs


### PR DESCRIPTION
Latest master is not pulled as the image pull policy is `IfNotPresent`
Issue: [MASCORE-11010](https://jsw.ibm.com/browse/MASCORE-11010)