### PR TITLE
[patch] dro cis crn public domain bug fix for gitops

### DIFF
--- a/image/cli/mascli/templates/gitops/appset-configs/cluster/ibm-dro.yaml.j2
+++ b/image/cli/mascli/templates/gitops/appset-configs/cluster/ibm-dro.yaml.j2
@@ -7,7 +7,7 @@ ibm_dro:
     dro_cmm_setup: {{ DRO_CMM_SETUP }}
     dro_install_plan: {{ DRO_INSTALL_PLAN }}
     imo_install_plan: {{ IMO_INSTALL_PLAN }}
-{% if DRO_PUBLIC_DOMAIN is defined and DRO_PUBLIC_DOMAIN and CIS_CRN is defined and CIS_CRN %}
+{% if DRO_PUBLIC_DOMAIN is defined and DRO_PUBLIC_DOMAIN and DRO_CIS_CRN is defined and DRO_CIS_CRN %}
     dro_public_domain: {{ DRO_PUBLIC_DOMAIN }}
     tls_certificate: "<path:{{ SECRETS_PATH }}:{{ SECRET_KET_DRO_TLS_CERT }} | base64decode >"
     tls_key: "<path:{{ SECRETS_PATH }}:{{ SECRET_KET_DRO_TLS_KEY }} | base64decode >"


### PR DESCRIPTION
## Description
Fixed to correct env variable that has cis crn for dro dns creation