### PR TITLE
[patch] Add missing "&" handling to printDescription()

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,4 @@ python/README.rst
 /.venv-docs
 /.venv-docs
 /mkdocs_plugins/mkdocs_mas_plugins.egg-info
+rbac-install.yaml

--- a/python/src/mas/cli/displayMixins.py
+++ b/python/src/mas/cli/displayMixins.py
@@ -44,7 +44,7 @@ class PrintMixin():
     def printDescription(self, content: list) -> None:
         content[0] = f"<{DESCRIPTIONCOLOR}>{content[0]}"
         content[len(content) - 1] = f"{content[len(content) - 1]}</{DESCRIPTIONCOLOR}>"
-        print_formatted_text(HTML("\n".join(content)))
+        print_formatted_text(HTML("\n".join(content).replace(' & ', ' &amp; ')))
 
     def printHighlight(self, message: str) -> None:
         if isinstance(message, list):


### PR DESCRIPTION
Fix handling of the "&" character in displayMixin's `printDescription()` function:

<img width="1648" height="1424" alt="image" src="https://github.com/user-attachments/assets/28cc8577-0a91-4c78-8d74-6d93f7fb7adb" />
