### PR TITLE
[patch] Fix missing mas app id to rds template for gitops

### DIFF
--- a/image/cli/mascli/templates/gitops/appset-configs/cluster/instance/db2-databases/ibm-dbs-rds-databases.yaml.j2
+++ b/image/cli/mascli/templates/gitops/appset-configs/cluster/instance/db2-databases/ibm-dbs-rds-databases.yaml.j2
@@ -1,4 +1,5 @@
 db2_namespace: {{ DB2_NAMESPACE }}
+mas_application_id: {{ MAS_APP_ID }}
 db2_instance_name: {{ DB2_INSTANCE_NAME }}
 host: <path:{{ SECRETS_PATH }}:{{ HOST }}>
 port: <path:{{ SECRETS_PATH }}:{{ PORT }}>


### PR DESCRIPTION
This is to add mas app id to rds template

MASCORE-11503 | https://jsw.ibm.com/browse/MASCORE-11503


<br class="Apple-interchange-newline">[MASCORE-11503](https://jsw.ibm.com/browse/MASCORE-11503)
How it is tested:
<img width="1723" height="807" alt="image" src="https://github.com/user-attachments/assets/f11178b3-31f1-46ae-95dd-f4422c8fcdb2" />

<img width="1728" height="1028" alt="image" src="https://github.com/user-attachments/assets/3d921a48-35fe-45c1-8cc7-24edb8c3ddd2" />
