### PR TITLE
[patch] Add --sls-channel in development mode

### DIFF
--- a/python/src/mas/cli/install/app.py
+++ b/python/src/mas/cli/install/app.py
@@ -336,7 +336,6 @@ class InstallApp(BaseApp, InstallSettingsMixin, InstallSummarizerMixin, ConfigGe
 
         self.setParam("sls_action", "install")
 
-
     @logMethodCall
     def configDRO(self) -> None:
         self.promptForString("Contact e-mail address", "dro_contact_email")

--- a/python/src/mas/cli/install/app.py
+++ b/python/src/mas/cli/install/app.py
@@ -326,7 +326,16 @@ class InstallApp(BaseApp, InstallSettingsMixin, InstallSummarizerMixin, ConfigGe
                     return
 
         self.slsLicenseFileLocal = self.promptForFile("License file", mustExist=True, envVar="SLS_LICENSE_FILE_LOCAL")
+
+        if self.devMode:
+            default_sls_channel = "3.x-dev"
+            # Check if it was provided via args already
+            if self.args.sls_channel and self.args.sls_channel != "":
+                default_sls_channel = self.args.sls_channel
+            self.promptForString("SLS channel", "sls_channel", default_sls_channel)
+
         self.setParam("sls_action", "install")
+
 
     @logMethodCall
     def configDRO(self) -> None:
@@ -1094,6 +1103,10 @@ class InstallApp(BaseApp, InstallSettingsMixin, InstallSummarizerMixin, ConfigGe
             elif key == "dedicated_sls":
                 if value:
                     self.setParam("sls_namespace", f"mas-{self.args.mas_instance_id}-sls")
+            elif key == "sls_channel":
+                if self.devMode:
+                    if value is not None and value != "":
+                        self.setParam("sls_channel", value)
 
             # These settings are used by the CLI rather than passed to the PipelineRun
             elif key == "storage_accessmode":

--- a/python/src/mas/cli/install/app.py
+++ b/python/src/mas/cli/install/app.py
@@ -712,7 +712,7 @@ class InstallApp(BaseApp, InstallSettingsMixin, InstallSummarizerMixin, ConfigGe
     def configAppChannel(self, appId):
         versions = self.getCompatibleVersions(self.params["mas_channel"], appId)
         if len(versions) == 0:
-            self.params[f"mas_app_channel_{appId}"] = prompt(HTML(f"<Yellow>Custom {appId.title()} channel</Yellow> "))
+            self.params[f"mas_app_channel_{appId}"] = prompt(HTML('<Yellow>Custom channel</Yellow> '))
         else:
             self.params[f"mas_app_channel_{appId}"] = versions[0]
 

--- a/python/src/mas/cli/install/app.py
+++ b/python/src/mas/cli/install/app.py
@@ -246,7 +246,7 @@ class InstallApp(BaseApp, InstallSettingsMixin, InstallSummarizerMixin, ConfigGe
         self.printH1("IBM Maximo Operator Catalog Selection")
         if self.devMode:
             self.promptForString("Select catalog source", "mas_catalog_version", default="v9-master-amd64")
-            self.promptForString("Select channel", "mas_channel", default="9.1.x-dev")
+            self.promptForString("Select channel", "mas_channel", default="9.2.x-dev")
         else:
             catalogInfo = getCurrentCatalog(self.dynamicClient)
 
@@ -712,7 +712,7 @@ class InstallApp(BaseApp, InstallSettingsMixin, InstallSummarizerMixin, ConfigGe
     def configAppChannel(self, appId):
         versions = self.getCompatibleVersions(self.params["mas_channel"], appId)
         if len(versions) == 0:
-            self.params[f"mas_app_channel_{appId}"] = prompt(HTML('<Yellow>Custom channel</Yellow> '))
+            self.params[f"mas_app_channel_{appId}"] = prompt(HTML(f"<Yellow>Custom {appId.title()} channel</Yellow> "))
         else:
             self.params[f"mas_app_channel_{appId}"] = versions[0]
 

--- a/python/src/mas/cli/install/argBuilder.py
+++ b/python/src/mas/cli/install/argBuilder.py
@@ -144,12 +144,12 @@ class installArgBuilderMixin():
                 command += f"  --sls-namespace \"{self.getParam('sls_namespace')}\""
                 addedSLSCmd = True
         if self.getParam("sls_channel") != "":
-                command += f"  --sls-channel \"{self.getParam('sls_channel')}\""
-                addedSLSCmd = True
+            command += f"  --sls-channel \"{self.getParam('sls_channel')}\""
+            addedSLSCmd = True
         if self.slsLicenseFileLocal:
             command += f"  --license-file \"{self.slsLicenseFileLocal}\""
             addedSLSCmd = True
-        if addedSLSCmd == True:
+        if addedSLSCmd is True:
             command += newline
 
         # IBM Data Reporting Operator (DRO)

--- a/python/src/mas/cli/install/argBuilder.py
+++ b/python/src/mas/cli/install/argBuilder.py
@@ -134,14 +134,22 @@ class installArgBuilderMixin():
 
         # IBM Suite License Service
         # -----------------------------------------------------------------------------
-        if self.getParam("sls_namespace") and self.getParam("sls_namespace") != "ibm-sls":
-            if self.getParam("mas_instance_id") and self.getParam("sls_namespace") == f"mas-{self.getParam('mas_instance_id')}-sls":
-                command += "  --dedicated-sls"
+        addedSLSCmd = False
+        if self.getParam("sls_namespace") != "ibm-sls":
+            if self.getParam("mas_instance_id") != "":
+                if self.getParam("sls_namespace") == f"mas-{self.getParam('mas_instance_id')}-sls":
+                    command += "  --dedicated-sls"
+                    addedSLSCmd = True
             else:
                 command += f"  --sls-namespace \"{self.getParam('sls_namespace')}\""
+                addedSLSCmd = True
+        if self.getParam("sls_channel") != "":
+                command += f"  --sls-channel \"{self.getParam('sls_channel')}\""
+                addedSLSCmd = True
         if self.slsLicenseFileLocal:
             command += f"  --license-file \"{self.slsLicenseFileLocal}\""
-        if self.getParam("sls_namespace") and self.getParam("sls_namespace") != "ibm-sls" or self.slsLicenseFileLocal:
+            addedSLSCmd = True
+        if addedSLSCmd == True:
             command += newline
 
         # IBM Data Reporting Operator (DRO)

--- a/python/src/mas/cli/install/argParser.py
+++ b/python/src/mas/cli/install/argParser.py
@@ -319,6 +319,11 @@ slsArgGroup.add_argument(
     default=False,
     help="Set the SLS namespace to mas-<instanceid>-sls"
 )
+slsArgGroup.add_argument(
+    "--sls-channel",
+    required=False,
+    help="Customize the SLS channel when in development mode",
+)
 
 # IBM Data Reporting Operator (DRO)
 # -----------------------------------------------------------------------------

--- a/python/src/mas/cli/install/summarizer.py
+++ b/python/src/mas/cli/install/summarizer.py
@@ -284,7 +284,10 @@ class InstallSummarizerMixin():
         self.printH2("IBM Suite License Service")
         self.printParamSummary("Namespace", "sls_namespace")
         if self.getParam("sls_action") == "install":
-            self.printSummary("Subscription Channel", "3.x")
+            if self.getParam("sls_channel") != "":
+                self.printSummary("Subscription Channel", self.getParam("sls_channel"))
+            else:
+                self.printSummary("Subscription Channel", "3.x")
             self.printParamSummary("IBM Open Registry", "sls_icr_cpopen")
             if self.slsLicenseFileLocal:
                 self.printSummary("License File", self.slsLicenseFileLocal)


### PR DESCRIPTION
## Details

- Added arg `--sls-channel` which is only considered when in development mode
- Updated interactive sls prompts, argBuilder, argParser, and summarizer accordingly
- Changed default MAS dev channel from `9.1.x-dev` to `9.2.x-dev`

## Testing

- Tested various scenarios and installs

E.g. ran `mas install --dev-mode --sls-channel 3.x-dev`

<img width="741" height="680" alt="Screenshot 2025-12-18 at 8 04 22 pm" src="https://github.com/user-attachments/assets/7ae57f1f-0e73-4bea-af50-cb47af4c5d8b" />

<img width="825" height="456" alt="Screenshot 2025-12-18 at 8 05 56 pm" src="https://github.com/user-attachments/assets/1912e39e-d5c7-4f48-a757-8e5fa76bb41c" />

<img width="821" height="87" alt="Screenshot 2025-12-18 at 8 06 07 pm" src="https://github.com/user-attachments/assets/32e2e0fd-cabf-4a2e-8312-c6d99d3a4f6d" />

<img width="1497" height="379" alt="Screenshot 2025-12-18 at 7 21 58 pm" src="https://github.com/user-attachments/assets/c7a8d9ab-91b6-488e-b912-ef4e640f4cd9" />

<img width="1508" height="832" alt="Screenshot 2025-12-18 at 7 22 15 pm" src="https://github.com/user-attachments/assets/ad4d9278-2fc1-4706-8bda-53c9940b15b0" />

<img width="758" height="307" alt="Screenshot 2025-12-18 at 7 22 42 pm" src="https://github.com/user-attachments/assets/f92c198b-f74b-4720-957d-1aac59f024ba" />

<img width="1518" height="576" alt="Screenshot 2025-12-18 at 7 22 58 pm" src="https://github.com/user-attachments/assets/2b0f85d2-6c58-4f76-919a-31cb0dc2a4b2" />
