### PR TITLE
[patch] Fix Grafana flow in interactive and non-interactive mode

### DIFF
--- a/python/src/mas/cli/install/app.py
+++ b/python/src/mas/cli/install/app.py
@@ -388,30 +388,33 @@ class InstallApp(BaseApp, InstallSettingsMixin, InstallSummarizerMixin, ConfigGe
             # We are not supporting Grafana on s390x /ppc64le at the moment
             self.setParam("grafana_action", "none")
         else:
-            try:
-                # Check if dynamicClient is available and resources.get() returns a valid API
-                if self.dynamicClient is None:
-                    self.setParam("grafana_action", "none")
-                else:
-                    packagemanifestAPI = self.dynamicClient.resources.get(api_version="packages.operators.coreos.com/v1", kind="PackageManifest")
-                    if packagemanifestAPI is None:
+            if self.isInteractiveMode and not self.yesOrNo("Install Grafana"):
+                self.setParam("grafana_action", "none")
+            else:
+                try:
+                    # Check if dynamicClient is available and resources.get() returns a valid API
+                    if self.dynamicClient is None:
                         self.setParam("grafana_action", "none")
                     else:
-                        packagemanifestAPI.get(name="grafana-operator", namespace="openshift-marketplace")
-                        if self.skipGrafanaInstall:
+                        packagemanifestAPI = self.dynamicClient.resources.get(api_version="packages.operators.coreos.com/v1", kind="PackageManifest")
+                        if packagemanifestAPI is None:
                             self.setParam("grafana_action", "none")
                         else:
-                            self.setParam("grafana_action", "install")
-            except NotFoundError:
-                self.setParam("grafana_action", "none")
+                            packagemanifestAPI.get(name="grafana-operator", namespace="openshift-marketplace")
+                            if self.skipGrafanaInstall:
+                                self.setParam("grafana_action", "none")
+                            else:
+                                self.setParam("grafana_action", "install")
+                except NotFoundError:
+                    self.setParam("grafana_action", "none")
 
-            if self.isInteractiveMode and self.showAdvancedOptions:
-                self.printH1("Configure Grafana")
-                if self.getParam("grafana_action") == "none":
-                    print_formatted_text("The Grafana operator package is not available in any catalogs on the target cluster, the installation of Grafana will be disabled")
-                else:
-                    self.promptForString("Install namespace", "grafana_v5_namespace", default="grafana5")
-                    self.promptForString("Grafana storage size", "grafana_instance_storage_size", default="10Gi")
+                if self.isInteractiveMode and self.showAdvancedOptions:
+                    self.printH1("Configure Grafana")
+                    if self.getParam("grafana_action") == "none":
+                        print_formatted_text("The Grafana operator package is not available in any catalogs on the target cluster, the installation of Grafana will be disabled")
+                    else:
+                        self.promptForString("Install namespace", "grafana_v5_namespace", default="grafana5")
+                        self.promptForString("Grafana storage size", "grafana_instance_storage_size", default="10Gi")
 
     @logMethodCall
     def arcgisSettings(self) -> None:

--- a/python/src/mas/cli/install/argBuilder.py
+++ b/python/src/mas/cli/install/argBuilder.py
@@ -187,6 +187,15 @@ class installArgBuilderMixin():
         if self.getParam('ocp_ingress') != "":
             command += f"  --ocp-ingress \"{self.getParam('ocp_ingress')}\"{newline}"
 
+        # Grafana
+        # -----------------------------------------------------------------------------
+        if self.getParam('skip_grafana_install') is True:
+            command += f"  --skip-grafana-install{newline}"
+        if self.getParam('grafana_v5_namespace') != "":
+            command += f"  --grafana-v5-namespace \"{self.getParam('grafana_v5_namespace')}\"{newline}"
+        if self.getParam('grafana_instance_storage_size') != "":
+            command += f"  --grafana-instance-storage-size \"{self.getParam('grafana_instance_storage_size')}\"{newline}"
+
         # MAS Applications
         # -----------------------------------------------------------------------------
         if self.installAssist:
@@ -573,8 +582,6 @@ class installArgBuilderMixin():
             command += f"  --dev-mode{newline}"
         if self.getParam('skip_pre_check') is True:
             command += f"  --skip-pre-check{newline}"
-        if self.getParam('skip_grafana_install') is True:
-            command += f"  --skip-grafana-install{newline}"
         if self.getParam('image_pull_policy') != "":
             command += f"  --image-pull-policy {self.getParam('image_pull_policy')}{newline}"
         if self.getParam('service_account_name') != "":

--- a/python/src/mas/cli/install/argParser.py
+++ b/python/src/mas/cli/install/argParser.py
@@ -434,6 +434,31 @@ ocpArgGroup.add_argument(
     help="Name of the secret holding the cluster's ingress certificates"
 )
 
+# Grafana
+# -----------------------------------------------------------------------------
+grafanaArgGroup = installArgParser.add_argument_group(
+    "Grafana",
+    "Configure Grafana installation, namespace and storage size."
+)
+grafanaArgGroup.add_argument(
+    "--skip-grafana-install",
+    required=False,
+    action="store_true",
+    help="Skip Grafana installation"
+)
+grafanaArgGroup.add_argument(
+    "--grafana-v5-namespace",
+    required=False,
+    help="Customize the Grafana namespace",
+    default="grafana5"
+)
+grafanaArgGroup.add_argument(
+    "--grafana-instance-storage-size",
+    required=False,
+    help="Customize the Grafana storage size",
+    default="10Gi"
+)
+
 # MAS Applications
 # -----------------------------------------------------------------------------
 masAppsArgGroup = installArgParser.add_argument_group(
@@ -1523,7 +1548,7 @@ approvalsGroup.add_argument(
 # -----------------------------------------------------------------------------
 otherArgGroup = installArgParser.add_argument_group(
     "More",
-    "Additional options including advanced/simplified mode toggles, license acceptance, development mode, Artifactory credentials, PVC wait control, pre-check skip, Grafana installation, confirmation prompts, image pull policy, and custom service account."
+    "Additional options including advanced/simplified mode toggles, license acceptance, development mode, Artifactory credentials, PVC wait control, pre-check skip, confirmation prompts, image pull policy, and custom service account."
 )
 otherArgGroup.add_argument(
     "--artifactory-username",
@@ -1566,12 +1591,6 @@ otherArgGroup.add_argument(
     required=False,
     action="store_true",
     help="Disable the 'pre-install-check' at the start of the install pipeline"
-)
-otherArgGroup.add_argument(
-    "--skip-grafana-install",
-    required=False,
-    action="store_true",
-    help="Skip Grafana installation"
 )
 otherArgGroup.add_argument(
     "--no-confirm",

--- a/python/src/mas/cli/install/params.py
+++ b/python/src/mas/cli/install/params.py
@@ -215,5 +215,10 @@ optionalParams = [
     "environment_type",
 
     # Certificate Issuer
-    "aiservice_certificate_issuer"
+    "aiservice_certificate_issuer",
+
+    # Grafana
+    "skip_grafana_install",
+    "grafana_v5_namespace",
+    "grafana_instance_storage_size"
 ]

--- a/python/src/mas/cli/install/summarizer.py
+++ b/python/src/mas/cli/install/summarizer.py
@@ -403,7 +403,12 @@ class InstallSummarizerMixin():
 
     def grafanaSummary(self) -> None:
         self.printH2("Grafana")
-        self.printSummary("Install Grafana", "Install" if self.getParam("grafana_action") == "install" else "Do Not Install")
+        if self.getParam("grafana_action") == "install":
+            self.printSummary("Install Grafana", "Install")
+            self.printParamSummary("Grafana namespace","grafana_v5_namespace")
+            self.printParamSummary("Grafana storage size","grafana_instance_storage_size")
+        else:
+            self.printSummary("Install Grafana", "Do Not Install")
 
     def installSummary(self) -> None:
         pass

--- a/python/src/mas/cli/install/summarizer.py
+++ b/python/src/mas/cli/install/summarizer.py
@@ -405,8 +405,8 @@ class InstallSummarizerMixin():
         self.printH2("Grafana")
         if self.getParam("grafana_action") == "install":
             self.printSummary("Install Grafana", "Install")
-            self.printParamSummary("Grafana namespace","grafana_v5_namespace")
-            self.printParamSummary("Grafana storage size","grafana_instance_storage_size")
+            self.printParamSummary("Grafana namespace", "grafana_v5_namespace")
+            self.printParamSummary("Grafana storage size", "grafana_instance_storage_size")
         else:
             self.printSummary("Install Grafana", "Do Not Install")
 

--- a/python/test/install/test_dev_mode.py
+++ b/python/test/install/test_dev_mode.py
@@ -301,6 +301,8 @@ def test_install_master_dev_mode_with_path_routing(tmpdir):
         '.*Install Visual Inspection.*': lambda msg: 'n',
         '.*Install.*Real Estate and Facilities.*': lambda msg: 'n',
         '.*Install AI Service.*': lambda msg: 'n',
+        # 20a. Grafana configuration (appears when advanced options are enabled)
+        '.*Install Grafana.*': lambda msg: 'y',
         # 21. MongoDB configuration
         '.*MongoDb namespace.*': lambda msg: 'mongoce',  # Use default MongoDB namespace
         '.*Create MongoDb cluster.*': lambda msg: 'y',

--- a/python/test/install/test_dev_mode.py
+++ b/python/test/install/test_dev_mode.py
@@ -96,6 +96,8 @@ def test_install_master_dev_mode(tmpdir):
         '.*Install Visual Inspection.*': lambda msg: 'n',
         '.*Install.*Real Estate and Facilities.*': lambda msg: 'n',
         '.*Install AI Service.*': lambda msg: 'n',
+        # 10a. Grafana configuration
+        '.*Install Grafana.*': lambda msg: 'y',
         # 11. MongoDB configuration
         '.*Create MongoDb cluster.*': lambda msg: 'y',
         # 12. Db2 configuration
@@ -174,6 +176,8 @@ def test_install_master_dev_mode_existing_catalog(tmpdir):
         '.*Install Visual Inspection.*': lambda msg: 'n',
         '.*Install.*Real Estate and Facilities.*': lambda msg: 'n',
         '.*Install AI Service.*': lambda msg: 'n',
+        # 10a. Grafana configuration
+        '.*Install Grafana.*': lambda msg: 'y',
         # 11. MongoDB configuration
         '.*Create MongoDb cluster.*': lambda msg: 'y',
         # 12. Db2 configuration
@@ -397,6 +401,9 @@ def test_install_master_dev_mode_non_interactive(tmpdir):
             "--cos-instance-name", "Object Storage for MAS - fvtcore",
             "--cos-bucket-name", "fvtcore-masdev-bucket-20260209-0209",
             "--db2-channel", "rotate",
+            "--skip-grafana-install",
+            "--grafana-v5-namespace", "grafana5",
+            "--grafana-instance-storage-size", "10Gi",
             "--additional-configs", f"{tmpdir}",
             "--storage-class-rwx", "ibmc-file-gold-gid",
             "--storage-class-rwo", "ibmc-block-gold",
@@ -484,6 +491,9 @@ def test_install_master_dev_mode_non_interactive_with_path_routing(tmpdir):
             "--cos-instance-name", "Object Storage for MAS - fvtcore",
             "--cos-bucket-name", "fvtcore-masdev-bucket-20260209-0209",
             "--db2-channel", "rotate",
+            "--skip-grafana-install",
+            "--grafana-v5-namespace", "grafana5",
+            "--grafana-instance-storage-size", "10Gi",
             "--additional-configs", f"{tmpdir}",
             "--storage-class-rwx", "ibmc-file-gold-gid",
             "--storage-class-rwo", "ibmc-block-gold",

--- a/python/test/install/test_existing_catalog.py
+++ b/python/test/install/test_existing_catalog.py
@@ -59,6 +59,8 @@ def test_install_interactive_existing_catalog(tmpdir):
         '.*Install Visual Inspection.*': lambda msg: 'n',
         '.*Install.*Real Estate and Facilities.*': lambda msg: 'n',
         '.*Install AI Service.*': lambda msg: 'n',
+        # 11a. Grafana configuration
+        '.*Install Grafana.*': lambda msg: 'y',
         # 12. MongoDB configuration
         '.*Create MongoDb cluster.*': lambda msg: 'y',
         # 13. Db2 configuration

--- a/python/test/install/test_no_catalog.py
+++ b/python/test/install/test_no_catalog.py
@@ -60,6 +60,8 @@ def test_install_interactive_no_catalog(tmpdir):
         '.*Install Visual Inspection.*': lambda msg: 'n',
         '.*Install.*Real Estate and Facilities.*': lambda msg: 'n',
         '.*Install AI Service.*': lambda msg: 'n',
+        # 12a. Grafana configuration
+        '.*Install Grafana.*': lambda msg: 'y',
         # 12. MongoDB configuration
         '.*Create MongoDb cluster.*': lambda msg: 'y',
         # 13. Db2 configuration


### PR DESCRIPTION
## Descripton

A customer raised the need to be able to set the Grafana namespace and storage size in non-interactive mode. Also there was no option to skip Grafana install when in interactive mode.

## Related issues
- https://github.com/ibm-mas/cli/issues/2089
- https://github.com/ibm-mas/cli/issues/2090
