### PR TITLE
[patch] Fix Monitor FVT waiting for IoT installation when IoT FVT is disabled (FVT CPD)

### DIFF
--- a/tekton/src/pipelines/mas-fvt-launcher.yml.j2
+++ b/tekton/src/pipelines/mas-fvt-launcher.yml.j2
@@ -444,9 +444,6 @@ spec:
         - name: ignore_failure
           value: "False"
       when:
-        - input: $(params.launchfvt_iot)
-          operator: in
-          values: ["true", "True"]
         - input: $(params.sync_with_install)
           operator: in
           values: ["true", "True"]


### PR DESCRIPTION
The waitfor-iot-after-monitor task was incorrectly gated by the launchfvt_iot parameter, which controls whether IoT FVT tests run. This caused Monitor FVT tests to skip waiting for IoT installation to complete when IoT FVT was disabled (FVT CPD).

In environments where IoT is installed but IoT FVT tests are not executed (launchfvt_iot=false), Monitor FVT would start immediately after Monitor installation, before IoT installation completed. This caused Monitor FVT tests to fail because they require IoT to be fully installed and registered in the MAS Core API.

The fix removes the launchfvt_iot condition from waitfor-iot-after-monitor, ensuring Monitor FVT always waits for IoT installation to complete when mas_monitor_install_order=before-iot, regardless of whether IoT FVT tests will be executed afterward.