### PR TITLE
[patch] include manualroutemgmt test suite in fvt-core

### DIFF
--- a/tekton/src/pipelines/mas-fvt-core.yml.j2
+++ b/tekton/src/pipelines/mas-fvt-core.yml.j2
@@ -114,7 +114,7 @@ spec:
 
     # Disruptive suites ran in serial mode
     # -------------------------------------------------------------------------
-    {{ lookup('template', 'taskdefs/fvt-core/phase4-disruptive.yml.j2', template_vars={'runAfter': ['coreapi-groupmgmt', 'coreapi-workspacemgmt', 'useractivation-overall', 'useractivation-expiresat', 'useractivation-inactivity', 'coreapi-dependencies', 'coreapi-usermgmt-v3', 'coreapi-other']}) | indent(4) }}
+    {{ lookup('template', 'taskdefs/fvt-core/phase4-disruptive.yml.j2', template_vars={'runAfter': ['coreapi-groupmgmt', 'coreapi-workspacemgmt', 'useractivation-overall', 'useractivation-expiresat', 'useractivation-inactivity', 'manualroutemgmt', 'coreapi-dependencies', 'coreapi-usermgmt-v3', 'coreapi-other']}) | indent(4) }}
 
   finally:
     # 1. Run CV

--- a/tekton/src/pipelines/taskdefs/fvt-core/phase2-under30min.yml.j2
+++ b/tekton/src/pipelines/taskdefs/fvt-core/phase2-under30min.yml.j2
@@ -48,4 +48,14 @@
     {{ lookup('template', 'taskdefs/fvt-core/common/params.yml.j2') | indent(4) }}
   runAfter: {{ runAfter }}
 
+# manualroutemgmt  ~15m
+# ------------------------------------------------------------------------------
+- name: manualroutemgmt
+  {{ lookup('template', 'taskdefs/fvt-core/common/taskref.yml.j2') | indent(2) }}
+  params:
+    - name: fvt_test_suite
+      value: manualroutemgmt
+    {{ lookup('template', 'taskdefs/fvt-core/common/params.yml.j2') | indent(4) }}
+  runAfter: {{ runAfter }}
+
 


### PR DESCRIPTION
## Description
Test the setting of the manualRouteMgmt flag in Suite CR

## Issues
https://jsw.ibm.com/browse/MASCORE-14061

## Testing
Run in personal FVT cluster, see dashboard https://dashboard.ibmmas.com/tests/pds run #6669.
The new Core->manualrroutemgmt test suite passed, Although the run has a number of test failures, none of these seem related, or to coincide with the running of the new suite.