### PR TITLE
[patch] Force option in argo sync is not supported when ServerSideApply is enabled

### DIFF
--- a/image/cli/mascli/functions/gitops_utils
+++ b/image/cli/mascli/functions/gitops_utils
@@ -749,7 +749,7 @@ function argocd_sync(){
   APP_NAME=$1
   echo
   echo "Force Application $APP_NAME to Sync ..."
-  argocd app sync $APP_NAME --force --timeout 30 --assumeYes --grpc-web
+  argocd app sync $APP_NAME --timeout 30 --assumeYes --grpc-web
   RC=$?
   echo "ArgoCD response for Force Application $APP_NAME to Sync: $RC"
 }


### PR DESCRIPTION
## Description
Recently when gitops operator was upgraded, we enabled ServerSideApply to fix a large annotation error
For FVT testing, argo app sync force option cannot be used since we have enabled ServerSideApply. 
Even though FVT tests has run successfully, because of this force option, sync is failing and hence needs to be removed