### PR TITLE
Backup for manage and db2 dev

### DIFF
--- a/docs/commands/backup.md
+++ b/docs/commands/backup.md
@@ -9,8 +9,11 @@ Usage information can be obtained using `mas backup --help`
 usage: mas backup [-i MAS_INSTANCE_ID] [--backup-version BACKUP_VERSION] [--backup-storage-size BACKUP_STORAGE_SIZE]
                   [--clean-backup] [--no-clean-backup] [--upload-backup] [--aws-access-key-id AWS_ACCESS_KEY_ID]
                   [--aws-secret-access-key AWS_SECRET_ACCESS_KEY] [--s3-bucket-name S3_BUCKET_NAME] [--s3-region S3_REGION]
-                  [--artifactory-url ARTIFACTORY_URL] [--artifactory-repository ARTIFACTORY_REPOSITORY] [--include-sls]
-                  [--exclude-sls] [--mongodb-namespace MONGODB_NAMESPACE] [--mongodb-instance-name MONGODB_INSTANCE_NAME]
+                  [--artifactory-url ARTIFACTORY_URL] [--artifactory-repository ARTIFACTORY_REPOSITORY]
+                  [--backup-manage-app] [--manage-workspace-id MANAGE_WORKSPACE_ID] [--backup-manage-db]
+                  [--manage-db2-namespace MANAGE_DB2_NAMESPACE] [--manage-db2-instance-name MANAGE_DB2_INSTANCE_NAME]
+                  [--manage-db2-backup-type {offline,online}] [--include-sls] [--exclude-sls]
+                  [--mongodb-namespace MONGODB_NAMESPACE] [--mongodb-instance-name MONGODB_INSTANCE_NAME]
                   [--mongodb-provider {community}] [--sls-namespace SLS_NAMESPACE] [--cert-manager-provider {redhat,ibm}]
                   [--artifactory-username ARTIFACTORY_USERNAME] [--artifactory-token ARTIFACTORY_TOKEN] [--dev-mode] [--no-confirm]
                   [--skip-pre-check] [-h]
@@ -47,6 +50,18 @@ Upload Configuration:
                         Artifactory URL for backup upload (dev-mode only)
   --artifactory-repository ARTIFACTORY_REPOSITORY
                         Artifactory repository for backup upload (dev-mode only)
+
+Manage Application Backup:
+  --backup-manage-app   Backup the Manage application
+  --manage-workspace-id MANAGE_WORKSPACE_ID
+                        Manage workspace ID
+  --backup-manage-db    Backup the Manage application database (Db2)
+  --manage-db2-namespace MANAGE_DB2_NAMESPACE
+                        Manage Db2 namespace (default: db2u)
+  --manage-db2-instance-name MANAGE_DB2_INSTANCE_NAME
+                        Manage Db2 instance name
+  --manage-db2-backup-type {offline,online}
+                        Manage Db2 backup type: offline (database unavailable) or online (database remains available)
 
 Components:
   --include-sls         Include SLS in backup (default: true)
@@ -189,6 +204,32 @@ mas backup \
   --no-confirm
 ```
 
+### Backup with Manage Application
+Backup MAS instance including the Manage application and its database:
+
+```bash
+mas backup \
+  --instance-id inst1 \
+  --backup-manage-app \
+  --manage-workspace-id masdev \
+  --backup-manage-db \
+  --manage-db2-namespace db2u \
+  --manage-db2-instance-name mas-inst1-masdev-manage \
+  --manage-db2-backup-type offline \
+  --no-confirm
+```
+
+### Backup with Manage Application Only (No Database)
+Backup the Manage application without backing up its database:
+
+```bash
+mas backup \
+  --instance-id inst1 \
+  --backup-manage-app \
+  --manage-workspace-id masdev \
+  --no-confirm
+```
+
 Notes
 -------------------------------------------------------------------------------
 
@@ -229,6 +270,17 @@ Two upload destinations are supported:
 - **S3**: Standard AWS S3 bucket upload (available in all modes)
 - **Artifactory**: Artifactory repository upload (requires `--dev-mode`)
 
+### Manage Application Backup
+The backup command can optionally include the Manage application and its Db2 database:
+
+- **Manage Application**: Backs up the Manage namespace resources and persistent volume data
+- **Manage Database**: Backs up the Db2 database associated with the Manage workspace
+  - **Offline backup**: Database is unavailable during backup (required for circular logging)
+  - **Online backup**: Database remains available during backup (requires archive logging)
+
+!!! note
+    If your Db2 instance uses circular logging (default), you must use offline backup type.
+
 ### Interactive Mode
 When running without `--instance-id`, the command enters interactive mode and will prompt for:
 
@@ -237,7 +289,8 @@ When running without `--instance-id`, the command enters interactive mode and wi
 3. Backup storage size
 4. Backup version (or auto-generate)
 5. Workspace cleanup preference
-6. Upload configuration (optional)
+6. Manage application backup configuration (optional)
+7. Upload configuration (optional)
 
 #### Example Interactive Mode Output
 

--- a/docs/commands/restore.md
+++ b/docs/commands/restore.md
@@ -122,14 +122,14 @@ mas restore
 Restore a specific MAS instance from a backup with default settings:
 
 ```bash
-mas restore --instance-id inst1 --restore-version 20260117-191701 --no-confirm
+mas restore --instance-id inst1 --restore-version 2020260117-191701 --no-confirm
 ```
 
 ### Restore with Custom Storage Size
 Specify a custom storage size for the restore PVC:
 
 ```bash
-mas restore --instance-id inst1 --restore-version 20260117-191701 --backup-storage-size 50Gi --no-confirm
+mas restore --instance-id inst1 --restore-version 2020260117-191701 --backup-storage-size 50Gi --no-confirm
 ```
 
 ### Restore with Changed MAS Domain
@@ -138,7 +138,7 @@ Restore a backup and change the MAS domain in the Suite CR:
 ```bash
 mas restore \
   --instance-id inst1 \
-  --restore-version 20260117-191701 \
+  --restore-version 2020260117-191701 \
   --mas-domain-restore new.domain.com \
   --no-confirm
 ```
@@ -149,7 +149,7 @@ Download a backup from S3 and restore it:
 ```bash
 mas restore \
   --instance-id inst1 \
-  --restore-version 20260117-191701 \
+  --restore-version 2020260117-191701 \
   --download-backup \
   --aws-access-key-id AKIAIOSFODNN7EXAMPLE \ #pragma: allowlist secret
   --aws-secret-access-key wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY \ #pragma: allowlist secret
@@ -164,7 +164,7 @@ Download and restore a backup with a custom archive name:
 ```bash
 mas restore \
   --instance-id inst1 \
-  --restore-version 20260117-191701 \
+  --restore-version 2020260117-191701 \
   --download-backup \
   --custom-backup-archive-name custom-backup-name.tar.gz \
   --aws-access-key-id AKIAIOSFODNN7EXAMPLE \ #pragma: allowlist secret
@@ -180,7 +180,7 @@ Restore a backup without including Suite License Service (useful when using exte
 ```bash
 mas restore \
   --instance-id inst1 \
-  --restore-version 20260117-191701 \
+  --restore-version 2020260117-191701 \
   --exclude-sls \
   --no-confirm
 ```
@@ -191,7 +191,7 @@ Restore using a custom SLS configuration file instead of the one from backup:
 ```bash
 mas restore \
   --instance-id inst1 \
-  --restore-version 20260117-191701 \
+  --restore-version 2020260117-191701 \
   --exclude-slscfg-from-backup \
   --sls-cfg-file /path/to/sls-config.yaml \
   --no-confirm
@@ -203,7 +203,7 @@ Restore SLS configuration from backup but change the SLS URL:
 ```bash
 mas restore \
   --instance-id inst1 \
-  --restore-version 20260117-191701 \
+  --restore-version 2020260117-191701 \
   --include-slscfg-from-backup \
   --sls-url-restore https://new-sls-url.com \
   --no-confirm
@@ -215,7 +215,7 @@ Restore using a custom DRO/BAS configuration file instead of the one from backup
 ```bash
 mas restore \
   --instance-id inst1 \
-  --restore-version 20260117-191701 \
+  --restore-version 2020260117-191701 \
   --exclude-drocfg-from-backup \
   --dro-cfg-file /path/to/dro-config.yaml \
   --no-confirm
@@ -227,7 +227,7 @@ Restore and install a new DRO instance:
 ```bash
 mas restore \
   --instance-id inst1 \
-  --restore-version 20260117-191701 \
+  --restore-version 2020260117-191701 \
   --include-dro \
   --ibm-entitlement-key YOUR_ENTITLEMENT_KEY \ #pragma: allowlist secret
   --contact-email admin@example.com \
@@ -243,7 +243,7 @@ Restore SLS instance with a custom domain:
 ```bash
 mas restore \
   --instance-id inst1 \
-  --restore-version 20260117-191701 \
+  --restore-version 2020260117-191701 \
   --include-sls \
   --sls-domain custom-sls.domain.com \
   --no-confirm
@@ -255,7 +255,7 @@ Restore without installing Grafana:
 ```bash
 mas restore \
   --instance-id inst1 \
-  --restore-version 20260117-191701 \
+  --restore-version 2020260117-191701 \
   --exclude-grafana \
   --no-confirm
 ```
@@ -264,14 +264,14 @@ mas restore \
 Skip the pre-restore validation check (use with caution):
 
 ```bash
-mas restore --instance-id inst1 --restore-version 20260117-191701 --skip-pre-check --no-confirm
+mas restore --instance-id inst1 --restore-version 2020260117-191701 --skip-pre-check --no-confirm
 ```
 
 ### Restore Without Workspace Cleanup
 Keep backup and config workspace contents after completion (useful for troubleshooting):
 
 ```bash
-mas restore --instance-id inst1 --restore-version 20260117-191701 --no-clean-backup --no-confirm
+mas restore --instance-id inst1 --restore-version 2020260117-191701 --no-clean-backup --no-confirm
 ```
 
 !!! note
@@ -283,7 +283,7 @@ A comprehensive example with all major options configured:
 ```bash
 mas restore \
   --instance-id inst1 \
-  --restore-version 20260117-191701 \
+  --restore-version 2020260117-191701 \
   --backup-storage-size 100Gi \
   --mas-domain-restore new.domain.com \
   --include-sls \

--- a/docs/guides/backup-restore.md
+++ b/docs/guides/backup-restore.md
@@ -578,7 +578,7 @@ Non-interactive mode is ideal for automation, scheduled restores, and CI/CD pipe
 ```bash
 docker run -ti --rm quay.io/ibmmas/cli mas restore \
   --instance-id inst1 \
-  --restore-version 20260117-191701 \
+  --restore-version 2020260117-191701 \
   --no-confirm
 ```
 
@@ -614,7 +614,7 @@ After launching the restore, a URL to the Tekton PipelineRun is displayed:
 
 ```
 View progress:
-  https://console-openshift-console.apps.cluster.example.com/k8s/ns/mas-inst1-pipelines/tekton.dev~v1beta1~PipelineRun/mas-restore-20260117-191701-YYMMDD-HHMM
+  https://console-openshift-console.apps.cluster.example.com/k8s/ns/mas-inst1-pipelines/tekton.dev~v1beta1~PipelineRun/mas-restore-2020260117-191701-YYMMDD-HHMM
 ```
 
 Use this URL to:
@@ -656,7 +656,7 @@ Restore Scenarios - Non-Interactive Mode
 ```bash
 mas restore \
   --instance-id inst1 \
-  --restore-version 20260117-191701 \
+  --restore-version 2020260117-191701 \
   --no-confirm
 ```
 
@@ -670,7 +670,7 @@ mas restore \
 ```bash
 mas restore \
   --instance-id inst1 \
-  --restore-version 20260117-191701 \
+  --restore-version 2020260117-191701 \
   --download-backup \
   --aws-access-key-id AKIAIOSFODNN7EXAMPLE \ #pragma: allowlist secret
   --aws-secret-access-key wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY \ #pragma: allowlist secret
@@ -689,7 +689,7 @@ mas restore \
 ```bash
 mas restore \
   --instance-id inst1 \
-  --restore-version 20260117-191701 \
+  --restore-version 2020260117-191701 \
   --mas-domain-restore new-cluster.example.com \
   --no-confirm
 ```
@@ -704,7 +704,7 @@ mas restore \
 ```bash
 mas restore \
   --instance-id inst1 \
-  --restore-version 20260117-191701 \
+  --restore-version 2020260117-191701 \
   --exclude-sls \
   --exclude-slscfg-from-backup \
   --sls-cfg-file /path/to/custom-sls-config.yaml \
@@ -721,7 +721,7 @@ mas restore \
 ```bash
 mas restore \
   --instance-id inst1 \
-  --restore-version 20260117-191701 \
+  --restore-version 2020260117-191701 \
   --include-sls \
   --include-slscfg-from-backup \
   --sls-url-restore https://new-sls.example.com \
@@ -738,7 +738,7 @@ mas restore \
 ```bash
 mas restore \
   --instance-id inst1 \
-  --restore-version 20260117-191701 \
+  --restore-version 2020260117-191701 \
   --include-dro \
   --ibm-entitlement-key YOUR_ENTITLEMENT_KEY \ #pragma: allowlist secret
   --contact-email admin@example.com \
@@ -758,7 +758,7 @@ mas restore \
 ```bash
 mas restore \
   --instance-id inst1 \
-  --restore-version 20260117-191701 \
+  --restore-version 2020260117-191701 \
   --exclude-grafana \
   --no-confirm
 ```
@@ -775,7 +775,7 @@ mas restore \
 ```bash
 mas restore \
   --instance-id inst1 \
-  --restore-version 20260117-191701 \
+  --restore-version 2020260117-191701 \
   --backup-storage-size 100Gi \
   --mas-domain-restore new-cluster.example.com \
   --include-sls \
@@ -808,7 +808,7 @@ mas restore \
 ```bash
 mas restore \
   --instance-id inst1 \
-  --restore-version 20260117-191701 \
+  --restore-version 2020260117-191701 \
   --no-clean-backup \
   --no-confirm
 ```
@@ -826,7 +826,7 @@ mas restore \
 ```bash
 mas restore \
   --instance-id inst1 \
-  --restore-version 20260117-191701 \
+  --restore-version 2020260117-191701 \
   --skip-pre-check \
   --no-confirm
 ```

--- a/docs/guides/backup-restore.md
+++ b/docs/guides/backup-restore.md
@@ -35,6 +35,7 @@ The `mas backup` command launches a Tekton pipeline that executes the following 
 - [`ibm.mas_devops.mongodb`](https://ibm-mas.github.io/ansible-devops/roles/mongodb/) - Backs up MongoDB Community Edition instance and database
 - [`ibm.mas_devops.sls`](https://ibm-mas.github.io/ansible-devops/roles/sls/) - Backs up Suite License Service data
 - [`ibm.mas_devops.suite_backup`](https://ibm-mas.github.io/ansible-devops/roles/suite_backup/) - Backs up MAS Core configuration
+- [`ibm.mas_devops.suite_app_backup`](https://ibm-mas.github.io/ansible-devops/roles/suite_app_backup/) - Backs up MAS application resources and persistent volume data
 
 For detailed information about the underlying Ansible automation, see the [Backup and Restore Playbook Documentation](https://ibm-mas.github.io/ansible-devops/playbooks/backup-restore/).
 
@@ -955,6 +956,8 @@ Additional Resources
 - [SLS Role](https://ibm-mas.github.io/ansible-devops/roles/sls/) - Suite License Service backup/restore
 - [Suite Backup Role](https://ibm-mas.github.io/ansible-devops/roles/suite_backup/) - MAS Core backup
 - [Suite Restore Role](https://ibm-mas.github.io/ansible-devops/roles/suite_restore/) - MAS Core restore
+- [Suite App Backup Role](https://ibm-mas.github.io/ansible-devops/roles/suite_app_backup/) - MAS application backup (generic)
+- [Db2 Role](https://ibm-mas.github.io/ansible-devops/roles/db2/) - Db2 database backup/restore
 - [Grafana Role](https://ibm-mas.github.io/ansible-devops/roles/grafana/) - Grafana installation
 - [DRO Role](https://ibm-mas.github.io/ansible-devops/roles/dro/) - Data Reporter Operator installation
 

--- a/python/src/mas/cli/backup/app.py
+++ b/python/src/mas/cli/backup/app.py
@@ -467,7 +467,3 @@ class BackupApp(BaseApp):
 
         # Always set to disk for pipeline as s3 upload is handled for the whole pipeline
         self.setParam("backup_vendor", "disk")
-
-        # Set backup version to match main backup version
-        if self.getParam("backup_version"):
-            self.setParam("db2_backup_version", self.getParam("backup_version"))

--- a/python/src/mas/cli/backup/app.py
+++ b/python/src/mas/cli/backup/app.py
@@ -455,12 +455,12 @@ class BackupApp(BaseApp):
             "Db2 backup can be performed online (database remains available) or offline (database unavailable during backup).",
             "Note: If your Db2 instance uses circular logging (default), you must use offline backup.",
             "Backup Types:",
-            " 1. online",
-            " 2. offline",
+            " 1. offline",
+            " 2. online",
         ])
         self.promptForListSelect(
             message="Select backup type",
-            options=["online", "offline"],
+            options=["offline", "online"],
             param="backup_type",
             default=1
         )

--- a/python/src/mas/cli/backup/app.py
+++ b/python/src/mas/cli/backup/app.py
@@ -465,8 +465,8 @@ class BackupApp(BaseApp):
             default=1
         )
 
-        # Always set to local for pipeline as s3 upload is handled for the whole pipeline
-        self.setParam("backup_vendor", "local")
+        # Always set to disk for pipeline as s3 upload is handled for the whole pipeline
+        self.setParam("backup_vendor", "disk")
 
         # Set backup version to match main backup version
         if self.getParam("backup_version"):

--- a/python/src/mas/cli/backup/app.py
+++ b/python/src/mas/cli/backup/app.py
@@ -10,7 +10,6 @@
 # *****************************************************************************
 
 import logging
-import logging.handlers
 from datetime import datetime
 from halo import Halo
 from prompt_toolkit import print_formatted_text, HTML
@@ -336,7 +335,7 @@ class BackupApp(BaseApp):
             # Determine upload destination based on dev_mode
             if self.devMode:
                 self.printDescription([
-                    "Development mode is enabled. Choose upload destination:"
+                    "Development mode is enabled. Choose upload destination:",
                     " 1. S3",
                     " 2. Artifactory",
                 ])
@@ -454,18 +453,20 @@ class BackupApp(BaseApp):
         # Backup type
         self.printDescription([
             "Db2 backup can be performed online (database remains available) or offline (database unavailable during backup).",
-            "Note: If your Db2 instance uses circular logging (default), you must use offline backup."
-            "Backup Types:"
+            "Note: If your Db2 instance uses circular logging (default), you must use offline backup.",
+            "Backup Types:",
             " 1. online",
             " 2. offline",
         ])
-        backupType = self.promptForListSelect(
+        self.promptForListSelect(
             message="Select backup type",
             options=["online", "offline"],
             param="backup_type",
             default=1
         )
-        self.setParam("backup_type", backupType)
+
+        # Always set to local for pipeline as s3 upload is handled for the whole pipeline
+        self.setParam("backup_vendor", "local")
 
         # Set backup version to match main backup version
         if self.getParam("backup_version"):

--- a/python/src/mas/cli/backup/app.py
+++ b/python/src/mas/cli/backup/app.py
@@ -337,6 +337,8 @@ class BackupApp(BaseApp):
             if self.devMode:
                 self.printDescription([
                     "Development mode is enabled. Choose upload destination:"
+                    " 1. S3",
+                    " 2. Artifactory",
                 ])
                 uploadDestination = self.promptForListSelect(
                     "Select upload destination",
@@ -443,18 +445,24 @@ class BackupApp(BaseApp):
         self.setParam("db2_namespace", db2Namespace)
 
         # DB2 instance name
-        db2InstanceName = self.promptForString("Enter Db2 instance name")
+        instanceId = self.getParam("mas_instance_id")
+        workspaceID = self.getParam("mas_workspace_id")
+        appId = self.getParam("mas_app_id")
+        db2InstanceName = self.promptForString("Enter Db2 instance name", default=f"mas-{instanceId}-{workspaceID}-{appId}")
         self.setParam("db2_instance_name", db2InstanceName)
 
         # Backup type
         self.printDescription([
             "Db2 backup can be performed online (database remains available) or offline (database unavailable during backup).",
             "Note: If your Db2 instance uses circular logging (default), you must use offline backup."
+            "Backup Types:"
+            " 1. online",
+            " 2. offline",
         ])
         backupType = self.promptForListSelect(
-            "Select backup type",
-            ["online", "offline"],
-            "backup_type",
+            message="Select backup type",
+            options=["online", "offline"],
+            param="backup_type",
             default=1
         )
         self.setParam("backup_type", backupType)

--- a/python/src/mas/cli/backup/argParser.py
+++ b/python/src/mas/cli/backup/argParser.py
@@ -111,6 +111,52 @@ uploadArgGroup.add_argument(
     help="Artifactory repository for backup upload"
 )
 
+manageAppArgGroup = backupArgParser.add_argument_group(
+    'Manage Application Backup',
+    'Configure backup of the Manage application and its database.'
+)
+manageAppArgGroup.add_argument(
+    '--backup-manage-app',
+    dest='backup_manage_app',
+    required=False,
+    action="store_const",
+    const="true",
+    help="Backup the Manage application"
+)
+manageAppArgGroup.add_argument(
+    '--manage-workspace-id',
+    dest='manage_workspace_id',
+    required=False,
+    help="Manage workspace ID"
+)
+manageAppArgGroup.add_argument(
+    '--backup-manage-db',
+    dest='backup_manage_db',
+    required=False,
+    action="store_const",
+    const="true",
+    help="Backup the Manage application database (Db2)"
+)
+manageAppArgGroup.add_argument(
+    '--manage-db2-namespace',
+    dest='manage_db2_namespace',
+    required=False,
+    help="Manage Db2 namespace (default: db2u)"
+)
+manageAppArgGroup.add_argument(
+    '--manage-db2-instance-name',
+    dest='manage_db2_instance_name',
+    required=False,
+    help="Manage Db2 instance name"
+)
+manageAppArgGroup.add_argument(
+    '--manage-db2-backup-type',
+    dest='manage_db2_backup_type',
+    required=False,
+    choices=["offline", "online"],
+    help="Manage Db2 backup type: offline (database unavailable) or online (database remains available)"
+)
+
 componentsArgGroup = backupArgParser.add_argument_group(
     'Components',
     'Configure which components to include in the backup.'

--- a/python/src/mas/cli/restore/app.py
+++ b/python/src/mas/cli/restore/app.py
@@ -350,7 +350,7 @@ class RestoreApp(BaseApp):
     def promptForBackupVersion(self) -> None:
         self.printH1("Backup Version Configuration")
         # Prompt user to enter custom backup version
-        restore_version = self.promptForString("Set the backup version to use for this restore operation. (e.g. 20260117-191701)")
+        restore_version = self.promptForString("Set the backup version to use for this restore operation. (e.g. 2020260117-191701)")
         self.setParam("restore_version", restore_version)
 
     def setDefaultParams(self) -> None:

--- a/tekton/generate-tekton-tasks.yml
+++ b/tekton/generate-tekton-tasks.yml
@@ -136,8 +136,10 @@
         dest: "{{ task_target_dir }}/{{ item }}.yaml"
       with_items:
         - clean-workspaces
+        - download-backup-archive
         - gencfg-workspace
         - must-gather
+        - suite-app-backup
         - suite-app-install
         - suite-app-uninstall
         - suite-app-upgrade
@@ -155,7 +157,6 @@
         - suite-upgrade
         - suite-verify
         - upload-backup-archive
-        - download-backup-archive
 
     # 7. Generate Tasks (OCP)
     # -------------------------------------------------------------------------

--- a/tekton/src/params/backup.yml.j2
+++ b/tekton/src/params/backup.yml.j2
@@ -243,11 +243,6 @@
   description: MAS workspace ID for application backup
   default: ""
 
-- name: mas_app_backup_version
-  type: string
-  description: Version/timestamp for the MAS app backup (defaults to backup_version if not provided)
-  default: ""
-
 # Db2 Backup Configuration
 # -----------------------------------------------------------------------------
 - name: db2_namespace
@@ -264,11 +259,6 @@
   type: string
   description: Action to perform for Db2 (backup)
   default: "backup"
-
-- name: db2_backup_version
-  type: string
-  description: Version/timestamp for the Db2 backup (defaults to backup_version if not provided)
-  default: ""
 
 - name: backup_type
   type: string

--- a/tekton/src/params/backup.yml.j2
+++ b/tekton/src/params/backup.yml.j2
@@ -220,3 +220,82 @@
   type: string
   default: ""
   description: Directory for MAS configuration files during restore
+
+# Manage Application Backup Configuration
+# -----------------------------------------------------------------------------
+- name: backup_manage_app
+  type: string
+  description: Whether to backup the Manage application (true/false)
+  default: "false"
+
+- name: backup_manage_db
+  type: string
+  description: Whether to backup the Manage database (Db2) (true/false)
+  default: "false"
+
+- name: mas_app_id
+  type: string
+  description: MAS application ID (e.g., manage)
+  default: ""
+
+- name: mas_workspace_id
+  type: string
+  description: MAS workspace ID for application backup
+  default: ""
+
+- name: mas_app_backup_version
+  type: string
+  description: Version/timestamp for the MAS app backup (defaults to backup_version if not provided)
+  default: ""
+
+# Db2 Backup Configuration
+# -----------------------------------------------------------------------------
+- name: db2_namespace
+  type: string
+  description: Db2 namespace for backup
+  default: ""
+
+- name: db2_instance_name
+  type: string
+  description: Db2 instance name for backup
+  default: ""
+
+- name: db2_action
+  type: string
+  description: Action to perform for Db2 (backup)
+  default: "backup"
+
+- name: db2_backup_version
+  type: string
+  description: Version/timestamp for the Db2 backup (defaults to backup_version if not provided)
+  default: ""
+
+- name: backup_type
+  type: string
+  description: Type of Db2 backup (online or offline)
+  default: "online"
+
+- name: backup_vendor
+  type: string
+  description: Storage backend for Db2 backup files (disk or s3)
+  default: "disk"
+
+- name: backup_s3_endpoint
+  type: string
+  description: S3 endpoint URL for Db2 backups
+  default: ""
+
+- name: backup_s3_bucket
+  type: string
+  description: S3 bucket name for Db2 backups
+  default: ""
+
+- name: backup_s3_access_key
+  type: string
+  description: S3 access key for Db2 backups
+  default: ""
+
+- name: backup_s3_secret_key
+  type: string
+  description: S3 secret key for Db2 backups
+  default: ""

--- a/tekton/src/params/backup.yml.j2
+++ b/tekton/src/params/backup.yml.j2
@@ -233,41 +233,31 @@
   description: Whether to backup the Manage database (Db2) (true/false)
   default: "false"
 
-- name: mas_app_id
+- name: manage_workspace_id
   type: string
-  description: MAS application ID (e.g., manage)
+  description: Manage workspace ID for application backup
   default: ""
 
-- name: mas_workspace_id
-  type: string
-  description: MAS workspace ID for application backup
-  default: ""
-
-# Db2 Backup Configuration
+# Manage Db2 Backup Configuration
 # -----------------------------------------------------------------------------
-- name: db2_namespace
+- name: manage_db2_namespace
   type: string
-  description: Db2 namespace for backup
+  description: Manage Db2 namespace for backup
   default: ""
 
-- name: db2_instance_name
+- name: manage_db2_instance_name
   type: string
-  description: Db2 instance name for backup
+  description: Manage Db2 instance name for backup
   default: ""
 
-- name: db2_action
+- name: manage_db2_backup_type
   type: string
-  description: Action to perform for Db2 (backup)
-  default: "backup"
-
-- name: backup_type
-  type: string
-  description: Type of Db2 backup (online or offline)
+  description: Type of Manage Db2 backup (online or offline)
   default: "online"
 
-- name: backup_vendor
+- name: manage_db2_backup_vendor
   type: string
-  description: Storage backend for Db2 backup files (disk or s3)
+  description: Storage backend for Manage Db2 backup files (disk or s3)
   default: "disk"
 
 - name: backup_s3_endpoint

--- a/tekton/src/pipelines/mas-backup.yml.j2
+++ b/tekton/src/pipelines/mas-backup.yml.j2
@@ -231,9 +231,9 @@ spec:
           value: $(params.mas_instance_id)
 
         - name: db2_namespace
-          value: $(params.db2_namespace)
+          value: $(params.manage_db2_namespace)
         - name: db2_instance_name
-          value: $(params.db2_instance_name)
+          value: $(params.manage_db2_instance_name)
         - name: db2_action
           value: backup
 
@@ -241,9 +241,9 @@ spec:
         - name: db2_backup_version
           value: $(params.backup_version)
         - name: backup_type
-          value: $(params.backup_type)
+          value: $(params.manage_db2_backup_type)
         - name: backup_vendor
-          value: $(params.backup_vendor)
+          value: $(params.manage_db2_backup_vendor)
         - name: backup_s3_endpoint
           value: $(params.backup_s3_endpoint)
         - name: backup_s3_bucket
@@ -278,9 +278,9 @@ spec:
         - name: mas_instance_id
           value: $(params.mas_instance_id)
         - name: mas_workspace_id
-          value: $(params.mas_workspace_id)
+          value: $(params.manage_workspace_id)
         - name: mas_app_id
-          value: $(params.mas_app_id)
+          value: manage
 
         - name: mas_backup_dir
           value: /workspace/backups

--- a/tekton/src/pipelines/mas-backup.yml.j2
+++ b/tekton/src/pipelines/mas-backup.yml.j2
@@ -29,6 +29,8 @@ spec:
     # 5. Backup MongoDB
     # 6. Backup SLS
     # 7. Backup MAS Suite
+    # 8. Backup Manage Database (Db2) - Optional
+    # 9. Backup Manage Application - Optional
 
     # 1. Pipeline Start
     # -------------------------------------------------------------------------
@@ -224,7 +226,89 @@ spec:
         - mongodb
         - sls
 
-    # 8. Upload Backup Archive (Optional)
+    # 8. Backup Manage Database (Db2) - Optional
+    # -------------------------------------------------------------------------
+    - name: manage-db2-backup
+      timeout: "0"
+      when:
+        - input: "$(params.backup_manage_db)"
+          operator: in
+          values: ["true", "True"]
+      params:
+        {{ lookup('template', pipeline_src_dir ~ '/taskdefs/common/cli-params.yml.j2') | indent(8) }}
+
+        - name: mas_instance_id
+          value: $(params.mas_instance_id)
+
+        - name: db2_namespace
+          value: $(params.db2_namespace)
+        - name: db2_instance_name
+          value: $(params.db2_instance_name)
+        - name: db2_action
+          value: backup
+
+        # Backup specific parameters
+        - name: db2_backup_version
+          value: $(params.db2_backup_version)
+        - name: backup_type
+          value: $(params.backup_type)
+        - name: backup_vendor
+          value: $(params.backup_vendor)
+        - name: backup_s3_endpoint
+          value: $(params.backup_s3_endpoint)
+        - name: backup_s3_bucket
+          value: $(params.backup_s3_bucket)
+        - name: backup_s3_access_key
+          value: $(params.backup_s3_access_key)
+        - name: backup_s3_secret_key
+          value: $(params.backup_s3_secret_key)
+
+      taskRef:
+        kind: Task
+        name: mas-devops-db2
+      workspaces:
+        - name: configs
+          workspace: shared-configs
+        - name: backups
+          workspace: shared-backups
+      runAfter:
+        - suite-backup
+
+    # 9. Backup Manage Application - Optional
+    # -------------------------------------------------------------------------
+    - name: manage-app-backup
+      timeout: "0"
+      when:
+        - input: "$(params.backup_manage_app)"
+          operator: in
+          values: ["true", "True"]
+      params:
+        {{ lookup('template', pipeline_src_dir ~ '/taskdefs/common/cli-params.yml.j2') | indent(8) }}
+
+        - name: mas_instance_id
+          value: $(params.mas_instance_id)
+        - name: mas_workspace_id
+          value: $(params.mas_workspace_id)
+        - name: mas_app_id
+          value: $(params.mas_app_id)
+
+        - name: mas_backup_dir
+          value: /workspace/backups
+        - name: mas_app_backup_version
+          value: $(params.mas_app_backup_version)
+
+      taskRef:
+        kind: Task
+        name: mas-devops-suite-app-backup
+      workspaces:
+        - name: configs
+          workspace: shared-configs
+        - name: backups
+          workspace: shared-backups
+      runAfter:
+        - suite-backup
+
+    # 10. Upload Backup Archive (Optional)
     # -------------------------------------------------------------------------
     - name: upload-backup-archive
       timeout: "0"
@@ -266,6 +350,8 @@ spec:
           workspace: shared-backups
       runAfter:
         - suite-backup
+        - manage-db2-backup
+        - manage-app-backup
 
   finally:
     # 1. Clean Backup Workspaces (Optional)

--- a/tekton/src/pipelines/mas-backup.yml.j2
+++ b/tekton/src/pipelines/mas-backup.yml.j2
@@ -64,8 +64,6 @@ spec:
       params:
         {{ lookup('template', pipeline_src_dir ~ '/taskdefs/common/cli-params.yml.j2') | indent(8) }}
 
-        {{ lookup('template', pipeline_src_dir ~ '/taskdefs/backup-restore/backup-params.yml.j2') | indent(8) }}
-
         - name: devops_suite_name
           value: backup-ibm-catalogs
 
@@ -95,8 +93,6 @@ spec:
       params:
         {{ lookup('template', pipeline_src_dir ~ '/taskdefs/common/cli-params.yml.j2') | indent(8) }}
 
-        {{ lookup('template', pipeline_src_dir ~ '/taskdefs/backup-restore/backup-params.yml.j2') | indent(8) }}
-
         - name: devops_suite_name
           value: backup-cert-manager
 
@@ -123,8 +119,6 @@ spec:
       timeout: "0"
       params:
         {{ lookup('template', pipeline_src_dir ~ '/taskdefs/common/cli-params.yml.j2') | indent(8) }}
-
-        {{ lookup('template', pipeline_src_dir ~ '/taskdefs/backup-restore/backup-params.yml.j2') | indent(8) }}
 
         - name: devops_suite_name
           value: backup-mongodb
@@ -162,8 +156,6 @@ spec:
       params:
         {{ lookup('template', pipeline_src_dir ~ '/taskdefs/common/cli-params.yml.j2') | indent(8) }}
 
-        {{ lookup('template', pipeline_src_dir ~ '/taskdefs/backup-restore/backup-params.yml.j2') | indent(8) }}
-
         - name: mas_instance_id
           value: $(params.mas_instance_id)
 
@@ -200,8 +192,6 @@ spec:
       timeout: "0"
       params:
         {{ lookup('template', pipeline_src_dir ~ '/taskdefs/common/cli-params.yml.j2') | indent(8) }}
-
-        {{ lookup('template', pipeline_src_dir ~ '/taskdefs/backup-restore/backup-params.yml.j2') | indent(8) }}
 
         - name: mas_instance_id
           value: $(params.mas_instance_id)
@@ -249,7 +239,7 @@ spec:
 
         # Backup specific parameters
         - name: db2_backup_version
-          value: $(params.db2_backup_version)
+          value: $(params.backup_version)
         - name: backup_type
           value: $(params.backup_type)
         - name: backup_vendor
@@ -295,7 +285,7 @@ spec:
         - name: mas_backup_dir
           value: /workspace/backups
         - name: mas_app_backup_version
-          value: $(params.mas_app_backup_version)
+          value: $(params.backup_version)
 
       taskRef:
         kind: Task

--- a/tekton/src/pipelines/mas-backup.yml.j2
+++ b/tekton/src/pipelines/mas-backup.yml.j2
@@ -262,7 +262,7 @@ spec:
         - name: backups
           workspace: shared-backups
       runAfter:
-        - suite-backup
+        - pre-backup-check
 
     # 9. Backup Manage Application - Optional
     # -------------------------------------------------------------------------

--- a/tekton/src/pipelines/taskdefs/backup-restore/backup-params.yml.j2
+++ b/tekton/src/pipelines/taskdefs/backup-restore/backup-params.yml.j2
@@ -1,2 +1,0 @@
-- name: backup_version
-  value: $(params.backup_version)

--- a/tekton/src/tasks/dependencies/db2.yml.j2
+++ b/tekton/src/tasks/dependencies/db2.yml.j2
@@ -165,6 +165,40 @@ spec:
       description: Optional MAS custom labels, comma separated list of key=value pairs
       default: ""
 
+    # Backup/Restore specific parameters
+    - name: db2_backup_version
+      type: string
+      description: Optional. Version/timestamp for the backup
+      default: ""
+    - name: mas_backup_dir
+      type: string
+      description: Directory to store backup files
+      default: ""
+    - name: backup_type
+      type: string
+      description: Type of backup (online or offline)
+      default: ""
+    - name: backup_vendor
+      type: string
+      description: Storage backend for database backup files (disk or s3)
+      default: ""
+    - name: backup_s3_endpoint
+      type: string
+      description: S3 endpoint URL for backups
+      default: ""
+    - name: backup_s3_bucket
+      type: string
+      description: S3 bucket name for backups
+      default: ""
+    - name: backup_s3_access_key
+      type: string
+      description: S3 access key for backups
+      default: ""
+    - name: backup_s3_secret_key
+      type: string
+      description: S3 secret key for backups
+      default: ""
+
   stepTemplate:
     env:
       {{ lookup('template', task_src_dir ~ '/common/cli-env.yml.j2') | indent(6) }}
@@ -280,6 +314,24 @@ spec:
       # Custom labels support
       - name: CUSTOM_LABELS
         value: $(params.custom_labels)
+
+      # Backup/Restore specific
+      - name: MAS_BACKUP_DIR
+        value: /workspace/backups
+      - name: DB2_BACKUP_VERSION
+        value: $(params.db2_backup_version)
+      - name: BACKUP_TYPE
+        value: $(params.backup_type)
+      - name: BACKUP_VENDOR
+        value: $(params.backup_vendor)
+      - name: BACKUP_S3_ENDPOINT
+        value: $(params.backup_s3_endpoint)
+      - name: BACKUP_S3_BUCKET
+        value: $(params.backup_s3_bucket)
+      - name: BACKUP_S3_ACCESS_KEY
+        value: $(params.backup_s3_access_key)
+      - name: BACKUP_S3_SECRET_KEY
+        value: $(params.backup_s3_secret_key)
   steps:
     - name: db2
       command:
@@ -291,4 +343,6 @@ spec:
 
   workspaces:
     - name: configs
+      optional: true
+    - name: backups
       optional: true

--- a/tekton/src/tasks/dependencies/db2.yml.j2
+++ b/tekton/src/tasks/dependencies/db2.yml.j2
@@ -320,7 +320,7 @@ spec:
         value: /workspace/backups
       - name: DB2_BACKUP_VERSION
         value: $(params.db2_backup_version)
-      - name: BACKUP_TYPE
+      - name: DB2_BACKUP_TYPE
         value: $(params.backup_type)
       - name: BACKUP_VENDOR
         value: $(params.backup_vendor)

--- a/tekton/src/tasks/suite-app-backup.yml.j2
+++ b/tekton/src/tasks/suite-app-backup.yml.j2
@@ -1,0 +1,67 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: mas-devops-suite-app-backup
+spec:
+  params:
+    {{ lookup('template', task_src_dir ~ '/common/cli-params.yml.j2') | indent(4) }}
+
+    - name: mas_instance_id
+      type: string
+      description: Instance ID
+
+    - name: mas_workspace_id
+      type: string
+      description: Workspace ID
+      default: ""
+
+    - name: mas_app_id
+      type: string
+      description: Application ID (e.g., manage)
+      default: ""
+
+    # Backup specific parameters
+    - name: mas_backup_dir
+      type: string
+      description: Directory to store backup files
+      default: ""
+    
+    - name: mas_app_backup_version
+      type: string
+      description: Version/timestamp for the MAS app backup
+      default: ""
+
+  stepTemplate:
+    env:
+      {{ lookup('template', task_src_dir ~ '/common/cli-env.yml.j2') | indent(6) }}
+
+      - name: MAS_INSTANCE_ID
+        value: $(params.mas_instance_id)
+      
+      - name: MAS_WORKSPACE_ID
+        value: $(params.mas_workspace_id)
+      
+      - name: MAS_APP_ID
+        value: $(params.mas_app_id)
+
+      # Backup specific
+      - name: MAS_BACKUP_DIR
+        value: /workspace/backups
+      
+      - name: MAS_APP_BACKUP_VERSION
+        value: $(params.mas_app_backup_version)
+
+  steps:
+    - name: suite-app-backup
+      command:
+        - /opt/app-root/src/run-role.sh
+        - suite_app_backup
+      image: quay.io/ibmmas/cli:latest
+      imagePullPolicy: $(params.image_pull_policy)
+      workingDir: /workspace/configs
+
+  workspaces:
+    - name: configs
+      optional: true
+    - name: backups

--- a/tekton/src/tasks/suite-app-backup.yml.j2
+++ b/tekton/src/tasks/suite-app-backup.yml.j2
@@ -1,4 +1,4 @@
----
+ ---
 apiVersion: tekton.dev/v1beta1
 kind: Task
 metadata:

--- a/tekton/src/tasks/suite-app-backup.yml.j2
+++ b/tekton/src/tasks/suite-app-backup.yml.j2
@@ -1,4 +1,4 @@
- ---
+---
 apiVersion: tekton.dev/v1beta1
 kind: Task
 metadata:

--- a/tekton/src/tasks/suite-backup.yml.j2
+++ b/tekton/src/tasks/suite-backup.yml.j2
@@ -16,7 +16,7 @@ spec:
       type: string
       description: Directory to store backup files
       default: ""
-    - name: backup_version
+    - name: suite_backup_version
       type: string
       description: Version/timestamp for the backup
       default: ""
@@ -34,7 +34,7 @@ spec:
       - name: MAS_BACKUP_DIR
         value: /workspace/backups
       - name: SUITE_BACKUP_VERSION
-        value: $(params.backup_version)
+        value: $(params.suite_backup_version)
 
   steps:
     - name: suite-backup


### PR DESCRIPTION
Dev -> Dev PR only

Adds the manage app and db2 to the mas backup command to allow the pipeline to run the tasks that call the new role created in https://github.com/ibm-mas/ansible-devops/pull/2104. Documentation also updated.

Pipeline runs after running mas backup with the manage option set:

<img width="4078" height="882" alt="image- 2026-02-06 at 14 07 51@2x" src="https://github.com/user-attachments/assets/b502786b-cced-4e62-bd86-b49649f71697" />


Needs https://github.com/ibm-mas/ansible-devops/pull/2104 and https://github.com/ibm-mas/python-devops/pull/184 merged first