### PR TITLE
[patch] Added the facilities in mas-upgrade pipeline

### DIFF
--- a/tekton/src/pipelines/mas-install.yml.j2
+++ b/tekton/src/pipelines/mas-install.yml.j2
@@ -472,7 +472,7 @@ spec:
     # 13.1 Dedicated Facilities Db2
     {{ lookup('template', pipeline_src_dir ~ '/taskdefs/apps/db2-setup-facilities.yml.j2') | indent(4)}}
       runAfter:
-        - suite-config-db2
+        - db2-manage
 
     # 13.2 Install Facilities
     {{ lookup('template', pipeline_src_dir ~ '/taskdefs/apps/facilities-app.yml.j2') | indent(4) }}

--- a/tekton/src/pipelines/mas-install.yml.j2
+++ b/tekton/src/pipelines/mas-install.yml.j2
@@ -472,7 +472,7 @@ spec:
     # 13.1 Dedicated Facilities Db2
     {{ lookup('template', pipeline_src_dir ~ '/taskdefs/apps/db2-setup-facilities.yml.j2') | indent(4)}}
       runAfter:
-        - db2-manage
+        - suite-config-db2
 
     # 13.2 Install Facilities
     {{ lookup('template', pipeline_src_dir ~ '/taskdefs/apps/facilities-app.yml.j2') | indent(4) }}

--- a/tekton/src/pipelines/mas-upgrade.yml.j2
+++ b/tekton/src/pipelines/mas-upgrade.yml.j2
@@ -130,7 +130,7 @@ spec:
       'operator': 'in',
       'values': ['true']
     }] %}
-    {%- set updated_task = task | combine({'when': merged_when, 'runAfter': ['suite-db2-setup-facilities']}, recursive=True) %}
+    {%- set updated_task = task | combine({'when': merged_when, 'runAfter': ['db2-manage']}, recursive=True) %}
     {%- set task_yaml = [updated_task] | to_nice_yaml(indent=2) %}
 
     {{ task_yaml | indent(4, false) }}

--- a/tekton/src/pipelines/mas-upgrade.yml.j2
+++ b/tekton/src/pipelines/mas-upgrade.yml.j2
@@ -124,7 +124,14 @@ spec:
     {%- set task_yaml = [updated_task] | to_nice_yaml(indent=2) %}
 
     {{ task_yaml | indent(4, false) }}
-    # 3.1.3 Configure Db2 in MAS
+    # 3.1.3 Dedicated Facilities Db2
+    {{ lookup('template', pipeline_src_dir ~ '/taskdefs/apps/db2-setup-facilities.yml.j2') | indent(4)}}
+      runAfter:
+        - db2-manage
+    
+    {{ task_yaml | indent(4, false) }}
+
+    # 3.1.4 Configure Db2 in MAS
     {%- set tasks = lookup('template', pipeline_src_dir ~ '/taskdefs/core/suite-config-db2.yml.j2') | from_yaml %}
     {%- set task = tasks[0] %}
     {%- set merged_when = (task.when | default([])) + [{
@@ -132,7 +139,7 @@ spec:
       'operator': 'in',
       'values': ['true']
     }] %}
-    {%- set updated_task = task | combine({'when': merged_when, 'runAfter': ['db2-manage']}, recursive=True) %}
+    {%- set updated_task = task | combine({'when': merged_when, 'runAfter': ['suite-db2-setup-facilities']}, recursive=True) %}
     {%- set task_yaml = [updated_task] | to_nice_yaml(indent=2) %}
 
     {{ task_yaml | indent(4, false) }}
@@ -400,12 +407,6 @@ spec:
     
     # 12 Install & Configure Facilities
     # -------------------------------------------------------------------------
-    # 12.1 Dedicated Facilities Db2
-    {{ lookup('template', pipeline_src_dir ~ '/taskdefs/apps/db2-setup-facilities.yml.j2') | indent(4)}}
-      runAfter:
-        - db2-manage
-
-    # 12.2 Install Facilities
     {{ lookup('template', pipeline_src_dir ~ '/taskdefs/apps/facilities-app.yml.j2') | indent(4) }}
       runAfter:
         - suite-config-db2

--- a/tekton/src/pipelines/mas-upgrade.yml.j2
+++ b/tekton/src/pipelines/mas-upgrade.yml.j2
@@ -174,6 +174,15 @@ spec:
 
     {{ task_yaml | indent(4, false) }}
 
+    {{ task_yaml | indent(4, false) }}
+    # 4.4 Facilities Install
+    {%- set tasks = lookup('template', pipeline_src_dir ~ '/taskdefs/apps/facilities-app.yml.j2') | from_yaml %}
+    {%- set task = tasks[0] %}
+    {%- set updated_task = task | combine({'when': merged_when, 'runAfter': ['suite-db2-setup-facilities']}, recursive=True) %}
+    {%- set task_yaml = [updated_task] | to_nice_yaml(indent=2) %}
+
+    {{ task_yaml | indent(4, false) }}
+
     # 5. Manage Upgrade (Phase 4)
     # -------------------------------------------------------------------------
     - name: app-manage-upgrade

--- a/tekton/src/pipelines/mas-upgrade.yml.j2
+++ b/tekton/src/pipelines/mas-upgrade.yml.j2
@@ -399,14 +399,14 @@ spec:
     # 12 Install & Configure Facilities
     # -------------------------------------------------------------------------
     # 12.1 Dedicated Facilities Db2
-      {{ lookup('template', pipeline_src_dir ~ '/taskdefs/apps/db2-setup-facilities.yml.j2') | indent(4)}}
-        runAfter:
-          - db2-manage
+    {{ lookup('template', pipeline_src_dir ~ '/taskdefs/apps/db2-setup-facilities.yml.j2') | indent(4)}}
+      runAfter:
+        - db2-manage
 
     # 12.2 Install Facilities
-      {{ lookup('template', pipeline_src_dir ~ '/taskdefs/apps/facilities-app.yml.j2') | indent(4) }}
-        runAfter:
-          - suite-config-db2
+    {{ lookup('template', pipeline_src_dir ~ '/taskdefs/apps/facilities-app.yml.j2') | indent(4) }}
+      runAfter:
+        - suite-config-db2
 
     # 13 Facilities Upgrade
     # -------------------------------------------------------------------------

--- a/tekton/src/pipelines/mas-upgrade.yml.j2
+++ b/tekton/src/pipelines/mas-upgrade.yml.j2
@@ -199,6 +199,28 @@ spec:
         - input: "$(params.should_install_manage_foundation)"
           operator: notin
           values: ["true"]
+    
+    # 5.1 Facilities Upgrade (Phase 4)
+    # -------------------------------------------------------------------------
+    - name: app-facilities-upgrade
+      timeout: "0"
+      params:
+        {{ lookup('template', pipeline_src_dir ~ '/taskdefs/common/cli-params.yml.j2') | indent(8) }}
+        - name: mas_instance_id
+          value: $(params.mas_instance_id)
+        - name: mas_app_id
+          value: facilities
+        - name: mas_app_channel
+          value: $(params.mas_app_channel_manage)
+        - name: skip_compatibility_check
+          value: $(params.skip_compatibility_check)
+        - name: devops_suite_name
+          value: app-facilities-upgrade
+      taskRef:
+        kind: Task
+        name: mas-devops-suite-app-upgrade
+      runAfter:
+        - app-install-facilities
 
     # 6. Monitor Upgrade (Monitor >= 9.2.0 - upgrades before IoT)
     # -------------------------------------------------------------------------

--- a/tekton/src/pipelines/mas-upgrade.yml.j2
+++ b/tekton/src/pipelines/mas-upgrade.yml.j2
@@ -9,6 +9,8 @@ spec:
     - name: shared-configs
     # PodTemplates configurations
     - name: shared-pod-templates
+    # Db2 License File
+    - name: shared-db2
   params:
     # 1. Common Parameters
     # -------------------------------------------------------------------------

--- a/tekton/src/pipelines/mas-upgrade.yml.j2
+++ b/tekton/src/pipelines/mas-upgrade.yml.j2
@@ -174,15 +174,6 @@ spec:
 
     {{ task_yaml | indent(4, false) }}
 
-    {{ task_yaml | indent(4, false) }}
-    # 4.4 Facilities Install
-    {%- set tasks = lookup('template', pipeline_src_dir ~ '/taskdefs/apps/facilities-app.yml.j2') | from_yaml %}
-    {%- set task = tasks[0] %}
-    {%- set updated_task = task | combine({'when': merged_when, 'runAfter': ['suite-db2-setup-facilities']}, recursive=True) %}
-    {%- set task_yaml = [updated_task] | to_nice_yaml(indent=2) %}
-
-    {{ task_yaml | indent(4, false) }}
-
     # 5. Manage Upgrade (Phase 4)
     # -------------------------------------------------------------------------
     - name: app-manage-upgrade
@@ -208,28 +199,6 @@ spec:
         - input: "$(params.should_install_manage_foundation)"
           operator: notin
           values: ["true"]
-    
-    # 5.1 Facilities Upgrade (Phase 4)
-    # -------------------------------------------------------------------------
-    - name: app-facilities-upgrade
-      timeout: "0"
-      params:
-        {{ lookup('template', pipeline_src_dir ~ '/taskdefs/common/cli-params.yml.j2') | indent(8) }}
-        - name: mas_instance_id
-          value: $(params.mas_instance_id)
-        - name: mas_app_id
-          value: facilities
-        - name: mas_app_channel
-          value: $(params.mas_app_channel_manage)
-        - name: skip_compatibility_check
-          value: $(params.skip_compatibility_check)
-        - name: devops_suite_name
-          value: app-facilities-upgrade
-      taskRef:
-        kind: Task
-        name: mas-devops-suite-app-upgrade
-      runAfter:
-        - app-install-facilities
 
     # 6. Monitor Upgrade (Monitor >= 9.2.0 - upgrades before IoT)
     # -------------------------------------------------------------------------
@@ -426,8 +395,42 @@ spec:
         - app-manage-upgrade
         - app-monitor-upgrade
         - app-monitor-upgrade-before-iot
+    
+    # 12 Install & Configure Facilities
+    # -------------------------------------------------------------------------
+    # 12.1 Dedicated Facilities Db2
+      {{ lookup('template', pipeline_src_dir ~ '/taskdefs/apps/db2-setup-facilities.yml.j2') | indent(4)}}
+        runAfter:
+          - db2-manage
 
-    # 12. Verify health of the cluster after upgrade
+    # 12.2 Install Facilities
+      {{ lookup('template', pipeline_src_dir ~ '/taskdefs/apps/facilities-app.yml.j2') | indent(4) }}
+        runAfter:
+          - suite-config-db2
+
+    # 13 Facilities Upgrade
+    # -------------------------------------------------------------------------
+    - name: app-facilities-upgrade
+      timeout: "0"
+      params:
+        {{ lookup('template', pipeline_src_dir ~ '/taskdefs/common/cli-params.yml.j2') | indent(8) }}
+        - name: mas_instance_id
+          value: $(params.mas_instance_id)
+        - name: mas_app_id
+          value: facilities
+        - name: mas_app_channel
+          value: $(params.mas_app_channel_manage)
+        - name: skip_compatibility_check
+          value: $(params.skip_compatibility_check)
+        - name: devops_suite_name
+          value: app-facilities-upgrade
+      taskRef:
+        kind: Task
+        name: mas-devops-suite-app-upgrade
+      runAfter:
+        - app-install-facilities
+
+    # 14. Verify health of the cluster after upgrade
     # -------------------------------------------------------------------------
     {{ lookup('template', 'taskdefs/cluster-setup/ocp-verify-all.yml.j2', template_vars={
         'name': 'post-upgrade-verify',

--- a/tekton/src/pipelines/mas-upgrade.yml.j2
+++ b/tekton/src/pipelines/mas-upgrade.yml.j2
@@ -9,8 +9,6 @@ spec:
     - name: shared-configs
     # PodTemplates configurations
     - name: shared-pod-templates
-    # Db2 License File
-    - name: shared-db2
   params:
     # 1. Common Parameters
     # -------------------------------------------------------------------------
@@ -124,14 +122,7 @@ spec:
     {%- set task_yaml = [updated_task] | to_nice_yaml(indent=2) %}
 
     {{ task_yaml | indent(4, false) }}
-    # 3.1.3 Dedicated Facilities Db2
-    {{ lookup('template', pipeline_src_dir ~ '/taskdefs/apps/db2-setup-facilities.yml.j2') | indent(4)}}
-      runAfter:
-        - db2-manage
-    
-    {{ task_yaml | indent(4, false) }}
-
-    # 3.1.4 Configure Db2 in MAS
+    # 3.1.3 Configure Db2 in MAS
     {%- set tasks = lookup('template', pipeline_src_dir ~ '/taskdefs/core/suite-config-db2.yml.j2') | from_yaml %}
     {%- set task = tasks[0] %}
     {%- set merged_when = (task.when | default([])) + [{
@@ -404,14 +395,8 @@ spec:
         - app-manage-upgrade
         - app-monitor-upgrade
         - app-monitor-upgrade-before-iot
-    
-    # 12 Install & Configure Facilities
-    # -------------------------------------------------------------------------
-    {{ lookup('template', pipeline_src_dir ~ '/taskdefs/apps/facilities-app.yml.j2') | indent(4) }}
-      runAfter:
-        - suite-config-db2
 
-    # 13 Facilities Upgrade
+    # 12 Facilities Upgrade
     # -------------------------------------------------------------------------
     - name: app-facilities-upgrade
       timeout: "0"
@@ -433,7 +418,7 @@ spec:
       runAfter:
         - app-install-facilities
 
-    # 14. Verify health of the cluster after upgrade
+    # 13. Verify health of the cluster after upgrade
     # -------------------------------------------------------------------------
     {{ lookup('template', 'taskdefs/cluster-setup/ocp-verify-all.yml.j2', template_vars={
         'name': 'post-upgrade-verify',

--- a/tekton/src/pipelines/mas-upgrade.yml.j2
+++ b/tekton/src/pipelines/mas-upgrade.yml.j2
@@ -416,7 +416,7 @@ spec:
         kind: Task
         name: mas-devops-suite-app-upgrade
       runAfter:
-        - app-install-facilities
+        - core-verify
 
     # 13. Verify health of the cluster after upgrade
     # -------------------------------------------------------------------------


### PR DESCRIPTION
## 1. Description
While monitoring the custom Day 2 pipeline FVT run, we observed that the facilities upgrade task is missing from the `mas-upgrade` pipeline flow. As a result, the facilities upgrade step was not executed in any of the scheduled or custom FVT Day 2 runs. Hence, added the facilities in `mas-upgrade` pipeline

## 2. Issue
- https://jsw.ibm.com/browse/MASREF-5096
 
## 3. Tests

<img width="2900" height="1874" alt="image" src="https://github.com/user-attachments/assets/40a7d721-a17f-4b44-a6b2-0190354e89ef" />

<img width="2432" height="1398" alt="image" src="https://github.com/user-attachments/assets/3186ec1d-361b-4549-9618-17ed5efd71ac" />


