### PR TITLE
[patch] Fix waitfor-monitor dependency to prevent timeout in after-iot scenario

### DIFF
--- a/tekton/src/pipelines/mas-fvt-launcher.yml.j2
+++ b/tekton/src/pipelines/mas-fvt-launcher.yml.j2
@@ -756,7 +756,8 @@ spec:
     # -------------------------------------------------------------------------
     # Wait for Monitor installation to complete before launching Monitor FVT
     # For Monitor >= 9.2.0 (before-iot): runs in parallel with waitfor-iot
-    # For Monitor < 9.2.0 (after-iot): runs after waitfor-iot (legacy behavior)
+    # For Monitor < 9.2.0 (after-iot): runs after both manage approval and waitfor-iot
+    # Note: Monitor installation depends on manage completing, so we must wait for manage approval
     - name: waitfor-monitor
       timeout: "0"
       taskRef:
@@ -793,6 +794,7 @@ spec:
           values: ["after-iot"]
       runAfter:
         - waitfor-iot
+        - approval-manage
 
     # Wait for Monitor (before-iot scenario) - runs in parallel with IoT
     - name: waitfor-monitor-before-iot

--- a/tekton/src/pipelines/mas-fvt-launcher.yml.j2
+++ b/tekton/src/pipelines/mas-fvt-launcher.yml.j2
@@ -149,25 +149,6 @@ spec:
     - name: aiservice_instance_id
       type: string
       default: ""
-    
-    # Monitor FVT Parameters
-    # -------------------------------------------------------------------------
-    - name: fvt_digest_monitor
-      type: string
-      default: ""
-      description: "Monitor FVT image digest"
-    - name: mas_app_channel_monitor
-      type: string
-      default: ""
-      description: "Monitor app channel version"
-    - name: mas_workspace_id
-      type: string
-      default: ""
-      description: "MAS workspace ID"
-    - name: fvt_test_suite
-      type: string
-      default: "fvt_9x"
-      description: "Monitor FVT test suite to run (fvt_9x, fvt_91x, fvt_mref, fvt_iot, fvt_scada, fvt_mist, fvt_monitor_only)"
 
   tasks:
     # 0. Configuration

--- a/tekton/src/pipelines/mas-fvt-launcher.yml.j2
+++ b/tekton/src/pipelines/mas-fvt-launcher.yml.j2
@@ -149,6 +149,25 @@ spec:
     - name: aiservice_instance_id
       type: string
       default: ""
+    
+    # Monitor FVT Parameters
+    # -------------------------------------------------------------------------
+    - name: fvt_digest_monitor
+      type: string
+      default: ""
+      description: "Monitor FVT image digest"
+    - name: mas_app_channel_monitor
+      type: string
+      default: ""
+      description: "Monitor app channel version"
+    - name: mas_workspace_id
+      type: string
+      default: ""
+      description: "MAS workspace ID"
+    - name: fvt_test_suite
+      type: string
+      default: "fvt_9x"
+      description: "Monitor FVT test suite to run (fvt_9x, fvt_91x, fvt_mref, fvt_iot, fvt_scada, fvt_mist, fvt_monitor_only)"
 
   tasks:
     # 0. Configuration

--- a/tekton/src/pipelines/mas-fvt-launcher.yml.j2
+++ b/tekton/src/pipelines/mas-fvt-launcher.yml.j2
@@ -1054,10 +1054,6 @@ spec:
         - input: $(params.launchfvt_predict)
           operator: in
           values: ["true", "True"]
-      when:
-        - input: $(params.launchfvt_predict)
-          operator: in
-          values: ["true", "True"]
       runAfter:
         - waitfor-predict
 


### PR DESCRIPTION


- Add approval-manage dependency to waitfor-monitor task for after-iot scenario
- This ensures waitfor-monitor only starts after manage FVT completes and is approved
- Fixes issue where waitfor-monitor would timeout waiting for monitor installation that couldn't start because manage was still waiting for approval
- Before-iot scenario already has this dependency and is unaffected
- No deadlock risk: IoT approval is independent of monitor in after-iot scenario

- Fix duplicate when clause in launchfvt-predict task