### PR TITLE
[patch] env var defaults should not be overrides

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "build/bin/config/oscap/ssg-rhel9-ds.xml|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2026-03-02T14:44:59Z",
+  "generated_at": "2026-03-03T15:13:46Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -264,7 +264,7 @@
         "hashed_secret": "1459943ba5fd876f7ef6e48f566a40b448a2bf08",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 491,
+        "line_number": 490,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/image/cli/mascli/functions/gitops_db2u_database
+++ b/image/cli/mascli/functions/gitops_db2u_database
@@ -405,8 +405,7 @@ function gitops_db2u_database() {
   # as both of these scrtipts modify the same file
   GIT_LOCK_BRANCH=$(git_lock_branch_name "gitops-db2u-database" "${ACCOUNT_ID}" "${CLUSTER_ID}" "${MAS_INSTANCE_ID}")
 
-  export SECRET_NAME_DB2_BACKUP=${ACCOUNT_ID}${SECRETS_KEY_SEPERATOR}${CLUSTER_ID}${SECRETS_KEY_SEPERATOR}${MAS_INSTANCE_ID}${SECRETS_KEY_SEPERATOR}db2_backup
-  export SECRET_NAME_ICD_AUTH_KEY=${ACCOUNT_ID}${SECRETS_KEY_SEPERATOR}${CLUSTER_ID}${SECRETS_KEY_SEPERATOR}icd
+
 
   #Defaults
   if [[ -z $DB2_TLS_VERSION ]]; then
@@ -505,6 +504,12 @@ DB2_WORKLOAD: '${DB2_WORKLOAD}'"
     else
       export DB2_INSTANCE_NAME=db2wh-${MAS_INSTANCE_ID}-${MAS_APP_ID}
     fi
+  fi
+  if [[ -z $SECRET_NAME_DB2_BACKUP ]]; then
+    export SECRET_NAME_DB2_BACKUP=${ACCOUNT_ID}${SECRETS_KEY_SEPERATOR}${CLUSTER_ID}${SECRETS_KEY_SEPERATOR}${MAS_INSTANCE_ID}${SECRETS_KEY_SEPERATOR}db2_backup
+  fi
+  if [[ -z $SECRET_NAME_ICD_AUTH_KEY ]]; then
+    export SECRET_NAME_ICD_AUTH_KEY=${ACCOUNT_ID}${SECRETS_KEY_SEPERATOR}${CLUSTER_ID}${SECRETS_KEY_SEPERATOR}icd
   fi
   if [[ -z $DB2_BACKUP_BUCKET_NAME ]]; then
     export DB2_BACKUP_BUCKET_NAME=${SECRET_NAME_DB2_BACKUP}#bucketName


### PR DESCRIPTION
Allows the following env vars to be set to non-default values when required:
- SECRET_NAME_DB2_BACKUP
- SECRET_NAME_ICD_AUTH_KEY

If unset, these values will default to the same value as before the changes in this PR were made, so existing users of the gitops_db2u_databases function will not be affected. I also checked that neither of these values are set explicitly in the commercial pipelines - meaning that we are not relying on the override to "fix" bad values mistakenly set in the pipelines.