### PR TITLE
[patch] Update installation of ArcGIS on CLI : MASCORE-10767

### DIFF
--- a/python/src/mas/cli/install/app.py
+++ b/python/src/mas/cli/install/app.py
@@ -372,6 +372,61 @@ class InstallApp(BaseApp, InstallSettingsMixin, InstallSummarizerMixin, ConfigGe
                 else:
                     self.promptForString("Install namespace", "grafana_v5_namespace", default="grafana5")
                     self.promptForString("Grafana storage size", "grafana_instance_storage_size", default="10Gi")
+    @logMethodCall
+    def arcgisSettings(self) -> None:
+        """
+        Configure ArcGIS as a shared dependency for Manage and Facilities.
+        This method detects if either Manage (with Spatial) or Facilities is selected
+        and prompts for ArcGIS installation accordingly.
+        """
+        needsArcGIS = False
+        apps_requiring_arcgis = []
+        
+        # Check if Manage with Spatial component is selected
+        if self.installManage and "spatial=" in self.getParam("mas_appws_components"):
+            needsArcGIS = True
+            apps_requiring_arcgis.append("Maximo Manage (Spatial)")
+        
+        # Check if Facilities is selected (MAS 9.1+)
+        if self.installFacilities:
+            needsArcGIS = True
+            apps_requiring_arcgis.append("Maximo Real Estate and Facilities")
+        
+        # Only prompt if ArcGIS is needed and we're on MAS 9.x
+        # Check the appropriate channel based on what's being installed
+        if needsArcGIS:
+            channel = self.getParam("mas_app_channel_manage") or self.getParam("mas_app_channel_facilities")
+            if channel and channel.startswith("9."):
+                # Build description based on what's being installed
+                description = [
+                    "",
+                    "Geospatial capabilities require a map server provider",
+                    "You may choose your preferred map provider later or you can enable IBM Maximo Location Services for Esri now"
+                ]
+                
+                # Add specific details based on installed applications
+                if len(apps_requiring_arcgis) == 1:
+                    description.append(f"This includes ArcGIS Enterprise as part of {apps_requiring_arcgis[0]} (Additional AppPoints required).")
+                else:
+                    description.append(f"This includes ArcGIS Enterprise for {' and '.join(apps_requiring_arcgis)} (Additional AppPoints required).")
+                
+                self.printDescription(description)
+                
+                if self.yesOrNo("Include IBM Maximo Location Services for Esri"):
+                    self.setParam("install_arcgis", "true")
+                    self.setParam("mas_arcgis_channel", channel)
+                    
+                    self.printDescription([
+                        "",
+                        "IBM Maximo Location Services for Esri License Terms",
+                        "For information about your IBM Maximo Location Services for Esri License visit: ",
+                        " - <Orange><u>https://ibm.biz/MAXArcGIS90-License</u></Orange>",
+                        "To continue with the installation, you must accept these additional license terms"
+                    ])
+                    
+                    if not self.yesOrNo("Do you accept the license terms"):
+                        exit(1)
+
 
     @logMethodCall
     def configSpecialCharacters(self):
@@ -1101,6 +1156,7 @@ class InstallApp(BaseApp, InstallSettingsMixin, InstallSummarizerMixin, ConfigGe
         self.aiServiceIntegrations()
 
         # Dependencies
+        self.arcgisSettings() # Will only prompt if Manage (with Spatial) or Facilities is selected
         self.configMongoDb()
         self.configDb2()
         self.configKafka()  # Will only do anything if IoT has been selected for install
@@ -1259,6 +1315,14 @@ class InstallApp(BaseApp, InstallSettingsMixin, InstallSummarizerMixin, ConfigGe
                 # only set if AI Service not being installed
                 if not vars(self.args).get("aiservice_instance_id") and value is not None and value != "":
                     self.setParam("manage_bind_aiservice_tenant_id", value)
+
+            # ArcGIS settings
+            elif key == "install_arcgis":
+                if value is not None and value != "":
+                    self.setParam("install_arcgis", value)
+            elif key == "mas_arcgis_channel":
+                if value is not None and value != "":
+                    self.setParam("mas_arcgis_channel", value)
 
             # Manage advanced settings that need extra processing
             elif key == "mas_app_settings_server_bundle_size":

--- a/python/src/mas/cli/install/app.py
+++ b/python/src/mas/cli/install/app.py
@@ -1156,7 +1156,7 @@ class InstallApp(BaseApp, InstallSettingsMixin, InstallSummarizerMixin, ConfigGe
         self.aiServiceIntegrations()
 
         # Dependencies
-        self.arcgisSettings() # Will only prompt if Manage (with Spatial) or Facilities is selected
+        self.arcgisSettings()  # Will only prompt if Manage (with Spatial) or Facilities is selected
         self.configMongoDb()
         self.configDb2()
         self.configKafka()  # Will only do anything if IoT has been selected for install

--- a/python/src/mas/cli/install/app.py
+++ b/python/src/mas/cli/install/app.py
@@ -372,6 +372,7 @@ class InstallApp(BaseApp, InstallSettingsMixin, InstallSummarizerMixin, ConfigGe
                 else:
                     self.promptForString("Install namespace", "grafana_v5_namespace", default="grafana5")
                     self.promptForString("Grafana storage size", "grafana_instance_storage_size", default="10Gi")
+
     @logMethodCall
     def arcgisSettings(self) -> None:
         """
@@ -381,17 +382,17 @@ class InstallApp(BaseApp, InstallSettingsMixin, InstallSummarizerMixin, ConfigGe
         """
         needsArcGIS = False
         apps_requiring_arcgis = []
-        
+
         # Check if Manage with Spatial component is selected
         if self.installManage and "spatial=" in self.getParam("mas_appws_components"):
             needsArcGIS = True
             apps_requiring_arcgis.append("Maximo Manage (Spatial)")
-        
+
         # Check if Facilities is selected (MAS 9.1+)
         if self.installFacilities:
             needsArcGIS = True
             apps_requiring_arcgis.append("Maximo Real Estate and Facilities")
-        
+
         # Only prompt if ArcGIS is needed and we're on MAS 9.x
         # Check the appropriate channel based on what's being installed
         if needsArcGIS:
@@ -403,19 +404,19 @@ class InstallApp(BaseApp, InstallSettingsMixin, InstallSummarizerMixin, ConfigGe
                     "Geospatial capabilities require a map server provider",
                     "You may choose your preferred map provider later or you can enable IBM Maximo Location Services for Esri now"
                 ]
-                
+
                 # Add specific details based on installed applications
                 if len(apps_requiring_arcgis) == 1:
                     description.append(f"This includes ArcGIS Enterprise as part of {apps_requiring_arcgis[0]} (Additional AppPoints required).")
                 else:
                     description.append(f"This includes ArcGIS Enterprise for {' and '.join(apps_requiring_arcgis)} (Additional AppPoints required).")
-                
+
                 self.printDescription(description)
-                
+
                 if self.yesOrNo("Include IBM Maximo Location Services for Esri"):
                     self.setParam("install_arcgis", "true")
                     self.setParam("mas_arcgis_channel", channel)
-                    
+
                     self.printDescription([
                         "",
                         "IBM Maximo Location Services for Esri License Terms",
@@ -423,10 +424,9 @@ class InstallApp(BaseApp, InstallSettingsMixin, InstallSummarizerMixin, ConfigGe
                         " - <Orange><u>https://ibm.biz/MAXArcGIS90-License</u></Orange>",
                         "To continue with the installation, you must accept these additional license terms"
                     ])
-                    
+
                     if not self.yesOrNo("Do you accept the license terms"):
                         exit(1)
-
 
     @logMethodCall
     def configSpecialCharacters(self):

--- a/python/src/mas/cli/install/app.py
+++ b/python/src/mas/cli/install/app.py
@@ -381,13 +381,11 @@ class InstallApp(BaseApp, InstallSettingsMixin, InstallSummarizerMixin, ConfigGe
         and prompts for ArcGIS installation accordingly.
         """
         needsArcGIS = False
-        hasSpatial = False
         apps_requiring_arcgis = []
 
         # Check if Manage with Spatial component is selected
         if self.installManage and "spatial=" in self.getParam("mas_appws_components"):
             needsArcGIS = True
-            hasSpatial = True
             apps_requiring_arcgis.append("Maximo Manage (Spatial)")
 
         # Check if Facilities is selected (MAS 9.1+)
@@ -429,9 +427,6 @@ class InstallApp(BaseApp, InstallSettingsMixin, InstallSummarizerMixin, ConfigGe
 
                     if not self.yesOrNo("Do you accept the license terms"):
                         exit(1)
-                elif hasSpatial:
-                    # Spatial requires ArcGIS - block installation if user declined
-                    self.fatalError("Maximo Manage Spatial component requires IBM Maximo Location Services for Esri. Installation cannot proceed without it.")
 
     @logMethodCall
     def configSpecialCharacters(self):
@@ -1499,11 +1494,6 @@ class InstallApp(BaseApp, InstallSettingsMixin, InstallSummarizerMixin, ConfigGe
             # ArcGIS requires either Spatial or Facilities to be installed
             if not hasSpatial and not hasFacilities:
                 self.fatalError("--install-arcgis requires either Manage with Spatial component (--manage-components must include 'spatial=') or Facilities (--facilities-channel) to be installed")
-
-        # Validate Spatial requires ArcGIS in non-interactive mode
-        if self.installManage and "spatial=" in self.getParam("mas_appws_components"):
-            if self.getParam("install_arcgis") != "true":
-                self.fatalError("Maximo Manage Spatial component requires IBM Maximo Location Services for Esri. Please set --install-arcgis=true")
 
     @logMethodCall
     def install(self, argv):

--- a/python/src/mas/cli/install/settings/manageSettings.py
+++ b/python/src/mas/cli/install/settings/manageSettings.py
@@ -21,38 +21,12 @@ logger = logging.getLogger(__name__)
 
 class ManageSettingsMixin():
 
-    def arcgisSettings(self) -> None:
-        # If Spatial is selected, then prompt to choose to add IBM Maximo Location Services for Esri, and prompt license
-        if "spatial=" in self.getParam("mas_appws_components") and self.getParam("mas_app_channel_manage").startswith("9."):
-            self.printDescription([
-                "",
-                "Maximo Spatial requires a map server provider in order to enable geospatial capabilities",
-                "You may choose your preferred map provider later or you can enable IBM Maximo Location Services for Esri now",
-                f"This includes ArcGIS Enterprise as part of the {self.manageAppName} and Maximo Spatial bundle (Additional AppPoints required)."
-            ])
-
-            if self.yesOrNo("Include IBM Maximo Location Services for Esri"):
-                self.setParam("install_arcgis", "true")
-                self.setParam("mas_arcgis_channel", self.getParam("mas_app_channel_manage"))
-
-                self.printDescription([
-                    "",
-                    "IBM Maximo Location Services for Esri License Terms",
-                    "For information about your IBM Maximo Location Services for Esri License visit: ",
-                    " - <Orange><u>https://ibm.biz/MAXArcGIS90-License</u></Orange>",
-                    "To continue with the installation, you must accept these additional license terms"
-                ])
-
-                if not self.yesOrNo("Do you accept the license terms"):
-                    exit(1)
-
     def manageSettings(self) -> None:
         if self.installManage:
             self.printH1(f"Configure Maximo {self.manageAppName}")
             self.printDescription([f"Customize your {self.manageAppName} installation, refer to the product documentation for more information"])
 
             self.manageSettingsComponents()
-            self.arcgisSettings()
 
             self.manageSettingsServerBundleConfig()
             self.manageSettingsJMS()

--- a/tekton/src/pipelines/mas-install.yml.j2
+++ b/tekton/src/pipelines/mas-install.yml.j2
@@ -297,6 +297,8 @@ spec:
     {{ lookup('template', pipeline_src_dir ~ '/taskdefs/dependencies/arcgis.yml.j2') | indent(4) }}
       runAfter:
         - suite-verify
+        - app-install-manage
+        - app-install-facilities
 
 
     # 7. Install & Configure IoT

--- a/tekton/src/pipelines/taskdefs/dependencies/arcgis.yml.j2
+++ b/tekton/src/pipelines/taskdefs/dependencies/arcgis.yml.j2
@@ -27,9 +27,9 @@
     name: mas-devops-arcgis
     kind: Task
   when:
-    - input: "$(params.mas_app_channel_manage)"
-      operator: notin
-      values: [""]
     - input: "$(params.install_arcgis)"
       operator: in
       values: ["true", "True"]
+    - input: "$(params.mas_arcgis_channel)"
+      operator: notin
+      values: [""]  


### PR DESCRIPTION
### Summary:
Refactored ArcGIS dependency configuration to support both Manage and MREF applications with proper installation ordering.

- Moved ArcGIS settings to generic location (app.py) from Manage-specific settings for reusability across Manage and MREF
- Updated installation order in Tekton pipeline to ensure ArcGIS installs after both Manage and Facilities apps (dependencies)
- Refactored configuration template (arcgis.yml.j2) to use generic settings structure

### Tested Using cli:18.5.1-pre.alfs-masr-6128-arcgis image. 
<img width="1679" height="977" alt="image" src="https://github.com/user-attachments/assets/bfac0a72-f3ca-4a8e-83b6-dd449eb3ec3f" />
<img width="1721" height="928" alt="image" src="https://github.com/user-attachments/assets/0aa4d5a3-83bf-402b-a76e-e4f0c306e1da" />

