### PR TITLE
[patch] Fix syntax issue in mirror command

### DIFF
--- a/image/cli/mascli/functions/mirror_images
+++ b/image/cli/mascli/functions/mirror_images
@@ -181,7 +181,6 @@ function mirror_to_registry_noninteractive() {
       --mirror-mongo)
         MIRROR_MONGOCE=true
         ;;
-        ;;
       --mirror-mongo-v7)
         MIRROR_MONGOCE_V7=true
         ;;


### PR DESCRIPTION
- Fix syntax issue that get printed on mas install command.

<img width="672" height="76" alt="image" src="https://github.com/user-attachments/assets/29d18e5a-d139-4c61-bafa-1b7dadac2a7a" />
