### PR TITLE
[patch] Fix NoSuchCatalogError handling in developer mode

### DIFF
--- a/python/src/mas/cli/aiservice/install/app.py
+++ b/python/src/mas/cli/aiservice/install/app.py
@@ -136,7 +136,7 @@ class AiServiceInstallApp(BaseApp, aiServiceInstallArgBuilderMixin, aiServiceIns
     @logMethodCall
     def interactiveMode(self, simplified: bool, advanced: bool) -> None:
         # Interactive mode
-        self.interactiveMode = True
+        self.isInteractiveMode = True
 
         if simplified:
             self.showAdvancedOptions = False
@@ -178,7 +178,7 @@ class AiServiceInstallApp(BaseApp, aiServiceInstallArgBuilderMixin, aiServiceIns
 
     @logMethodCall
     def nonInteractiveMode(self) -> None:
-        self.interactiveMode = False
+        self.isInteractiveMode = False
 
         # Set defaults
         # ---------------------------------------------------------------------

--- a/python/src/mas/cli/install/app.py
+++ b/python/src/mas/cli/install/app.py
@@ -397,7 +397,7 @@ class InstallApp(BaseApp, InstallSettingsMixin, InstallSummarizerMixin, ConfigGe
             except NotFoundError:
                 self.setParam("grafana_action", "none")
 
-            if self.interactiveMode and self.showAdvancedOptions:
+            if self.isInteractiveMode and self.showAdvancedOptions:
                 self.printH1("Configure Grafana")
                 if self.getParam("grafana_action") == "none":
                     print_formatted_text("The Grafana operator package is not available in any catalogs on the target cluster, the installation of Grafana will be disabled")
@@ -937,10 +937,8 @@ class InstallApp(BaseApp, InstallSettingsMixin, InstallSummarizerMixin, ConfigGe
         else:
             self.installFacilities = False
 
-        # TODO: May be have to change this condition if Manage 9.0 is not supporting AI Cofig Application
         # AI Service is only installable on Manage 9.x as AI Config Application is not supported on Manage 8.x
-
-        if self.devMode or isVersionEqualOrAfter('9.0.0', self.getParam("mas_app_channel_manage")):
+        if isVersionEqualOrAfter('9.0.0', self.getParam("mas_app_channel_manage")):
             self.installAIService = self.yesOrNo("Install AI Service")
             if self.installAIService:
                 self.configAIService()
@@ -1294,7 +1292,7 @@ class InstallApp(BaseApp, InstallSettingsMixin, InstallSummarizerMixin, ConfigGe
     @logMethodCall
     def interactiveMode(self, simplified: bool, advanced: bool) -> None:
         # Interactive mode
-        self.interactiveMode = True
+        self.isInteractiveMode = True
 
         if simplified:
             self.showAdvancedOptions = False
@@ -1349,7 +1347,7 @@ class InstallApp(BaseApp, InstallSettingsMixin, InstallSummarizerMixin, ConfigGe
 
     @logMethodCall
     def nonInteractiveMode(self) -> None:
-        self.interactiveMode = False
+        self.isInteractiveMode = False
 
         # Set defaults
         # ---------------------------------------------------------------------
@@ -1771,7 +1769,7 @@ class InstallApp(BaseApp, InstallSettingsMixin, InstallSummarizerMixin, ConfigGe
         ])
 
         # Validate IngressController configuration for path-based routing (non-interactive mode only)
-        if not self.interactiveMode and self.getParam("mas_routing_mode") == "path":
+        if not self.isInteractiveMode and self.getParam("mas_routing_mode") == "path":
             ingressControllerName = None
             if hasattr(self.args, 'mas_ingress_controller_name') and self.args.mas_ingress_controller_name:
                 ingressControllerName = self.args.mas_ingress_controller_name

--- a/python/src/mas/cli/install/settings/additionalConfigs.py
+++ b/python/src/mas/cli/install/settings/additionalConfigs.py
@@ -27,7 +27,7 @@ class AdditionalConfigsMixin():
     if TYPE_CHECKING:
         # Attributes from BaseApp and other mixins
         params: Dict[str, str]
-        interactiveMode: bool
+        _interactiveMode: bool
         localConfigDir: str | None
         noConfirm: bool
         templatesDir: str
@@ -92,7 +92,7 @@ class AdditionalConfigsMixin():
             ...
 
     def additionalConfigs(self) -> None:
-        if self.interactiveMode:
+        if self.isInteractiveMode:
             self.printH1("Additional Configuration")
             self.printDescription([
                 "Additional resource definitions can be applied to the OpenShift Cluster during the MAS configuration step",
@@ -136,7 +136,7 @@ class AdditionalConfigsMixin():
             self.additionalConfigsSecret = additionalConfigsSecret
 
     def podTemplates(self) -> None:
-        if self.interactiveMode and self.showAdvancedOptions:
+        if self.isInteractiveMode and self.showAdvancedOptions:
             self.printH1("Configure Pod Templates")
             self.printDescription([
                 "The CLI supports two pod template profiles out of the box that allow you to reconfigure MAS for either a guaranteed or best effort QoS level",

--- a/python/test/install/test_dev_mode.py
+++ b/python/test/install/test_dev_mode.py
@@ -1,0 +1,288 @@
+#!/usr/bin/env python
+# *****************************************************************************
+# Copyright (c) 2026 IBM Corporation and other Contributors.
+#
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+#
+# *****************************************************************************
+
+from utils import InstallTestConfig, run_install_test
+import sys
+import os
+import pytest
+from mas.devops.data import NoSuchCatalogError
+
+# Add test directory to path for utils import
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+
+
+def test_install_master_no_dev_mode(tmpdir):
+    """Test expected NoSuchCatalogError is raised"""
+
+    # Define prompt handlers with expected patterns and responses
+    prompt_handlers = {
+        # 1. Cluster connection
+        '.*Proceed with this cluster?.*': lambda msg: 'y',
+        # 2. Install flavour (advanced options)
+        '.*Show advanced installation options.*': lambda msg: 'n',
+        # 3. Catalog selection
+        '.*Select catalog.*': lambda msg: "v9-master-amd64"
+    }
+
+    # Create test configuration with no existing catalog
+    config = InstallTestConfig(
+        prompt_handlers=prompt_handlers,
+        current_catalog=None,  # No catalog installed
+        architecture='amd64',
+        is_sno=False,
+        is_airgap=False,
+        storage_class_name='nfs-client',
+        storage_provider='nfs',
+        storage_provider_name='NFS Client',
+        ocp_version='4.18.0',
+        timeout_seconds=30
+    )
+
+    # Run the test and expect NoSuchCatalogError to be raised
+    with pytest.raises(NoSuchCatalogError):
+        run_install_test(tmpdir, config)
+
+
+def test_install_master_dev_mode(tmpdir):
+    """Test interactive installation when no catalog is installed with --dev-mode flag."""
+
+    # Define prompt handlers with expected patterns and responses
+    prompt_handlers = {
+        # 1. Cluster connection
+        '.*Proceed with this cluster?.*': lambda msg: 'y',
+        # 2. Install flavour (advanced options)
+        '.*Show advanced installation options.*': lambda msg: 'n',
+        # 3. Catalog selection
+        '.*Select catalog.*': lambda msg: "v9-master-amd64",
+        '.*Select channel.*': lambda msg: '9.1.x-dev',
+        # 4. Storage classes
+        ".*Use the auto-detected storage classes.*": lambda msg: 'y',
+        # 5. SLS configuration
+        '.*SLS channel.*': lambda msg: '1.x-stable',
+        '.*License file.*': lambda msg: f'{tmpdir}/authorized_entitlement.lic',
+        # 6. DRO configuration
+        ".*Contact e-mail address.*": lambda msg: 'maximo@ibm.com',
+        ".*Contact first name.*": lambda msg: 'Test',
+        ".*Contact last name.*": lambda msg: 'Test',
+        # 7. ICR & Artifactory credentials
+        ".*IBM entitlement key.*": lambda msg: 'testEntitlementKey',
+        ".*Artifactory username.*": lambda msg: 'testUsername',
+        ".*Artifactory token.*": lambda msg: 'testToken',
+        # 8. MAS Instance configuration
+        '.*Instance ID.*': lambda msg: 'testinst',
+        '.*Workspace ID.*': lambda msg: 'testws',
+        '.*Workspace.*name.*': lambda msg: 'Test Workspace',
+        # 9. Operational mode
+        '.*Operational Mode.*': lambda msg: '1',
+        # 10. Application selection
+        '.*Install IoT.*': lambda msg: 'y',
+        '.*Custom channel for iot.*': lambda msg: '9.1.x-dev',
+        '.*Install Monitor.*': lambda msg: 'n',
+        '.*Install Manage.*': lambda msg: 'y',
+        '.*Custom channel for manage.*': lambda msg: '9.1.x-dev',
+        '.*Select components to enable.*': lambda msg: 'n',
+        '.*Include customization archive.*': lambda msg: 'n',
+        '.*Install Predict.*': lambda msg: 'n',
+        '.*Install Assist.*': lambda msg: 'n',
+        '.*Install Optimizer.*': lambda msg: 'n',
+        '.*Install Visual Inspection.*': lambda msg: 'n',
+        '.*Install.*Real Estate and Facilities.*': lambda msg: 'n',
+        '.*Install AI Service.*': lambda msg: 'n',
+        # 11. MongoDB configuration
+        '.*Create MongoDb cluster.*': lambda msg: 'y',
+        # 12. Db2 configuration
+        '.*Create system Db2 instance.*': lambda msg: 'y',
+        '.*Re-use System Db2 instance for Manage application.*': lambda msg: 'n',
+        '.*Create Manage dedicated Db2 instance.*': lambda msg: 'y',
+        # 13. Kafka configuration
+        '.*Create system Kafka instance.*': lambda msg: 'y',
+        '.*Kafka version.*': lambda msg: '3.8.0',
+        # 14. Final confirmation
+        '.*Use additional configurations.*': lambda msg: 'n',
+        ".*Proceed with these settings.*": lambda msg: 'y',
+    }
+
+    # Create test configuration with no existing catalog and --dev-mode flag
+    config = InstallTestConfig(
+        prompt_handlers=prompt_handlers,
+        current_catalog=None,  # No catalog installed
+        architecture='amd64',
+        is_sno=False,
+        is_airgap=False,
+        storage_class_name='nfs-client',
+        storage_provider='nfs',
+        storage_provider_name='NFS Client',
+        ocp_version='4.18.0',
+        timeout_seconds=30,
+        argv=['--dev-mode']
+    )
+
+    # Run the test
+    run_install_test(tmpdir, config)
+
+
+def test_install_master_dev_mode_existing_catalog(tmpdir):
+    """Test interactive installation when no catalog is installed with --dev-mode flag."""
+
+    # Define prompt handlers with expected patterns and responses
+    prompt_handlers = {
+        # 1. Cluster connection
+        '.*Proceed with this cluster?.*': lambda msg: 'y',
+        # 2. Install flavour (advanced options)
+        '.*Show advanced installation options.*': lambda msg: 'n',
+        # 3. Catalog selection
+        '.*Select catalog.*': lambda msg: "v9-master-amd64",
+        '.*Select channel.*': lambda msg: '9.1.x-dev',
+        # 4. Storage classes
+        ".*Use the auto-detected storage classes.*": lambda msg: 'y',
+        # 5. SLS configuration
+        '.*SLS channel.*': lambda msg: '1.x-stable',
+        '.*License file.*': lambda msg: f'{tmpdir}/authorized_entitlement.lic',
+        # 6. DRO configuration
+        ".*Contact e-mail address.*": lambda msg: 'maximo@ibm.com',
+        ".*Contact first name.*": lambda msg: 'Test',
+        ".*Contact last name.*": lambda msg: 'Test',
+        # 7. ICR & Artifactory credentials
+        ".*IBM entitlement key.*": lambda msg: 'testEntitlementKey',
+        ".*Artifactory username.*": lambda msg: 'testUsername',
+        ".*Artifactory token.*": lambda msg: 'testToken',
+        # 8. MAS Instance configuration
+        '.*Instance ID.*': lambda msg: 'testinst',
+        '.*Workspace ID.*': lambda msg: 'testws',
+        '.*Workspace.*name.*': lambda msg: 'Test Workspace',
+        # 9. Operational mode
+        '.*Operational Mode.*': lambda msg: '1',
+        # 10. Application selection
+        '.*Install IoT.*': lambda msg: 'y',
+        '.*Custom channel for iot.*': lambda msg: '9.1.x-dev',
+        '.*Install Monitor.*': lambda msg: 'n',
+        '.*Install Manage.*': lambda msg: 'y',
+        '.*Custom channel for manage.*': lambda msg: '9.1.x-dev',
+        '.*Select components to enable.*': lambda msg: 'n',
+        '.*Include customization archive.*': lambda msg: 'n',
+        '.*Install Predict.*': lambda msg: 'n',
+        '.*Install Assist.*': lambda msg: 'n',
+        '.*Install Optimizer.*': lambda msg: 'n',
+        '.*Install Visual Inspection.*': lambda msg: 'n',
+        '.*Install.*Real Estate and Facilities.*': lambda msg: 'n',
+        '.*Install AI Service.*': lambda msg: 'n',
+        # 11. MongoDB configuration
+        '.*Create MongoDb cluster.*': lambda msg: 'y',
+        # 12. Db2 configuration
+        '.*Create system Db2 instance.*': lambda msg: 'y',
+        '.*Re-use System Db2 instance for Manage application.*': lambda msg: 'n',
+        '.*Create Manage dedicated Db2 instance.*': lambda msg: 'y',
+        # 13. Kafka configuration
+        '.*Create system Kafka instance.*': lambda msg: 'y',
+        '.*Kafka version.*': lambda msg: '3.8.0',
+        # 14. Final confirmation
+        '.*Use additional configurations.*': lambda msg: 'n',
+        ".*Proceed with these settings.*": lambda msg: 'y',
+    }
+
+    # Create test configuration with no existing catalog and --dev-mode flag
+    config = InstallTestConfig(
+        prompt_handlers=prompt_handlers,
+        current_catalog={'catalogId': "v9-master-amd64"},
+        architecture='amd64',
+        is_sno=False,
+        is_airgap=False,
+        storage_class_name='nfs-client',
+        storage_provider='nfs',
+        storage_provider_name='NFS Client',
+        ocp_version='4.18.0',
+        timeout_seconds=30,
+        argv=['--dev-mode']
+    )
+
+    # Run the test
+    run_install_test(tmpdir, config)
+
+
+def test_install_master_dev_mode_non_interactive(tmpdir):
+    """Test non-interactive installation when no catalog is installed with --dev-mode flag."""
+
+    # Define prompt handlers with expected patterns and responses
+    prompt_handlers = {}
+
+    # Create test configuration with no existing catalog and --dev-mode flag
+    config = InstallTestConfig(
+        prompt_handlers=prompt_handlers,
+        current_catalog=None,  # No catalog installed
+        architecture='amd64',
+        is_sno=False,
+        is_airgap=False,
+        storage_class_name='nfs-client',
+        storage_provider='nfs',
+        storage_provider_name='NFS Client',
+        ocp_version='4.18.0',
+        timeout_seconds=30,
+        argv=[
+            "--dev-mode",
+            "--artifactory-username", "ARTIFACTORY_USERNAME",
+            "--artifactory-token", "ARTIFACTORY_TOKEN",
+            "--mas-catalog-version", "v9-master-amd64",
+            "--mas-instance-id", "fvtcore",
+            "--mas-workspace-id", "masdev",
+            "--mas-workspace-name", "MAS Development",
+            "--superuser-username", "MAS_SUPERUSER_USERNAME",
+            "--superuser-password", "MAS_SUPERUSER_PASSWORD",
+            "--mas-channel", "9.2.x-dev",
+            "--assist-channel", "9.2.x-dev",
+            "--iot-channel", "9.2.x-dev",
+            "--db2-system", "--kafka-provider", "strimzi",
+            "--monitor-channel", "9.2.x-dev",
+            "--manage-channel", "9.2.x-dev",
+            "--manage-components", "",
+            "--db2-manage", "--manage-jdbc", "workspace-application",
+            "--manage-customization-archive-name", "fvtcustomarchive",
+            "--manage-customization-archive-url", "https://ibm.com/manage-custom-archive-latest.zip",
+            "--manage-customization-archive-username", "FVT_ARTIFACTORY_USERNAME",
+            "--manage-customization-archive-password", "FVT_ARTIFACTORY_TOKEN",
+            "--optimizer-channel", "",
+            "--predict-channel", "",
+            "--visualinspection-channel", "",
+            "--facilities-channel", "",
+            "--cos", "ibm",
+            "--cos-resourcegroup", "fvt-layer3",
+            "--cos-apikey", "IBMCLOUD_APIKEY",
+            "--cos-instance-name", "Object Storage for MAS - fvtcore",
+            "--cos-bucket-name", "fvtcore-masdev-bucket-20260209-0209",
+            "--db2-channel", "rotate",
+            "--additional-configs", f"{tmpdir}",
+            "--storage-class-rwx", "ibmc-file-gold-gid",
+            "--storage-class-rwo", "ibmc-block-gold",
+            "--storage-pipeline", "ibmc-file-gold-gid",
+            "--storage-accessmode", "ReadWriteMany",
+            "--ibm-entitlement-key", "IBM_ENTITLEMENT_KEY",
+            "--license-file", f"{tmpdir}/authorized_entitlement.lic",
+            "--uds-email", "iotf@uk.ibm.com",
+            "--uds-firstname", "First",
+            "--uds-lastname", "Last",
+            "--sls-namespace", "sls-fvtcore",
+            "--sls-channel", "3.x-dev",
+            "--approval-core", "100:300:true",
+            "--approval-assist", "100:300:true",
+            "--approval-iot", "100:300:true",
+            "--approval-manage", "100:600:true",
+            "--approval-monitor", "100:300:true",
+            "--approval-optimizer", "100:300:true",
+            "--approval-predict", "100:300:true",
+            "--approval-visualinspection", "100:300:true",
+            "--approval-facilities", "100:300:true",
+            "--accept-license",
+            "--no-confirm",
+        ]
+    )
+    # Run the test
+    run_install_test(tmpdir, config)
+
+# Made with Bob

--- a/python/test/utils/prompt_tracker.py
+++ b/python/test/utils/prompt_tracker.py
@@ -30,11 +30,12 @@ class PromptTracker:
         self.prompt_handlers = prompt_handlers
         self.match_counts = {pattern: 0 for pattern in prompt_handlers.keys()}
 
-    def handle_prompt(self, **kwargs) -> str:
+    def handle_prompt(self, *args, **kwargs) -> str:
         """
         Handle a prompt by matching it against registered patterns.
 
         Args:
+            *args: Positional arguments (first arg is typically the message/HTML object)
             **kwargs: Keyword arguments containing 'message' and other prompt parameters.
 
         Returns:
@@ -43,7 +44,13 @@ class PromptTracker:
         Raises:
             AssertionError: If no pattern matches the prompt.
         """
-        message = str(kwargs['message'])
+        # Extract message from either positional args or kwargs
+        if args:
+            message = str(args[0])
+        elif 'message' in kwargs:
+            message = str(kwargs['message'])
+        else:
+            raise AssertionError(f"No message found in prompt call. Args: {args}, Kwargs: {kwargs}")
 
         # Try to match against all registered patterns
         for pattern, handler in self.prompt_handlers.items():
@@ -52,7 +59,7 @@ class PromptTracker:
                 return handler(message)
 
         # No pattern matched - fail the test with debug info
-        raise AssertionError(f"Unmatched prompt in test: {message}\nFull kwargs: {kwargs}")
+        raise AssertionError(f"Unmatched prompt in test: {message}\nFull args: {args}, kwargs: {kwargs}")
 
     def verify_all_prompts_matched(self, allow_unmatched: bool = False):
         """


### PR DESCRIPTION
Fixes an issue in the CLI in developer mode where the getCatalog function in mas-devops was changed to raise a `NoSuchCatalogError` instead of returning `None`.


Also adds four `--dev-mode` unit tests:

- No catalog installed (interactive mode)
- No catalog installed (non-interactive mode)
- Master catalog already installed (interactive mode without --dev-mode flag)
- Master catalog already installed (interactive mode with --dev-mode flag)

Also fixes an issue where `self.interactiveMode` was being used as both a boolean property and a function name.  The boolean property is now `isInteractiveMode`.