### PR TITLE
[patch] Update Gitops operator to 1.17 (Argocd v3.0)

### DIFF
--- a/image/cli/mascli/templates/gitops/bootstrap/subscription.yaml
+++ b/image/cli/mascli/templates/gitops/bootstrap/subscription.yaml
@@ -5,7 +5,7 @@ metadata:
   name: openshift-gitops
   namespace: openshift-operators
 spec:
-    channel: gitops-1.16
+    channel: gitops-1.17
     installPlanApproval: Automatic
     name: openshift-gitops-operator
     source: redhat-operators


### PR DESCRIPTION
## Description
Update Gitops operator to 1.17 which contains ArgoCD v3.0
