### PR TITLE
[minor] Support for jdbc additional connection url for incluster-db2 type for IOT AND remove redundant code for gitops

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "build/bin/config/oscap/ssg-rhel9-ds.xml|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2025-12-11T07:52:20Z",
+  "generated_at": "2025-12-12T06:47:34Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -390,7 +390,7 @@
         "hashed_secret": "b2817467154949a61f8e9ad31d1eeaf03221cbfa",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 664,
+        "line_number": 660,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -398,7 +398,7 @@
         "hashed_secret": "effb7852555adce89885fb075fb43a77a1e0e77e",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 849,
+        "line_number": 845,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -406,7 +406,7 @@
         "hashed_secret": "2582aea6f911bd00fc04cb25e0ec16d5ead62068",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 851,
+        "line_number": 847,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -562,7 +562,7 @@
         "hashed_secret": "146abac680841f15b3e7b5259e1dfcdd9de49fdd",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 14,
+        "line_number": 13,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/image/cli/mascli/functions/gitops_mas_config
+++ b/image/cli/mascli/functions/gitops_mas_config
@@ -61,7 +61,6 @@ JDBC Configuration (required if MAS_CONFIG_TYPE is "jdbc"):
   --jdbc-type ${COLOR_YELLOW}JDBC_TYPE${TEXT_RESET}                           Set to 'incluster-db2' when wanting to use the gitops configured, via gitops-db2u-database, db2u cluster (defaults to incluster-db2)
   --jdbc-instance-name ${COLOR_YELLOW}JDBC_INSTANCE_NAME${TEXT_RESET}         The JDBC instance name to use. Required for all JDBC_TYPE's
   --jdbc-connection-url ${COLOR_YELLOW}JDBC_CONNECTION_URL${TEXT_RESET}       The JDBC connection URL. Required when JDBC_TYPE is not incluster-db2
-  --jdbc-connection-url-additional-params ${COLOR_YELLOW}JDBC_CONNECTION_URL_ADDITIONAL_PARAMS${TEXT_RESET}  Additional parameters for JDBC connection URL
   --jdbc-certificate-file ${COLOR_YELLOW}JDBC_CERTIFICATE_FILE${TEXT_RESET}   Path to file containing CA Certificate for JDBC server. Required when JDBC_TYPE is not incluster-db2
   --jdbc-route ${COLOR_YELLOW}JDBC_ROUTE${TEXT_RESET}                         By default routes are not exposed to public. To expose route, set this to public.
 
@@ -235,9 +234,6 @@ function gitops_mas_config_noninteractive() {
         ;;
       --jdbc-connection-url)
         export JDBC_CONNECTION_URL=$1 && shift
-        ;;
-      --jdbc-connection-url-additional-params)
-        export JDBC_CONNECTION_URL_ADDITIONAL_PARAMS=$1 && shift
         ;;
       --jdbc-certificate-file)
         export JDBC_CERTIFICATE_FILE=$1 && shift

--- a/image/cli/mascli/templates/gitops/appset-configs/cluster/instance/configs/ibm-mas-jdbc-config.yaml.j2
+++ b/image/cli/mascli/templates/gitops/appset-configs/cluster/instance/configs/ibm-mas-jdbc-config.yaml.j2
@@ -8,7 +8,6 @@ mas_config_api_version: "config.mas.ibm.com"
 use_postdelete_hooks: {{ USE_POSTDELETE_HOOKS }}
 
 jdbc_type: {{ JDBC_TYPE }}
-jdbc_connection_url_additional_params: {{ JDBC_CONNECTION_URL_ADDITIONAL_PARAMS }}
 jdbc_instance_name: <path:{{ SECRETS_PATH }}:{{ SECRET_KEY_JDBC_INSTANCE_NAME }}>
 jdbc_instance_username: <path:{{ SECRETS_PATH }}:{{ SECRET_KEY_JDBC_USERNAME }}>
 jdbc_instance_password: <path:{{ SECRETS_PATH }}:{{ SECRET_KEY_JDBC_PASSWORD }}>

--- a/tekton/src/pipelines/gitops/deprovision-mas-instance.yml.j2
+++ b/tekton/src/pipelines/gitops/deprovision-mas-instance.yml.j2
@@ -180,8 +180,6 @@ spec:
           value: $(params.mas_instance_id)
         - name: jdbc_type_iot
           value: $(params.jdbc_type_iot)
-        - name: jdbc_connection_url_additional_params_iot
-          value: $(params.jdbc_connection_url_additional_params_iot)
         - name: jdbc_instance_name_iot
           value: $(params.jdbc_instance_name_iot)
         - name: jdbc_route_iot

--- a/tekton/src/pipelines/gitops/gitops-mas-apps.yml.j2
+++ b/tekton/src/pipelines/gitops/gitops-mas-apps.yml.j2
@@ -951,6 +951,8 @@ spec:
           value: $(params.db2_tolerate_value_iot)
         - name: db2_tolerate_effect
           value: $(params.db2_tolerate_effect_iot)
+        - name: jdbc_connection_url_additional_params
+          value: $(params.jdbc_connection_url_additional_params_iot)
         - name: jdbc_route
           value: $(params.jdbc_route_iot)
         - name: db2_timezone
@@ -999,8 +1001,6 @@ spec:
           value: system
         - name: jdbc_type
           value: $(params.jdbc_type_iot)
-        - name: jdbc_connection_url_additional_params
-          value: $(params.jdbc_connection_url_additional_params_iot)
         - name: jdbc_instance_name
           value: $(params.jdbc_instance_name_iot)
         - name: jdbc_connection_url

--- a/tekton/src/tasks/gitops/gitops-deprovision-suite-config.yml.j2
+++ b/tekton/src/tasks/gitops/gitops-deprovision-suite-config.yml.j2
@@ -70,8 +70,6 @@ spec:
         value: $(params.avp_aws_secret_region)
       - name: JDBC_TYPE_IOT
         value: $(params.jdbc_type_iot)
-      - name: JDBC_CONNECTION_URL_ADDITIONAL_PARAMS_IOT
-        value: $(params.jdbc_connection_url_additional_params_iot)
       - name: JDBC_INSTANCE_NAME_IOT
         value: $(params.jdbc_instance_name_iot)
       - name: JDBC_ROUTE_IOT

--- a/tekton/src/tasks/gitops/gitops-jdbc-config.yml.j2
+++ b/tekton/src/tasks/gitops/gitops-jdbc-config.yml.j2
@@ -36,9 +36,6 @@ spec:
     - name: jdbc_type
       type: string
       default: incluster-db2
-    - name: jdbc_connection_url_additional_params
-      type: string
-      default: ""
     - name: jdbc_instance_name
       type: string
     - name: jdbc_connection_url
@@ -83,8 +80,6 @@ spec:
         value: $(params.mas_workspace_id)
       - name: JDBC_TYPE
         value: $(params.jdbc_type)
-      - name: JDBC_CONNECTION_URL_ADDITIONAL_PARAMS
-        value: $(params.jdbc_connection_url_additional_params)
       - name: JDBC_INSTANCE_NAME
         value: $(params.jdbc_instance_name)
       - name: JDBC_CONNECTION_URL


### PR DESCRIPTION
## Issue

https://jsw.ibm.com/browse/MASCORE-11199

## Description

* For jdbc incluster-db2 db2-type only, allow for an optional config `jdbc_connection_url_additional_params.
* Eliminated  misconfiguration of JDBC_CONNECTION_URL_ADDITIONAL_PARAMS across CLI functions, templates, and Tekton pipeline/task definitions. 
* This streamlines JDBC configuration by removing unused or redundant parameters.

**Why:**

* Required **jdbc_connection_url_additional_params** for IOT.

**Impact:**

* it will include this additional parameter in case of jdbc : incluster-db2 db2-type only, jdbc_connection_url_additional_params .

## Test Results

* After pipeline execution, the system generates valid gitops-envs:

**argo-cd**
(https://openshift-gitops-server-openshift-gitops.apps.noble4.cp.fyre.ibm.com/applications/openshift-gitops/db2-db.noble4.sls01.iot?operation=false&node=batch%2FJob%2Fdb2u-sls01%2Fpostsync-setup-db2-2164734315%2F0&tab=logs)

**Pipeline Run:**
(https://cloud.ibm.com/devops/pipelines/tekton/8bb11078-2a03-43b2-9d30-df3ea17af143/runs/6f3fcda4-1127-4d93-9871-a30936fa0d69/gitops-jdbc-config-facilities?env_id=ibm:yp:us-south&view=logs)

**gitops-envs**
(https://github.ibm.com/maximoappsuite/gitops-envs/commit/e1cc1e79d3ed5ced9ca61e752e24d7d7172a4606)

