### PR TITLE
[patch] remove extra double quote in command when --allow-special-chars is set

### DIFF
--- a/python/src/mas/cli/install/argBuilder.py
+++ b/python/src/mas/cli/install/argBuilder.py
@@ -62,7 +62,7 @@ class installArgBuilderMixin():
         command += f" --mas-workspace-name \"{self.getParam('mas_workspace_name')}\"{newline}"
 
         if self.getParam('mas_special_characters') == "true":
-            command += f" --allow-special-chars \"{newline}"
+            command += f" --allow-special-chars {newline}"
 
         # ECK Integration
         # -----------------------------------------------------------------------------


### PR DESCRIPTION
## Description:
There is an extra double quote is getting added to the interactive command displayed like this 
```
mas install --mas-catalog-version v9-260129-amd64 --ibm-entitlement-key $IBM_ENTITLEMENT_KEY \
  --mas-channel 9.1.x --mas-instance-id dev01 --mas-workspace-id wsdev01 --mas-workspace-name "Dev_01_Workspace" \
 --allow-special-chars " \
```
after running the command interactively. Fixed by removign the quote from the displaying command

## Issue:
There is a customer case opened related to this.
- https://jsw.ibm.com/browse/MASCORE-12694

## Test
Here's the command after fixing.
```
mas install --mas-catalog-version v9-260226-amd64 --ibm-entitlement-key $IBM_ENTITLEMENT_KEY \
  --mas-channel 9.1.x --mas-instance-id test1 --mas-workspace-id masdev --mas-workspace-name "masdev" \
 --allow-special-chars  \
  --additional-configs "/mnt/home" \
  --non-prod \
  --disable-ca-trust \
  --disable-walkme \
  --disable-feature-usage \
  --disable-usability-metrics \
  --disable-deployment-progression \
  --storage-class-rwo "" --storage-class-rwx "" \
  --storage-pipeline "" --storage-accessmode "ReadWriteMany" \
  --contact-email "" --contact-firstname "" --contact-lastname "" \
  --dro-namespace "redhat-marketplace" \
  --mongodb-namespace "mongoce" \
  --manage-channel "9.1.x" \
  --manage-jdbc "workspace-application" \
  --manage-components "" \
  --manage-base-language "EN" \
  --manage-secondary-languages "EN" \
  --manage-server-timezone "GMT" \
  --accept-license --no-confirm
```