### PR TITLE
[patch] Add scheduler-crews tests to phase5

### DIFF
--- a/tekton/src/pipelines/taskdefs/fvt-manage/phase5.yml.j2
+++ b/tekton/src/pipelines/taskdefs/fvt-manage/phase5.yml.j2
@@ -5,6 +5,7 @@
 # - fvt-manage-base-ui-directprint (selenium)
 # - fvt-manage-base-ui-adhoc-report (selenium)
 # - fvt-manage-base-ui-userprofile (cypress)
+# - fvt-manage-base-ui-scheduler-crews (cypress)
 # - fvt-manage-base-ui-scheduler-scheduling (cypress)
 # - fvt-manage-base-ui-scheduler-dispatching (cypress)
 # - fvt-manage-base-ui-scheduler-planning (cypress)
@@ -110,6 +111,24 @@
     - fvt-manage-base-ui-communication-temp
     - fvt-manage-base-ui-scheduler-classic
 
+# Scheduler Crews Cypress test
+- name: fvt-manage-base-ui-scheduler-crews
+  {{ lookup('template', 'taskdefs/fvt-manage/ui-cypress/taskref.yml.j2') | indent(2) }}
+  params:
+    {{ lookup('template', pipeline_src_dir ~ '/taskdefs/fvt-manage/ui-cypress/params.yml.j2') | indent(4) }}
+    - name: fvt_test_suite
+      value: base-ui-scheduler-crews
+  when:
+    - input: "base"
+      operator: in
+      values: ["$(tasks.fvt-component.results.component_names[*])"]
+  runAfter:
+    - fvt-manage-base-ui-escalation-action
+    - fvt-manage-base-ui-birt-report
+    - fvt-manage-base-ui-user-crud
+    - fvt-manage-base-ui-user-consumption
+    - fvt-manage-base-ui-communication-temp
+    - fvt-manage-base-ui-scheduler-classic
 
 # Scheduling Dashboard Cypress test
 - name: fvt-manage-base-ui-scheduler-scheduling


### PR DESCRIPTION
Add **_fvt-manage-base-ui-scheduler-crews_** tests to phase5.

Evidences: ### 

- ansible-playbooks:
_generate-tekton-tasks_
<img width="3840" height="2160" alt="image" src="https://github.com/user-attachments/assets/9b5a5fcd-204d-4e87-afac-4e72920dc8b8" />

_generate-tekton-pipelines_
<img width="3840" height="2160" alt="image" src="https://github.com/user-attachments/assets/c78d550e-6570-4f72-85e3-baeb26781a66" />

- Test logs (run via tkn):
<img width="1896" height="478" alt="image" src="https://github.com/user-attachments/assets/36dde17b-d8fb-4755-a47c-cc66c539ed1a" />

