### PR TITLE
[doc] Add compatibility reports note to catalogs

### DIFF
--- a/docs/catalogs/v9-260216-amd64.md
+++ b/docs/catalogs/v9-260216-amd64.md
@@ -63,6 +63,11 @@ By default an in-cluster MongoDb (CE) instance will be created when you install 
 
 [Amazon DocumentDB](https://aws.amazon.com/documentdb/) provides [MongoDb compatability](https://docs.aws.amazon.com/documentdb/latest/developerguide/compatibility.html) and may be used as an alternative to MongoDb.  This catalog is certified compatible with **DocumentDb Engine Version v5.0.0**.
 
+Software Product Compatibility Reports
+-------------------------------------------------------------------------------
+Please refer to the official compatibility reports by searching for “Maximo Application Suite” using [link](https://www.ibm.com/software/reports/compatibility/clarity/index.html). to review the complete list of compatibility requirements. Services that are not explicitly listed are not supported.
+
+
 Package Manifest
 -------------------------------------------------------------------------------
 

--- a/docs/catalogs/v9-260226-amd64.md
+++ b/docs/catalogs/v9-260226-amd64.md
@@ -63,6 +63,11 @@ By default an in-cluster MongoDb (CE) instance will be created when you install 
 
 [Amazon DocumentDB](https://aws.amazon.com/documentdb/) provides [MongoDb compatability](https://docs.aws.amazon.com/documentdb/latest/developerguide/compatibility.html) and may be used as an alternative to MongoDb.  This catalog is certified compatible with **DocumentDb Engine Version v5.0.0**.
 
+Software Product Compatibility Reports
+-------------------------------------------------------------------------------
+Please refer to the official compatibility reports by searching for “Maximo Application Suite” using [link](https://www.ibm.com/software/reports/compatibility/clarity/index.html). to review the complete list of compatibility requirements. Services that are not explicitly listed are not supported.
+
+
 Package Manifest
 -------------------------------------------------------------------------------
 


### PR DESCRIPTION
Insert a "Software Product Compatibility Reports" section into two catalog docs (v9-260216-amd64.md and v9-260226-amd64.md). The new note directs users to IBM's compatibility reports (search for “Maximo Application Suite” at the provided IBM link) to review full compatibility requirements and clarifies that services not explicitly listed are not supported.