### PR TITLE
[patch] Add Cluster back to ArgoCD

### DIFF
--- a/image/cli/mascli/functions/gitops_bootstrap
+++ b/image/cli/mascli/functions/gitops_bootstrap
@@ -330,6 +330,19 @@ function gitops_bootstrap() {
     export ARGOCD_PASSWORD=$(oc get secret ${ARGOCD_CR_NAME}-cluster -n ${ARGOCLUSTER_NAMESPACE} -ojsonpath='{.data.admin\.password}' | base64 -d ; echo)
   fi
 
+  # 11. Add cluster to ARgoCD
+  argocd login ${ARGOCD_URL} --username ${ARGOCD_USERNAME} --password ${ARGOCD_PASSWORD} --insecure --skip-test-tls
+  export K8S_AUTH_CONTEXT=$(oc whoami -c)
+  argocd cluster add $K8S_AUTH_CONTEXT -y
+  rc=$?
+  if [[ $rc != "0" ]]; then
+    echo 
+    echo "argocd cluster add failed with $rc, try again"
+    echo
+    sleep 10
+    argocd cluster add $K8S_AUTH_CONTEXT -y
+  fi
+
   echo "${COLOR_GREEN}ArgoCD is now available at https://${ARGOCD_URL} username is: admin and password: ${ARGOCD_PASSWORD} ${COLOR_RESET}"
   echo
 


### PR DESCRIPTION
Adds back the adding of the cluster during gitops bootstrap that was incorrectly removed previously