### PR TITLE
[patch] Fix mirroring to only mirror a single architecture

### DIFF
--- a/image/cli/mascli/functions/help/mirror_images_help
+++ b/image/cli/mascli/functions/help/mirror_images_help
@@ -1,0 +1,109 @@
+function mirror_to_registry_help_header() {
+  [[ -n "$1" ]] && echo_warning "$1"
+  reset_colors
+  cat << EOM
+Usage:
+  mas mirror-images [options]
+Where ${COLOR_YELLOW}specified${TEXT_RESET} each option may also be defined by setting the appropriate environment variable.
+When no options are specified on the command line, interactive-mode will be enabled by default.
+
+Mirror Mode (Required):
+  -m, --mode ${COLOR_YELLOW}MIRROR_MODE${TEXT_RESET}                         Operation mode (direct, to-filesystem, from-filesystem)
+  -d, --dir ${COLOR_YELLOW}MIRROR_WORKING_DIR${TEXT_RESET}                   Working directory for the mirror process
+
+Registry Details (Required):
+  -H, --host ${COLOR_YELLOW}REGISTRY_PUBLIC_HOST${TEXT_RESET}                 Hostname of the target registry
+  -P, --port ${COLOR_YELLOW}REGISTRY_PUBLIC_PORT${TEXT_RESET}                 Port number for the target registry
+  -u, --username ${COLOR_YELLOW}REGISTRY_USERNAME${TEXT_RESET}                Username to authenticate to the target registry
+  -p, --password ${COLOR_YELLOW}REGISTRY_PASSWORD${TEXT_RESET}                Password to authenticate to the target registry
+
+Registry Prefix (Optional):
+  -x, --prefix ${COLOR_YELLOW}REGISTRY_PREFIX${TEXT_RESET}                    Prefix for the mirror image
+
+AWS Elastic Container Registry (Optional):
+  -r, --aws-ecr-region ${COLOR_YELLOW}REGISTRY_ECR_AWS_REGION${TEXT_RESET}    The AWS region if the target registry is Elastic Container Registry
+  -e, --target-is-ecr                                                         Indicate that the target registry is Elastic Container Registry
+
+Source Registry Entitlements (Required based on what content you choose to mirror):
+      --ibm-entitlement ${COLOR_YELLOW}IBM_ENTITLEMENT_KEY${TEXT_RESET}       IBM Entitlement Key
+      --artifactory-username ${COLOR_YELLOW}ARTIFACTORY_USERNAME${TEXT_RESET} Artifactory Username
+      --artifactory-token ${COLOR_YELLOW}ARTIFACTORY_TOKEN${TEXT_RESET}       Artifactory Token
+
+Maximo Operator Catalog Selection (Optional):
+  -c, --catalog ${COLOR_YELLOW}MAS_CATALOG_VERSION${TEXT_RESET}               Maximo Operator Catalog Version to mirror (e.g. v9-240625-amd64)
+  -C, --channel ${COLOR_YELLOW}MAS_CHANNEL${TEXT_RESET}                       Maximo Application Suite Channel to mirror (e.g. 9.1.x)
+EOM
+}
+
+
+function mirror_to_registry_help() {
+  mirror_to_registry_help_header
+  cat << EOM
+
+Content Selection (Core Platform):
+      --mirror-catalog                            Mirror the IBM Maximo Operator Catalog
+      --mirror-core                               Mirror images for IBM Maximo Application Suite Core
+
+Content Selection (Applications):
+      --mirror-assist                             Mirror images for IBM Maximo Assist
+      --mirror-iot                                Mirror images for IBM Maximo IoT
+      --mirror-manage                             Mirror images for IBM Maximo Manage
+      --mirror-icd                                Mirror image  for IBM Maximo IT (Separately entitled IBM Maximo Manage extension)
+      --mirror-monitor                            Mirror images for IBM Maximo Monitor
+      --mirror-optimizer                          Mirror images for IBM Maximo Optimizer
+      --mirror-predict                            Mirror images for IBM Maximo Predict
+      --mirror-visualinspection                   Mirror images for IBM Maximo Visual Inspection
+
+Content Selection (Cloud Pak for Data):
+      --mirror-cp4d                               Mirror images for IBM Cloud Pak for Data Platform
+      --mirror-wsl                                Mirror images for IBM Watson Studio Local
+      --mirror-wml                                Mirror images for IBM Watson Machine Learning
+      --mirror-spark                              Mirror images for IBM Analytics Engine (Spark)
+      --mirror-cognos                             Mirror images for IBM Cognos Analytics
+
+Content Selection (Other Dependencies):
+      --mirror-cfs                                Mirror images for IBM Cloud Pak Foundation Services
+      --mirror-sls                                Mirror images for IBM Suite License Service
+      --mirror-tsm                                Mirror images for IBM Truststore Manager
+      --mirror-mongo                              Mirror images for MongoDb Community Edition
+      --mirror-mongo-v5                           Mirror images for MongoDb Community Edition version 5
+      --mirror-mongo-v6                           Mirror images for MongoDb Community Edition version 6
+      --mirror-mongo-v7                           Mirror images for MongoDb Community Edition version 7
+      --mirror-db2                                Mirror images for IBM Db2
+      --mirror-odf                                Mirror images for ODF
+
+Content Selection (All images included):
+      --mirror-everything                         Mirror all MAS related images (including dependencies)
+
+Other Commands:
+      --no-confirm                                Mirror images without prompting for confirmation
+  -h, --help                                      Show this help message
+EOM
+  [[ -n "$1" ]] && exit 1 || exit 0
+}
+
+
+function mirror_aiservice_to_registry_help() {
+  mirror_to_registry_help_header
+  cat << EOM
+
+Content Selection (AI Service):
+      --mirror-catalog                            Mirror the IBM Maximo Operator Catalog
+      --mirror-aiservice                          Mirror images for IBM Maximo Application Suite AI Service
+
+Content Selection (Dependencies):
+      --mirror-minio                              Mirror images for minio
+      --mirror-db2                                Mirror images for IBM Db2
+      --mirror-mariadb                            Mirror images for mariadb
+      --mirror-opendatahub                        Mirror images for opendatahub
+      --mirror-odf                                Mirror images for ODF
+
+Content Selection (All images included):
+      --mirror-everything                         Mirror all ai-service related images (including dependencies)
+
+Other Commands:
+      --no-confirm                                Mirror images without prompting for confirmation
+  -h, --help                                      Show this help message
+EOM
+  [[ -n "$1" ]] && exit 1 || exit 0
+}

--- a/image/cli/mascli/functions/mirror_aiservice_images
+++ b/image/cli/mascli/functions/mirror_aiservice_images
@@ -1,29 +1,6 @@
 #!/bin/bash
 
-function mirror_aiservice_to_registry_help() {
-  mirror_to_registry_help_header
-  cat << EOM
-
-Content Selection (Core Platform):
-      --mirror-catalog                            Mirror the IBM Maximo Operator Catalog
-      --mirror-aiservice                          Mirror images for IBM Maximo Application Suite AI Service
-
-Content Selection (Dependencies):
-      --mirror-minio                              Mirror images for minio 
-      --mirror-db2                                Mirror images for IBM Db2
-      --mirror-mariadb                            Mirror images for mariadb
-      --mirror-opendatahub                        Mirror images for opendatahub
-      --mirror-odf                                Mirror images for ODF
-
-Content Selection (All images included):
-      --mirror-everything                         Mirror all ai-service related images (including dependencies)
-
-Other Commands:
-      --no-confirm                                Mirror images without prompting for confirmation
-  -h, --help                                      Show this help message
-EOM
-  [[ -n "$1" ]] && exit 1 || exit 0
-}
+. $CLI_DIR/functions/help/mirror_images_help
 
 function mirror_aiservice_everything() {
     # Core
@@ -135,7 +112,7 @@ function mirror_aiservice_to_registry_noninteractive() {
       --mirror-opendatahub)
         MIRROR_OPENDATAHUB=true
         ;;
- 
+
       --no-confirm)
         NO_CONFIRM=true
         ;;
@@ -207,10 +184,10 @@ function mirror_aiservice_to_registry() {
 export MIRROR_MINIO
   export MIRROR_DB2U
   export MIRROR_MARIADB
-  
+
   export MIRROR_OPENDATAHUB
   export MIRROR_ODF
-  
+
   if [[ "$MIRROR_CATALOG" == true ||
     "$MIRROR_MINIO" == true ||
     "$MIRROR_DB2U" == true ||

--- a/image/cli/mascli/functions/mirror_images
+++ b/image/cli/mascli/functions/mirror_images
@@ -1,51 +1,6 @@
 #!/bin/bash
+. $CLI_DIR/functions/help/mirror_images_help
 
-function mirror_to_registry_help() {
-  mirror_to_registry_help_header
-  cat << EOM
-
-Content Selection (Core Platform):
-      --mirror-catalog                            Mirror the IBM Maximo Operator Catalog
-      --mirror-core                               Mirror images for IBM Maximo Application Suite Core
-
-Content Selection (Applications):
-      --mirror-assist                             Mirror images for IBM Maximo Assist
-      --mirror-iot                                Mirror images for IBM Maximo IoT
-      --mirror-manage                             Mirror images for IBM Maximo Manage
-      --mirror-icd                                Mirror image  for IBM Maximo IT (Separately entitled IBM Maximo Manage extension)
-      --mirror-monitor                            Mirror images for IBM Maximo Monitor
-      --mirror-optimizer                          Mirror images for IBM Maximo Optimizer
-      --mirror-predict                            Mirror images for IBM Maximo Predict
-      --mirror-visualinspection                   Mirror images for IBM Maximo Visual Inspection
-
-Content Selection (Cloud Pak for Data):
-      --mirror-cp4d                               Mirror images for IBM Cloud Pak for Data Platform
-      --mirror-wsl                                Mirror images for IBM Watson Studio Local
-      --mirror-wml                                Mirror images for IBM Watson Machine Learning
-      --mirror-spark                              Mirror images for IBM Analytics Engine (Spark)
-      --mirror-cognos                             Mirror images for IBM Cognos Analytics
-
-Content Selection (Other Dependencies):
-      --mirror-cfs                                Mirror images for IBM Cloud Pak Foundation Services
-      --mirror-sls                                Mirror images for IBM Suite License Service
-      --mirror-tsm                                Mirror images for IBM Truststore Manager
-      --mirror-mongo                              Mirror images for MongoDb Community Edition
-      --mirror-mongo-v5                           Mirror images for MongoDb Community Edition version 5
-      --mirror-mongo-v6                           Mirror images for MongoDb Community Edition version 6
-      --mirror-mongo-v7                           Mirror images for MongoDb Community Edition version 7
-      --mirror-db2                                Mirror images for IBM Db2
-      --mirror-appconnect                         Mirror images for IBM AppConnect
-      --mirror-odf                                Mirror images for ODF
-
-Content Selection (All images included):
-      --mirror-everything                         Mirror all MAS related images (including dependencies)
-
-Other Commands:
-      --no-confirm                                Mirror images without prompting for confirmation
-  -h, --help                                      Show this help message
-EOM
-  [[ -n "$1" ]] && exit 1 || exit 0
-}
 
 function mirror_everything() {
     # Core
@@ -69,14 +24,11 @@ function mirror_everything() {
     MIRROR_SLS=true
     MIRROR_TRUSTSTOREMGR=true
     MIRROR_MONGOCE=true
-    MIRROR_MONGOCE_V4=true
-    MIRROR_MONGOCE_V5=true
     MIRROR_MONGOCE_V6=true
     MIRROR_MONGOCE_V7=true
     MIRROR_MONGOCE_V8=true
 
     MIRROR_DB2U=true
-    MIRROR_APPCONNECT=true
     MIRROR_ODF=true
 
     # Dependencies (CP4D)
@@ -118,7 +70,6 @@ function mirror_to_registry_noninteractive() {
   MIRROR_WML=false
   MIRROR_SPARK=false
   MIRROR_COGNOS=false
-  MIRROR_APPCONNECT=false
   MIRROR_ODF=false
 
   while [[ $# -gt 0 ]]
@@ -230,12 +181,6 @@ function mirror_to_registry_noninteractive() {
       --mirror-mongo)
         MIRROR_MONGOCE=true
         ;;
-      --mirror-mongo-v4)
-        MIRROR_MONGOCE_V4=true
-        ;;
-      --mirror-mongo-v5)
-        MIRROR_MONGOCE_V5=true
-        ;;
       --mirror-mongo-v6)
         MIRROR_MONGOCE_V6=true
         ;;
@@ -247,9 +192,6 @@ function mirror_to_registry_noninteractive() {
         ;;
       --mirror-db2)
         MIRROR_DB2U=true
-        ;;
-      --mirror-appconnect)
-        MIRROR_APPCONNECT=true
         ;;
       --mirror-odf)
         MIRROR_ODF=true
@@ -350,9 +292,10 @@ function mirror_to_registry_interactive() {
       echo
       echo "MongoDb Community Edition options for mirroring:"
       echo "  1. Default MongoDb version set by catalog source (recommended)"
-      echo "  2. MongoDb version 4"
-      echo "  3. MongoDb version 5"
-      echo "  4. Mirror all supported MongoDb versions"
+      echo "  2. MongoDb version 6"
+      echo "  3. MongoDb version 7"
+      echo "  4. MongoDb version 8"
+      echo "  5. Mirror all supported MongoDb versions"
       reset_colors
       echo
       prompt_for_input "Select the MongoDb Community Edition mirroring option" MONGOCE_SELECTION "1"
@@ -363,15 +306,19 @@ function mirror_to_registry_interactive() {
           MIRROR_MONGOCE=true
           ;;
         2)
-          MIRROR_MONGOCE_V4=true
+          MIRROR_MONGOCE_V6=true
           ;;
         3)
-          MIRROR_MONGOCE_V5=true
+          MIRROR_MONGOCE_V7=true
           ;;
         4)
+          MIRROR_MONGOCE_V8=true
+          ;;
+        5)
           MIRROR_MONGOCE=true
-          MIRROR_MONGOCE_V4=true
-          MIRROR_MONGOCE_V5=true
+          MIRROR_MONGOCE_V6=true
+          MIRROR_MONGOCE_V7=true
+          MIRROR_MONGOCE_V8=true
           ;;
 
         # Invalid Selection
@@ -390,7 +337,6 @@ function mirror_to_registry_interactive() {
     prompt_for_confirm "IBM Analytics Engine (Spark)" MIRROR_SPARK
     prompt_for_confirm "IBM Cognos Analytics" MIRROR_COGNOS
 
-    prompt_for_confirm "IBM AppConnect" MIRROR_APPCONNECT
     prompt_for_confirm "Red Hat ODF" MIRROR_ODF
 
   fi
@@ -410,11 +356,6 @@ function mirror_to_registry_interactive() {
 
 }
 
-
-
-
-
-
 function mirror_to_registry() {
   # Take the first parameter off (it will be mirror-images)
   shift
@@ -428,8 +369,6 @@ function mirror_to_registry() {
   export MIRROR_SLS
   export MIRROR_TRUSTSTOREMGR
   export MIRROR_MONGOCE
-  export MIRROR_MONGOCE_V4
-  export MIRROR_MONGOCE_V5
   export MIRROR_MONGOCE_V6
   export MIRROR_MONGOCE_V7
   export MIRROR_MONGOCE_V8
@@ -439,7 +378,6 @@ function mirror_to_registry() {
   export MIRROR_WSL
   export MIRROR_SPARK
   export MIRROR_COGNOS
-  export MIRROR_APPCONNECT
   export MIRROR_ODF
   export MIRROR_MAS_ICD
 
@@ -449,13 +387,10 @@ function mirror_to_registry() {
     "$MIRROR_SLS" == true ||
     "$MIRROR_TRUSTSTOREMGR" == true ||
     "$MIRROR_MONGOCE" == true ||
-    "$MIRROR_MONGOCE_V4" == true ||
-    "$MIRROR_MONGOCE_V5" == true ||
     "$MIRROR_MONGOCE_V6" == true ||
     "$MIRROR_MONGOCE_V7" == true ||
     "$MIRROR_MONGOCE_V8" == true ||
     "$MIRROR_DB2U" == true ||
-    "$MIRROR_APPCONNECT" == true ||
     "$MIRROR_ODF" == true ||
     "$MIRROR_CP4D" == true ||
     "$MIRROR_WSL" == true ||
@@ -507,13 +442,10 @@ function mirror_to_registry() {
   show_mirror_status "IBM Suite License Service ..........." $MIRROR_SLS
   show_mirror_status "IBM Truststore Manager .............." $MIRROR_TRUSTSTOREMGR
   show_mirror_status "MongoDb Community Edition ..........." $MIRROR_MONGOCE
-  show_mirror_status "+ Version 4 ........................." $MIRROR_MONGOCE_V4
-  show_mirror_status "+ Version 5 ........................." $MIRROR_MONGOCE_V5
   show_mirror_status "+ Version 6 ........................." $MIRROR_MONGOCE_V6
   show_mirror_status "+ Version 7 ........................." $MIRROR_MONGOCE_V7
   show_mirror_status "+ Version 8 ........................." $MIRROR_MONGOCE_V8
   show_mirror_status "IBM Db2 ............................." $MIRROR_DB2U
-  show_mirror_status "IBM AppConnect ......................" $MIRROR_APPCONNECT
   show_mirror_status "RedHat ODF .........................." $MIRROR_ODF
   show_mirror_status "OpenDataHub ........................." $MIRROR_OPENDATAHUB
 

--- a/image/cli/mascli/functions/mirror_images_common
+++ b/image/cli/mascli/functions/mirror_images_common
@@ -29,43 +29,6 @@ function show_mirror_status() {
   fi
 }
 
-function mirror_to_registry_help_header() {
-  [[ -n "$1" ]] && echo_warning "$1"
-  reset_colors
-  cat << EOM
-Usage:
-  mas mirror-images [options]
-Where ${COLOR_YELLOW}specified${TEXT_RESET} each option may also be defined by setting the appropriate environment variable.
-When no options are specified on the command line, interactive-mode will be enabled by default.
-
-Mirror Mode (Required):
-  -m, --mode ${COLOR_YELLOW}MIRROR_MODE${TEXT_RESET}                         Operation mode (direct, to-filesystem, from-filesystem)
-  -d, --dir ${COLOR_YELLOW}MIRROR_WORKING_DIR${TEXT_RESET}                   Working directory for the mirror process
-
-Registry Details (Required):
-  -H, --host ${COLOR_YELLOW}REGISTRY_PUBLIC_HOST${TEXT_RESET}                 Hostname of the target registry
-  -P, --port ${COLOR_YELLOW}REGISTRY_PUBLIC_PORT${TEXT_RESET}                 Port number for the target registry
-  -u, --username ${COLOR_YELLOW}REGISTRY_USERNAME${TEXT_RESET}                Username to authenticate to the target registry
-  -p, --password ${COLOR_YELLOW}REGISTRY_PASSWORD${TEXT_RESET}                Password to authenticate to the target registry
-
-Registry Prefix (Optional):
-  -x, --prefix ${COLOR_YELLOW}REGISTRY_PREFIX${TEXT_RESET}                    Prefix for the mirror image
-
-AWS Elastic Container Registry (Optional):
-  -r, --aws-ecr-region ${COLOR_YELLOW}REGISTRY_ECR_AWS_REGION${TEXT_RESET}    The AWS region if the target registry is Elastic Container Registry
-  -e, --target-is-ecr                                                         Indicate that the target registry is Elastic Container Registry
-
-Source Registry Entitlements (Required based on what content you choose to mirror):
-      --ibm-entitlement ${COLOR_YELLOW}IBM_ENTITLEMENT_KEY${TEXT_RESET}       IBM Entitlement Key
-      --artifactory-username ${COLOR_YELLOW}ARTIFACTORY_USERNAME${TEXT_RESET} Artifactory Username
-      --artifactory-token ${COLOR_YELLOW}ARTIFACTORY_TOKEN${TEXT_RESET}       Artifactory Token
-
-Maximo Operator Catalog Selection (Optional):
-  -c, --catalog ${COLOR_YELLOW}MAS_CATALOG_VERSION${TEXT_RESET}               Maximo Operator Catalog Version to mirror (e.g. v9-240625-amd64)
-  -C, --channel ${COLOR_YELLOW}MAS_CHANNEL${TEXT_RESET}                       Maximo Application Suite Channel to mirror (e.g. 9.1.x)
-EOM
-}
-
 function mirror_to_registry_interactive_common() {
   load_config
   echo
@@ -148,6 +111,8 @@ function mirror_to_registry_common() {
   export ARTIFACTORY_USERNAME
   export ARTIFACTORY_TOKEN
 
+  set_target_arch
+
   echo
   reset_colors
   echo_h2 "Review Settings"
@@ -171,6 +136,7 @@ function mirror_to_registry_common() {
   echo_h4 "IBM Operator Catalog" "    "
   echo_reset_dim "Catalog Version ..................... ${COLOR_MAGENTA}${MAS_CATALOG_VERSION}"
   echo_reset_dim "MAS Update Channel .................. ${COLOR_MAGENTA}${MAS_CHANNEL}"
+  echo_reset_dim "Target Architecture ................. ${COLOR_MAGENTA}${MIRROR_SINGLE_ARCH}"
 }
 
 function confirm_mirror() {
@@ -190,4 +156,17 @@ function confirm_mirror() {
 
   export ARTIFACTORY_USERNAME=""
   export ARTIFACTORY_TOKEN=""
+}
+
+function set_target_arch() {
+  if [[ "$MAS_CATALOG_VERSION" == *"amd64"* ]]; then
+    export MIRROR_SINGLE_ARCH="amd64"
+  elif [[ "$MAS_CATALOG_VERSION" == *"ppc64le"* ]]; then
+    export MIRROR_SINGLE_ARCH="ppc64le"
+  elif [[ "$MAS_CATALOG_VERSION" == *"s390x"* ]]; then
+    export MIRROR_SINGLE_ARCH="s390x"
+  else
+    echo -e "${COLOR_RED}Usage Error: Could not determine target architecture from catalog version: $MAS_CATALOG_VERSION${TEXT_RESET}\n"
+    exit 1
+  fi
 }


### PR DESCRIPTION
Updates the CLI function to set the `MIRROR_SINGLE_ARCH` env var based on the catalog chosen to mirror from.

See results: https://github.com/ibm-mas/ansible-devops/pull/2041

Part of the fix for https://github.com/ibm-mas/ansible-devops/issues/1918