### PR TITLE
[patch] Remove kafka dependency for monitor

### DIFF
--- a/python/src/mas/cli/install/app.py
+++ b/python/src/mas/cli/install/app.py
@@ -1630,6 +1630,14 @@ class InstallApp(BaseApp, InstallSettingsMixin, InstallSummarizerMixin, ConfigGe
                     self.setParam("mongodb_action", "byo")
                     self.setParam("sls_mongodb_cfg_file", "/workspace/additional-configs/mongodb-system.yaml")
 
+                # If there is a file named kafka-<instance>-system.yaml we will use this as a BYO Kafka datasource
+                if self.localConfigDir is not None:
+                    instanceId = self.getParam("mas_instance_id")
+                    if instanceId is not None and instanceId != "":
+                        kafkaConfigFile = path.join(self.localConfigDir, f"kafka-{instanceId}-system.yaml")
+                        if path.exists(kafkaConfigFile):
+                            self.setParam("kafka_action_system", "byo")
+
             elif key == "pod_templates":
                 # For the named configurations we will convert into the path
                 if value in ["best-effort", "guaranteed"]:
@@ -1883,6 +1891,13 @@ class InstallApp(BaseApp, InstallSettingsMixin, InstallSummarizerMixin, ConfigGe
             arcgis_channel = self.getParam("mas_arcgis_channel")
             if arcgis_channel and not isVersionEqualOrAfter('9.0.0', arcgis_channel):
                 self.fatalError(f"--arcgis-channel must be 9.0 or later (current: {arcgis_channel})")
+
+        # Validate Kafka requirements for IoT installation in non-interactive mode
+        if self.installIoT:
+            kafkaAction = self.getParam("kafka_action_system")
+            hasKafkaConfig = kafkaAction in ["install", "byo"]
+            if not hasKafkaConfig:
+                self.fatalError("--iot-channel requires Kafka configuration. Provide Kafka install arguments such as --kafka-provider, or supply a BYO Kafka config file named kafka-<mas-instance-id>-system.yaml using --additional-configs")
 
     @logMethodCall
     def install(self, argv):

--- a/python/src/mas/cli/install/settings/kafkaSettings.py
+++ b/python/src/mas/cli/install/settings/kafkaSettings.py
@@ -11,7 +11,6 @@
 from typing import TYPE_CHECKING, Dict, List, NoReturn
 from os import path
 from prompt_toolkit import print_formatted_text
-from mas.devops.utils import isVersionEqualOrAfter
 
 
 if TYPE_CHECKING:
@@ -24,7 +23,6 @@ class KafkaSettingsMixin():
         # Attributes from BaseApp and other mixins
         params: Dict[str, str]
         installIoT: bool
-        installMonitor: bool
         showAdvancedOptions: bool
         localConfigDir: str | None
 
@@ -74,15 +72,10 @@ class KafkaSettingsMixin():
             ...
 
     def configKafka(self) -> None:
-        # Check if we should use the new dependency (Monitor >= 9.2.0)
-        monitorChannel = self.getParam("mas_app_channel_monitor")
-        useNewDependency = monitorChannel and isVersionEqualOrAfter('9.2.0', monitorChannel)
-
-        if (useNewDependency and self.installMonitor) or (not useNewDependency and self.installIoT):
-            appName = "Monitor" if (useNewDependency and self.installMonitor) else "IoT"
+        if self.installIoT:
             self.printH1("Configure Kafka")
             self.printDescription([
-                f"Maximo {appName} requires a shared system-scope Kafka instance",
+                "Maximo IoT requires a shared system-scope Kafka instance",
                 "Supported Kafka providers: Strimzi, Red Hat AMQ Streams, IBM Cloud Event Streams and AWS MSK",
                 "You may also choose to configure MAS to use an existing Kafka instance by providing a pre-existing configuration file"
             ])


### PR DESCRIPTION
Hi Team,
As Maximo Monitor is removing its dependency on Kafka, these changes ensure that Kafka is installed only for IoT. Monitor will require Kafka only when IoT is present.

--------
Adding CLI prompts and pipeline run for evidence.

[ibmmas/cli:19.9.0-pre.removekafkaformonitor]mascli$ mas install --dev-mode --skip-pre-check

IBM Maximo Application Suite Admin CLI v19.9.0-pre.removekafkaformonitor
Powered by https://github.com/ibm-mas/ansible-devops/ and https://tekton.dev/


1) Set Target OpenShift Cluster
Already connected to OCP Cluster:
 https://console-openshift-console.apps.mondevfyre1.cp.fyre.ibm.com

Proceed with this cluster? [y/n] y

2) Choose Install Mode
There are two flavours of the interactive install to choose from: Simplified and Advanced.  The simplified option will present fewer dialogs, but you lose the ability to configure the following aspects of the installation:
 - Configure installation namespaces
 - Provide pod templates
 - Configure Single Sign-On (SSO) settings - Configure whether to trust well-known certificate authorities by default (defaults to enabled)
 - Configure whether the Guided Tour feature is enabled (defaults to enabled)
 - Configure whether special characters are allowed in usernames and userids (defaults to disabled)
 - Configure a custom domain, DNS integrations, routing mode and manual certificates
 - Customize Maximo Manage database settings (schema, tablespace, indexspace)
 - Customize Maximo Manage server bundle configuration (defaults to "all" configuration)
 - Enable optional Maximo Manage integration Cognos Analytics and Watson Studio Local
 - Enable optional Real Estate and Facilities configurations
 - Customize Db2 node affinity and tolerations, memory, cpu, and storage settings (when using the IBM Db2 Universal Operator)
 - Choose alternative Apache Kafka providers (default to Strimzi)
 - Customize Grafana storage settings
Show advanced installation options? [y/n] y

3) IBM Maximo Operator Catalog Selection
Select catalog source v9-master-amd64
Select channel 9.2.x-dev

4) Configure Storage Class Usage
Maximo Application Suite and it's dependencies require storage classes that support ReadWriteOnce (RWO) and ReadWriteMany (RWX) access modes:
  - ReadWriteOnce volumes can be mounted as read-write by multiple pods on a single node.
  - ReadWriteMany volumes can be mounted as read-write by multiple pods across many nodes.

Storage provider auto-detected: NFS Client
  - Storage class (ReadWriteOnce): nfs-client
  - Storage class (ReadWriteMany): nfs-client
Use the auto-detected storage classes? [y/n] y

5) Configure AppPoint Licensing
By default the MAS instance will be configured to use a cluster-shared License, this provides a shared pool of AppPoints available to all MAS instances on the cluster.

Alternatively you may choose to install using a dedicated license only available to this MAS instance.
  1. Install MAS with Cluster-Shared License (AppPoints)
  2. Install MAS with Dedicated License (AppPoints)
SLS Mode 1
License file /tmp/entitlement.lic
SLS channel 3.x-dev
Contact e-mail address xxx
Contact first name xxx
Contact last name xxx
IBM Data Reporter Operator (DRO) Namespace redhat-marketplace

6) Configure IBM Container Registry
IBM entitlement key ************************************************************************************************************************************************************************************************
Artifactory username pmqcloud@us.ibm.com
Artifactory token ****************************************************************

7) Configure MAS Instance
Instance ID restrictions:
 - Must be 3-12 characters long
 - Must only use lowercase letters, numbers, and hypen (-) symbol
 - Must start with a lowercase letter
 - Must end with a lowercase letter or a number
Instance ID onlymonitor1

Workspace ID restrictions:
 - Must be 3-12 characters long
 - Must only use lowercase letters and numbers
 - Must start with a lowercase letter
Workspace ID main

Workspace display name restrictions:
 - Must be 3-300 characters long
Workspace name main

8) Configure Operational Mode
Maximo Application Suite can be installed in a non-production mode for internal development and testing, this setting cannot be changed after installation:
 - All applications, add-ons, and solutions have 0 (zero) installation AppPoints in non-production installations.
 - These specifications are also visible in the metrics that are shared with IBM and in the product UI.

  1. Production
  2. Non-Production
Operational Mode 1

9) Certificate Authority Trust
By default, Maximo Application Suite is configured to trust well-known certificate authoritories, you can disable this so that it will only trust the CAs that you explicitly define
Trust default CAs? [y/n] y

10) Cluster Ingress Secret Override
In most OpenShift clusters the installation is able to automatically locate the default ingress certificate, however in some configurations it is necessary to manually configure the name of the secret
Unless you see an error during the ocp-verify stage indicating that the secret can not be determined you do not need to set this and can leave the response empty
Cluster ingress certificate secret name

11) Configure Domain & Certificate Management
Configure domain & certificate management? [y/n] y
Configure custom domain? [y/n] y
MAS top-level domain onlymonitor1.ibmmasmonitor.com

DNS Integrations:
  1. Cloudflare
  2. IBM Cloud Internet Services
  3. AWS Route 53
  4. None (I will set up DNS myself)
DNS Provider 2
CIS e-mail xxx
CIS API token xxx
CIS CRN xxx
CIS subdomain onlymonitor1
Certificate Issuer:
  1. LetsEncrypt (Production)
  2. LetsEncrypt (Staging)
  3. Self-Signed
Certificate issuer 1
By default, DNS CNAME records will be created pointing to the domain of the cluster ingress (ingress.config.openshift.io/cluster).
CloudFlare and CIS DNS integrations support the ability to provide an alternative domain, which may be necessary if you are using OpenShift Container Platform in a non-standard networking configuration.
Cluster Ingress Domain Override
Configure manual certificates? [y/n] n

12) Configure Routing Mode
Maximo Application Suite can be configured in one of two ways:

  1. Single domain with path-based routing across the suite
     Example: https://onlymonitor1.onlymonitor1.ibmmasmonitor.com/admin

  2. Multi domain with subdomain-based routing across the suite
     Example: https://admin.onlymonitor1.onlymonitor1.ibmmasmonitor.com

Path-based routing requires the IngressController to have the routeAdmission policy
set to 'InterNamespaceAllowed'. This allows routes to claim the same hostname across
different namespaces, which is necessary for path-based routing to function correctly.

For more information refer to:
https://docs.redhat.com/en/documentation/openshift_container_platform/4.20/html/ingress_and_load_balancing/routes#nw-route-admission-policy_configuring-routes
Routing Mode 2

13) Single Sign-On (SSO)
Many aspects of Maximo Application Suite's Single Sign-On (SSO) can be customized:
 - Idle session automatic logout timer
 - Session, access token, and refresh token timeouts
 - Default identity provider (IDP), and seamless login
 - Brower cookie properties
Configure SSO properties? [y/n] n

14) Configure special characters for userID and username
By default Maximo Application Suite will not allow special characters in usernames and userIDs, and this is the recommended setting.  However, legacy Maximo products allowed this, so for maximum compatibilty when migrating from EAM 7 you can choose to enable this support.
Allow special characters for user IDs and usernames? [y/n] n

15) Adoption Metrics Reporting
Adoption Metrics are used by IBM to measure feature adoption, user engagement, and the success of product initiatives.
You can control three types of metrics:
 - Feature Adoption: Tracks feature usage to understand adoption and improve the product
 - Deployment Progression: Tracks progression of tasks and workflows within the product
 - Usability: Tracks user interface interactions to improve usability

When enabled (y), you permit IBM to capture and analyze these metrics to help improve the Maximo Application Suite experience.
When disabled (n), you are opting out of sending that specific metric type to IBM.
Enable feature adoption metrics? [y/n] n
Enable deployment progression metrics? [y/n] n
Enable usability metrics? [y/n] n

16) Enable Guided Tour
By default, Maximo Application Suite is configured with guided tour, you can disable this if it not required
Enable Guided Tour? [y/n] n

17) Application Selection
Install IoT? [y/n] n
Install Monitor? [y/n] y
Custom channel for monitor9.2.x-dev
Install Manage? [y/n] n
Manage foundation installs the following capabilities: User, Security groups, Application configurator and Mobile configurator.
Custom channel for manage9.2.x-dev
Install Assist? [y/n] n
Install Optimizer? [y/n] n
Install Visual Inspection? [y/n] n
Install Real Estate and Facilities? [y/n] n
Install AI Service? [y/n] n

18) Configure Maximo Manage foundation
Customize your Manage foundation installation, refer to the product documentation for more information

18.1) Maximo Manage foundation Settings - Database
Customise the schema, tablespace, indexspace, and encryption settings used by Manage foundation
Customize database settings? [y/n] n

18.2) Maximo Manage foundation Settings - Other
Configure additional settings:
  - Base and additional languages
  - Server timezone
Manage foundation server timezone GMT

18.3) Maximo Manage foundation Settings - Languages
Define the base language for Maximo Manage foundation
Base language EN
Define the additional languages to be configured in Maximo Manage foundation. Provide a comma-separated list of the supported languages indexes, for example: 'DA,EN,ZH-TW'
A complete list of available language codes is available online:
    https://www.ibm.com/docs/en/mas-cd/mhmpmh-and-p-u/continuous-delivery?topic=deploy-language-support
Secondary language JA,DE

19) Configure MongoDb
The installer can setup mongoce in your OpenShift cluster (available only for amd64) or you may choose to configure MAS to use an existing mongodb
Create MongoDb cluster using MongoDb Community Edition Operator? [y/n] y
MongoDb namespace mongoce

20) Configure Databases
The installer can setup one or more IBM Db2 instances in your OpenShift cluster for the use of applications that require a JDBC datasource (IoT, Manage foundation, Monitor, & Predict, Real Estate and Facilities) or you may choose to configure MAS to use an existing database

20.1) Database Configuration for Maximo Monitor
Maximo Monitor requires a shared system-scope Db2 instance because other applications in the suite require access to the same database source
 - Only IBM Db2 is supported for this database
Create system Db2 instance using the IBM Db2 Universal Operator? [y/n] y

20.2) Database Configuration for Maximo Manage foundation
Maximo Manage foundation can be configured to share the system Db2 instance or use it's own dedicated database:
 - Use of a shared instance has a significant footprint reduction but is only recommended for development/test/demo installs
 - In most production systems you will want to use a dedicated database
 - IBM Db2, Oracle Database, & Microsoft SQL Server are all supported database options
Re-use System Db2 instance for Manage foundation application? [y/n] n
Create Manage foundation dedicated Db2 instance using the IBM Db2 Universal Operator? [y/n] y
Available Db2 instance types for Manage foundation:
  1. DB2 Warehouse (Default option)
  2. DB2 Online Transactional Processing (OLTP)
Select the Manage foundation dedicated DB2 instance type 1

20.3) Installation Namespace
Install namespace db2u

20.4) Node Affinity and Tolerations
Note that the same settings are applied to both the IoT and Manage foundation Db2 instances
Use existing node labels and taints to control scheduling of the Db2 workload in your cluster
For more information refer to the Red Hat documentation:
 - https://docs.redhat.com/en/documentation/openshift_container_platform/4.20/html/nodes/controlling-pod-placement-onto-nodes-scheduling#nodes-scheduler-node-affinity
 - https://docs.redhat.com/en/documentation/openshift_container_platform/4.20/html/nodes/controlling-pod-placement-onto-nodes-scheduling#nodes-scheduler-taints-tolerations
 - https://docs.redhat.com/en/documentation/openshift_container_platform/4.19/html/nodes/controlling-pod-placement-onto-nodes-scheduling#nodes-scheduler-node-affinity
 - https://docs.redhat.com/en/documentation/openshift_container_platform/4.19/html/nodes/controlling-pod-placement-onto-nodes-scheduling#nodes-scheduler-taints-tolerations
 - https://docs.openshift.com/container-platform/4.18/nodes/scheduling/nodes-scheduler-node-affinity.html
 - https://docs.openshift.com/container-platform/4.18/nodes/scheduling/nodes-scheduler-taints-tolerations.html
 - https://docs.openshift.com/container-platform/4.17/nodes/scheduling/nodes-scheduler-node-affinity.html
 - https://docs.openshift.com/container-platform/4.17/nodes/scheduling/nodes-scheduler-taints-tolerations.html
Configure node affinity? [y/n] n
Configure node tolerations? [y/n] n

20.5) Database CPU & Memory
Note that the same settings are applied to both the IoT and Manage foundation Db2 instances
Customize CPU and memory request/limit? [y/n] n

20.6) Database Storage Capacity
Note that the same settings are applied to both the IoT and Manage foundation Db2 instances
Customize storage capacity? [y/n] n
Select Db2 Custom Resource(CR)? [y/n] n
Install Grafana? [y/n] n

21) Additional Configuration
Additional resource definitions can be applied to the OpenShift Cluster during the MAS configuration step
The primary purpose of this is to apply configuration for Maximo Application Suite itself, but you can use this to deploy ANY additional resource into your cluster
Use additional configurations? [y/n] n

22) Configure Pod Templates
The CLI supports two pod template profiles out of the box that allow you to reconfigure MAS for either a guaranteed or best effort QoS level
For more information about the Kubernetes quality of service (QoS) levels, see https://kubernetes.io/docs/concepts/workloads/pods/pod-qos/
You may also choose to use your own customized pod template definitions
Use pod templates? [y/n] n

23) Non-Interactive Install Command
Save and re-use the following script to re-run this install without needing to answer the interactive prompts again

export IBM_ENTITLEMENT_KEY=x
export ARTIFACTORY_USERNAME=x
export ARTIFACTORY_TOKEN=x
mas install --mas-catalog-version v9-master-amd64 --ibm-entitlement-key $IBM_ENTITLEMENT_KEY \
  --mas-channel 9.2.x-dev --mas-instance-id onlymonitor1 --mas-workspace-id main --mas-workspace-name "main" \
  --routing "subdomain" \
  --domain "onlymonitor1.ibmmasmonitor.com" \
  --dns-provider cis --cis-apikey "xxx" --cis-subdomain "onlymonitor1" --cis-crn "xxx" --cis-email "xxx" \
  --mas-cluster-issuer "onlymonitor1-cis-le-prod" \
  --disable-walkme \
  --disable-feature-usage \
  --disable-usability-metrics \
  --disable-deployment-progression \
  --storage-class-rwo "nfs-client" --storage-class-rwx "nfs-client" \
  --storage-pipeline "nfs-client" --storage-accessmode "ReadWriteMany" \
  --sls-channel "3.x-dev"  --license-file "/tmp/entitlement.lic" \
  --contact-email "xxx" --contact-firstname "xxx" --contact-lastname "xxx" \
  --dro-namespace "redhat-marketplace" \
  --mongodb-namespace "mongoce" \
  --monitor-channel "9.2.x-dev" \
  --manage-channel "9.2.x-dev" \
  --manage-jdbc "workspace-application" \
  --manage-components "" \
  --manage-base-language "EN" \
  --manage-secondary-languages "JA,DE" \
  --manage-server-timezone "GMT" \
  --db2-system \
  --db2-manage \
  --db2-channel "v110509.0" \
  --db2-namespace "db2u" \
  --db2-type "db2wh" \
  --db2-timezone "GMT" \
  --db2-cpu-requests "4000m" \
  --db2-cpu-limits "6000m" \
  --db2-memory-requests "8Gi" \
  --db2-memory-limits "12Gi" \
  --db2-backup-storage "50Gi" \
  --db2-data-storage "50Gi" \
  --db2-logs-storage "10Gi" \
  --db2-meta-storage "10Gi" \
  --db2-temp-storage "10Gi" \
  --db2u-kind "db2ucluster" \
  --artifactory-username $ARTIFACTORY_USERNAME --artifactory-token $ARTIFACTORY_TOKEN \
  --dev-mode \
  --accept-license --no-confirm

24) Review Settings
Connected to:
 - https://console-openshift-console.apps.mondevfyre1.cp.fyre.ibm.com

24.1) Pipeline Configuration
  Service Account ......................... Default
  Image Pull Policy ....................... Default
  Skip Pre-Install Healthcheck ............ Yes

24.2) OpenShift Container Platform
  Worker Node Architecture ................ amd64
  Storage Class Provider .................. nfs
  ReadWriteOnce Storage Class ............. nfs-client
  ReadWriteMany Storage Class ............. nfs-client
  Certificate Manager ..................... redhat
  Cluster Ingress Certificate Secret ...... Default
  Single Node OpenShift ................... No

24.3) IBM Data Reporter Operator (DRO) Configuration
  Contact e-mail .......................... xxx
  First name .............................. xxx
  Last name ............................... xxx
  Install Namespace ....................... redhat-marketplace

24.4) IBM Suite License Service
  Namespace ............................... Default
  Subscription Channel .................... 3.x-dev
  IBM Open Registry ....................... docker-na-public.artifactory.swg-devops.com/wiotp-docker-local/cpopen
  License File ............................ /tmp/entitlement.lic

24.5) IBM Maximo Application Suite
  Instance ID ............................. onlymonitor1
  Workspace ID ............................ main
  Workspace Name .......................... main

  Operational Mode ........................ Production
  Install Mode ............................ Connected Install

  Domain Name ............................. onlymonitor1.ibmmasmonitor.com
  DNS Provider ............................ cis
  Certificate Issuer ...................... onlymonitor1-cis-le-prod
  CIS e-mail .............................. xxx
  CIS API Key ............................. xxx
  CIS CRN ................................. xxx
  CIS subdomain ........................... onlymonitor1

  Network Routing Mode .................... subdomain

  Configure Suite to run in IPV6 .......... Default

  Manual Certificates ..................... None

  Enable Guided Tour ...................... false

  Catalog Version ......................... v9-master-amd64
  Subscription Channel .................... 9.2.x-dev

  IBM Entitled Registry ................... docker-na-public.artifactory.swg-devops.com/wiotp-docker-local
  IBM Open Registry ....................... docker-na-public.artifactory.swg-devops.com/wiotp-docker-local/cpopen

  Enable feature adoption metrics ......... false

  Enable deployment progression metrics ... false

  Enable usability metrics ................ false

  Trust Default Cert Authorities .......... true

  Additional Config ....................... Not Configured
  Pod Templates ........................... Not Configured

24.6) IBM Maximo Application Suite Applications
  IoT ..................................... Do Not Install
  Monitor ................................. 9.2.x-dev
  Manage foundation ....................... 9.2.x-dev
  Loc Srv Esri (arcgis) ................... Do Not Install
  Predict ................................. Do Not Install
  Optimizer ............................... Do Not Install
  Assist .................................. Do Not Install
  Visual Inspection ....................... Do Not Install
  Facilities .............................. Do Not Install

24.7) MongoDb
  Type .................................... MongoCE Operator
  Install Namespace ....................... mongoce

24.8) IBM Db2 Univeral Operator Configuration
  System Instance ......................... Install
  Dedicated Manage Instance ............... Install
   - Type ................................. db2wh
   - Timezone ............................. GMT

  Install Namespace ....................... db2u
  Subscription Channel .................... v110509.0

  CPU Request ............................. 4000m
  CPU Limit ............................... 6000m
  Memory Request .......................... 8Gi
  Memory Limit  ........................... 12Gi

  Meta Storage ............................ 10Gi
  Data Storage ............................ 50Gi
  Backup Storage .......................... 50Gi
  Temp Storage ............................ 10Gi
  Transaction Logs Storage ................ 10Gi

  Node Affinity ........................... None
  Node Tolerations ........................ None

24.9) Cloud Object Storage
  Type .................................... None

24.10) Grafana
  Install Grafana ......................... Do Not Install

Please carefully review your choices above, correcting mistakes now is much easier than after the install has begun
Proceed with these settings? [y/n] y

25) Launch Install
✅️ OpenShift Pipelines Operator is installed and ready to use
✅️ Namespace is ready (mas-onlymonitor1-pipelines)
✅️ MAS CLI image deployment test completed
✅️ Latest Tekton definitions are installed (v19.9.0-pre.removekafkaformonitor)
✅️ PipelineRun for onlymonitor1 install submitted

View progress:
  https://console-openshift-console.apps.mondevfyre1.cp.fyre.ibm.com/k8s/ns/mas-onlymonitor1-pipelines/tekton.dev~v1beta1~PipelineRun/onlymonitor1-install-260416-1142
