### PR TITLE
[patch] fix the missing separator issue in clean recipe

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -241,7 +241,7 @@ run: ## Run the CLI container image locally
 clean: ## Remove built artifacts
 	rm image/cli/install/ibm-mas_devops.tar.gz
 	rm image/cli/bin/templates/ibm-mas-tekton.yaml
-  rm -rf image/cli/rbac
+	rm -rf image/cli/rbac
 
 # ==============================================================================
 # OpenShift Pod Management Targets


### PR DESCRIPTION
## Description

- fix the missing separator issue in clean recipe

- previously
  <img width="902" height="90" alt="image" src="https://github.com/user-attachments/assets/306e395c-4297-4482-a948-0c11ad2dbc36" />

- now
  <img width="1498" height="222" alt="image" src="https://github.com/user-attachments/assets/0defeec1-3be8-4fa6-9bd1-44293aae785e" />
