### PR TITLE
[patch] Publish $BRANCHNAME tag alias for cli image

### DIFF
--- a/.github/workflows/build-cli.yml
+++ b/.github/workflows/build-cli.yml
@@ -436,19 +436,22 @@ jobs:
       - name: Publish the manifest
         run: |
           echo "GITHUB_REF=$GITHUB_REF"
+          echo "GITHUB_REF_NAME=$GITHUB_REF_NAME"
           echo "GITHUB_EVENT_NAME=$GITHUB_EVENT_NAME"
 
           # Login to quay.io
-          docker login --username "${{ secrets.QUAYIO_USERNAME }}" --password "${{ secrets.QUAYIO_PASSWORD }}" quay.io
+          echo "${{ secrets.QUAYIO_PASSWORD }}" | docker login quay.io --username "${{ secrets.QUAYIO_USERNAME }}" --password-stdin
 
           # Publish the manifest
           $GITHUB_WORKSPACE/build/bin/docker-manifest.sh -r quay.io/ibmmas/cli --target-platforms amd64,s390x,arm64,ppc64le
 
-          # Re-issue the manifest under an alias where needed
+          # Re-issue the manifest under an alias
           # https://github.com/docker/buildx/issues/1744#issuecomment-1896645786
           if [[ "$GITHUB_EVENT_NAME" == "release" ]]; then
+            echo "Publishing quay.io/ibmmas/cli:latest alias"
             docker buildx imagetools create -t quay.io/ibmmas/cli:latest quay.io/ibmmas/cli:${{ env.DOCKER_TAG }}
           else
+            echo "Publishing quay.io/ibmmas/cli:${{ env.GITHUB_REF_NAME }} alias"
             docker buildx imagetools create -t quay.io/ibmmas/cli:${{ env.GITHUB_REF_NAME }} quay.io/ibmmas/cli:${{ env.DOCKER_TAG }}
           fi
 

--- a/.github/workflows/build-cli.yml
+++ b/.github/workflows/build-cli.yml
@@ -451,8 +451,8 @@ jobs:
             echo "Publishing quay.io/ibmmas/cli:latest alias"
             docker buildx imagetools create -t quay.io/ibmmas/cli:latest quay.io/ibmmas/cli:${{ env.DOCKER_TAG }}
           else
-            echo "Publishing quay.io/ibmmas/cli:${{ env.GITHUB_REF_NAME }} alias"
-            docker buildx imagetools create -t quay.io/ibmmas/cli:${{ env.GITHUB_REF_NAME }} quay.io/ibmmas/cli:${{ env.DOCKER_TAG }}
+            echo "Publishing quay.io/ibmmas/cli:$GITHUB_REF_NAME alias"
+            docker buildx imagetools create -t quay.io/ibmmas/cli:$GITHUB_REF_NAME quay.io/ibmmas/cli:${{ env.DOCKER_TAG }}
           fi
 
 

--- a/.github/workflows/build-cli.yml
+++ b/.github/workflows/build-cli.yml
@@ -446,10 +446,10 @@ jobs:
 
           # Re-issue the manifest under an alias where needed
           # https://github.com/docker/buildx/issues/1744#issuecomment-1896645786
-          if [[ "$GITHUB_REF" == "refs/heads/master" ]]; then
-            docker buildx imagetools create -t quay.io/ibmmas/cli:master quay.io/ibmmas/cli:${{ env.DOCKER_TAG }}
-          elif [[ "$GITHUB_EVENT_NAME" == "release" ]]; then
+          if [[ "$GITHUB_EVENT_NAME" == "release" ]]; then
             docker buildx imagetools create -t quay.io/ibmmas/cli:latest quay.io/ibmmas/cli:${{ env.DOCKER_TAG }}
+          else
+            docker buildx imagetools create -t quay.io/ibmmas/cli:${{ env.GITHUB_REF_NAME }} quay.io/ibmmas/cli:${{ env.DOCKER_TAG }}
           fi
 
 


### PR DESCRIPTION
This change will make it much easier for developers to manage longer-life development branches of the CLI in their environment configurations, it will provide a fixed docker tag for all images on a specific branch, regardless of the version.  Similar to the `latest` tag for releases.