### PR TITLE
[patch] MongoCfg health status showing healthy even when failed true

### DIFF
--- a/image/cli/mascli/templates/gitops/bootstrap/argocd.yaml.j2
+++ b/image/cli/mascli/templates/gitops/bootstrap/argocd.yaml.j2
@@ -950,13 +950,13 @@ spec:
           if obj.status ~= nil then
             if obj.status.conditions ~= nil then
               for i, condition in ipairs(obj.status.conditions) do
-                if condition.type == "Failure" and condition.status == "True" then
-                  hs.status = "Degraded"
+                if condition.type == "Ready" and condition.status == "True" then
+                  hs.status = "Healthy"
                   hs.message = condition.message
                   return hs
                 end
-                if condition.type == "Ready" and condition.status == "True" then
-                  hs.status = "Healthy"
+                if condition.type == "Failure" and condition.status == "True" then
+                  hs.status = "Degraded"
                   hs.message = condition.message
                   return hs
                 end


### PR DESCRIPTION
Issue: [MASCORE-13868](https://jsw.ibm.com/browse/MASCORE-13868)

## Description
When there is failure, Failed status is true but Ready status is not reset to False. But still, Argo should set the resource as healthy only if failed is false

