### PR TITLE
[patch] Improve update handling of various CPD edge cases

### DIFF
--- a/python/src/mas/cli/update/app.py
+++ b/python/src/mas/cli/update/app.py
@@ -435,34 +435,7 @@ class UpdateApp(BaseApp):
             ""
         ])
 
-    def detectCP4D(self) -> bool:
-        # Important:
-        # This CLI can run independent of the ibm.mas_devops collection, so we cannot reference
-        # the case bundles in there anymore
-        # Longer term we will centralise this information inside the mas-devops python collection,
-        # where it can be made available to both the ansible collection and this python package.
-        cp4dVersions = {
-            "v9-240625-amd64": "4.8.0",
-            "v9-240730-amd64": "4.8.0",
-            "v9-240827-amd64": "4.8.0",
-            "v9-241003-amd64": "4.8.0",
-            "v9-241107-amd64": "4.8.0",
-            "v9-241205-amd64": "5.0.0",
-            "v9-250109-amd64": "5.0.0",
-            "v9-250206-amd64": "5.0.0",
-            "v9-250306-amd64": "5.0.0",
-            "v9-250403-amd64": "5.0.0",
-            "v9-250501-amd64": "5.0.0",
-            "v9-250624-amd64": "5.1.3",
-            "v9-250731-amd64": "5.1.3",
-            "v9-250828-amd64": "5.1.3",
-            "v9-250902-amd64": "5.1.3",
-            "v9-250925-amd64": "5.1.3",
-            "v9-251010-amd64": "5.1.3",
-            "v9-251030-amd64": "5.1.3",
-            "v9-251127-amd64": "5.1.3",
-        }
-
+    def detectCP4D(self) -> None:
         with Halo(text='Checking for IBM Cloud Pak for Data', spinner=self.spinner) as h:
             try:
                 cpdAPI = self.dynamicClient.resources.get(api_version="cpd.ibm.com/v1", kind="Ibmcpd")
@@ -478,13 +451,38 @@ class UpdateApp(BaseApp):
                 #     }
                 # }]
 
-                if len(cpds) > 0:
+                if len(cpds) > 1:
+                    cpdNamespaces = []
+                    for cpd in cpds:
+                        cpdNamespaces.append(cpd["metadata"]["namespace"])
+                    h.stop_and_persist(symbol=self.successIcon, text=f"Detected multiple instances of Cloud Pak for Data in the cluster, these will NOT be updated: {', '.join(cpdNamespaces)}")
+                    self.printDescription([
+                        "<u>Multiple Cloud Pak for Data Instances</u>",
+                        "The MAS install, update, and upgrade functions are designed to work together and support the Maximo reference deployment topology.",
+                        "Multiple instances of Cloud Pak for Data have been detected on the target cluster, so none will be modified:",
+                        "- If you used the Maximo Ansible collection to install CP4D, see: https://ibm-mas.github.io/ansible-devops/",
+                        "- If you used the Cloud Pak for Data CLI to install CP4D, see: https://github.com/IBM/cpd-cli"
+                    ])
+                    return
+                elif len(cpds) == 1:
                     cpdInstanceNamespace = cpds[0]["metadata"]["namespace"]
                     cpdInstanceVersion = cpds[0]["spec"]["version"]
+
+                    if cpdInstanceNamespace != "ibm-cpd":
+                        h.stop_and_persist(symbol=self.successIcon, text=f"Standalone Cloud Pak for Data {cpdInstanceVersion} in namespace {cpdInstanceNamespace}) will NOT be updated")
+                        self.printDescription([
+                            "<u>Standalone Cloud Pak for Data</u>",
+                            "The MAS install, update, and upgrade functions are designed to work together and support the Maximo reference deployment topology.",
+                            "This instance of Cloud Pak for Data appears to have been created outside of this, so will not be modified:",
+                            "- If you used the Maximo Ansible collection to install CP4D, see: https://ibm-mas.github.io/ansible-devops/",
+                            "- If you used the Cloud Pak for Data CLI to install CP4D, see: https://github.com/IBM/cpd-cli"
+                        ])
+                        return
+
                     if self.args.cpd_product_version:
                         cpdTargetVersion = self.getParam("cpd_product_version")
                     else:
-                        cpdTargetVersion = cp4dVersions[self.getParam("mas_catalog_version")]
+                        cpdTargetVersion = self.chosenCatalog["cpd_product_version_default"]
 
                     currentCpdVersionMajorMinor = f"{cpdInstanceVersion.split('.')[0]}.{cpdInstanceVersion.split('.')[1]}"
                     targetCpdVersionMajorMinor = f"{cpdTargetVersion.split('.')[0]}.{cpdTargetVersion.split('.')[1]}"
@@ -504,7 +502,7 @@ class UpdateApp(BaseApp):
                             ])
 
                         # Lookup the storage classes already used by CP4D
-                        # Note: this should be done by the Ansible role, but isn't
+                        # TODO: this should be done by the Ansible role, but isn't
                         if "storageClass" in cpds[0]["spec"]:
                             cpdFileStorage = cpds[0]["spec"]["storageClass"]
                         elif "fileStorageClass" in cpds[0]["spec"]:


### PR DESCRIPTION
Reviewing the code in the cli there are a number of problems around edge cases for CP4D update, that this update addresses:

- Doesn't handle multiple instances of CPD being installed (which should result in the CLI ignoring all CPD instances in the update)
- Doesn't handle "other" instances of CPD being present (which should result in the CLI ignoring CPD) -- this is the scenario being reported here
- Doesn't get the target version of CPD from the single source of truth (the catalog metadata)
- Doesn't handle skipping CPD updates (e.g. 4.6.6 direct to 5.2.0)


None of these scenarios will prevent an update proceeding, but the big issue we have (as reported by customer - TS020960908) is that when a standalone CPD install is detected (one that is not part of what we are managing in the install/update/upgrade) it results in the update flagging a CP4D update as required, which will create a new install of CPD as part of the managed dependency stack (in `ibm-cpd` namespace).

### Really old catalog
<img width="1752" height="308" alt="image" src="https://github.com/user-attachments/assets/b65c332d-dd8f-44a1-92e0-20d8487825f6" />

### Older catalog that can't be updated to directly
<img width="1274" height="327" alt="image" src="https://github.com/user-attachments/assets/2adc6f66-a799-4501-8c7f-5121164cff6e" />

### Multiple CPD instances
<img width="1548" height="895" alt="image" src="https://github.com/user-attachments/assets/2613b6c6-f598-4b31-b204-4c359dd98747" />

### Found a Standalone CPD instance (not in ibm-cpd namespace)
<img width="1557" height="897" alt="image" src="https://github.com/user-attachments/assets/107ee1ce-7b15-4aef-a9d1-779148f952bd" />
