### PR TITLE
[patch] Facilities FVT waitfor-manage task to complete 

### DIFF
--- a/tekton/src/pipelines/mas-fvt-launcher.yml.j2
+++ b/tekton/src/pipelines/mas-fvt-launcher.yml.j2
@@ -940,6 +940,7 @@ spec:
           values: ["true", "True"]
       runAfter:
         - approval-suite-verify
+        - waitfor-manage
 
     - name: launchfvt-facilities
       timeout: "0"


### PR DESCRIPTION
Wait for manage to complete before start executing the facilities FVT test.
User creation tests will fail without this change.

PFVT test results:
https://dashboard.ibmmas.com/tests/mref/testsuite/ibm-mas-facilities/facilities_fvt
[7:45](https://ibm-isl-team.slack.com/archives/D09EQ77SBGA/p1766153752680869)

PFVT branch ::
[7:46](https://ibm-isl-team.slack.com/archives/D09EQ77SBGA/p1766153767611499)
https://github.ibm.com/maximoappsuite/fvt-personal/blob/facility/mas.env


<img width="1898" height="648" alt="image" src="https://github.com/user-attachments/assets/fcabac9c-6404-4e03-b36b-51b5c924259c" />
