### PR TITLE
[patch] Fix Bug caused by installAIService flag in 8.x version of manage

### DIFF
--- a/mkdocs_plugins/mkdocs_mas_catalogs/__init__.py
+++ b/mkdocs_plugins/mkdocs_mas_catalogs/__init__.py
@@ -85,20 +85,34 @@ class MASCatalogsPlugin(BasePlugin):
 
     def _get_catalog_data(self, catalog_tag):
         """Get catalog data and handle errors."""
-        catalog = getCatalog(catalog_tag)
+        try:
+            catalog = getCatalog(catalog_tag)
 
-        if not catalog:
-            return (
-                None,
-                f"""!!! error
+            if not catalog:
+                return (
+                    None,
+                    f"""!!! error
     Catalog {catalog_tag} not found in python-devops.
 
     Make sure the catalog metadata exists at:
     `python-devops/src/mas/devops/data/catalogs/{catalog_tag}.yaml`
 """,
-            )
+                )
 
-        return catalog, None
+            return catalog, None
+        except Exception as e:
+            # Handle NoSuchCatalogError and other exceptions gracefully
+            return (
+                None,
+                f"""!!! warning
+    Catalog {catalog_tag} metadata not available in python-devops.
+
+    This is an older catalog version. The metadata file does not exist at:
+    `python-devops/src/mas/devops/data/catalogs/{catalog_tag}.yaml`
+
+    Error: {str(e)}
+""",
+            )
 
     def _render_details(self, catalog_tag):
         """Render the Details section."""

--- a/mkdocs_plugins/mkdocs_mas_catalogs/__init__.py
+++ b/mkdocs_plugins/mkdocs_mas_catalogs/__init__.py
@@ -85,34 +85,20 @@ class MASCatalogsPlugin(BasePlugin):
 
     def _get_catalog_data(self, catalog_tag):
         """Get catalog data and handle errors."""
-        try:
-            catalog = getCatalog(catalog_tag)
+        catalog = getCatalog(catalog_tag)
 
-            if not catalog:
-                return (
-                    None,
-                    f"""!!! error
+        if not catalog:
+            return (
+                None,
+                f"""!!! error
     Catalog {catalog_tag} not found in python-devops.
 
     Make sure the catalog metadata exists at:
     `python-devops/src/mas/devops/data/catalogs/{catalog_tag}.yaml`
 """,
-                )
-
-            return catalog, None
-        except Exception as e:
-            # Handle NoSuchCatalogError and other exceptions gracefully
-            return (
-                None,
-                f"""!!! warning
-    Catalog {catalog_tag} metadata not available in python-devops.
-
-    This is an older catalog version. The metadata file does not exist at:
-    `python-devops/src/mas/devops/data/catalogs/{catalog_tag}.yaml`
-
-    Error: {str(e)}
-""",
             )
+
+        return catalog, None
 
     def _render_details(self, catalog_tag):
         """Render the Details section."""

--- a/python/src/mas/cli/install/app.py
+++ b/python/src/mas/cli/install/app.py
@@ -926,14 +926,15 @@ class InstallApp(BaseApp, InstallSettingsMixin, InstallSummarizerMixin, ConfigGe
         else:
             self.installFacilities = False
 
-        self.installAIService = False
         # TODO: May be have to change this condition if Manage 9.0 is not supporting AI Cofig Application
         # AI Service is only installable on Manage 9.x as AI Config Application is not supported on Manage 8.x
 
-        if not self.getParam("mas_app_channel_manage").startswith("8."):
+        if isVersionEqualOrAfter('9.0.0', self.getParam("mas_app_channel_manage")):
             self.installAIService = self.yesOrNo("Install AI Service")
             if self.installAIService:
                 self.configAIService()
+        else:
+            self.installAIService = False
 
     @logMethodCall
     def configAppChannel(self, appId):

--- a/python/src/mas/cli/install/app.py
+++ b/python/src/mas/cli/install/app.py
@@ -925,8 +925,11 @@ class InstallApp(BaseApp, InstallSettingsMixin, InstallSummarizerMixin, ConfigGe
                 self.configAppChannel("facilities")
         else:
             self.installFacilities = False
+
+        self.installAIService = False
         # TODO: May be have to change this condition if Manage 9.0 is not supporting AI Cofig Application
         # AI Service is only installable on Manage 9.x as AI Config Application is not supported on Manage 8.x
+
         if not self.getParam("mas_app_channel_manage").startswith("8."):
             self.installAIService = self.yesOrNo("Install AI Service")
             if self.installAIService:


### PR DESCRIPTION
There was one bug:
While installing Manage with channel 8.x, we were not setting the installAIService flag at all.
So when the Manage AIService Binding section appeared under Manage Settings, it tried to access the InstallAIService flag, which caused the issue below.
```11.2) Maximo Manage Settings - Customization
Provide a customization archive to be used in the Manage build process
Include customization archive? [y/n] n
Traceback (most recent call last):
  File "/opt/app-root/bin/mas-cli", line 58, in <module>
    app.install(argv[2:])
  File "/opt/app-root/lib64/python3.12/site-packages/mas/cli/install/app.py", line 78, in wrapper
    result = func(self, *args, **kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/app-root/lib64/python3.12/site-packages/mas/cli/install/app.py", line 1604, in install
    self.interactiveMode(simplified=args.simplified, advanced=args.advanced)
  File "/opt/app-root/lib64/python3.12/site-packages/mas/cli/install/app.py", line 78, in wrapper
    result = func(self, *args, **kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/app-root/lib64/python3.12/site-packages/mas/cli/install/app.py", line 1188, in interactiveMode
    self.manageSettings()
  File "/opt/app-root/lib64/python3.12/site-packages/mas/cli/install/settings/manageSettings.py", line 35, in manageSettings
    self.manageSettingsAiService()
  File "/opt/app-root/lib64/python3.12/site-packages/mas/cli/install/settings/manageSettings.py", line 271, in manageSettingsAiService
    if self.installAIService:
       ^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'InstallApp' objechas no attribute 'installAIService'
[ibmmas/cli:18.13.0]mascli$
```

After setting the Default value of installAIService I have tested the CLI for Manage 8.11 in Interactive mode - so now this bug was fixed.
