### PR TITLE
[patch] Omit optional db2 backup fields for gitops

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,5 @@ python/README.rst
 /.venv-docs
 /mkdocs_plugins/mkdocs_mas_plugins.egg-info
 rbac-install.yaml
+
+.venv

--- a/image/cli/mascli/templates/gitops/appset-configs/cluster/instance/db2-databases/ibm-db2u-database.yaml.j2
+++ b/image/cli/mascli/templates/gitops/appset-configs/cluster/instance/db2-databases/ibm-db2u-database.yaml.j2
@@ -125,8 +125,12 @@ db2_backup_bucket_name: <path:{{ SECRETS_PATH }}:{{ DB2_BACKUP_BUCKET_NAME }}>
 db2_backup_bucket_endpoint: <path:{{ SECRETS_PATH }}:{{ DB2_BACKUP_BUCKET_ENDPOINT }}>
 db2_backup_bucket_access_key: <path:{{ SECRETS_PATH }}:{{ SECRET_KEY_DB2_BACKUP_BUCKET_ACCESS_KEY }}>
 db2_backup_bucket_secret_key: <path:{{ SECRETS_PATH }}:{{ SECRET_KEY_DB2_BACKUP_BUCKET_SECRET_KEY }}>
+
+{% if SKIP_BACKUP_NOTIFICATION != 'true' %}
 db2_backup_notify_slack_url: {{DB2_BACKUP_NOTIFY_SLACK_URL}}
 db2_backup_icd_auth_key: <path:{{ SECRETS_PATH }}:{{ SECRET_KEY_DB2_BACKUP_ICD_AUTH_KEY }}>
+{% endif %}
+
 {% endif %}
 
 {% if ALLOW_LIST is defined and ALLOW_LIST != '' %}


### PR DESCRIPTION
## Description

In `gitops_db2u_database`, when  the `SKIP_BACKUP_NOTIFICATION` flag is set the associated `db2_backup_notify_slack_url` and `db2_backup_icd_auth_key` properties are not necessary and so should be omitted from the generated `ibm-db2-databases.yaml` configuration file.

NOTE: This change is more than just cleaning up unused properties; if the `SKIP_BACKUP_NOTIFICATION` flag is set and the `db2_backup_icd_auth_key` property is not omitted, it will likely end up referencing a secret that does not exist and so will prevent ArgoCD from being able to render the application's Helm chart.

## Testing

Verified that running `gitops_db2_database` with the `SKIP_BACKUP_NOTIFICATION` flag set successfully generates `ibm-db2u-databases.yaml` with`db2_backup_notify_slack_url` and  `db2_backup_icd_auth_key` omitted as expected.


Verified that running `gitops_db2_database` with the `SKIP_BACKUP_NOTIFICATION` flag unset (the default) successfully generates `ibm-db2u-databases.yaml` with the `db2_backup_notify_slack_url` and  `db2_backup_icd_auth_key` properties present as expected.
