### PR TITLE
[minor] Cli base image update to include ibm_db python package and creation of rds instance with no db

### DIFF
--- a/image/cli/Dockerfile
+++ b/image/cli/Dockerfile
@@ -8,6 +8,7 @@ LABEL quay.expires-after=3w
 COPY app-root/src/ /opt/app-root/src/
 COPY rbac/ /opt/app-root/src/rbac/
 COPY mascli/ /mascli/
+COPY masfvt/ /masfvt/
 COPY usr/bin/ /usr/bin/
 
 # 2. Set up Environment

--- a/image/cli/Dockerfile
+++ b/image/cli/Dockerfile
@@ -43,4 +43,3 @@ RUN --mount=type=secret,id=ARTIFACTORY_TOKEN \
     ibmcloud config --check-version=false && \
     ln -s /opt/app-root/lib/python3.12/site-packages /mascli/site-packages && \
     rm -rf /tmp/install
-

--- a/image/cli/Dockerfile
+++ b/image/cli/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/ibmmas/cli-base:latest
+FROM quay.io/ibmmas/cli-base:1.10.1-pre.ibm-db
 ARG VERSION_LABEL
 
 # Auto-expire the image in quay.io after 3 weeks
@@ -8,7 +8,6 @@ LABEL quay.expires-after=3w
 COPY app-root/src/ /opt/app-root/src/
 COPY rbac/ /opt/app-root/src/rbac/
 COPY mascli/ /mascli/
-COPY masfvt/ /masfvt/
 COPY usr/bin/ /usr/bin/
 
 # 2. Set up Environment

--- a/image/cli/Dockerfile
+++ b/image/cli/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/ibmmas/cli-base:1.10.1-pre.ibm-db
+FROM quay.io/ibmmas/cli-base:1.11.0-pre.stable
 ARG VERSION_LABEL
 
 # Auto-expire the image in quay.io after 3 weeks

--- a/image/cli/Dockerfile
+++ b/image/cli/Dockerfile
@@ -43,3 +43,4 @@ RUN --mount=type=secret,id=ARTIFACTORY_TOKEN \
     ibmcloud config --check-version=false && \
     ln -s /opt/app-root/lib/python3.12/site-packages /mascli/site-packages && \
     rm -rf /tmp/install
+

--- a/image/cli/Dockerfile
+++ b/image/cli/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/ibmmas/cli-base:1.11.0-pre.stable
+FROM quay.io/ibmmas/cli-base:latest
 ARG VERSION_LABEL
 
 # Auto-expire the image in quay.io after 3 weeks

--- a/image/cli/install/permissions-updates.sh
+++ b/image/cli/install/permissions-updates.sh
@@ -11,7 +11,10 @@ chmod +x /mascli/mas
 chmod +x /mascli/must-gather/*
 chmod +x /mascli/debug/*
 chmod +x /mascli/backup-restore/*
-chmod -R ug+w /masfvt
+# Only chmod /masfvt if it exists
+if [ -d /masfvt ]; then
+  chmod -R ug+w /masfvt
+fi
 chmod +x /usr/bin/gather
 chmod -R g+w $ANSIBLE_COLLECTIONS_PATH/ibm/mas_devops
 ln -s $ANSIBLE_COLLECTIONS_PATH/ibm/mas_devops /mascli/ansible-devops

--- a/image/cli/mascli/templates/gitops/appset-configs/cluster/instance/ibm-iac-rdsdb2.tf.j2
+++ b/image/cli/mascli/templates/gitops/appset-configs/cluster/instance/ibm-iac-rdsdb2.tf.j2
@@ -35,7 +35,6 @@ module "db2rds-{{RDS_APP}}" {
   db2_enabled_cloudwatch_logs_exports = ["diag.log", "notify.log"]
   db2_additional_security_groups      = local.cluster.security_groups
   region_name                         = "{{REGION_NAME}}"
-  db_name                             = "BLUDB"
   db2_identifier                      = "rds"
   engine_version                      = var.engine_version
   multi_az                            = false


### PR DESCRIPTION
Jira: https://jsw.ibm.com/browse/MASCORE-13709

Cli base image update and creation of rds instance with optional db
saas-env-starter ref: https://github.ibm.com/maximoappsuite/saas-envs-starter/pull/163

Description:
1. Update gitops to use new cli digest image for db operations. The new clid digest image does not requitre gitops to install ibm-db.
2. Create database based in instance and app id. This changes is added to unblock backup and restore operation as primary database created during rds instance creation cant be dropped.

Jira:
https://jsw.ibm.com/browse/MASCORE-13709
<img width="1527" height="817" alt="image" src="https://github.com/user-attachments/assets/25fa8688-0274-48ee-bd79-1f109e4e32ef" />

Argo:
<img width="1455" height="847" alt="image" src="https://github.com/user-attachments/assets/0d541a52-9687-4c6e-821f-ae77d0812a9e" />

Create DB:
<img width="1641" height="719" alt="image" src="https://github.com/user-attachments/assets/195a1f0b-d672-467c-b844-582089b6eaff" />

Secret manager got update:
<img width="1728" height="893" alt="image" src="https://github.com/user-attachments/assets/2d1c9adf-9069-407e-94bd-c4c6d8296a07" />

Cli digest image test result:
<img width="1343" height="707" alt="image" src="https://github.com/user-attachments/assets/7751b1f4-6d5e-4307-bcb3-b513be5e2da1" />

New db created using gitiops:
https://github.com/ibm-mas/gitops/pull/457
<img width="1708" height="837" alt="image" src="https://github.com/user-attachments/assets/7f48c555-df06-44bc-b439-f3a848266e8c" />

