### PR TITLE
[patch] Add rhoai-migration to Tekton task list

### DIFF
--- a/tekton/generate-tekton-tasks.yml
+++ b/tekton/generate-tekton-tasks.yml
@@ -38,6 +38,7 @@
         - mongodb
         - nvidia-gpu
         - ocs
+        - rhoai-migration
         - sls-registry-update
         - sls
         - turbonomic


### PR DESCRIPTION
Add 'rhoai-migration' to the list in tekton/generate-tekton-tasks.yml so Tekton task generation includes the rhoai migration entry. This ensures related tasks/features are considered during task generation.