### PR TITLE
[patch] Fix update overriding user's mongodb namespace

### DIFF
--- a/docs/catalogs/v8-220717-amd64.md
+++ b/docs/catalogs/v8-220717-amd64.md
@@ -6,7 +6,14 @@ nav_title: Operator Catalog
 IBM Maximo Operator Catalog v8 (Jul 28 2022)
 ===============================================================================
 
-:::mas-catalog-details
+Details
+-------------------------------------------------------------------------------
+
+<table>
+  <tr><td>Image</td><td>icr.io/cpopen/ibm-maximo-operator-catalog</tr></tr>
+  <tr><td>Tag</td><td>v8-220717-amd64</tr></tr>
+  <tr><td>Digest</td><td>sha256:02db98338386f874dead37fb9a0b956fe59b851db09440e5523b634f7341e4bf</tr></tr>
+</table>
 
 !!! warning
     This catalog is only certified for use on OpenShift Container Platform versions 4.8, 4.9, & 4.10, which have all reached end of support as of **September 10th, 2023**.  For more information about the OCP lifecycle refer to the [Red Hat OpenShift Container Platform Life Cycle Policy](https://access.redhat.com/support/policy/updates/openshift/)
@@ -15,10 +22,27 @@ IBM Maximo Operator Catalog v8 (Jul 28 2022)
     This release of the catalog is no longer supported due to the shutdown of IBM User Data Services, the first operator catalog release that supports it's replacement (IBM Data Reporter Operator) is the [February 2024 update](v8-240227-amd64.md)
 
 
-:::mas-catalog-install
+Manual Installation
+-------------------------------------------------------------------------------
+`oc apply -f https://raw.githubusercontent.com/ibm-mas/cli/master/catalogs/v8-220717-amd64.yaml`
 
 
-:::mas-catalog-source
+Source
+-------------------------------------------------------------------------------
+```yaml
+apiVersion: operators.coreos.com/v1alpha1
+kind: CatalogSource
+metadata:
+  name: ibm-operator-catalog
+  namespace: openshift-marketplace
+spec:
+  displayName: IBM Maximo Operators (v8-220717-amd64)
+  publisher: IBM
+  description: Static Catalog Source for IBM Maximo Application Suite
+  sourceType: grpc
+  image: icr.io/cpopen/ibm-maximo-operator-catalog@sha256:02db98338386f874dead37fb9a0b956fe59b851db09440e5523b634f7341e4bf
+  priority: 90
+```
 
 
 OpenShift Container Platform Support

--- a/docs/catalogs/v8-220805-amd64.md
+++ b/docs/catalogs/v8-220805-amd64.md
@@ -6,7 +6,14 @@ nav_title: Operator Catalog
 IBM Maximo Operator Catalog v8 (Aug 5 2022)
 ===============================================================================
 
-:::mas-catalog-details
+Details
+-------------------------------------------------------------------------------
+
+<table>
+  <tr><td>Image</td><td>icr.io/cpopen/ibm-maximo-operator-catalog</tr></tr>
+  <tr><td>Tag</td><td>v8-220805-amd64</tr></tr>
+  <tr><td>Digest</td><td>sha256:012839d2dd801863b5a1f35de3d1e1e39d8e4a3e707f894beee091608c09aca4</tr></tr>
+</table>
 
 !!! warning
     This catalog is only certified for use on OpenShift Container Platform versions 4.8, 4.9, & 4.10, which have all reached end of support as of **September 10th, 2023**.  For more information about the OCP lifecycle refer to the [Red Hat OpenShift Container Platform Life Cycle Policy](https://access.redhat.com/support/policy/updates/openshift/)
@@ -15,10 +22,27 @@ IBM Maximo Operator Catalog v8 (Aug 5 2022)
     This release of the catalog is no longer supported due to the shutdown of IBM User Data Services, the first operator catalog release that supports it's replacement (IBM Data Reporter Operator) is the [February 2024 update](v8-240227-amd64.md)
 
 
-:::mas-catalog-install
+Manual Installation
+-------------------------------------------------------------------------------
+`oc apply -f https://raw.githubusercontent.com/ibm-mas/cli/master/catalogs/v8-220805-amd64.yaml`
 
 
-:::mas-catalog-source
+Source
+-------------------------------------------------------------------------------
+```yaml
+apiVersion: operators.coreos.com/v1alpha1
+kind: CatalogSource
+metadata:
+  name: ibm-operator-catalog
+  namespace: openshift-marketplace
+spec:
+  displayName: IBM Maximo Operators (v8-220805-amd64)
+  publisher: IBM
+  description: Static Catalog Source for IBM Maximo Application Suite
+  sourceType: grpc
+  image: icr.io/cpopen/ibm-maximo-operator-catalog@sha256:012839d2dd801863b5a1f35de3d1e1e39d8e4a3e707f894beee091608c09aca4
+  priority: 90
+```
 
 
 OpenShift Container Platform Support

--- a/docs/catalogs/v8-220927-amd64.md
+++ b/docs/catalogs/v8-220927-amd64.md
@@ -6,7 +6,14 @@ nav_title: Operator Catalog
 IBM Maximo Operator Catalog v8 (220927)
 ===============================================================================
 
-:::mas-catalog-details
+Details
+-------------------------------------------------------------------------------
+
+<table>
+  <tr><td>Image</td><td>icr.io/cpopen/ibm-maximo-operator-catalog</tr></tr>
+  <tr><td>Tag</td><td>v8-220927-amd64</tr></tr>
+  <tr><td>Digest</td><td>sha256:37d492a851137567bcfea0b5530fca05374a08a78b41afb712e17c2542016ae7</tr></tr>
+</table>
 
 Other IBM content curated from `icr.io/cpopen/ibm-operator-catalog@sha256:9c7552673a8d90bfe1da16dd8c28288b00cf6ffd6bad6edb26042c2991f266e0`
 
@@ -17,10 +24,27 @@ Other IBM content curated from `icr.io/cpopen/ibm-operator-catalog@sha256:9c7552
     This release of the catalog is no longer supported due to the shutdown of IBM User Data Services, the first operator catalog release that supports it's replacement (IBM Data Reporter Operator) is the [February 2024 update](v8-240227-amd64.md)
 
 
-:::mas-catalog-install
+Manual Installation
+-------------------------------------------------------------------------------
+`oc apply -f https://raw.githubusercontent.com/ibm-mas/cli/master/catalogs/v8-220927-amd64.yaml`
 
 
-:::mas-catalog-source
+Source
+-------------------------------------------------------------------------------
+```yaml
+apiVersion: operators.coreos.com/v1alpha1
+kind: CatalogSource
+metadata:
+  name: ibm-operator-catalog
+  namespace: openshift-marketplace
+spec:
+  displayName: IBM Maximo Operators (v8-220927-amd64)
+  publisher: IBM
+  description: Static Catalog Source for IBM Maximo Application Suite
+  sourceType: grpc
+  image: icr.io/cpopen/ibm-maximo-operator-catalog@sha256:37d492a851137567bcfea0b5530fca05374a08a78b41afb712e17c2542016ae7
+  priority: 90
+```
 
 
 OpenShift Container Platform Support

--- a/docs/catalogs/v8-221025-amd64.md
+++ b/docs/catalogs/v8-221025-amd64.md
@@ -6,7 +6,14 @@ nav_title: Operator Catalog
 IBM Maximo Operator Catalog v8 (221025)
 ===============================================================================
 
-:::mas-catalog-details
+Details
+-------------------------------------------------------------------------------
+
+<table>
+  <tr><td>Image</td><td>icr.io/cpopen/ibm-maximo-operator-catalog</tr></tr>
+  <tr><td>Tag</td><td>v8-221025-amd64</tr></tr>
+  <tr><td>Digest</td><td>sha256:993d5ca2f327494abf3dc7175968bc12165a341c6f1f95a0d50ecde6a5663c7f</tr></tr>
+</table>
 
 Other IBM content curated from `icr.io/cpopen/ibm-operator-catalog@sha256:9c7552673a8d90bfe1da16dd8c28288b00cf6ffd6bad6edb26042c2991f266e0`
 
@@ -17,10 +24,27 @@ Other IBM content curated from `icr.io/cpopen/ibm-operator-catalog@sha256:9c7552
     This release of the catalog is no longer supported due to the shutdown of IBM User Data Services, the first operator catalog release that supports it's replacement (IBM Data Reporter Operator) is the [February 2024 update](v8-240227-amd64.md)
 
 
-:::mas-catalog-install
+Manual Installation
+-------------------------------------------------------------------------------
+`oc apply -f https://raw.githubusercontent.com/ibm-mas/cli/master/catalogs/v8-221025-amd64.yaml`
 
 
-:::mas-catalog-source
+Source
+-------------------------------------------------------------------------------
+```yaml
+apiVersion: operators.coreos.com/v1alpha1
+kind: CatalogSource
+metadata:
+  name: ibm-operator-catalog
+  namespace: openshift-marketplace
+spec:
+  displayName: IBM Maximo Operators (v8-221025-amd64)
+  publisher: IBM
+  description: Static Catalog Source for IBM Maximo Application Suite
+  sourceType: grpc
+  image: icr.io/cpopen/ibm-maximo-operator-catalog@sha256:993d5ca2f327494abf3dc7175968bc12165a341c6f1f95a0d50ecde6a5663c7f
+  priority: 90
+```
 
 
 OpenShift Container Platform Support

--- a/docs/catalogs/v8-221129-amd64.md
+++ b/docs/catalogs/v8-221129-amd64.md
@@ -6,7 +6,14 @@ nav_title: Operator Catalog
 IBM Maximo Operator Catalog v8 (221129)
 ===============================================================================
 
-:::mas-catalog-details
+Details
+-------------------------------------------------------------------------------
+
+<table>
+  <tr><td>Image</td><td>icr.io/cpopen/ibm-maximo-operator-catalog</tr></tr>
+  <tr><td>Tag</td><td>v8-221129-amd64</tr></tr>
+  <tr><td>Digest</td><td>sha256:56905868dcf7ae8ca0901cfd92225a3f52db250c091987fe81b149dbacb4df13</tr></tr>
+</table>
 
 Other IBM content curated from `icr.io/cpopen/ibm-operator-catalog@sha256:9c7552673a8d90bfe1da16dd8c28288b00cf6ffd6bad6edb26042c2991f266e0`
 
@@ -23,10 +30,27 @@ Other IBM content curated from `icr.io/cpopen/ibm-operator-catalog@sha256:9c7552
     This release of the catalog is no longer supported due to the shutdown of IBM User Data Services, the first operator catalog release that supports it's replacement (IBM Data Reporter Operator) is the [February 2024 update](v8-240227-amd64.md)
 
 
-:::mas-catalog-install
+Manual Installation
+-------------------------------------------------------------------------------
+`oc apply -f https://raw.githubusercontent.com/ibm-mas/cli/master/catalogs/v8-221129-amd64.yaml`
 
 
-:::mas-catalog-source
+Source
+-------------------------------------------------------------------------------
+```yaml
+apiVersion: operators.coreos.com/v1alpha1
+kind: CatalogSource
+metadata:
+  name: ibm-operator-catalog
+  namespace: openshift-marketplace
+spec:
+  displayName: IBM Maximo Operators (v8-221129-amd64)
+  publisher: IBM
+  description: Static Catalog Source for IBM Maximo Application Suite
+  sourceType: grpc
+  image: icr.io/cpopen/ibm-maximo-operator-catalog@sha256:56905868dcf7ae8ca0901cfd92225a3f52db250c091987fe81b149dbacb4df13
+  priority: 90
+```
 
 
 OpenShift Container Platform Support

--- a/docs/catalogs/v8-221228-amd64.md
+++ b/docs/catalogs/v8-221228-amd64.md
@@ -6,7 +6,14 @@ nav_title: Operator Catalog
 IBM Maximo Operator Catalog v8 (221228)
 ===============================================================================
 
-:::mas-catalog-details
+Details
+-------------------------------------------------------------------------------
+
+<table>
+  <tr><td>Image</td><td>icr.io/cpopen/ibm-maximo-operator-catalog</tr></tr>
+  <tr><td>Tag</td><td>v8-221228-amd64</tr></tr>
+  <tr><td>Digest</td><td>sha256:505a135ba1af2cee548703e85b17764074b7479dbbf506b132d5871af793073f</tr></tr>
+</table>
 
 Other IBM content curated from `icr.io/cpopen/ibm-operator-catalog@sha256:9c7552673a8d90bfe1da16dd8c28288b00cf6ffd6bad6edb26042c2991f266e0`
 
@@ -20,10 +27,27 @@ Other IBM content curated from `icr.io/cpopen/ibm-operator-catalog@sha256:9c7552
     This release of the catalog is no longer supported due to the shutdown of IBM User Data Services, the first operator catalog release that supports it's replacement (IBM Data Reporter Operator) is the [February 2024 update](v8-240227-amd64.md)
 
 
-:::mas-catalog-install
+Manual Installation
+-------------------------------------------------------------------------------
+`oc apply -f https://raw.githubusercontent.com/ibm-mas/cli/master/catalogs/v8-221228-amd64.yaml`
 
 
-:::mas-catalog-source
+Source
+-------------------------------------------------------------------------------
+```yaml
+apiVersion: operators.coreos.com/v1alpha1
+kind: CatalogSource
+metadata:
+  name: ibm-operator-catalog
+  namespace: openshift-marketplace
+spec:
+  displayName: IBM Maximo Operators (v8-221228-amd64)
+  publisher: IBM
+  description: Static Catalog Source for IBM Maximo Application Suite
+  sourceType: grpc
+  image: icr.io/cpopen/ibm-maximo-operator-catalog@sha256:505a135ba1af2cee548703e85b17764074b7479dbbf506b132d5871af793073f
+  priority: 90
+```
 
 
 OpenShift Container Platform Support

--- a/docs/catalogs/v8-230111-amd64.md
+++ b/docs/catalogs/v8-230111-amd64.md
@@ -6,7 +6,14 @@ nav_title: Operator Catalog
 IBM Maximo Operator Catalog v8 (230111)
 ===============================================================================
 
-:::mas-catalog-details
+Details
+-------------------------------------------------------------------------------
+
+<table>
+  <tr><td>Image</td><td>icr.io/cpopen/ibm-maximo-operator-catalog</tr></tr>
+  <tr><td>Tag</td><td>v8-230111-amd64</tr></tr>
+  <tr><td>Digest</td><td>sha256:b2e90b0df49abf86bfef938f92aa366d7768ba395241090cb98a1a154765a4b3</tr></tr>
+</table>
 
 Other IBM content curated from `icr.io/cpopen/ibm-operator-catalog@sha256:9c7552673a8d90bfe1da16dd8c28288b00cf6ffd6bad6edb26042c2991f266e0`
 
@@ -17,10 +24,27 @@ Other IBM content curated from `icr.io/cpopen/ibm-operator-catalog@sha256:9c7552
     This release of the catalog is no longer supported due to the shutdown of IBM User Data Services, the first operator catalog release that supports it's replacement (IBM Data Reporter Operator) is the [February 2024 update](v8-240227-amd64.md)
 
 
-:::mas-catalog-install
+Manual Installation
+-------------------------------------------------------------------------------
+`oc apply -f https://raw.githubusercontent.com/ibm-mas/cli/master/catalogs/v8-230111-amd64.yaml`
 
 
-:::mas-catalog-source
+Source
+-------------------------------------------------------------------------------
+```yaml
+apiVersion: operators.coreos.com/v1alpha1
+kind: CatalogSource
+metadata:
+  name: ibm-operator-catalog
+  namespace: openshift-marketplace
+spec:
+  displayName: IBM Maximo Operators (v8-230111-amd64)
+  publisher: IBM
+  description: Static Catalog Source for IBM Maximo Application Suite
+  sourceType: grpc
+  image: icr.io/cpopen/ibm-maximo-operator-catalog@sha256:b2e90b0df49abf86bfef938f92aa366d7768ba395241090cb98a1a154765a4b3
+  priority: 90
+```
 
 
 Red Hat OpenShift Container Platform Support

--- a/docs/catalogs/v8-230217-amd64.md
+++ b/docs/catalogs/v8-230217-amd64.md
@@ -6,7 +6,14 @@ nav_title: Operator Catalog
 IBM Maximo Operator Catalog v8 (230217)
 ===============================================================================
 
-:::mas-catalog-details
+Details
+-------------------------------------------------------------------------------
+
+<table>
+  <tr><td>Image</td><td>icr.io/cpopen/ibm-maximo-operator-catalog</tr></tr>
+  <tr><td>Tag</td><td>v8-230217-amd64</tr></tr>
+  <tr><td>Digest</td><td>sha256:c23bd01da3025008d2ed550b6a2ef912179c34922c924eb9448cbb663a46b6b9</tr></tr>
+</table>
 
 Other IBM content curated from `icr.io/cpopen/ibm-operator-catalog@sha256:8521ac8527cf723041066e88997a264094d5f8eae20e9ffe30353444768cb3c0`
 
@@ -17,10 +24,27 @@ Other IBM content curated from `icr.io/cpopen/ibm-operator-catalog@sha256:8521ac
     This release of the catalog is no longer supported due to the shutdown of IBM User Data Services, the first operator catalog release that supports it's replacement (IBM Data Reporter Operator) is the [February 2024 update](v8-240227-amd64.md)
 
 
-:::mas-catalog-install
+Manual Installation
+-------------------------------------------------------------------------------
+`oc apply -f https://raw.githubusercontent.com/ibm-mas/cli/master/catalogs/v8-230217-amd64.yaml`
 
 
-:::mas-catalog-source
+Source
+-------------------------------------------------------------------------------
+```yaml
+apiVersion: operators.coreos.com/v1alpha1
+kind: CatalogSource
+metadata:
+  name: ibm-operator-catalog
+  namespace: openshift-marketplace
+spec:
+  displayName: IBM Maximo Operators (v8-230217-amd64)
+  publisher: IBM
+  description: Static Catalog Source for IBM Maximo Application Suite
+  sourceType: grpc
+  image: icr.io/cpopen/ibm-maximo-operator-catalog@sha256:c23bd01da3025008d2ed550b6a2ef912179c34922c924eb9448cbb663a46b6b9
+  priority: 90
+```
 
 Red Hat OpenShift Container Platform Support
 -------------------------------------------------------------------------------

--- a/docs/catalogs/v8-230314-amd64.md
+++ b/docs/catalogs/v8-230314-amd64.md
@@ -6,7 +6,14 @@ nav_title: Operator Catalog
 IBM Maximo Operator Catalog v8 (230217)
 ===============================================================================
 
-:::mas-catalog-details
+Details
+-------------------------------------------------------------------------------
+
+<table>
+  <tr><td>Image</td><td>icr.io/cpopen/ibm-maximo-operator-catalog</tr></tr>
+  <tr><td>Tag</td><td>v8-230314-amd64</tr></tr>
+  <tr><td>Digest</td><td>sha256:8d8304e53e67ee6a7aacddee0491e41ac5f725fb80e4e0aa34409c38a363b632</tr></tr>
+</table>
 
 Other IBM content curated from `icr.io/cpopen/ibm-operator-catalog@sha256:8521ac8527cf723041066e88997a264094d5f8eae20e9ffe30353444768cb3c0`
 
@@ -16,10 +23,27 @@ Other IBM content curated from `icr.io/cpopen/ibm-operator-catalog@sha256:8521ac
 !!! warning
     This release of the catalog is no longer supported due to the shutdown of IBM User Data Services, the first operator catalog release that supports it's replacement (IBM Data Reporter Operator) is the [February 2024 update](v8-240227-amd64.md)
 
-:::mas-catalog-install
+Manual Installation
+-------------------------------------------------------------------------------
+`oc apply -f https://raw.githubusercontent.com/ibm-mas/cli/master/catalogs/v8-230314-amd64.yaml`
 
 
-:::mas-catalog-source
+Source
+-------------------------------------------------------------------------------
+```yaml
+apiVersion: operators.coreos.com/v1alpha1
+kind: CatalogSource
+metadata:
+  name: ibm-operator-catalog
+  namespace: openshift-marketplace
+spec:
+  displayName: IBM Maximo Operators (v8-230314-amd64)
+  publisher: IBM
+  description: Static Catalog Source for IBM Maximo Application Suite
+  sourceType: grpc
+  image: icr.io/cpopen/ibm-maximo-operator-catalog@sha256:8d8304e53e67ee6a7aacddee0491e41ac5f725fb80e4e0aa34409c38a363b632
+  priority: 90
+```
 
 Red Hat OpenShift Container Platform Support
 -------------------------------------------------------------------------------

--- a/image/cli/mascli/mas
+++ b/image/cli/mascli/mas
@@ -276,9 +276,6 @@ case $1 in
     echo "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!" >> $LOGFILE
     echo "!! update                                                                    !!" >> $LOGFILE
     echo "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!" >> $LOGFILE
-
-    echo "${TEXT_UNDERLINE}IBM Maximo Application Suite Update Manager (v${VERSION})${TEXT_RESET}"
-    echo "Powered by ${COLOR_CYAN}${TEXT_UNDERLINE}https://github.com/ibm-mas/ansible-devops/${TEXT_RESET} and ${COLOR_CYAN}${TEXT_UNDERLINE}https://tekton.dev/${TEXT_RESET}"
     # Take the first parameter off (it will be "update")
     shift
     # Run the new Python-based install
@@ -727,7 +724,7 @@ case $1 in
     gitops_iac_manage_pr_cmd "$@"
     ;;
 
-    
+
   gitops-deprovision-aiservice-tenant)
     echo "${TEXT_UNDERLINE}IBM Maximo Application Suite AIService Tenant deprovision Manager (v${VERSION})${TEXT_RESET}"
     echo "Powered by ${COLOR_CYAN}${TEXT_UNDERLINE}https://github.com/ibm-mas/gitops/${TEXT_RESET}"

--- a/mkdocs_plugins/mkdocs_mas_catalogs/__init__.py
+++ b/mkdocs_plugins/mkdocs_mas_catalogs/__init__.py
@@ -9,7 +9,7 @@ __version__ = "0.1.0"
 
 # Try to import from installed package first
 try:
-    from mas.devops.data import getCatalog, getOCPLifecycleData, getCatalogEditorial
+    from mas.devops.data import getCatalog, getOCPLifecycleData, getCatalogEditorial, NoSuchCatalogError
 except ImportError:
     # Development fallback: add python-devops to path
     PYTHON_DEVOPS_PATH = (
@@ -17,7 +17,7 @@ except ImportError:
     )
     if PYTHON_DEVOPS_PATH.exists():
         sys.path.insert(0, str(PYTHON_DEVOPS_PATH))
-        from mas.devops.data import getCatalog, getOCPLifecycleData, getCatalogEditorial
+        from mas.devops.data import getCatalog, getOCPLifecycleData, getCatalogEditorial, NoSuchCatalogError
     else:
         raise ImportError(
             "Could not import mas.devops.data. "
@@ -85,9 +85,10 @@ class MASCatalogsPlugin(BasePlugin):
 
     def _get_catalog_data(self, catalog_tag):
         """Get catalog data and handle errors."""
-        catalog = getCatalog(catalog_tag)
-
-        if not catalog:
+        try:
+            catalog = getCatalog(catalog_tag)
+            return catalog, None
+        except NoSuchCatalogError:
             return (
                 None,
                 f"""!!! error
@@ -97,8 +98,6 @@ class MASCatalogsPlugin(BasePlugin):
     `python-devops/src/mas/devops/data/catalogs/{catalog_tag}.yaml`
 """,
             )
-
-        return catalog, None
 
     def _render_details(self, catalog_tag):
         """Render the Details section."""

--- a/python/src/mas/cli/cli.py
+++ b/python/src/mas/cli/cli.py
@@ -1,5 +1,5 @@
 # *****************************************************************************
-# Copyright (c) 2024 IBM Corporation and other Contributors.
+# Copyright (c) 2024, 2026 IBM Corporation and other Contributors.
 #
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
@@ -292,7 +292,7 @@ class BaseApp(PrintMixin, PromptMixin):
             return []
 
     @logMethodCall
-    def fatalError(self, message: str, exception: Exception = None) -> None:
+    def fatalError(self, message: str, exception: Exception | None = None) -> None:
         if exception is not None:
             logger.error(message)
             logger.exception(exception, stack_info=True)
@@ -331,7 +331,7 @@ class BaseApp(PrintMixin, PromptMixin):
             return ""
 
     @property
-    def dynamicClient(self):
+    def dynamicClient(self) -> DynamicClient:
         if self._dynClient is not None:
             return self._dynClient
         else:
@@ -396,7 +396,7 @@ class BaseApp(PrintMixin, PromptMixin):
         self.lookupTargetArchitecture()
 
     @logMethodCall
-    def lookupTargetArchitecture(self, architecture: str = None) -> None:
+    def lookupTargetArchitecture(self, architecture: str | None = None) -> None:
         logger.debug("Looking up worker node architecture")
         if architecture is not None:
             self.architecture = architecture

--- a/python/src/mas/cli/displayMixins.py
+++ b/python/src/mas/cli/displayMixins.py
@@ -46,7 +46,7 @@ class PrintMixin():
         content[len(content) - 1] = f"{content[len(content) - 1]}</{DESCRIPTIONCOLOR}>"
         print_formatted_text(HTML("\n".join(content).replace(' & ', ' &amp; ')))
 
-    def printHighlight(self, message: str) -> None:
+    def printHighlight(self, message: str | list[str]) -> None:
         if isinstance(message, list):
             message = "\n".join(message)
 

--- a/python/src/mas/cli/update/app.py
+++ b/python/src/mas/cli/update/app.py
@@ -98,7 +98,7 @@ class UpdateApp(BaseApp):
         isMasInstalled = self.reviewMASInstance()
         isAiServiceInstalled = self.reviewAiServiceInstance()
         if not isMasInstalled and not isAiServiceInstalled:
-            self.fatalError(["No MAS or AI Service instances were detected on the cluster => nothing to update! See log file for details"])
+            self.fatalError("No MAS or AI Service instances were detected on the cluster => nothing to update! See log file for details")
 
         if self.args.mas_catalog_version is None:
             # Interactive mode
@@ -350,8 +350,10 @@ class UpdateApp(BaseApp):
                 mongoDbAPI = self.dynamicClient.resources.get(api_version="mongodbcommunity.mongodb.com/v1", kind="MongoDBCommunity")
 
                 if self.getParam("mongodb_namespace") != "":
+                    logger.debug(f"Looking for MongoDBCommunity instances in {self.getParam('mongodb_namespace')}")
                     mongoClusters = mongoDbAPI.get(namespace=self.getParam("mongodb_namespace")).to_dict()["items"]
                 else:
+                    logger.debug("Looking for MongoDBCommunity instances in all namespaces")
                     mongoClusters = mongoDbAPI.get().to_dict()["items"]
 
                 if len(mongoClusters) > 0:

--- a/python/src/mas/cli/update/app.py
+++ b/python/src/mas/cli/update/app.py
@@ -19,7 +19,7 @@ from openshift.dynamic.exceptions import NotFoundError, ResourceNotFoundError
 
 from ..cli import BaseApp
 from .argParser import updateArgParser
-from mas.devops.data import getCatalog
+from mas.devops.data import getCatalog, getNewestCatalogTag
 from mas.devops.ocp import createNamespace, getConsoleURL, getClusterVersion, isClusterVersionInRange
 from mas.devops.mas import listMasInstances, getCurrentCatalog
 from mas.devops.aiservice import listAiServiceInstances
@@ -107,6 +107,8 @@ class UpdateApp(BaseApp):
         # Validations
         if not self.devMode:
             self.validateCatalog()
+        else:
+            self.chosenCatalog = getCatalog(getNewestCatalogTag())
 
         self.printH1("Dependency Update Checks")
         with Halo(text='Checking for IBM Watson Discovery', spinner=self.spinner) as h:
@@ -326,11 +328,13 @@ class UpdateApp(BaseApp):
                         "- User accounts set up in the v4 instance will not be migrated"
                     ])
                     self.setParam("grafana_v5_upgrade", "true")
+                    return True
                 else:
                     h.stop_and_persist(symbol=self.successIcon, text="Grafana Operator v4 is not installed")
-                return
+                    return False
             except (ResourceNotFoundError, NotFoundError):
                 h.stop_and_persist(symbol=self.successIcon, text="Grafana Operator v4 is not installed")
+                return False
 
     def detectMongoDb(self) -> None:
         with Halo(text='Checking for MongoDb CE', spinner=self.spinner) as h:
@@ -342,53 +346,20 @@ class UpdateApp(BaseApp):
             else:
                 self.setParam("mongodb_replicas", "3")
 
-            # Determine the namespace
             try:
                 mongoDbAPI = self.dynamicClient.resources.get(api_version="mongodbcommunity.mongodb.com/v1", kind="MongoDBCommunity")
-                mongoClusters = mongoDbAPI.get().to_dict()["items"]
+
+                if self.getParam("mongodb_namespace") != "":
+                    mongoClusters = mongoDbAPI.get(namespace=self.getParam("mongodb_namespace")).to_dict()["items"]
+                else:
+                    mongoClusters = mongoDbAPI.get().to_dict()["items"]
 
                 if len(mongoClusters) > 0:
                     mongoNamespace = mongoClusters[0]["metadata"]["namespace"]
                     currentMongoVersion = mongoClusters[0]["status"]["version"]
+                    targetMongoVersion = self.chosenCatalog["mongo_extras_version_default"]
 
                     self.setParam("mongodb_namespace", mongoNamespace)
-
-                    # Important:
-                    # This CLI can run independent of the ibm.mas_devops collection, so we cannot reference
-                    # the case bundles in there anymore
-                    # Longer term we will centralise this information inside the mas-devops python collection,
-                    # where it can be made available to both the ansible collection and this python package.
-                    defaultMongoVersion = "8.0.17"
-                    mongoVersions = {
-                        "v9-240625-amd64": "6.0.12",
-                        "v9-240730-amd64": "6.0.12",
-                        "v9-240827-amd64": "6.0.12",
-                        "v9-241003-amd64": "6.0.12",
-                        "v9-241107-amd64": "7.0.12",
-                        "v9-241205-amd64": "7.0.12",
-                        "v9-250109-amd64": "7.0.12",
-                        "v9-250206-amd64": "7.0.12",
-                        "v9-250306-amd64": "7.0.12",
-                        "v9-250403-amd64": "7.0.12",
-                        "v9-250501-amd64": "7.0.12",
-                        "v9-250624-amd64": "7.0.12",
-                        "v9-250731-amd64": "7.0.22",
-                        "v9-250828-amd64": "7.0.22",
-                        "v9-250902-amd64": "7.0.22",
-                        "v9-250925-amd64": "7.0.23",
-                        "v9-251010-amd64": "7.0.23",
-                        "v9-251030-amd64": "7.0.23",
-                        "v9-251127-amd64": "8.0.13",
-                        "v9-251224-amd64": "8.0.13",
-                        "v9-251231-amd64": "8.0.17",
-                        "v9-260129-amd64": "8.0.17",
-                    }
-                    catalogVersion = self.getParam('mas_catalog_version')
-                    if catalogVersion in mongoVersions:
-                        targetMongoVersion = mongoVersions[self.getParam('mas_catalog_version')]
-                    else:
-                        targetMongoVersion = defaultMongoVersion
-
                     self.setParam("mongodb_version", targetMongoVersion)
 
                     targetMongoVersionMajor = targetMongoVersion.split(".")[0]


### PR DESCRIPTION
When we inspect the cluster to determine the current version of any MongoDb instances we are accidentally over-writing the namespace chosen by the user when invoking the update

- Fix for https://github.com/ibm-mas/cli/issues/2037


Changes:
- Improved handling of command line params: inavlid combinations of parameters will result in an error (e.g. providing command flags for non-interactive mode without providing the `--catalog` parameter
- Fixed documentation for the oldest operator catalogs
- Fixed duplication of MongoDb versions in the CLI (by referencing the catalog data files)


```
IBM Maximo Application Suite Admin CLI v18.15.1-pre.djp
Powered by https://github.com/ibm-mas/ansible-devops/ and https://tekton.dev/

Update the IBM Maximo Operator Catalog, and related MAS dependencies by configuring and launching the MAS Update Tekton Pipeline.

Usage (non-interactive mode):
  mas update -c MAS_CATALOG_VERSION [--db2-namespace DB2_NAMESPACE]
                  [--mongodb-namespace MONGODB_NAMESPACE] [--mongodb-v5-upgrade]
                  [--mongodb-v6-upgrade] [--mongodb-v7-upgrade] [--mongodb-v8-upgrade]
                  [--kafka-namespace KAFKA_NAMESPACE] [--kafka-provider {redhat,strimzi}]
                  [--artifactory-username ARTIFACTORY_USERNAME]
                  [--artifactory-token ARTIFACTORY_TOKEN] [--dev-mode]
                  [--cp4d-version CPD_PRODUCT_VERSION] [--no-confirm] [--skip-pre-check]

Usage (interactive mode):
  mas update

Usage (help):
  mas update -h
```
