### PR TITLE
[patch] Add unittest for PR 2067

### DIFF
--- a/python/test/test_baseapp.py
+++ b/python/test/test_baseapp.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env python
+# *****************************************************************************
+# Copyright (c) 2026 IBM Corporation and other Contributors.
+#
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+#
+# *****************************************************************************
+
+import os
+from mas.cli.cli import BaseApp
+from prompt_toolkit.application import create_app_session
+from prompt_toolkit.output import DummyOutput
+
+
+def test_version():
+    """
+    Test that BaseApp.version matches the VERSION environment variable when set
+    """
+    expected_version = "100.0.0-pre.local"
+    if 'VERSION' in os.environ:
+        expected_version = os.environ['VERSION']
+
+    with create_app_session(output=DummyOutput()):
+        app = BaseApp()
+        assert app.version == expected_version, f"Expected version {expected_version}, but got {app.version}"


### PR DESCRIPTION
PR #2067 should have introduced new unit tests to cover the bug it was fixing.  This PR adds those missing tests.

## Success
```
pytest -x test/test_baseapp.py 
========================================================================================== test session starts ===========================================================================================
platform linux -- Python 3.12.12, pytest-9.0.2, pluggy-1.6.0
rootdir: /mnt/c/Users/097891866/Documents/GitHub/ibm-mas/cli/python
configfile: pytest.ini
plugins: mock-3.15.1, requests-mock-1.12.1
collected 1 item                                                                                                                                                                                         

test/test_baseapp.py .                                                                                                                                                                             [100%] 

=========================================================================================== 1 passed in 10.65s ===========================================================================================
```

## Failure
Failure is expected, as the build system hasn't ran to modify the version in the source locally.

```
VERSION=1.0.0 pytest -x test/test_baseapp.py
========================================================================================== test session starts ===========================================================================================
platform linux -- Python 3.12.12, pytest-9.0.2, pluggy-1.6.0
rootdir: /mnt/c/Users/097891866/Documents/GitHub/ibm-mas/cli/python
configfile: pytest.ini
plugins: mock-3.15.1, requests-mock-1.12.1
collected 1 item                                                                                                                                                                                         

test/test_baseapp.py F

================================================================================================ FAILURES ================================================================================================
______________________________________________________________________________________________ test_version ______________________________________________________________________________________________

    def test_version():
        """
        Test that BaseApp.version matches the VERSION environment variable when set
        """
        expected_version = "100.0.0-pre.local"
        if 'VERSION' in os.environ:
            expected_version = os.environ['VERSION']

        with create_app_session(output=DummyOutput()):
            app = BaseApp()
>           assert app.version == expected_version, f"Expected version {expected_version}, but got {app.version}"
E           AssertionError: Expected version 1.0.0, but got 100.0.0-pre.local
E           assert '100.0.0-pre.local' == '1.0.0'
E
E             - 1.0.0
E             + 100.0.0-pre.local

test/test_baseapp.py:28: AssertionError
======================================================================================== short test summary info =========================================================================================
FAILED test/test_baseapp.py::test_version - AssertionError: Expected version 1.0.0, but got 100.0.0-pre.local
!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! stopping after 1 failures !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
=========================================================================================== 1 failed in 19.19s ===========================================================================================
```