### PR TITLE
[patch] Update Backend.tf bucket with repo in IaC Automation

### DIFF
--- a/image/cli/mascli/templates/gitops/appset-configs/cluster/instance/ibm-iac-backend.tf.j2
+++ b/image/cli/mascli/templates/gitops/appset-configs/cluster/instance/ibm-iac-backend.tf.j2
@@ -2,7 +2,7 @@
   "terraform": {
     "backend": {
       "s3": {
-        "bucket": "mas-aws-build",
+        "bucket": "{{GITHUB_REPO}}",
         "key": "mas-instance/{{MAS_INSTANCE_ID}}/terraform.tfstate",
         "region": "{{REGION_NAME}}",
         "use_lockfile": true


### PR DESCRIPTION
## Changes:
Bucket name needs to be same as Github Repo, instead of mas-aws-build always.


