### PR TITLE
[doc] Correct supported OCP version statement

### DIFF
--- a/docs/catalogs/index.md
+++ b/docs/catalogs/index.md
@@ -98,7 +98,7 @@ Note: The Red Hat Extended Update Support Add-on Term 1 offering is included wit
         </tr>
         <tr>
           <td><span style="font-weight: bold">v9-260326</span><br/><a href="v9-260326-amd64/">amd64</a> | <a href="v9-260326-s390x/">s390x</a> | <a href="v9-260326-ppc64le/">ppc64le</a></td>
-          <td><span style="font-weight: bold">4.16 - 4.20</span><br/><a href="https://access.redhat.com/support/policy/updates/openshift" target="_blank">EOS Oct 21, 2027 ↗</a></td>
+          <td><span style="font-weight: bold">4.16 - 4.21</span><br/><a href="https://access.redhat.com/support/policy/updates/openshift" target="_blank">EOS Oct 21, 2027 ↗</a></td>
           <td>5.2.0</td>
           <td>7.0 - 8.0</td>
           <td>latest</td>


### PR DESCRIPTION
As per the instructions in here - https://ibm-mas.github.io/cli/catalogs/v9-260326-amd64/, OCP 4.21 is supported for March release catalog.