### PR TITLE
[patch] Enable Collaborate addon for Manage 9.2 or higher

### DIFF
--- a/python/src/mas/cli/install/settings/manageSettings.py
+++ b/python/src/mas/cli/install/settings/manageSettings.py
@@ -15,6 +15,7 @@ from mas.devops.aiservice import listAiServiceTenantInstances, listAiServiceInst
 from openshift.dynamic.exceptions import ResourceNotFoundError
 from ...validators import AiserviceTeanantIDValidator
 from prompt_toolkit import print_formatted_text, HTML
+from mas.devops.utils import isVersionEqualOrAfter
 
 import logging
 logger = logging.getLogger(__name__)
@@ -176,8 +177,11 @@ class ManageSettingsMixin():
                     self.params["mas_appws_components"] += ",aip=latest"
                 if self.yesOrNo(" - Vegetation Management"):
                     self.params["mas_appws_components"] += ",vegm=latest"
-                if self.yesOrNo(" - Collaborate"):
-                    self.params["mas_appws_components"] += ",collaborate=latest"
+                # Collaborate is only available in Manage 9.2 or higher
+                manageChannel = self.getParam("mas_app_channel_manage")
+                if manageChannel and isVersionEqualOrAfter('9.2.0', manageChannel):
+                    if self.yesOrNo(" - Collaborate"):
+                        self.params["mas_appws_components"] += ",collaborate=latest"
                 logger.debug(f"Generated mas_appws_components = {self.params['mas_appws_components']}")
 
                 if ",icd=" in self.params["mas_appws_components"]:


### PR DESCRIPTION
Collaborate option available when selecting 9.2.x-dev
<img width="1724" height="610" alt="image" src="https://github.com/user-attachments/assets/b7e74264-2d04-437e-9216-08b6fa2addb6" />

Collaborate option not available when selecting 9.2.x-dev
<img width="1494" height="591" alt="image" src="https://github.com/user-attachments/assets/231e0de7-1616-44c1-a219-45f2e36e652b" />
