### PR TITLE
[minor] Support for jdbc additional connection url for incluster-db2 type for manage, facilities in gitops .

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "build/bin/config/oscap/ssg-rhel9-ds.xml|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2025-11-27T18:06:52Z",
+  "generated_at": "2025-12-09T09:41:35Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -444,7 +444,7 @@
         "hashed_secret": "b2817467154949a61f8e9ad31d1eeaf03221cbfa",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 576,
+        "line_number": 582,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "build/bin/config/oscap/ssg-rhel9-ds.xml|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2025-12-09T09:41:35Z",
+  "generated_at": "2025-12-11T07:52:20Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -262,7 +262,7 @@
         "hashed_secret": "1459943ba5fd876f7ef6e48f566a40b448a2bf08",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 487,
+        "line_number": 491,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/image/cli/mascli/functions/gitops_db2u_database
+++ b/image/cli/mascli/functions/gitops_db2u_database
@@ -60,6 +60,7 @@ IBM DB2U:
       --db2-database-db-config-yaml ${COLOR_YELLOW}DB2_DATABASE_DB_CONFIG_YAML${TEXT_RESET}                   Yaml file containing the db2ucluster database db config section.
       --db2-addons-audit-config-yaml ${COLOR_YELLOW}DB2_ADDONS_AUDIT_CONFIG_YAML${TEXT_RESET}                 Yaml file containing the db2ucluster addons audit config section.
       --jdbc-route ${COLOR_YELLOW}JDBC_ROUTE${TEXT_RESET}                                                     By default routes are not exposed to public. To expose route, set this to public.
+      --jdbc-connection-url-additional-params ${COLOR_YELLOW}JDBC_CONNECTION_URL_ADDITIONAL_PARAMS${TEXT_RESET}  Additional parameters for JDBC connection URL
       --db2-timezone ${COLOR_YELLOW}DB2_TIMEZONE${TEXT_RESET}                                                 DB2 DB Timezone (optional, DB2 default of "UTC" will be used if not specified)
       --db2-backup-notify-slack-url ${COLOR_YELLOW}DB2_BACKUP_NOTIFY_SLACK_URL${TEXT_RESET}                   Slack URL to notify DB2 backup failures
       --replica-db  ${COLOR_YELLOW}REPLICA_DB${TEXT_RESET}                                                    Flag to know that this is ReplicaDB instance
@@ -277,6 +278,9 @@ function gitops_db2u_database_noninteractive() {
         ;;
       --db2-tolerate-effect)
         export DB2_TOLERATE_EFFECT=$1 && shift
+        ;;
+      --jdbc-connection-url-additional-params)
+        export JDBC_CONNECTION_URL_ADDITIONAL_PARAMS=$1 && shift
         ;;
       --jdbc-route)
         export JDBC_ROUTE=$1 && shift

--- a/image/cli/mascli/functions/gitops_suite
+++ b/image/cli/mascli/functions/gitops_suite
@@ -139,6 +139,12 @@ function gitops_suite_noninteractive() {
   # cert-manager namespace, in case redhat default value is cert-manager
   export CERT_MANAGER_NAMESPACE=${CERT_MANAGER_NAMESPACE:-"cert-manager"}
 
+  #GenericAddon default
+  export EXTENSIONS=${EXTENSIONS:-"false"}
+  export ADDITIONAL_VPN=${ADDITIONAL_VPN:-"false"}
+  export ENHANCED_DR=${ENHANCED_DR:-"false"}
+
+
   if [ ! -z "$STANDALONE_SLS_SERVICE" ]; then
       CLEAN_PATH=$(echo "$STANDALONE_SLS_SERVICE" | sed 's#<ref:##; s#>##')
       IFS='/' read -r -a PARTS <<< "$CLEAN_PATH"

--- a/image/cli/mascli/templates/gitops/appset-configs/cluster/instance/db2-databases/ibm-db2u-database.yaml.j2
+++ b/image/cli/mascli/templates/gitops/appset-configs/cluster/instance/db2-databases/ibm-db2u-database.yaml.j2
@@ -106,6 +106,10 @@ mas_annotations:
 {%- endif %}
 jdbc_route: {{JDBC_ROUTE}}
 
+{%- if JDBC_CONNECTION_URL_ADDITIONAL_PARAMS is defined and JDBC_CONNECTION_URL_ADDITIONAL_PARAMS !='' %}
+jdbc_connection_url_additional_params: {{ JDBC_CONNECTION_URL_ADDITIONAL_PARAMS }}
+{%- endif %}
+
 db2_timezone: {{DB2_TIMEZONE}}
 
 {% if STORAGE_CLASS_DEFINITIONS and IS_REPLICA_TASK != 'true' %}

--- a/tekton/src/pipelines/gitops/gitops-mas-apps.yml.j2
+++ b/tekton/src/pipelines/gitops/gitops-mas-apps.yml.j2
@@ -1114,6 +1114,8 @@ spec:
           value: $(params.db2_tolerate_value_manage)
         - name: db2_tolerate_effect
           value: $(params.db2_tolerate_effect_manage)
+        - name: jdbc_connection_url_additional_params
+          value: $(params.jdbc_connection_url_additional_params_manage)
         - name: jdbc_route
           value: $(params.jdbc_route_manage)
         - name: db2_timezone
@@ -1167,8 +1169,6 @@ spec:
           value: $(params.mas_workspace_id)
         - name: jdbc_type
           value: $(params.jdbc_type_manage)
-        - name: jdbc_connection_url_additional_params
-          value: $(params.jdbc_connection_url_additional_params_manage)
         - name: jdbc_instance_name
           value: $(params.jdbc_instance_name_manage)
         - name: jdbc_connection_url
@@ -1417,6 +1417,8 @@ spec:
           value: $(params.db2_tolerate_value_facilities)
         - name: db2_tolerate_effect
           value: $(params.db2_tolerate_effect_facilities)
+        - name: jdbc_connection_url_additional_params
+          value: $(params.jdbc_connection_url_additional_params_facilities)
         - name: jdbc_route
           value: $(params.jdbc_route_facilities)
         - name: db2_timezone
@@ -1468,8 +1470,6 @@ spec:
           value: $(params.mas_workspace_id)
         - name: jdbc_type
           value: $(params.jdbc_type_facilities)
-        - name: jdbc_connection_url_additional_params
-          value: $(params.jdbc_connection_url_additional_params_facilities)
         - name: jdbc_instance_name
           value: $(params.jdbc_instance_name_facilities)
         - name: jdbc_connection_url

--- a/tekton/src/tasks/gitops/gitops-db2u-database.yml.j2
+++ b/tekton/src/tasks/gitops/gitops-db2u-database.yml.j2
@@ -111,6 +111,9 @@ spec:
     - name: jdbc_route
       type: string
       default: ""
+    - name: jdbc_connection_url_additional_params
+      type: string
+      default: ""
     - name: db2_backup_notify_slack_url
       type: string
       default: ""
@@ -239,6 +242,8 @@ spec:
         value: $(params.mas_app_id)
       - name: JDBC_ROUTE
         value: $(params.jdbc_route)
+      - name: JDBC_CONNECTION_URL_ADDITIONAL_PARAMS
+        value: $(params.jdbc_connection_url_additional_params)
       - name: DB2_BACKUP_NOTIFY_SLACK_URL
         value: $(params.db2_backup_notify_slack_url)
       - name: AUTO_BACKUP


### PR DESCRIPTION
## Issue

https://jsw.ibm.com/browse/MASCORE-11149
https://jsw.ibm.com/browse/MASCORE-10456

## Description

* For jdbc incluster-db2 db2-type only, allow for an optional config `jdbc_connection_url_additional_params.
* The default values  are not being handled correctly in GitOps environments.
The addition_vpn ,extension,enhanced_dr field shows an empty value instead of defaulting to false when no value is provided.

**Why:**

* Required **jdbc_connection_url_additional_params** for manage and facilities.

**Impact:**

* it will include this additional parameter in case of jdbc : incluster-db2 db2-type only, jdbc_connection_url_additional_params .

## Test Results

* After pipeline execution, the system generates valid gitops-envs:

(https://github.ibm.com/maximoappsuite/gitops-envs/commit/57f752f475c7055a0ad987613301330ed2dca54e)

##MANAGE

**gitops-envs :**
(https://github.ibm.com/maximoappsuite/gitops-envs/blob/master/fyre-noble4-dev/noble4/sls01/ibm-db2u-databases.yaml#L200)

**argo-cd:**
(https://openshift-gitops-server-openshift-gitops.apps.noble4.cp.fyre.ibm.com/applications/openshift-gitops/db2-db.noble4.sls01.manage?operation=false&node=batch%2FJob%2Fdb2u-sls01%2Fpostsync-setup-db2-1926815013&tab=logs)

##FACILITIES

**gitops-envs :**
(https://github.ibm.com/maximoappsuite/gitops-envs/blob/master/fyre-noble4-dev/noble4/sls01/ibm-db2u-databases.yaml#L83)

**argo-cd:**
(https://openshift-gitops-server-openshift-gitops.apps.noble4.cp.fyre.ibm.com/applications/openshift-gitops/db2-db.noble4.sls01.facilities?operation=false&node=batch%2FJob%2Fdb2u-sls01%2Fpostsync-setup-db2-3924952715%2F0&tab=logs)


**Pipeline Run:**
(https://cloud.ibm.com/devops/pipelines/tekton/8bb11078-2a03-43b2-9d30-df3ea17af143/runs/e451d813-5873-45d4-aa5a-ef3e0efe99ea/gitops-db2u-database-facilities?env_id=ibm:yp:us-south&view=params)


