### PR TITLE
[patch] Update catalogs table with v9 release details

### DIFF
--- a/docs/catalogs/index.md
+++ b/docs/catalogs/index.md
@@ -104,11 +104,11 @@ Note: The Red Hat Extended Update Support Add-on Term 1 offering is included wit
           <td style="font-style: italic">N/A</td>
         </tr>
         <tr>
-          <td style="font-style: italic">v9-260226</td>
-          <td style="font-style: italic">TBD</td>
-          <td style="font-style: italic">TBD</td>
-          <td style="font-style: italic">TBD</td>
-          <td style="font-style: italic">N/A</td>
+          <td><span style="font-weight: bold">v9-260226</span><br/><a href="v9-260226-amd64/">amd64</a> | <a href="v9-260226-s390x/">s390x</a> | <a href="v9-260226-ppc64le/">ppc64le</a></td>
+          <td><span style="font-weight: bold">4.16 - 4.20</span><br/><a href="https://access.redhat.com/support/policy/updates/openshift" target="_blank">EOS Feb 25, 2027 ↗</a></td>
+          <td>5.2.0</td>
+          <td>7.0 - 8.0</td>
+          <td>latest</td>
         </tr>
         <tr>
           <td><span style="font-weight: bold">v9-260129</span><br/><a href="v9-260129-amd64/">amd64</a> | <a href="v9-260129-s390x/">s390x</a> | <a href="v9-260129-ppc64le/">ppc64le</a></td>
@@ -145,14 +145,14 @@ Note: The Red Hat Extended Update Support Add-on Term 1 offering is included wit
           <td><span style="font-weight: bold">4.16 - 4.19</span><br/><a href="https://access.redhat.com/support/policy/updates/openshift" target="_blank">EOS Feb 25, 2027 ↗</a></td>
           <td>5.2.0</td>
           <td>7.0 - 8.0</td>
-          <td>latest</td>
+          <td>18.4.0</td>
         </tr>
         <tr>
           <td><span style="font-weight: bold">v9-251127</span><br/><a href="v9-251127-amd64/">amd64</a> | <a href="v9-251127-s390x/">s390x</a> | <a href="v9-251127-ppc64le/">ppc64le</a></td>
           <td><span style="font-weight: bold">4.16 - 4.19</span><br/><a href="https://access.redhat.com/support/policy/updates/openshift" target="_blank">EOS Feb 25, 2027 ↗</a></td>
           <td>5.1.3</td>
           <td>7.0 - 8.0</td>
-          <td>latest</td>
+          <td>17.2.0</td>
         </tr>
         <tr>
           <td><span style="font-weight: bold">v9-251030</span><br/><a href="v9-251030-amd64/">amd64</a> | <a href="v9-251030-s390x/">s390x</a> | <a href="v9-251030-ppc64le/">ppc64le</a></td>


### PR DESCRIPTION
Populate the catalogs table in docs/catalogs/index.md for several v9 releases: add architecture links and concrete values for v9-260226 (arch links, kernel range 4.16–4.20 with EOS link/date, 5.2.0, 7.0–8.0, latest) and replace placeholder "latest" entries with explicit versions for v9-260129 (18.4.0) and v9-251127 (17.2.0). This replaces TBD/italic placeholders with actual release data for clearer documentation.