### PR TITLE
[patch] Implement error handling for Slack message posting

### DIFF
--- a/image/cli/app-root/src/finalizer.py
+++ b/image/cli/app-root/src/finalizer.py
@@ -772,6 +772,6 @@ if __name__ == "__main__":
             message.append(SlackUtil.buildSection(f"Test result summary for *<https://dashboard.ibmmas.com/tests/{instanceId}|{instanceId}#{build}>*"))
             message.append(SlackUtil.buildSection("Sorry.  The build is so bad it can't even be summarized within the size limit of a Slack message!"))
             try:
-              postMessage(FVT_SLACK_CHANNEL, message, threadId)
+                postMessage(FVT_SLACK_CHANNEL, message, threadId)
             except Exception as e:
                 print(f"An exception occured posting the test result summary to Slack: {e}")

--- a/image/cli/app-root/src/finalizer.py
+++ b/image/cli/app-root/src/finalizer.py
@@ -771,4 +771,7 @@ if __name__ == "__main__":
             message.append(SlackUtil.buildHeader(f"{product}"))
             message.append(SlackUtil.buildSection(f"Test result summary for *<https://dashboard.ibmmas.com/tests/{instanceId}|{instanceId}#{build}>*"))
             message.append(SlackUtil.buildSection("Sorry.  The build is so bad it can't even be summarized within the size limit of a Slack message!"))
-            postMessage(FVT_SLACK_CHANNEL, message, threadId)
+            try:
+              postMessage(FVT_SLACK_CHANNEL, message, threadId)
+            except Exception as e:
+                print(f"An exception occured posting the test result summary to Slack: {e}")


### PR DESCRIPTION
Added error handling for posting messages to Slack, which should not be a fatal - pipeline failing - exception.