### PR TITLE
[minor] Add support for scheduling configuration for AI Service tenant for GitOps deployments

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,8 +3,7 @@
     "files": "build/bin/config/oscap/ssg-rhel9-ds.xml|^.secrets.baseline$|^docs/catalogs/",
     "lines": null
   },
-
-  "generated_at": "2026-05-01T10:41:14Z",
+  "generated_at": "2026-05-07T14:37:02Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -225,7 +224,7 @@
         "hashed_secret": "b2817467154949a61f8e9ad31d1eeaf03221cbfa",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 368,
+        "line_number": 372,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "build/bin/config/oscap/ssg-rhel9-ds.xml|^.secrets.baseline$|^docs/catalogs/",
     "lines": null
   },
-  "generated_at": "2026-05-12T10:45:15Z",
+  "generated_at": "2026-05-12T12:20:28Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -234,7 +234,7 @@
         "hashed_secret": "b2817467154949a61f8e9ad31d1eeaf03221cbfa",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 368,
+        "line_number": 372,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/image/cli/mascli/functions/gitops_aiservice_tenant
+++ b/image/cli/mascli/functions/gitops_aiservice_tenant
@@ -258,8 +258,8 @@ function gitops_aiservice_tenant_noninteractive() {
         export TENANT_ENTITLEMENT_END_DATE=$1 && shift
         ;;
 
-      --tenant-scheduling-config-file)
-        export TENANT_SCHEDULING_CONFIG_FILE=$1 && shift
+      --tenant-scheduling-config-yaml)
+        export TENANT_SCHEDULING_CONFIG_YAML=$1 && shift
         ;;
 
       # Automatic GitHub Push
@@ -401,8 +401,8 @@ function gitops_aiservice_tenant() {
   echo_reset_dim "tenant ID ...................................................... ${COLOR_MAGENTA}${TENANT_ID}"
   echo_reset_dim "cluster domain ................................................. ${COLOR_MAGENTA}${CLUSTER_DOMAIN}"
   echo_reset_dim "in SaaS environment ............................................ ${COLOR_MAGENTA}${IN_SAAS_ENV}"
-if [[ -n "$TENANT_SCHEDULING_CONFIG_FILE" ]]
-  echo_reset_dim "Scheduling constraints (tolerations/nodeSelector) .............. ${COLOR_MAGENTA}Configured"
+if [[ -n "$TENANT_SCHEDULING_CONFIG_YAML" ]]
+  echo_reset_dim "Scheduling constraints (tolerations/nodeSelector) .............. ${COLOR_MAGENTA}${TENANT_SCHEDULING_CONFIG_YAML}"
 else
   echo_reset_dim "Scheduling constraints (tolerations/nodeSelector) .............. ${COLOR_MAGENTA}Not Configured"
 fi
@@ -485,6 +485,13 @@ fi
   fi
   sm_verify_secret_exists ${SECRETS_PREFIX}rsl "rsl_org_id,rsl_token"
   sm_verify_secret_exists ${SECRETS_PREFIX}watsonx "watsonxai_apikey,watsonxai_project_id"
+
+  # Load scheduling config file
+  # ---------------------------------------------------------------------------
+  if [[ -n "$TENANT_SCHEDULING_CONFIG_YAML" && -s "$TENANT_SCHEDULING_CONFIG_YAML" ]]; then
+    export TENANT_SCHEDULING_CONFIG=$(yq eval '.' ${TENANT_SCHEDULING_CONFIG_YAML})
+    echo -e "\n - TENANT_SCHEDULING_CONFIG CONTENT .................. ${TENANT_SCHEDULING_CONFIG}"
+  fi
   
   # finally push them into the git repo
 

--- a/image/cli/mascli/functions/gitops_aiservice_tenant
+++ b/image/cli/mascli/functions/gitops_aiservice_tenant
@@ -26,6 +26,7 @@ ibm_aiservice_tenant(required):
       --slscfg-url ${COLOR_YELLOW}SLSCFG_URL${TEXT_RESET}                                                   URL of the SLS configuration service
       --aiservice-watsonxai-url ${COLOR_YELLOW}AISERVICE_WATSONXAI_URL${TEXT_RESET}                         Endpoint URL for Watsonx.ai
       --aiservice-watsonx-full ${COLOR_YELLOW}AISERVICE_WATSONX_FULL${TEXT_RESET}                           Full URL for Watsonx.ai including API key
+      --tenant-scheduling-config-file ${COLOR_YELLOW}TENANT_SCHEDULING_CONFIG_FILE${TEXT_RESET}             Path to tenant scheduling configuration file (tolerations and nodeSelector)
 
 AiService :
 --aiservice-namespace ${COLOR_YELLOW}AISERVICE_NAMESPACE${TEXT_RESET}                                       The namespace where AI Service is deployed
@@ -256,7 +257,10 @@ function gitops_aiservice_tenant_noninteractive() {
       --tenant-entitlement-end-date)
         export TENANT_ENTITLEMENT_END_DATE=$1 && shift
         ;;
-        
+
+      --tenant-scheduling-config-file)
+        export TENANT_SCHEDULING_CONFIG_FILE=$1 && shift
+        ;;
 
       # Automatic GitHub Push
       -P|--github-push)
@@ -387,37 +391,42 @@ function gitops_aiservice_tenant() {
 
   # echo all the variables of gitops envs
 
-  # -- aiservice
-  echo_reset_dim "Aiservice namespace ........................... ${COLOR_MAGENTA}${AISERVICE_NAMESPACE}"
-  echo_reset_dim "Catalog channel ............................... ${COLOR_MAGENTA}${CATALOG_CHANNEL}"
-  echo_reset_dim "Catalog source ................................ ${COLOR_MAGENTA}${CATALOG_SOURCE}"
-  echo_reset_dim "AiService provision tenant ................... ${COLOR_MAGENTA}${AISERVICE_PROVISION_TENANT}"
-  echo_reset_dim "AiService instance ID ......................... ${COLOR_MAGENTA}${AISERVICE_INSTANCE_ID}"
-  echo_reset_dim "tenant namespace ............................. ${COLOR_MAGENTA}${TENANT_NAMESPACE}"
-  echo_reset_dim "tenant ID .................................... ${COLOR_MAGENTA}${TENANT_ID}"
-  echo_reset_dim "cluster domain ............................... ${COLOR_MAGENTA}${CLUSTER_DOMAIN}"
-  echo_reset_dim "in SaaS environment .......................... ${COLOR_MAGENTA}${IN_SAAS_ENV}"
+  # -- aiservice tenant
+  echo_reset_dim "Aiservice namespace ............................................ ${COLOR_MAGENTA}${AISERVICE_NAMESPACE}"
+  echo_reset_dim "Catalog channel ................................................ ${COLOR_MAGENTA}${CATALOG_CHANNEL}"
+  echo_reset_dim "Catalog source ................................................. ${COLOR_MAGENTA}${CATALOG_SOURCE}"
+  echo_reset_dim "AiService provision tenant ..................................... ${COLOR_MAGENTA}${AISERVICE_PROVISION_TENANT}"
+  echo_reset_dim "AiService instance ID .......................................... ${COLOR_MAGENTA}${AISERVICE_INSTANCE_ID}"
+  echo_reset_dim "tenant namespace ............................................... ${COLOR_MAGENTA}${TENANT_NAMESPACE}"
+  echo_reset_dim "tenant ID ...................................................... ${COLOR_MAGENTA}${TENANT_ID}"
+  echo_reset_dim "cluster domain ................................................. ${COLOR_MAGENTA}${CLUSTER_DOMAIN}"
+  echo_reset_dim "in SaaS environment ............................................ ${COLOR_MAGENTA}${IN_SAAS_ENV}"
+if [[ -n "$TENANT_SCHEDULING_CONFIG_FILE" ]]
+  echo_reset_dim "Scheduling constraints (tolerations/nodeSelector) .............. ${COLOR_MAGENTA}Configured"
+else
+  echo_reset_dim "Scheduling constraints (tolerations/nodeSelector) .............. ${COLOR_MAGENTA}Not Configured"
+fi
 
-  echo_reset_dim "MAS ICR CP registry .......................... ${COLOR_MAGENTA}${MAS_ICR_CP}"
-  echo_reset_dim "MAS ICR CPOPEN registry ...................... ${COLOR_MAGENTA}${MAS_ICR_CPOPEN}"
+  echo_reset_dim "MAS ICR CP registry ............................................ ${COLOR_MAGENTA}${MAS_ICR_CP}"
+  echo_reset_dim "MAS ICR CPOPEN registry ........................................ ${COLOR_MAGENTA}${MAS_ICR_CPOPEN}"
 
   # -- SLS
-  echo_reset_dim "SLS subscription ID .......................... ${COLOR_MAGENTA}${AISERVICE_SLS_SUBSCRIPTION_ID}"
-  echo_reset_dim "SLS service param file path .................. ${COLOR_MAGENTA}${STANDALONE_SLS_SERVICE}"
+  echo_reset_dim "SLS subscription ID ............................................ ${COLOR_MAGENTA}${AISERVICE_SLS_SUBSCRIPTION_ID}"
+  echo_reset_dim "SLS service param file path .................................... ${COLOR_MAGENTA}${STANDALONE_SLS_SERVICE}"
   if [ ! -z "$STANDALONE_SLS_SERVICE" ]; then
-    echo_reset_dim "ICN ........................................ ${COLOR_MAGENTA}${ICN}"
-    echo_reset_dim "SAAS_SUB_ID ........................................ ${COLOR_MAGENTA}${SAAS_SUB_ID}"
+    echo_reset_dim "ICN .......................................................... ${COLOR_MAGENTA}${ICN}"
+    echo_reset_dim "SAAS_SUB_ID .................................................. ${COLOR_MAGENTA}${SAAS_SUB_ID}"
   fi
   # -- Watsonx
-  echo_reset_dim "Watsonx.ai URL ............................... ${COLOR_MAGENTA}${AISERVICE_WATSONXAI_URL}"
-  echo_reset_dim "Watsonx.ai full URL .......................... ${COLOR_MAGENTA}${AISERVICE_WATSONX_FULL}"
-  echo_reset_dim "watsonx.ai instance ID ......................... ${COLOR_MAGENTA}${AISERVICE_WATSONX_INSTANCE_ID}"
-  echo_reset_dim "watsonx.ai version ............................. ${COLOR_MAGENTA}${AISERVICE_WATSONX_VERSION}"
-  echo_reset_dim "watsonx.ai username ........................... ${COLOR_MAGENTA}${AISERVICE_WATSONX_USERNAME}"
-  echo_reset_dim "Aiservice operator log level ................... ${COLOR_MAGENTA}${AISERVICE_OPERATOR_LOG_LEVEL}"
+  echo_reset_dim "Watsonx.ai URL ................................................. ${COLOR_MAGENTA}${AISERVICE_WATSONXAI_URL}"
+  echo_reset_dim "Watsonx.ai full URL ............................................ ${COLOR_MAGENTA}${AISERVICE_WATSONX_FULL}"
+  echo_reset_dim "watsonx.ai instance ID ......................................... ${COLOR_MAGENTA}${AISERVICE_WATSONX_INSTANCE_ID}"
+  echo_reset_dim "watsonx.ai version ............................................. ${COLOR_MAGENTA}${AISERVICE_WATSONX_VERSION}"
+  echo_reset_dim "watsonx.ai username ............................................ ${COLOR_MAGENTA}${AISERVICE_WATSONX_USERNAME}"
+  echo_reset_dim "Aiservice operator log level ................................... ${COLOR_MAGENTA}${AISERVICE_OPERATOR_LOG_LEVEL}"
   # -- STORAGE
-  echo_reset_dim "SSL enabled .................................. ${COLOR_MAGENTA}${AISERVICE_STORAGE_SSL}"
-  echo_reset_dim "Storage provider ............................. ${COLOR_MAGENTA}${AISERVICE_STORAGE_PROVIDER}"
+  echo_reset_dim "SSL enabled .................................................... ${COLOR_MAGENTA}${AISERVICE_STORAGE_SSL}"
+  echo_reset_dim "Storage provider ............................................... ${COLOR_MAGENTA}${AISERVICE_STORAGE_PROVIDER}"
   AVP_TYPE=aws  # Support for IBM will be added later
   sm_login
 

--- a/image/cli/mascli/functions/gitops_aiservice_tenant
+++ b/image/cli/mascli/functions/gitops_aiservice_tenant
@@ -490,7 +490,7 @@ fi
   # ---------------------------------------------------------------------------
   if [[ -n "$TENANT_SCHEDULING_CONFIG_YAML" && -s "$TENANT_SCHEDULING_CONFIG_YAML" ]]; then
     export TENANT_SCHEDULING_CONFIG=$(yq eval '.' ${TENANT_SCHEDULING_CONFIG_YAML})
-    echo -e "\n - TENANT_SCHEDULING_CONFIG CONTENT .................. ${TENANT_SCHEDULING_CONFIG}"
+    echo -e "\n - TENANT_SCHEDULING_CONFIG content .................. ${TENANT_SCHEDULING_CONFIG}"
   fi
   
   # finally push them into the git repo

--- a/image/cli/mascli/functions/gitops_aiservice_tenant
+++ b/image/cli/mascli/functions/gitops_aiservice_tenant
@@ -401,7 +401,7 @@ function gitops_aiservice_tenant() {
   echo_reset_dim "tenant ID ...................................................... ${COLOR_MAGENTA}${TENANT_ID}"
   echo_reset_dim "cluster domain ................................................. ${COLOR_MAGENTA}${CLUSTER_DOMAIN}"
   echo_reset_dim "in SaaS environment ............................................ ${COLOR_MAGENTA}${IN_SAAS_ENV}"
-if [[ -n "$TENANT_SCHEDULING_CONFIG_YAML" ]]
+if [[ -n "$TENANT_SCHEDULING_CONFIG_YAML" ]]; then
   echo_reset_dim "Scheduling constraints (tolerations/nodeSelector) .............. ${COLOR_MAGENTA}${TENANT_SCHEDULING_CONFIG_YAML}"
 else
   echo_reset_dim "Scheduling constraints (tolerations/nodeSelector) .............. ${COLOR_MAGENTA}Not Configured"

--- a/image/cli/mascli/templates/gitops/appset-configs/cluster/instance/ibm-aiservice-tenant.yaml.j2
+++ b/image/cli/mascli/templates/gitops/appset-configs/cluster/instance/ibm-aiservice-tenant.yaml.j2
@@ -55,3 +55,7 @@ ibm_aiservice_tenant:
   tenant_entitlement_end_date: "{{ TENANT_ENTITLEMENT_END_DATE }}"
   
   aiservice_operator_log_level: "{{ AISERVICE_OPERATOR_LOG_LEVEL }}"
+
+{% if TENANT_SCHEDULING_CONFIG_FILE is defined and TENANT_SCHEDULING_CONFIG_FILE != '' %}
+  tenant_scheduling_config: {{ TENANT_SCHEDULING_CONFIG_FILE }}
+{% endif %}

--- a/image/cli/mascli/templates/gitops/appset-configs/cluster/instance/ibm-aiservice-tenant.yaml.j2
+++ b/image/cli/mascli/templates/gitops/appset-configs/cluster/instance/ibm-aiservice-tenant.yaml.j2
@@ -56,6 +56,7 @@ ibm_aiservice_tenant:
   
   aiservice_operator_log_level: "{{ AISERVICE_OPERATOR_LOG_LEVEL }}"
 
-{% if TENANT_SCHEDULING_CONFIG_FILE is defined and TENANT_SCHEDULING_CONFIG_FILE != '' %}
-  tenant_scheduling_config: {{ TENANT_SCHEDULING_CONFIG_FILE }}
+{% if TENANT_SCHEDULING_CONFIG is defined and TENANT_SCHEDULING_CONFIG != '' %}
+  tenant_scheduling_config:
+    {{ TENANT_SCHEDULING_CONFIG | indent(4)}}
 {% endif %}

--- a/tekton/src/pipelines/gitops/gitops-aiservice-tenant-pipeline.yml.j2
+++ b/tekton/src/pipelines/gitops/gitops-aiservice-tenant-pipeline.yml.j2
@@ -90,8 +90,9 @@ spec:
       type: string
     - name: tenant_entitlement_end_date
       type: string
-    - name: tenant_scheduling_config_file
+    - name: tenant_scheduling_config_yaml
       type: string
+      default: ""
 
     # standalone sls
     - name: sls_service
@@ -100,6 +101,7 @@ spec:
 
   workspaces:
     - name: configs
+    - name: shared-gitops-configs
   tasks:
     - name: run-gitops-aiservice-tenant
       taskRef:
@@ -107,6 +109,8 @@ spec:
       workspaces:
         - name: configs
           workspace: configs
+        - name: shared-gitops-configs
+          workspace: shared-gitops-configs
       params:
         - name: cluster_name
           value: $(params.cluster_name)
@@ -192,7 +196,7 @@ spec:
           value: $(params.tenant_entitlement_start_date)
         - name: tenant_entitlement_end_date
           value: $(params.tenant_entitlement_end_date)
-        - name: tenant_scheduling_config_file
-          value: $(params.tenant_scheduling_config_file)
+        - name: tenant_scheduling_config_yaml
+          value: $(params.tenant_scheduling_config_yaml)
         - name: sls_service
           value: $(params.sls_service)

--- a/tekton/src/pipelines/gitops/gitops-aiservice-tenant-pipeline.yml.j2
+++ b/tekton/src/pipelines/gitops/gitops-aiservice-tenant-pipeline.yml.j2
@@ -90,6 +90,8 @@ spec:
       type: string
     - name: tenant_entitlement_end_date
       type: string
+    - name: tenant_scheduling_config_file
+      type: string
 
     # standalone sls
     - name: sls_service
@@ -190,5 +192,7 @@ spec:
           value: $(params.tenant_entitlement_start_date)
         - name: tenant_entitlement_end_date
           value: $(params.tenant_entitlement_end_date)
+        - name: tenant_scheduling_config_file
+          value: $(params.tenant_scheduling_config_file)
         - name: sls_service
           value: $(params.sls_service)

--- a/tekton/src/tasks/gitops/gitops-aiservice-tenant.yml.j2
+++ b/tekton/src/tasks/gitops/gitops-aiservice-tenant.yml.j2
@@ -220,3 +220,4 @@ spec:
       image: quay.io/ibmmas/cli:latest
   workspaces:
     - name: configs
+    - name: shared-gitops-configs

--- a/tekton/src/tasks/gitops/gitops-aiservice-tenant.yml.j2
+++ b/tekton/src/tasks/gitops/gitops-aiservice-tenant.yml.j2
@@ -87,6 +87,8 @@ spec:
       type: string
     - name: tenant_entitlement_end_date
       type: string
+    - name: tenant_scheduling_config_file
+      type: string
     - name: sls_service
       type: string
       default: ""
@@ -173,6 +175,8 @@ spec:
         value: $(params.tenant_entitlement_start_date)
       - name: TENANT_ENTITLEMENT_END_DATE
         value: $(params.tenant_entitlement_end_date)
+      - name: TENANT_SCHEDULING_CONFIG_FILE
+        value: $(params.tenant_scheduling_config_file)
       - name: STANDALONE_SLS_SERVICE
         value: $(params.sls_service)
     envFrom:

--- a/tekton/src/tasks/gitops/gitops-aiservice-tenant.yml.j2
+++ b/tekton/src/tasks/gitops/gitops-aiservice-tenant.yml.j2
@@ -87,7 +87,7 @@ spec:
       type: string
     - name: tenant_entitlement_end_date
       type: string
-    - name: tenant_scheduling_config_file
+    - name: tenant_scheduling_config_yaml
       type: string
     - name: sls_service
       type: string
@@ -175,8 +175,8 @@ spec:
         value: $(params.tenant_entitlement_start_date)
       - name: TENANT_ENTITLEMENT_END_DATE
         value: $(params.tenant_entitlement_end_date)
-      - name: TENANT_SCHEDULING_CONFIG_FILE
-        value: $(params.tenant_scheduling_config_file)
+      - name: TENANT_SCHEDULING_CONFIG_YAML
+        value: $(params.tenant_scheduling_config_yaml)
       - name: STANDALONE_SLS_SERVICE
         value: $(params.sls_service)
     envFrom:


### PR DESCRIPTION
## Description

- Add support for configuring scheduling policies(tolerations & nodeSelector) for AI workloads for specific AI Service tenant.
- Updated templates for gitops-envs YAML files.
- Updated GitOps tekton definitions for gitops-envs YAML files.

## Test Results

- Created a Tenant with scheduling configuration and ensured that tenant application is synced without any error and tolerations and nodeSelector are configured for AIServiceTenant CR.
- Created a Tenant without scheduling configuration and ensured that tenant application is synced without any error.
- Updated an existing tenant to add scheduling configuration and ensured that tenant application is synced without any error.
- Updated an existing tenant to remove scheduling configuration and ensured that tenant application is synced without any error.

<img width="1023" height="332" alt="Screenshot 2026-05-12 at 5 32 27 PM" src="https://github.com/user-attachments/assets/9841cd6a-fe1d-4305-816d-a59adcda43ee" />
<img width="806" height="714" alt="Screenshot 2026-05-11 at 2 43 22 PM" src="https://github.com/user-attachments/assets/3e2e3b3f-7911-4bea-9d4e-6cf62d3e6992" />
<img width="1104" height="533" alt="Screenshot 2026-05-11 at 6 44 33 PM" src="https://github.com/user-attachments/assets/352166eb-23a4-4b1c-b498-b9431cc96ab8" />
<img width="1384" height="706" alt="Screenshot 2026-05-11 at 6 44 47 PM" src="https://github.com/user-attachments/assets/9aa2a249-42c7-4211-81f7-85e2fde5f46b" />
<img width="1104" height="533" alt="Screenshot 2026-05-11 at 6 44 33 PM" src="https://github.com/user-attachments/assets/fb460d1e-9e60-4520-98dc-5552ff4860f9" />

## Related PR

- ibm-mas/gitops#453
