### PR TITLE
[minor] Add support to enable IPv6 networking for AI Service

### DIFF
--- a/docs/guides/aiservice-install.md
+++ b/docs/guides/aiservice-install.md
@@ -84,6 +84,7 @@ The interactive install will guide you through the following steps:
         <li><strong>Channel:</strong> AI Service version channel (e.g., 9.1.x)</li>
         <li><strong>S3 Storage Configuration:</strong> Configure object storage for AI Service data (MinIO or external S3)</li>
         <li><strong>Certificate Issuer (Advanced Mode Only):</strong> Optionally configure a pre-configured certificate issuer for AI Service</li>
+        <li><strong>Network configuration (Advanced Mode Only):</strong> Optionally enable IPv6 SingleStack network configuration for AI Service</li>
         <li><strong>Database Configuration:</strong> Set up database connection for AI Service</li>
         <li><strong>RSL Configuration:</strong> Configure Red Hat Service Locator integration</li>
         <li><strong>Tenant Configuration:</strong> Set up AI Service tenant(s)</li>
@@ -224,6 +225,12 @@ docker run -e IBM_ENTITLEMENT_KEY -ti --rm -v ~:/mnt/home quay.io/ibmmas/cli:@@C
 | Parameter | Description | Required | Example |
 |-----------|-------------|----------|---------|
 | `--aiservice-certificate-issuer` | Name of the certificate issuer for AI Service | No | `letsencrypt-prod` |
+
+### Enable IPv6 Networking
+
+| Parameter | Description | Required | Example |
+|-----------|-------------|----------|---------|
+| `--enable-ipv6` | Enable IPv6 SingleStack networking for AI Service | No | N/A |
 
 ### OpenDataHub Configuration
 

--- a/python/src/mas/cli/aiservice/install/app.py
+++ b/python/src/mas/cli/aiservice/install/app.py
@@ -130,6 +130,7 @@ class AiServiceInstallApp(BaseApp, aiServiceInstallArgBuilderMixin, aiServiceIns
         self.printDescription([
             "There are two flavours of the interactive install to choose from: <u>Simplified</u> and <u>Advanced</u>.  The simplified option will present fewer dialogs, but you lose the ability to configure the following aspects of the installation:",
             " - Configure certificate issuer",
+            " - Enable IPv6 SingleStack networking for services",
         ])
         self.showAdvancedOptions = self.yesOrNo("Show advanced installation options")
 
@@ -332,14 +333,14 @@ class AiServiceInstallApp(BaseApp, aiServiceInstallArgBuilderMixin, aiServiceIns
 
             elif key == "manual_certificates":
                 if value is not None:
-                    self.setParam("mas_manual_cert_mgmt", True)
+                    self.setParam("mas_manual_cert_mgmt", "true")
                     self.manualCertsDir = value
                 else:
-                    self.setParam("mas_manual_cert_mgmt", False)
+                    self.setParam("mas_manual_cert_mgmt", "false")
                     self.manualCertsDir = None
 
             elif key == "enable_ipv6":
-                self.setParam("enable_ipv6", True)
+                self.setParam("enable_ipv6", "true")
 
             # Fail if there's any arguments we don't know how to handle
             else:
@@ -565,6 +566,9 @@ class AiServiceInstallApp(BaseApp, aiServiceInstallArgBuilderMixin, aiServiceIns
         # Configure Certificate Issuer
         self.configCertIssuer()
 
+        # Configure Network configuration for services
+        self.configNetworking()
+
     @logMethodCall
     def configCertIssuer(self):
         if self.showAdvancedOptions:
@@ -572,6 +576,12 @@ class AiServiceInstallApp(BaseApp, aiServiceInstallArgBuilderMixin, aiServiceIns
             configureCertIssuer = self.yesOrNo('Configure certificate issuer')
             if configureCertIssuer:
                 self.promptForString("Certificate issuer name", "aiservice_certificate_issuer")
+
+    @logMethodCall
+    def configNetworking(self):
+        if self.showAdvancedOptions:
+            self.printH1("Network configuration for services")
+            self.yesOrNo('Enable IPv6 SingleStack networking', 'enable_ipv6')
 
     @logMethodCall
     def aiServiceTenantSettings(self) -> None:

--- a/python/src/mas/cli/aiservice/install/argBuilder.py
+++ b/python/src/mas/cli/aiservice/install/argBuilder.py
@@ -108,6 +108,10 @@ class aiServiceInstallArgBuilderMixin():
         if self.getParam('aiservice_certificate_issuer') != "":
             command += f"  --aiservice-certificate-issuer \"{self.getParam('aiservice_certificate_issuer')}\"{newline}"
 
+        # Enable IPv6 networking
+        if self.getParam('enable_ipv6').lower() == "true":
+            command += f"  --enable-ipv6{newline}"
+
         if self.getParam('aiservice_s3_accesskey') != "":
             command += f"  --s3-accesskey \"{self.getParam('aiservice_s3_accesskey')}\"{newline}"
         if self.getParam('aiservice_s3_secretkey') != "":

--- a/python/src/mas/cli/aiservice/install/argParser.py
+++ b/python/src/mas/cli/aiservice/install/argParser.py
@@ -422,11 +422,27 @@ aiServiceArgGroup.add_argument(
     default="non-production",
     help="Environment type (default: non-production)"
 )
-aiServiceArgGroup.add_argument(
+
+# AI Service advanced configuration
+# -----------------------------------------------------------------------------
+aiserviceAdvancedArgGroup = aiServiceinstallArgParser.add_argument_group(
+    "Advanced configuration for AI Service",
+    "Advanced configuration options for AI Service including certificates issuer and IPv6 support"
+)
+aiserviceAdvancedArgGroup.add_argument(
     "--aiservice-certificate-issuer",
     dest="aiservice_certificate_issuer",
     required=False,
     help="Provide the name of the Issuer to configure AI Service to issue certificates",
+)
+aiserviceAdvancedArgGroup.add_argument(
+    "--enable-ipv6",
+    dest="enable_ipv6",
+    required=False,
+    default="false",
+    help="Configure AI Service to run in IPv6. Before setting this option, be sure your cluster is configured in IPv6",
+    action="store_const",
+    const="true"
 )
 
 

--- a/python/src/mas/cli/aiservice/install/params.py
+++ b/python/src/mas/cli/aiservice/install/params.py
@@ -103,4 +103,7 @@ optionalParams = [
 
     # Certificate Issuer
     "aiservice_certificate_issuer",
+
+    # Enable IPv6 networking
+    "enable_ipv6",
 ]

--- a/python/src/mas/cli/aiservice/install/summarizer.py
+++ b/python/src/mas/cli/aiservice/install/summarizer.py
@@ -50,7 +50,7 @@ class aiServiceInstallSummarizerMixin():
         if "aiservice_certificate_issuer" in self.params:
             self.printParamSummary("Certificate Issuer", "aiservice_certificate_issuer")
 
-        self.printParamSummary("Configure AI Service to run in IPv6", "enable_ipv6")
+        self.printParamSummary("Configure AI Service to run in IPv6 mode", "enable_ipv6")
 
         self.printH2("AI Service Tenant Entitlement")
         self.printParamSummary("Entitlement Type", "tenant_entitlement_type")

--- a/python/src/mas/cli/aiservice/install/summarizer.py
+++ b/python/src/mas/cli/aiservice/install/summarizer.py
@@ -50,6 +50,8 @@ class aiServiceInstallSummarizerMixin():
         if "aiservice_certificate_issuer" in self.params:
             self.printParamSummary("Certificate Issuer", "aiservice_certificate_issuer")
 
+        self.printParamSummary("Configure AI Service to run in IPv6", "enable_ipv6")
+
         self.printH2("AI Service Tenant Entitlement")
         self.printParamSummary("Entitlement Type", "tenant_entitlement_type")
         self.printParamSummary("Start Date", "tenant_entitlement_start_date")

--- a/python/test/aiservice/install/test_app.py
+++ b/python/test/aiservice/install/test_app.py
@@ -77,6 +77,8 @@ def test_install_noninteractive(tmpdir):
                              '--dro-namespace', 'redhat-marketplace',
                              '--mongodb-namespace', 'mongoce',
                              '--aiservice-channel', '9.1.x',
+                             '--aiservice-certificate-issuer', 'cert-issuer',
+                             '--enable-ipv6',
                              '--s3-accesskey', 'test',
                              '--s3-secretkey', 'test',
                              '--s3-host', 'minio-service.minio.svc.cluster.local',
@@ -187,6 +189,8 @@ def test_install_interactive_advanced(tmpdir):
                     return 'y'
                 if re.match('.*Certificate issuer name.*', message):
                     return 'cert-issuer'
+                if re.match('.*Enable IPv6 SingleStack networking.*', message):
+                    return 'y'
                 if re.match('.*RSL url.*', message):
                     return 'https://rls.maximo.test.ibm.com'
                 if re.match('.*ORG Id of RSL.*', message):

--- a/tekton/src/pipelines/taskdefs/aiservice/aiservice.yml.j2
+++ b/tekton/src/pipelines/taskdefs/aiservice/aiservice.yml.j2
@@ -90,8 +90,11 @@
     # RHOAI flag
     - name: rhoai
       value: $(params.rhoai)
+
     - name: aiservice_certificate_issuer
       value: $(params.aiservice_certificate_issuer)
+    - name: enable_ipv6
+      value: $(params.enable_ipv6)
 
   taskRef:
     name: mas-devops-aiservice

--- a/tekton/src/tasks/aiservice/aiservice.yml.j2
+++ b/tekton/src/tasks/aiservice/aiservice.yml.j2
@@ -154,9 +154,16 @@ spec:
 
     # RHOAI flag
     - name: rhoai
+    
     # Certificate Issuer
     - name: aiservice_certificate_issuer
       type: string
+
+    # Enable IPv6 networking
+    - name: enable_ipv6
+      type: string
+      description: Optional boolean parameter that when set to True, configures services in SingleStack IPv6 networking
+      default: "False"
 
   stepTemplate:
     env:
@@ -258,6 +265,10 @@ spec:
       # Certificate Issuer
       - name: AISERVICE_CERTIFICATE_ISSUER
         value: $(params.aiservice_certificate_issuer)
+
+      # Enable IPv6
+      - name: ENABLE_IPV6
+        value: $(params.enable_ipv6)
 
   steps:
     - name: aiservice


### PR DESCRIPTION
## Description

- Add support to enable IPv6 networking for AI Service.
- Setting the `enable_ipv6` option configures all services created by AI Service with `ipFamilyPolicy` set to `SingleStack` and `ipFamilies` set to `IPv6`.


## Testing
<img width="667" height="617" alt="Screenshot 2026-04-07 at 3 29 56 PM" src="https://github.com/user-attachments/assets/b0da6e37-b16d-45a8-90de-b87cd57dfc90" />
<img width="506" height="141" alt="Screenshot 2026-04-07 at 3 29 43 PM" src="https://github.com/user-attachments/assets/1c13d109-7c49-46a9-9188-756adf7b0f59" />
<img width="359" height="56" alt="Screenshot 2026-04-07 at 3 20 05 PM" src="https://github.com/user-attachments/assets/56acc53d-c450-4cb1-a27d-54b56bc03389" />
<img width="478" height="106" alt="Screenshot 2026-04-07 at 3 19 08 PM" src="https://github.com/user-attachments/assets/977792ed-7b3c-4b48-8a7c-349a8cb9a8fb" />


