### PR TITLE
[patch] Fix centralized SLS FVT issues for gitops

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "build/bin/config/oscap/ssg-rhel9-ds.xml|^.secrets.baseline$|^docs/catalogs/",
     "lines": null
   },
-  "generated_at": "2026-05-10T18:20:55Z",
+  "generated_at": "2026-05-12T05:58:16Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -702,7 +702,7 @@
         "hashed_secret": "fee2d55ad9a49a95fc89abe8f414dad66704ebfd",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 21,
+        "line_number": 22,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,11 +3,7 @@
     "files": "build/bin/config/oscap/ssg-rhel9-ds.xml|^.secrets.baseline$|^docs/catalogs/",
     "lines": null
   },
-<<<<<<< mascore13986
-  "generated_at": "2026-05-12T05:58:16Z",
-=======
-  "generated_at": "2026-05-12T09:51:04Z",
->>>>>>> master
+  "generated_at": "2026-05-12T10:45:15Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -406,11 +402,7 @@
         "hashed_secret": "b2817467154949a61f8e9ad31d1eeaf03221cbfa",
         "is_secret": false,
         "is_verified": false,
-<<<<<<< mascore13986
-        "line_number": 704,
-=======
         "line_number": 747,
->>>>>>> master
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -418,11 +410,7 @@
         "hashed_secret": "effb7852555adce89885fb075fb43a77a1e0e77e",
         "is_secret": false,
         "is_verified": false,
-<<<<<<< mascore13986
-        "line_number": 923,
-=======
         "line_number": 982,
->>>>>>> master
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -430,11 +418,7 @@
         "hashed_secret": "2582aea6f911bd00fc04cb25e0ec16d5ead62068",
         "is_secret": false,
         "is_verified": false,
-<<<<<<< mascore13986
-        "line_number": 925,
-=======
         "line_number": 984,
->>>>>>> master
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -718,11 +702,7 @@
         "hashed_secret": "fee2d55ad9a49a95fc89abe8f414dad66704ebfd",
         "is_secret": false,
         "is_verified": false,
-<<<<<<< mascore13986
         "line_number": 22,
-=======
-        "line_number": 21,
->>>>>>> master
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/image/cli/mascli/templates/gitops/appset-configs/cluster/instance/ibm-sls.yaml.j2
+++ b/image/cli/mascli/templates/gitops/appset-configs/cluster/instance/ibm-sls.yaml.j2
@@ -8,6 +8,7 @@ ibm_sls:
   sls_channel: {{ SLS_CHANNEL }}
   sls_entitlement_file: <path:{{ SECRETS_PATH }}:{{ SECRET_KEY_LICENSE_FILE }}>
   ibm_entitlement_key: <path:{{ SECRETS_PATH }}:{{ SECRET_KEY_IBM_ENTITLEMENT }}>
+{% endif %}
   
   # aws docdb
   mongodb_provider: "{{ MONGODB_PROVIDER }}"
@@ -56,6 +57,4 @@ ibm_sls:
 {%- endif -%}
 {% if INTERNAL_CERTIFICATE_AUTHORITY is defined and INTERNAL_CERTIFICATE_AUTHORITY != '' %}
   internal_certificate_authority: {{ INTERNAL_CERTIFICATE_AUTHORITY }}
-{% endif %}
-
 {% endif %}

--- a/tekton/src/pipelines/gitops/gitops-mas-fvt-preparer-pipeline.yml.j2
+++ b/tekton/src/pipelines/gitops/gitops-mas-fvt-preparer-pipeline.yml.j2
@@ -175,6 +175,9 @@ spec:
     - name: smtp_use_sendgrid
       type: string
       default: ""
+    - name: standalone_sls_service
+      type: string
+      default: ""
 
   tasks:
     - name: mas-launchfvt
@@ -315,6 +318,8 @@ spec:
           value: $(params.avp_aws_secret_region)
         - name: use_sendgrid
           value: $(params.smtp_use_sendgrid)
+        - name: standalone_sls_service
+          value: $(params.standalone_sls_service)
 
       workspaces:
         - name: configs

--- a/tekton/src/tasks/gitops/gitops-mas-fvt-preparer.yml.j2
+++ b/tekton/src/tasks/gitops/gitops-mas-fvt-preparer.yml.j2
@@ -506,7 +506,9 @@ spec:
             # Extract ICN and subscription ID from STANDALONE_SLS_SERVICE path
             CLEAN_PATH=$(echo "$STANDALONE_SLS_SERVICE" | sed 's#<ref:##; s#>##')
             IFS='/' read -r -a PARTS <<< "$CLEAN_PATH"
+            {% raw %}
             if [ ${#PARTS[@]} -lt 6 ]; then
+            {% endraw %}
               echo "Error: Invalid SLS service parameter file Path $STANDALONE_SLS_SERVICE format." >&2
               exit 1
             fi

--- a/tekton/src/tasks/gitops/gitops-mas-fvt-preparer.yml.j2
+++ b/tekton/src/tasks/gitops/gitops-mas-fvt-preparer.yml.j2
@@ -182,6 +182,9 @@ spec:
     - name: use_sendgrid
       type: string
       default: ""
+    - name: standalone_sls_service
+      type: string
+      default: ""
 
   stepTemplate:
     name: gitops-mas-fvt-preparer
@@ -326,6 +329,8 @@ spec:
         value: $(params.avp_aws_secret_region)
       - name: USE_SENDGRID
         value: $(params.use_sendgrid)
+      - name: STANDALONE_SLS_SERVICE
+        value: $(params.standalone_sls_service)
 
     envFrom:
       - configMapRef:
@@ -495,7 +500,25 @@ spec:
           MONGO_CONFIG_APP="${MAS_INSTANCE_ID}-mongo-system.${CLUSTER_NAME}"
           BAS_CONFIG_APP="${MAS_INSTANCE_ID}-bas-system.${CLUSTER_NAME}"
           SLS_CONFIG_APP="${MAS_INSTANCE_ID}-sls-system.${CLUSTER_NAME}"
-          SLS_APP_NAME="sls.${CLUSTER_NAME}.${MAS_INSTANCE_ID}"
+
+          # Check if centralized SLS is being used
+          if [ ! -z "$STANDALONE_SLS_SERVICE" ]; then
+            # Extract ICN and subscription ID from STANDALONE_SLS_SERVICE path
+            CLEAN_PATH=$(echo "$STANDALONE_SLS_SERVICE" | sed 's#<ref:##; s#>##')
+            IFS='/' read -r -a PARTS <<< "$CLEAN_PATH"
+            if [ ${#PARTS[@]} -lt 6 ]; then
+              echo "Error: Invalid SLS service parameter file Path $STANDALONE_SLS_SERVICE format." >&2
+              exit 1
+            fi
+            CENTRALIZED_ICN="${PARTS[3]}"
+            SAAS_SUB_ID="${PARTS[4]}"
+            # Use centralized SLS format: sls.icnid.subscriptionid
+            SLS_APP_NAME="sls.${CENTRALIZED_ICN}.${SAAS_SUB_ID}"
+          else
+            # Use standalone SLS format
+            SLS_APP_NAME="sls.${CLUSTER_NAME}.${MAS_INSTANCE_ID}"
+          fi
+
           SUITE_APP_NAME="suite.${CLUSTER_NAME}.${MAS_INSTANCE_ID}"
           WORKSPACE_APP="${MAS_WORKSPACE_ID}.suite.${CLUSTER_NAME}.${MAS_INSTANCE_ID}"
 


### PR DESCRIPTION
Issue: [MASCORE-13986](https://jsw.ibm.com/browse/MASCORE-13986)

## Description
1. If centralized SLS is enabled, we need to check sls.icn.subscriptionid app is healthy
2. Mongocfg was failing due to required params missing in ibm-sls.yaml file when centralized sls is enabled

## Testing
Tested in fvtsaas
https://cloud.ibm.com/devops/pipelines/tekton/a9b62902-737f-4f72-8288-ba7e67cf706b/runs/a2eea978-a042-4c75-86de-887e8054540d/mas-launchfvt?env_id=ibm:yp:us-south&view=logs
https://openshift-gitops-server-openshift-gitops.apps.fvtsaas.ydr4.p1.openshiftapps.com/applications/openshift-gitops/instance.fvtsaas.fvtsaas2?view=tree&resource=&operation=false