### PR TITLE
[minor] MAF storage class generation to use cluster-level naming convention in case of generated(efs) in gitops

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "build/bin/config/oscap/ssg-rhel9-ds.xml|^.secrets.baseline$|^docs/catalogs/",
     "lines": null
   },
-  "generated_at": "2026-05-12T10:34:32Z",
+  "generated_at": "2026-05-12T13:35:52Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -410,7 +410,7 @@
         "hashed_secret": "effb7852555adce89885fb075fb43a77a1e0e77e",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 936,
+        "line_number": 938,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -418,7 +418,7 @@
         "hashed_secret": "2582aea6f911bd00fc04cb25e0ec16d5ead62068",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 938,
+        "line_number": 940,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "build/bin/config/oscap/ssg-rhel9-ds.xml|^.secrets.baseline$|^docs/catalogs/",
     "lines": null
   },
-  "generated_at": "2026-05-10T18:20:55Z",
+  "generated_at": "2026-05-12T08:01:24Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -410,7 +410,7 @@
         "hashed_secret": "effb7852555adce89885fb075fb43a77a1e0e77e",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 923,
+        "line_number": 934,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -418,7 +418,7 @@
         "hashed_secret": "2582aea6f911bd00fc04cb25e0ec16d5ead62068",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 925,
+        "line_number": 936,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "build/bin/config/oscap/ssg-rhel9-ds.xml|^.secrets.baseline$|^docs/catalogs/",
     "lines": null
   },
-  "generated_at": "2026-05-13T06:26:32Z",
+  "generated_at": "2026-05-13T06:31:15Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -254,7 +254,7 @@
         "hashed_secret": "b2817467154949a61f8e9ad31d1eeaf03221cbfa",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 502,
+        "line_number": 498,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "build/bin/config/oscap/ssg-rhel9-ds.xml|^.secrets.baseline$|^docs/catalogs/",
     "lines": null
   },
-  "generated_at": "2026-05-12T09:55:53Z",
+  "generated_at": "2026-05-12T10:34:32Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -410,7 +410,7 @@
         "hashed_secret": "effb7852555adce89885fb075fb43a77a1e0e77e",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 942,
+        "line_number": 936,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -418,7 +418,7 @@
         "hashed_secret": "2582aea6f911bd00fc04cb25e0ec16d5ead62068",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 944,
+        "line_number": 938,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "build/bin/config/oscap/ssg-rhel9-ds.xml|^.secrets.baseline$|^docs/catalogs/",
     "lines": null
   },
-  "generated_at": "2026-05-13T06:31:15Z",
+  "generated_at": "2026-05-15T10:16:49Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -410,7 +410,7 @@
         "hashed_secret": "effb7852555adce89885fb075fb43a77a1e0e77e",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 997,
+        "line_number": 1001,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -418,7 +418,7 @@
         "hashed_secret": "2582aea6f911bd00fc04cb25e0ec16d5ead62068",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 999,
+        "line_number": 1003,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "build/bin/config/oscap/ssg-rhel9-ds.xml|^.secrets.baseline$|^docs/catalogs/",
     "lines": null
   },
-  "generated_at": "2026-05-12T08:01:24Z",
+  "generated_at": "2026-05-12T09:55:53Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -410,7 +410,7 @@
         "hashed_secret": "effb7852555adce89885fb075fb43a77a1e0e77e",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 934,
+        "line_number": 942,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -418,7 +418,7 @@
         "hashed_secret": "2582aea6f911bd00fc04cb25e0ec16d5ead62068",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 936,
+        "line_number": 944,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "build/bin/config/oscap/ssg-rhel9-ds.xml|^.secrets.baseline$|^docs/catalogs/",
     "lines": null
   },
-  "generated_at": "2026-05-15T10:16:49Z",
+  "generated_at": "2026-05-15T11:32:43Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -410,7 +410,7 @@
         "hashed_secret": "effb7852555adce89885fb075fb43a77a1e0e77e",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1001,
+        "line_number": 996,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -418,7 +418,7 @@
         "hashed_secret": "2582aea6f911bd00fc04cb25e0ec16d5ead62068",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1003,
+        "line_number": 998,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/image/cli/mascli/functions/gitops_mas_config
+++ b/image/cli/mascli/functions/gitops_mas_config
@@ -813,7 +813,9 @@ function gitops_mas_config() {
     fi
 
     if [ "${MAS_CONFIG_TYPE}" == "appcfg" ]; then
+
       sm_login
+      
       # Set pod template yaml
       # ---------------------------------------------------------------------------
       if [[ -n "$MAS_APPCFG_POD_TEMPLATE_YAML" && -s "$MAS_APPCFG_POD_TEMPLATE_YAML" ]]; then

--- a/image/cli/mascli/functions/gitops_mas_config
+++ b/image/cli/mascli/functions/gitops_mas_config
@@ -814,14 +814,6 @@ function gitops_mas_config() {
 
     if [ "${MAS_CONFIG_TYPE}" == "appcfg" ]; then
 
-      # Hardcode MAS_APP_ID to "manage" for appcfg if not already set
-      # MAF is currently only supported for Manage application
-      # ---------------------------------------------------------------------------
-      if [[ -z "${MAS_APP_ID}" ]]; then
-        export MAS_APP_ID="manage"
-        echo -e "\n - MAS_APP_ID not set, defaulting to 'manage' for appcfg"
-      fi
-
       # Set pod template yaml
       # ---------------------------------------------------------------------------
       if [[ -n "$MAS_APPCFG_POD_TEMPLATE_YAML" && -s "$MAS_APPCFG_POD_TEMPLATE_YAML" ]]; then
@@ -830,12 +822,14 @@ function gitops_mas_config() {
       fi
 
       # Process storage class name (handle generated(efs) directive)
-      # Use "main" dependency like Manage app workspace configuration
+      # For MAF appcfg, use cluster-level storage class: efs-{CLUSTER_ID}-main
+      # Do not include MAS_INSTANCE_ID or MAS_APP_ID in the storage class name
       # ---------------------------------------------------------------------------
       export STORAGE_CLASS_DEFINITIONS
       if [[ -n "${MAF_STORAGE_CLASSNAME}" ]]; then
-        STORAGE_CLASS_DEFINITIONS=$(generate_storage_class_def "${MAF_STORAGE_CLASSNAME}" "${CLUSTER_ID}" "${MAS_INSTANCE_ID}" "${MAS_APP_ID}" "main" "${STORAGE_CLASS_DEFINITIONS}") || exit 1
-        MAF_STORAGE_CLASSNAME=$(generate_storage_class_name "${MAF_STORAGE_CLASSNAME}" "${CLUSTER_ID}" "${MAS_INSTANCE_ID}" "${MAS_APP_ID}" "main")
+        # Pass empty strings for MAS_INSTANCE_ID and MAS_APP_ID to generate cluster-level storage class
+        STORAGE_CLASS_DEFINITIONS=$(generate_storage_class_def "${MAF_STORAGE_CLASSNAME}" "${CLUSTER_ID}" "" "" "main" "${STORAGE_CLASS_DEFINITIONS}") || exit 1
+        MAF_STORAGE_CLASSNAME=$(generate_storage_class_name "${MAF_STORAGE_CLASSNAME}" "${CLUSTER_ID}" "" "" "main")
         
         echo -e "\n - MAF_STORAGE_CLASSNAME (processed) ............... ${MAF_STORAGE_CLASSNAME}"
       fi

--- a/image/cli/mascli/functions/gitops_mas_config
+++ b/image/cli/mascli/functions/gitops_mas_config
@@ -821,6 +821,17 @@ function gitops_mas_config() {
         echo -e "\n - MAS_APPCFG_POD_TEMPLATE CONTENT .................. ${MAS_APPCFG_POD_TEMPLATE}"
       fi
 
+      # Process storage class name (handle generated(efs) directive)
+      # Use "main" dependency like Manage app workspace configuration
+      # ---------------------------------------------------------------------------
+      export STORAGE_CLASS_DEFINITIONS
+      if [[ -n "${MAF_STORAGE_CLASSNAME}" ]]; then
+        STORAGE_CLASS_DEFINITIONS=$(generate_storage_class_def "${MAF_STORAGE_CLASSNAME}" "${CLUSTER_ID}" "${MAS_INSTANCE_ID}" "${MAS_APP_ID}" "main" "${STORAGE_CLASS_DEFINITIONS}") || exit 1
+        MAF_STORAGE_CLASSNAME=$(generate_storage_class_name "${MAF_STORAGE_CLASSNAME}" "${CLUSTER_ID}" "${MAS_INSTANCE_ID}" "${MAS_APP_ID}" "main")
+        
+        echo -e "\n - MAF_STORAGE_CLASSNAME (processed) ............... ${MAF_STORAGE_CLASSNAME}"
+      fi
+
     fi
 
     if [ "${MAS_CONFIG_TYPE}" == "sls" ]; then

--- a/image/cli/mascli/functions/gitops_mas_config
+++ b/image/cli/mascli/functions/gitops_mas_config
@@ -888,8 +888,12 @@ function gitops_mas_config() {
       # ---------------------------------------------------------------------------
       export STORAGE_CLASS_DEFINITIONS
       if [[ -n "${MAF_STORAGE_CLASSNAME}" ]]; then
-        # Generate the actual storage class name from generated(efs) directive if applicable
-        # Generate storage class definition if needed
+        # Resolve generated(efs) to actual storage class name (e.g., efs-cluster1-main)
+        # If not generated(efs), this will return the input unchanged
+        MAF_STORAGE_CLASSNAME=$(generate_storage_class_name "${MAF_STORAGE_CLASSNAME}" "${CLUSTER_ID}" "" "" "main")
+        
+        # Generate storage class definition YAML if this is a generated(efs) directive
+        # This will look up the EFS filesystem and create the storage class definition
         STORAGE_CLASS_DEFINITIONS=$(generate_storage_class_def "${MAF_STORAGE_CLASSNAME}" "${CLUSTER_ID}" "" "" "main" "${STORAGE_CLASS_DEFINITIONS}") || exit 1
 
         echo -e "\n - MAF_STORAGE_CLASSNAME (processed) ............... ${MAF_STORAGE_CLASSNAME}"

--- a/image/cli/mascli/functions/gitops_mas_config
+++ b/image/cli/mascli/functions/gitops_mas_config
@@ -888,10 +888,10 @@ function gitops_mas_config() {
       # ---------------------------------------------------------------------------
       export STORAGE_CLASS_DEFINITIONS
       if [[ -n "${MAF_STORAGE_CLASSNAME}" ]]; then
-        # Pass empty strings for MAS_INSTANCE_ID and MAS_APP_ID to generate cluster-level storage class
+        # Generate the actual storage class name from generated(efs) directive if applicable
+        # Generate storage class definition if needed
         STORAGE_CLASS_DEFINITIONS=$(generate_storage_class_def "${MAF_STORAGE_CLASSNAME}" "${CLUSTER_ID}" "" "" "main" "${STORAGE_CLASS_DEFINITIONS}") || exit 1
-        MAF_STORAGE_CLASSNAME=$(generate_storage_class_name "${MAF_STORAGE_CLASSNAME}" "${CLUSTER_ID}" "" "" "main")
-        
+
         echo -e "\n - MAF_STORAGE_CLASSNAME (processed) ............... ${MAF_STORAGE_CLASSNAME}"
       fi
 

--- a/image/cli/mascli/functions/gitops_mas_config
+++ b/image/cli/mascli/functions/gitops_mas_config
@@ -814,6 +814,14 @@ function gitops_mas_config() {
 
     if [ "${MAS_CONFIG_TYPE}" == "appcfg" ]; then
 
+      # Hardcode MAS_APP_ID to "manage" for appcfg if not already set
+      # MAF is currently only supported for Manage application
+      # ---------------------------------------------------------------------------
+      if [[ -z "${MAS_APP_ID}" ]]; then
+        export MAS_APP_ID="manage"
+        echo -e "\n - MAS_APP_ID not set, defaulting to 'manage' for appcfg"
+      fi
+
       # Set pod template yaml
       # ---------------------------------------------------------------------------
       if [[ -n "$MAS_APPCFG_POD_TEMPLATE_YAML" && -s "$MAS_APPCFG_POD_TEMPLATE_YAML" ]]; then

--- a/image/cli/mascli/functions/gitops_mas_config
+++ b/image/cli/mascli/functions/gitops_mas_config
@@ -886,15 +886,10 @@ function gitops_mas_config() {
       # For MAF appcfg, use cluster-level storage class: efs-{CLUSTER_ID}-main
       # Do not include MAS_INSTANCE_ID or MAS_APP_ID in the storage class name
       # ---------------------------------------------------------------------------
-      export STORAGE_CLASS_DEFINITIONS
       if [[ -n "${MAF_STORAGE_CLASSNAME}" ]]; then
         # Resolve generated(efs) to actual storage class name (e.g., efs-cluster1-main)
         # If not generated(efs), this will return the input unchanged
         MAF_STORAGE_CLASSNAME=$(generate_storage_class_name "${MAF_STORAGE_CLASSNAME}" "${CLUSTER_ID}" "" "" "main")
-        
-        # Generate storage class definition YAML if this is a generated(efs) directive
-        # This will look up the EFS filesystem and create the storage class definition
-        STORAGE_CLASS_DEFINITIONS=$(generate_storage_class_def "${MAF_STORAGE_CLASSNAME}" "${CLUSTER_ID}" "" "" "main" "${STORAGE_CLASS_DEFINITIONS}") || exit 1
 
         echo -e "\n - MAF_STORAGE_CLASSNAME (processed) ............... ${MAF_STORAGE_CLASSNAME}"
       fi

--- a/image/cli/mascli/functions/gitops_mas_config
+++ b/image/cli/mascli/functions/gitops_mas_config
@@ -813,7 +813,7 @@ function gitops_mas_config() {
     fi
 
     if [ "${MAS_CONFIG_TYPE}" == "appcfg" ]; then
-
+      sm_login
       # Set pod template yaml
       # ---------------------------------------------------------------------------
       if [[ -n "$MAS_APPCFG_POD_TEMPLATE_YAML" && -s "$MAS_APPCFG_POD_TEMPLATE_YAML" ]]; then

--- a/tekton/src/tasks/gitops/gitops-app-config.yml.j2
+++ b/tekton/src/tasks/gitops/gitops-app-config.yml.j2
@@ -101,6 +101,9 @@ spec:
           --config-action upsert \
           --mas-config-scope system \
           --mas-config-type appcfg \
+          --maf-enabled "$MAF_ENABLED" \
+          --maf-storageClassName "$MAF_STORAGE_CLASSNAME" \
+          --maf-size "$MAF_SIZE" \
           --dir /tmp/init-app-config
 
         exit $?


### PR DESCRIPTION
## Issue
<!-- Provide links to Jira issues related to this change. If there are no Jira issues related to this change, why are you working on it? -->
https://jsw.ibm.com/browse/MASCORE-14020 : MAF storageClassName not resolved from generated(efs) in gitops-envs output


## Description
<!-- Provide a summary of the changes. Focus on *why* the changes are being made and the *impact* of the changes. -->

This PR updates the MAF storage class name generation logic to use cluster-level naming conventions when using the `generated(efs)` directive.

**Changes:**
1. **`gitops_mas_config` function** (lines 826-837): Modified the storage class generation for MAF appcfg to the generated storage class name follows the cluster-level pattern: `efs-{CLUSTER_ID}-main`

2. **`gitops-app-config.yml.j2` Tekton task** (lines 104-106): Updated the command-line arguments to pass MAF-related parameters (`--maf-enabled`, `--maf-storageClassName`, `--maf-size`) to the `mas gitops-mas-config` command

**Why this change is needed:**
- MAF requires a cluster-level storage class that can be shared across multiple MAS instances and applications within the same cluster
- When using `generated(efs)` directive, the storage class should be created at cluster scope, not instance/app scope


**Impact:**
- MAF configurations will now correctly use cluster-scoped storage classes when `generated(efs)` is specified

## Test Results
<!-- Please describe how the change has been tested. If you have not performed any testing please explain why. Provide links to any relevant automated test cases not contained in this pull request. -->

- [x] Verified storage class name generation produces `efs-{CLUSTER_ID}-main` format when using `generated(efs)`
- [x] Tested MAF appcfg deployment with the updated storage class logic
- [x] Confirmed Tekton task passes correct parameters to the CLI function
- [x] Validated that storage class definitions are created at cluster level

<img width="1728" height="917" alt="image" src="https://github.com/user-attachments/assets/77147268-24c1-49fc-b300-9f1a04d4e1f8" />

<img width="946" height="950" alt="image" src="https://github.com/user-attachments/assets/3b0bdab8-042c-405c-85e6-c7a785091852" />

## Backporting
<!-- Does the change you are making need backporting? Create a seperate PR with the same name as this one but add the corresponding backport version to the end (`(8.10)`, `(8.11)`  or `(9.0)`) and provide a link to the PRs so that we can review and process the PRs together.

- 9.0 - #issuenumber
- 8.11 - #issuenumber
- 8.10 - #issuenumber

DELETE THIS SECTION if no backporting is required -->

## Related Pull Requests
<!-- Please list any related pull requests in other repositories. -->

https://github.ibm.com/maximoappsuite/saas-tekton/pull/230

<hr/>

### :warning: Notes for Reviewers
* Ensure you have understood the [guidelines](https://pages.github.ibm.com/maximoappsuite/playbook/tools/github/#guidelines) before proceeding with a review.
* Ensure all sections in the PR template are appropriately completed.
* Pay special attention to the storage class naming logic - verify that passing empty strings for instance/app IDs correctly generates cluster-level storage class names when `generated(efs)` is used
* Review the parameter passing from Tekton task to the CLI function to ensure consistency
