### PR TITLE
[patch] Remove unnecessary RDS parameters from gitops-mas-apps

### DIFF
--- a/tekton/src/pipelines/gitops/gitops-mas-apps.yml.j2
+++ b/tekton/src/pipelines/gitops/gitops-mas-apps.yml.j2
@@ -871,14 +871,8 @@ spec:
           value: iot
         - name: jdbc_connection_url_additional_params
           value: $(params.jdbc_connection_url_additional_params_iot)
-        - name: db2_instance_registry_yaml
-          value: $(params.db2_instance_registry_yaml_iot)
-        - name: db2_instance_dbm_config_yaml
-          value: $(params.db2_instance_dbm_config_yaml_iot)
         - name: db2_database_db_config_yaml
           value: $(params.db2_database_db_config_yaml_iot)
-        - name: db2_addons_audit_config_yaml
-          value: $(params.db2_addons_audit_config_yaml_iot)
 
       workspaces:
         - name: configs
@@ -1080,14 +1074,8 @@ spec:
           value: $(params.replica_db_manage)
         - name: jdbc_connection_url_additional_params
           value: $(params.jdbc_connection_url_additional_params_manage)
-        - name: db2_instance_registry_yaml
-          value: $(params.db2_instance_registry_yaml_manage)
-        - name: db2_instance_dbm_config_yaml
-          value: $(params.db2_instance_dbm_config_yaml_manage)
         - name: db2_database_db_config_yaml
           value: $(params.db2_database_db_config_yaml_manage)
-        - name: db2_addons_audit_config_yaml
-          value: $(params.db2_addons_audit_config_yaml_manage)
       workspaces:
         - name: configs
           workspace: configs
@@ -1424,15 +1412,9 @@ spec:
           value: $(params.replica_db_facilities)
         - name: jdbc_connection_url_additional_params
           value: $(params.jdbc_connection_url_additional_params_facilities)
-        - name: db2_instance_registry_yaml
-          value: $(params.db2_instance_registry_yaml_facilities)
-        - name: db2_instance_dbm_config_yaml
-          value: $(params.db2_instance_dbm_config_yaml_facilities)
         - name: db2_database_db_config_yaml
           value: $(params.db2_database_db_config_yaml_facilities)
-        - name: db2_addons_audit_config_yaml
-          value: $(params.db2_addons_audit_config_yaml_facilities)
-
+      
       workspaces:
         - name: configs
           workspace: configs


### PR DESCRIPTION
Removes unnecessary RDS-related parameters from `gitops-mas-apps.yaml` for a cleaner configuration in `CLI` repository.