### PR TITLE
[patch] Add 5.2.0 to cpdUpgradePath mapping

### DIFF
--- a/python/src/mas/cli/update/app.py
+++ b/python/src/mas/cli/update/app.py
@@ -478,6 +478,7 @@ class UpdateApp(BaseApp):
                     return
                 elif len(cpds) == 1:
                     cpdUpgradePath = {
+                        "5.2.0": "5.2.0",
                         "5.1.3": "5.2.0",
                         "5.0.0": "5.1.3",
                     }


### PR DESCRIPTION
Included a direct mapping for version 5.2.0 in the cpdUpgradePath dictionary to ensure proper handling of this version during upgrade checks.


<img width="1661" height="1038" alt="pue mas-update260223-2000 sama" src="https://github.com/user-attachments/assets/a0fbb305-fc5e-4949-94cc-b9d3ff52bbdb" />

