### PR TITLE
[patch] Fix condition for Install AI Service section while in dev-mode

### DIFF
--- a/python/src/mas/cli/install/app.py
+++ b/python/src/mas/cli/install/app.py
@@ -940,7 +940,7 @@ class InstallApp(BaseApp, InstallSettingsMixin, InstallSummarizerMixin, ConfigGe
         # TODO: May be have to change this condition if Manage 9.0 is not supporting AI Cofig Application
         # AI Service is only installable on Manage 9.x as AI Config Application is not supported on Manage 8.x
 
-        if isVersionEqualOrAfter('9.0.0', self.getParam("mas_app_channel_manage")):
+        if self.devMode or isVersionEqualOrAfter('9.0.0', self.getParam("mas_app_channel_manage")):
             self.installAIService = self.yesOrNo("Install AI Service")
             if self.installAIService:
                 self.configAIService()


### PR DESCRIPTION
When we are trying to use custom channel of Manage in dev-mode then isVersionEqualOrAfter ( In Install AI Service section ) throw error like 
`ValueError: mashp is not valid SemVer string`
this change will fix this error for dev-mode.