### PR TITLE
[patch] Add option to skip scheduling configuration for AI Service tenant

### DIFF
--- a/python/src/mas/cli/aiservice/install/app.py
+++ b/python/src/mas/cli/aiservice/install/app.py
@@ -720,7 +720,9 @@ class AiServiceInstallApp(BaseApp, aiServiceInstallArgBuilderMixin, aiServiceIns
                 "  `nodeSelector`: Dictionary of node label key-value pairs",
             ])
 
-            self.aiserviceTenantSchedulingConfigFileLocal = self.promptForFile("Scheduling configuration YAML file", mustExist=True, envVar="AISERVICE_TENANT_SCHEDULING_CONFIG_FILE")
+            configSchedulingConstraints = self.yesOrNo('Configure Scheduling policies for AI Service tenant')
+            if configSchedulingConstraints:
+                self.aiserviceTenantSchedulingConfigFileLocal = self.promptForFile("Scheduling configuration YAML file", mustExist=True, envVar="AISERVICE_TENANT_SCHEDULING_CONFIG_FILE")
 
     def _setMinioStorageDefaults(self) -> None:
         """

--- a/python/src/mas/cli/install/app.py
+++ b/python/src/mas/cli/install/app.py
@@ -1562,7 +1562,9 @@ class InstallApp(BaseApp, InstallSettingsMixin, InstallSummarizerMixin, ConfigGe
                 "  `nodeSelector`: Dictionary of node label key-value pairs",
             ])
 
-            self.aiserviceTenantSchedulingConfigFileLocal = self.promptForFile("Scheduling configuration YAML file", mustExist=True, envVar="AISERVICE_TENANT_SCHEDULING_CONFIG_FILE")
+            configSchedulingConstraints = self.yesOrNo('Configure Scheduling policies for AI Service tenant')
+            if configSchedulingConstraints:
+                self.aiserviceTenantSchedulingConfigFileLocal = self.promptForFile("Scheduling configuration YAML file", mustExist=True, envVar="AISERVICE_TENANT_SCHEDULING_CONFIG_FILE")
 
     @logMethodCall
     def _setMinioStorageDefaults(self) -> None:

--- a/python/test/aiservice/install/test_app.py
+++ b/python/test/aiservice/install/test_app.py
@@ -180,6 +180,8 @@ def test_install_interactive_advanced(tmpdir):
                     return ''
                 if re.match('.*Instance ID.*', message):
                     return 'apmdevops'
+                if re.match('.*Configure Scheduling policies for AI Service tenant.*', message):
+                    return 'y'
                 if re.match('.*Scheduling constraints YAML file.*', message):
                     return f'{tmpdir}/aiservice-tenant-affinity-config.yaml'
                 if re.match('.*Operational Mode.*', message):


### PR DESCRIPTION
## Description

- Add a prompt to confirm that user would like to configure scheduling policies for AI Service tenant so that it can be skipped if user don't want to configure.

## Test Results
<img width="957" height="154" alt="Screenshot 2026-05-14 at 12 57 25 PM" src="https://github.com/user-attachments/assets/9913f25f-65e1-4bee-8643-6e77e9ce59f6" />
<img width="486" height="191" alt="Screenshot 2026-05-14 at 3 02 09 PM" src="https://github.com/user-attachments/assets/7261189b-f144-46d9-a395-996a8cb94943" />

## Related PR

- #2240