### PR TITLE
[patch] update buildx version

### DIFF
--- a/build/bin/.functions.sh
+++ b/build/bin/.functions.sh
@@ -52,7 +52,7 @@ function echo_highlight() {
 # - https://stackoverflow.com/questions/65365797/docker-buildx-exec-user-process-caused-exec-format-error
 function install_buildx() {
   mkdir -vp ~/.docker/cli-plugins/
-  curl --silent -L "https://github.com/docker/buildx/releases/download/v0.19.3/buildx-v0.19.3.linux-amd64" > ~/.docker/cli-plugins/docker-buildx
+  curl --silent -L "https://github.com/docker/buildx/releases/download/v0.31.1/buildx-v0.31.1.linux-amd64" > ~/.docker/cli-plugins/docker-buildx
   chmod a+x ~/.docker/cli-plugins/docker-buildx
 
   sudo apt-get update

--- a/build/bin/.functions.sh
+++ b/build/bin/.functions.sh
@@ -52,7 +52,7 @@ function echo_highlight() {
 # - https://stackoverflow.com/questions/65365797/docker-buildx-exec-user-process-caused-exec-format-error
 function install_buildx() {
   mkdir -vp ~/.docker/cli-plugins/
-  curl --silent -L "https://github.com/docker/buildx/releases/download/v0.11.2/buildx-v0.11.2.linux-amd64" > ~/.docker/cli-plugins/docker-buildx
+  curl --silent -L "https://github.com/docker/buildx/releases/download/v0.19.3/buildx-v0.19.3.linux-amd64" > ~/.docker/cli-plugins/docker-buildx
   chmod a+x ~/.docker/cli-plugins/docker-buildx
 
   sudo apt-get update


### PR DESCRIPTION
v0.19.3

Error:
```
Error:    Error response from daemon: client version 1.43 is too old. Minimum supported API version is 1.44, please upgrade your client to a newer version: driver not connecting
ERROR: failed to initialize builder builder-arm64 (builder-arm640): Error response from daemon: client version 1.43 is too old. Minimum supported API version is 1.44, please upgrade your client to a newer version
```