### PR TITLE
[patch] prefix change from ENABLE_IPV6 to OCP_ENABLE_IPV6

### DIFF
--- a/image/cli/mascli/functions/provision_fyre
+++ b/image/cli/mascli/functions/provision_fyre
@@ -104,7 +104,7 @@ function provision_fyre_noninteractive() {
         OCP_FIPS_ENABLED=true
         ;;
       --enable-ipv6)
-        ENABLE_IPV6=true
+        OCP_ENABLE_IPV6=true
         ;;
 
       # Worker configuration
@@ -181,7 +181,7 @@ function provision_fyre_noninteractive() {
   fi
 
   # IPV6 supported only in rtp site
-  if [[ "$ENABLE_IPV6" == "true" ]]; then
+  if [[ "$OCP_ENABLE_IPV6" == "true" ]]; then
     FYRE_SITE=rtp
   fi
 
@@ -276,7 +276,7 @@ function provision_fyre_interactive() {
     prompt_for_number "Worker Node Memory (max 64)" FYRE_WORKER_MEMORY "16"
     prompt_for_input "Worker Additional Disk Sizes (GB, comma-seperated list)" FYRE_WORKER_ADDITIONAL_DISKS
     prompt_for_confirm "Enable FIPS? " OCP_FIPS_ENABLED
-    prompt_for_confirm "Enable IPV6? " ENABLE_IPV6
+    prompt_for_confirm "Enable IPV6? " OCP_ENABLE_IPV6
   else
     FYRE_QUOTA_TYPE="quick_burn"
     if [[ "$FYRE_SITE" != "svl" ]]; then
@@ -368,7 +368,7 @@ function provision_fyre() {
   export FYRE_WORKER_MEMORY
   export FYRE_WORKER_ADDITIONAL_DISKS
   export OCP_FIPS_ENABLED
-  export ENABLE_IPV6
+  export OCP_ENABLE_IPV6
 
   export OCP_STORAGE_PROVIDER
 
@@ -409,7 +409,7 @@ function provision_fyre() {
     echo_reset_dim "Worker Node Memory ........ ${COLOR_MAGENTA}${FYRE_WORKER_MEMORY:-Default}"
     echo_reset_dim "Worker Node Disks ......... ${COLOR_MAGENTA}${FYRE_WORKER_ADDITIONAL_DISKS:-None}"
     echo_reset_dim "Enable FIPS? .............. ${COLOR_MAGENTA}${OCP_FIPS_ENABLED:-None}"
-    echo_reset_dim "Enable IPV6? .............. ${COLOR_MAGENTA}${ENABLE_IPV6:-None}"
+    echo_reset_dim "Enable IPV6? .............. ${COLOR_MAGENTA}${OCP_ENABLE_IPV6:-None}"
   fi
 
   reset_colors

--- a/tekton/src/tasks/aiservice/aiservice.yml.j2
+++ b/tekton/src/tasks/aiservice/aiservice.yml.j2
@@ -272,7 +272,7 @@ spec:
         value: $(params.aiservice_certificate_issuer)
 
       # Enable IPv6
-      - name: ENABLE_IPV6
+      - name: OCP_ENABLE_IPV6
         value: $(params.enable_ipv6)
 
   steps:

--- a/tekton/src/tasks/suite-install.yml.j2
+++ b/tekton/src/tasks/suite-install.yml.j2
@@ -189,7 +189,7 @@ spec:
         value: $(params.mas_manual_cert_mgmt)
       - name: MAS_TRUST_DEFAULT_CAS
         value: $(params.mas_trust_default_cas)
-      - name: ENABLE_IPV6
+      - name: OCP_ENABLE_IPV6
         value: $(params.enable_ipv6)
       # Enable optional integration with ECK logstash
       - name: ECK_ENABLE_LOGSTASH


### PR DESCRIPTION
added prefix to the variable

I have made the changes accordingly. and validated in this run

https://cloud.ibm.com/devops/pipelines/tekton/3612e317-4d13-42a4-b798-d7db422549f8/runs/933a8f93-65ee-4757-b7be-d8e5bc6498c2/install?env_id=ibm:yp:us-south&view=logs

https://github.ibm.com/maximoappsuite/fvt-personal/tree/ipv6test