### PR TITLE
[patch] Fix IoT FVT launch dependency to allow independent execution in pre-9.2

### DIFF
--- a/tekton/src/pipelines/mas-fvt-launcher.yml.j2
+++ b/tekton/src/pipelines/mas-fvt-launcher.yml.j2
@@ -516,14 +516,11 @@ spec:
         - input: $(params.sync_with_install)
           operator: in
           values: ["true", "True"]
-        - input: $(params.launchfvt_iot)
-          operator: in
-          values: ["true", "True"]
         - input: $(params.mas_monitor_install_order)
           operator: in
           values: ["after-iot"]
       runAfter:
-        - launchfvt-iot
+        - waitfor-iot
 
     # Approve IoT (before-iot scenario) - only after both Monitor and IoT FVT complete
     # For Monitor >= 9.2.0: IoT installs after Monitor, so approval happens after both FVTs
@@ -543,14 +540,11 @@ spec:
         - input: $(params.sync_with_install)
           operator: in
           values: ["true", "True"]
-        - input: $(params.launchfvt_iot)
-          operator: in
-          values: ["true", "True"]
         - input: $(params.mas_monitor_install_order)
           operator: in
           values: ["before-iot"]
       runAfter:
-        - launchfvt-iot-after-monitor
+        - waitfor-iot-after-monitor
 
 
     # 5. Application FVT - Manage
@@ -899,14 +893,11 @@ spec:
         - input: $(params.sync_with_install)
           operator: in
           values: ["true", "True"]
-        - input: $(params.launchfvt_monitor)
-          operator: in
-          values: ["true", "True"]
         - input: $(params.mas_monitor_install_order)
           operator: in
           values: ["after-iot"]
       runAfter:
-        - launchfvt-monitor
+        - waitfor-monitor
 
     # Approve Monitor for Monitor >= 9.2.0 (before-iot scenario)
     # This runs immediately after Monitor installation completes, allowing IoT to start
@@ -924,9 +915,6 @@ spec:
           value: approved
       when:
         - input: $(params.sync_with_install)
-          operator: in
-          values: ["true", "True"]
-        - input: $(params.launchfvt_monitor)
           operator: in
           values: ["true", "True"]
         - input: $(params.mas_monitor_install_order)

--- a/tekton/src/pipelines/mas-fvt-launcher.yml.j2
+++ b/tekton/src/pipelines/mas-fvt-launcher.yml.j2
@@ -456,6 +456,8 @@ spec:
       runAfter:
         - approval-monitor-before-iot
 
+    # Launch IoT FVT (Monitor < 9.2.0 - after IoT)
+    # For pre-9.2 installations, IoT installs before Monitor and can run independently
     - name: launchfvt-iot
       timeout: "0"
       params:
@@ -470,8 +472,32 @@ spec:
         - input: $(params.launchfvt_iot)
           operator: in
           values: ["true", "True"]
+        - input: $(params.mas_monitor_install_order)
+          operator: in
+          values: ["after-iot"]
       runAfter:
         - waitfor-iot
+
+    # Launch IoT FVT (Monitor >= 9.2.0 - before IoT)
+    # For post-9.2 installations, IoT installs after Monitor, so wait for Monitor approval first
+    - name: launchfvt-iot-after-monitor
+      timeout: "0"
+      params:
+        - name: image_pull_policy
+          value: $(params.image_pull_policy)
+        - name: pipelinerun_name
+          value: "$(params.mas_instance_id)-fvt-iot"
+      taskRef:
+        kind: Task
+        name: mas-launchfvt-iot
+      when:
+        - input: $(params.launchfvt_iot)
+          operator: in
+          values: ["true", "True"]
+        - input: $(params.mas_monitor_install_order)
+          operator: in
+          values: ["before-iot"]
+      runAfter:
         - waitfor-iot-after-monitor
 
     - name: approval-iot
@@ -524,8 +550,7 @@ spec:
           operator: in
           values: ["before-iot"]
       runAfter:
-        - launchfvt-iot
-        - launchfvt-monitor-before-iot
+        - launchfvt-iot-after-monitor
 
 
     # 5. Application FVT - Manage


### PR DESCRIPTION


Split launchfvt-iot into two separate tasks to fix dependency issue where IoT FVT was blocked by Monitor installation even when Monitor wasn't needed.

Changes:
- Split launchfvt-iot into two tasks:
  * launchfvt-iot: For pre-9.2 (after-iot), runs independently after waitfor-iot
  * launchfvt-iot-after-monitor: For 9.2+ (before-iot), runs after waitfor-iot-after-monitor
- Updated approval-iot-after-monitor to reference launchfvt-iot-after-monitor for clearer and more consistent dependency chain

This matches the existing pattern used for Monitor tasks (launchfvt-monitor and launchfvt-monitor-before-iot) and allows IoT FVT to run early in 8.10 installations without waiting for Monitor to complete.