### PR TITLE
[patch] Fix non-interactive command generation for "--manage-jms" flag

### DIFF
--- a/python/src/mas/cli/install/argBuilder.py
+++ b/python/src/mas/cli/install/argBuilder.py
@@ -208,7 +208,7 @@ class installArgBuilderMixin():
             if self.getParam('mas_app_settings_server_bundles_size') != "":
                 command += f"  --manage-server-bundle-size \"{self.getParam('mas_app_settings_server_bundles_size')}\"{newline}"
             if self.getParam('mas_app_settings_default_jms') != "":
-                command += f"  --manage-jms \"{self.getParam('mas_app_settings_default_jms')}\"{newline}"
+                command += f"  --manage-jms {newline}"
             if self.getParam('mas_app_settings_persistent_volumes_flag') == "true":
                 command += f"  --manage-persistent-volumes{newline}"
             if self.getParam('mas_app_settings_demodata') == "true":


### PR DESCRIPTION
The string `--manage-jms true` is being added to the generated command, but it only need to be `--manage-jms` because this is a store_true flag:

```python
manageArgGroup.add_argument(
    "--manage-jms",
    dest="mas_app_settings_default_jms",
    required=False,
    help="Set JMS configuration",
    action="store_const",
    const="true"
)
```

- Fixes #1982