### PR TITLE
[patch] show prompt for clean workspace in restore

### DIFF
--- a/python/src/mas/cli/restore/app.py
+++ b/python/src/mas/cli/restore/app.py
@@ -171,6 +171,9 @@ class RestoreApp(BaseApp):
 
             self.promptForDownloadConfiguration()
 
+            # Prompt for clean backup option if not provided
+            self.promptForCleanBackup()
+
         # Set default values for optional parameters if not provided
         self.setDefaultParams()
         self.setNonInteractiveDROParams()
@@ -575,13 +578,17 @@ class RestoreApp(BaseApp):
                 artifactoryRepository = self.promptForString("Artifactory Repository")
                 self.setParam("artifactory_repository", artifactoryRepository)
 
-            cleanBackup = self.yesOrNo("Clean the downloaded backup files after completion")
-            if cleanBackup:
-                self.setParam("clean_backup", "true")
-            else:
-                self.setParam("clean_backup", "false")
         else:
             self.setParam("download_backup", "false")
+
+    def promptForCleanBackup(self):
+        self.printH1("Workspace Cleanup Configuration")
+        cleanBackup = self.yesOrNo("Clean the workspace(pvc) after completion")
+        if cleanBackup:
+            self.setParam("clean_backup", "true")
+        else:
+            self.setParam("clean_backup", "false")
+
 
     def promptForManageAppRestore(self) -> None:
         """Prompt user for Manage application restore configuration"""

--- a/python/src/mas/cli/restore/app.py
+++ b/python/src/mas/cli/restore/app.py
@@ -589,7 +589,6 @@ class RestoreApp(BaseApp):
         else:
             self.setParam("clean_backup", "false")
 
-
     def promptForManageAppRestore(self) -> None:
         """Prompt user for Manage application restore configuration"""
         self.printH1("Manage Application Restore")


### PR DESCRIPTION
Changes:

- clean_backup param is now passed to pipelinrun (python-devops PR - https://github.com/ibm-mas/python-devops/pull/239), previously it was just using the default `true` and always executing cleanup.
- In Restore, Show prompt for workspace cleanup even when download is not done. this will help preserve the backup files in the pvc if user wants to preserve the files in the pvc.


Tests:

Now cleanup is skipped in backup flow and restore flow
<img width="908" height="448" alt="Screenshot 2026-03-26 at 10 23 31" src="https://github.com/user-attachments/assets/4203009d-bac6-4e75-b364-46e6b02d9eb6" />

<img width="842" height="481" alt="Screenshot 2026-03-26 at 10 24 23" src="https://github.com/user-attachments/assets/81d72039-1365-437b-9833-373233c93a1b" />

------------------------------------------------------------------------------------------------------------------

Interactive for restore shows prompt for cleanup 

<img width="621" height="266" alt="Screenshot 2026-03-26 at 10 25 49" src="https://github.com/user-attachments/assets/c88c3360-5906-4daf-9d18-4cd7677aafbf" />

