### PR TITLE
[patch] Remove unused JDBC connection URL params for IoT

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "build/bin/config/oscap/ssg-rhel9-ds.xml|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2025-12-12T06:47:34Z",
+  "generated_at": "2025-12-15T10:42:49Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"

--- a/tekton/src/pipelines/gitops/deprovision-mas-instance.yml.j2
+++ b/tekton/src/pipelines/gitops/deprovision-mas-instance.yml.j2
@@ -41,8 +41,6 @@ spec:
     # JDBC
     - name: jdbc_type_iot
       type: string
-    - name: jdbc_connection_url_additional_params_iot
-      type: string
     - name: jdbc_instance_name_iot
       type: string
     - name: jdbc_route_iot

--- a/tekton/src/tasks/gitops/gitops-deprovision-suite-config.yml.j2
+++ b/tekton/src/tasks/gitops/gitops-deprovision-suite-config.yml.j2
@@ -28,8 +28,6 @@ spec:
     - name: jdbc_type_iot
       type: string
       default: "incluster-db2"
-    - name: jdbc_connection_url_additional_params_iot
-      type: string
     - name: jdbc_instance_name_iot
       type: string
       default: ""
@@ -117,7 +115,6 @@ spec:
         --mas-app-id "iot" \
         --dir /tmp/deprovision-suite-config-iotdb \
         --jdbc-type "$JDBC_TYPE_IOT" \
-        --jdbc-connection-url-additional-params "$JDBC_CONNECTION_URL_ADDITIONAL_PARAMS_IOT" \
         --jdbc-route "$JDBC_ROUTE_IOT" \
         --jdbc-instance-name "$JDBC_INSTANCE_NAME_IOT" \
         || exit 1


### PR DESCRIPTION
**[minor] Support for jdbc additional connection url for incluster-db2 type for IOT AND remove redundant code for gitops #1957** 


part of this above pr.
Remove unused JDBC connection URL params for IoT 
