### PR TITLE
[patch] update default mongo version 8.0.17

### DIFF
--- a/python/src/mas/cli/update/app.py
+++ b/python/src/mas/cli/update/app.py
@@ -358,7 +358,7 @@ class UpdateApp(BaseApp):
                     # the case bundles in there anymore
                     # Longer term we will centralise this information inside the mas-devops python collection,
                     # where it can be made available to both the ansible collection and this python package.
-                    defaultMongoVersion = "8.0.13"
+                    defaultMongoVersion = "8.0.17"
                     mongoVersions = {
                         "v9-240625-amd64": "6.0.12",
                         "v9-240730-amd64": "6.0.12",
@@ -379,7 +379,7 @@ class UpdateApp(BaseApp):
                         "v9-251010-amd64": "7.0.23",
                         "v9-251030-amd64": "7.0.23",
                         "v9-251127-amd64": "8.0.13",
-                        "v9-251224-amd64": "8.0.13",
+                        "v9-251224-amd64": "8.0.17",
                     }
                     catalogVersion = self.getParam('mas_catalog_version')
                     if catalogVersion in mongoVersions:


### PR DESCRIPTION
- Update mongo ce to 8.0.17

## Description
- Updated mongo to 8.0.17 from 8.0.13 to fix the [Mongo CVE (mongodb-cve-2025-14847)](https://w3.ibm.com/w3publisher/ciso-vulnerability-management/ciso-override-notifications/2025/mongodb-cve-2025-14847)

## Test Results
- FVT result: https://dashboard.ibmmas.com/tests/mng8017