### PR TITLE
[patch] Fix CP4D deprovisioning in gitops

### DIFF
--- a/tekton/src/pipelines/gitops/gitops-mas-apps.yml.j2
+++ b/tekton/src/pipelines/gitops/gitops-mas-apps.yml.j2
@@ -498,6 +498,7 @@ spec:
       type: string
     - name: cp4d_action
       type: string
+      default: ""
     - name: cpfs_size
       type: string
       default: "small"
@@ -3201,4 +3202,4 @@ spec:
       when:
         - input: "$(params.cp4d_action)"
           operator: in
-          values: ["uninstall"]
+          values: ["uninstall", ""]


### PR DESCRIPTION
**Issue**
https://jsw.ibm.com/browse/MASCORE-12828

**Description**
gitops-deprovision-cp4d wasn't getting invoked during the pipeline execution resulting in cp4d.yaml not getting deleted. Added a default value to cp4d_action in order to solve this.

File to be deleted: https://github.ibm.com/maximoappsuite/gitops-envs/blob/master/fyre-noble8-dev/noble8/nivtest/ibm-cp4d.yaml

Pipeline to monitor: https://cloud.ibm.com/devops/pipelines/tekton/8bb11078-2a03-43b2-9d30-df3ea17af143/runs?env_id=ibm:yp:us-south&triggerName=noble8

**Test Result**
https://github.ibm.com/maximoappsuite/gitops-envs/commit/232236d3ad861d84cfc38f7df3aca0ef415d5866
