### PR TITLE
[patch] Update gitops-aiservice-tenant-pipeline.yml.j2 for gitops

### DIFF
--- a/tekton/src/pipelines/gitops/gitops-aiservice-tenant-pipeline.yml.j2
+++ b/tekton/src/pipelines/gitops/gitops-aiservice-tenant-pipeline.yml.j2
@@ -48,7 +48,7 @@ spec:
       type: string
     - name: mas_icr_cpopen
       type: string
-    - name: drocfg_url
+    - name: dro_url
       type: string
     - name: slscfg_url
       type: string
@@ -150,8 +150,8 @@ spec:
           value: $(params.mas_icr_cp)
         - name: mas_icr_cpopen
           value: $(params.mas_icr_cpopen)
-        - name: drocfg_url
-          value: $(params.drocfg_url)
+        - name: dro_url
+          value: $(params.dro_url)
         - name: slscfg_url
           value: $(params.slscfg_url)
         - name: aiservice_sls_subscription_id


### PR DESCRIPTION
Ticket: [MASAIB-2072](https://jsw.ibm.com/browse/MASAIB-2072)

Changes:

- AI Service needs to point to the dro secret name instead of the droai secret name.
- The changes are related to migrating from droai to dro. Previously, it was linked to the droai secret name, so the keys were    different. I have updated them accordingly (e.g., drocfg_url, dro_url) for the AI Service.

Test Result:

- I have tested this in our GitOps dev cluster, and it is working fine. I have also attached a screenshot for reference.

<img width="2049" height="930" alt="Screenshot 2026-04-14 at 11 23 36 AM" src="https://github.com/user-attachments/assets/bd13a936-bfae-44bb-991b-6bd9505859a2" />
<img width="1978" height="1147" alt="Screenshot 2026-04-09 at 12 47 01 PM" src="https://github.com/user-attachments/assets/05f6cc2c-fa6c-4038-bf29-4cad76d55fcc" />
<img width="1751" height="746" alt="Screenshot 2026-04-09 at 12 47 09 PM" src="https://github.com/user-attachments/assets/ae880979-79e6-42aa-9e9e-f8578a4d6712" />
<img width="1758" height="809" alt="Screenshot 2026-04-10 at 11 33 58 AM" src="https://github.com/user-attachments/assets/c1d96453-36b7-4240-accc-cd81b9352a4c" />
<img width="1988" height="891" alt="Screenshot 2026-04-10 at 11 57 52 AM" src="https://github.com/user-attachments/assets/5189c00b-aeb2-41cf-8730-5c2891a346d6" />
<img width="1990" height="770" alt="Screenshot 2026-04-10 at 11 58 07 AM" src="https://github.com/user-attachments/assets/04702ba2-128e-4276-bc08-d6f9ff539316" />
