### PR TITLE
[patch] Record routingMode in devops db during FVT

### DIFF
--- a/image/cli/app-root/src/finalizer.py
+++ b/image/cli/app-root/src/finalizer.py
@@ -352,6 +352,8 @@ if __name__ == "__main__":
                     print(f"Unable to determine {productId} build information: {e}")
             else:
                 print(f"Unable to determine {productId} version: status.versions.reconciled unavailable")
+            if cr.status and cr.status.settings and cr.status.settings.routingMode:
+                setObject[f"products.{productId}.routingMode"] = cr.status.settings.routingMode
         except Exception as e:
             print(f"Unable to determine {productId} version: {e}")
 

--- a/tekton/src/pipelines/taskdefs/fvt-core/phase4-disruptive.yml.j2
+++ b/tekton/src/pipelines/taskdefs/fvt-core/phase4-disruptive.yml.j2
@@ -63,7 +63,8 @@
     - name: fvt_test_suite
       value: pathbasedrouting
     {{ lookup('template', 'taskdefs/fvt-core/common/params.yml.j2') | indent(4) }}
-  runAfter: authservice
+  runAfter: 
+    - authservice
 
 # 6. coreidp-ldap
 # -------------------------------------------------------------------------

--- a/tekton/src/pipelines/taskdefs/fvt-core/phase4-disruptive.yml.j2
+++ b/tekton/src/pipelines/taskdefs/fvt-core/phase4-disruptive.yml.j2
@@ -1,6 +1,7 @@
 # Why are these suites disruptive?
 # - smtp: only test_smtpcfg is disruptive - deletes and recreates SMTPCfg multiple times
 # - trustcas: changes Suite config and verifies using SCIM whether defult CAs are included (or not) in the truststore
+# - pathbasedrouting: changes the suite routingMode, recreates routes and causes a number of pods to restart.
 # - adoptionusagemetering: I can't see anything disruptive happening in this suite at all !?
 # - coreidp-ldap: reconfigures MAS IDP multiple times
 # - coreidp-saml: reconfigures MAS IDP multiple times
@@ -41,7 +42,7 @@
     {{ lookup('template', 'taskdefs/fvt-core/common/params.yml.j2') | indent(4) }}
   runAfter: {{ runAfter }}
 
-# authservice ~3m
+# 4. authservice ~3m
 # -----------------------------------------------------------------------------
 - name: authservice
   {{ lookup('template', 'taskdefs/fvt-core/common/taskref.yml.j2') | indent(2) }}
@@ -54,7 +55,17 @@
     - core-trustcas
     - adoptionusagemetering
 
-# 4. coreidp-ldap
+# 5. pathbasedrouting
+# -------------------------------------------------------------------------
+- name: pathbasedrouting
+  {{ lookup('template', 'taskdefs/fvt-core/common/taskref.yml.j2') | indent(2) }}
+  params:
+    - name: fvt_test_suite
+      value: pathbasedrouting
+    {{ lookup('template', 'taskdefs/fvt-core/common/params.yml.j2') | indent(4) }}
+  runAfter: authservice
+
+# 6. coreidp-ldap
 # -------------------------------------------------------------------------
 - name: coreidp-ldap
   {{ lookup('template', 'taskdefs/fvt-core/common/taskref.yml.j2') | indent(2) }}
@@ -63,9 +74,9 @@
       value: coreidp-ldap
     {{ lookup('template', 'taskdefs/fvt-core/common/params.yml.j2') | indent(4) }}
   runAfter:
-    - authservice
+    - pathbasedrouting
 
-# 5. coreidp-saml
+# 7. coreidp-saml
 # -------------------------------------------------------------------------
 - name: coreidp-saml
   {{ lookup('template', 'taskdefs/fvt-core/common/taskref.yml.j2') | indent(2) }}
@@ -76,7 +87,7 @@
   runAfter:
     - coreidp-ldap
 
-# 6. coreidp-saml-ui
+# 8. coreidp-saml-ui
 # -------------------------------------------------------------------------
 - name: coreidp-saml-ui
   {{ lookup('template', 'taskdefs/fvt-core/common/taskref.yml.j2') | indent(2) }}
@@ -87,7 +98,7 @@
   runAfter:
     - coreidp-saml
 
-# 7. coreidp-ssoconfig
+# 9. coreidp-ssoconfig
 # -------------------------------------------------------------------------
 - name: coreidp-ssoconfig
   {{ lookup('template', 'taskdefs/fvt-core/common/taskref.yml.j2') | indent(2) }}
@@ -98,7 +109,7 @@
   runAfter:
     - coreidp-saml-ui
 
-# 8. licensingapi
+# 10. licensingapi
 # -------------------------------------------------------------------------
 - name: licensingapi
   {{ lookup('template', 'taskdefs/fvt-core/common/taskref.yml.j2') | indent(2) }}
@@ -109,7 +120,7 @@
   runAfter:
     - coreidp-ssoconfig
 
-# 9. usagebilling
+# 11. usagebilling
 # -------------------------------------------------------------------------
 - name: usagebilling
   {{ lookup('template', 'taskdefs/fvt-core/common/taskref.yml.j2') | indent(2) }}
@@ -125,7 +136,7 @@
     - name: pod-templates
       workspace: shared-pod-templates
 
-# 10. operatormaturity
+# 12. operatormaturity
 # -------------------------------------------------------------------------
 - name: operatormaturity
   {{ lookup('template', 'taskdefs/fvt-core/common/taskref.yml.j2') | indent(2) }}


### PR DESCRIPTION
### Description
when the Suite, or app CR contains a routing Mode, send it to the mongodatabase as part of the FVT results

### Issues
https://jsw.ibm.com/browse/MASCORE-11538 

### Testing
Ran in [pds-path](https://dashboard.ibmmas.com/tests/pds-path) personal FVT, see dashboard screenshot below:

<img width="372" height="713" alt="Product Information ibm-mas" src="https://github.com/user-attachments/assets/b6ada6d5-3a39-414d-ab26-8d58a094cf06" />
