### PR TITLE
[patch] FVT - sync window not deleted properly

### DIFF
--- a/tekton/src/tasks/gitops/gitops-mas-fvt-preparer.yml.j2
+++ b/tekton/src/tasks/gitops/gitops-mas-fvt-preparer.yml.j2
@@ -736,7 +736,7 @@ spec:
 
         # Remove argocd window
         argocd_login
-        ARGOWINDOW=$(argocd proj windows list mas | grep "$CLUSTER_NAME.$MAS_INSTANCE_ID\b" | cut -c1-1)
+        ARGOWINDOW=$(argocd proj windows list mas | grep "$CLUSTER_NAME.$MAS_INSTANCE_ID\b" | sed 's/%!(EXTRA.*)//' | cut -c1-1)
         echo "argo:argocd proj windows delete mas $ARGOWINDOW"
         argocd proj windows delete mas $ARGOWINDOW --grpc-web
 


### PR DESCRIPTION
Issue: [MASCORE-12682](https://jsw.ibm.com/browse/MASCORE-12682)

## Description
Sync window for fvtsaas2 is not deleted properly
This is mainly because of the difference in argocd cli version(v3.2.0+66b2f30) and server version(v3.0.23+7cedae7)