### PR TITLE
[patch] initialize license file attributes to prevent errors

### DIFF
--- a/python/src/mas/cli/install/app.py
+++ b/python/src/mas/cli/install/app.py
@@ -2085,6 +2085,8 @@ class InstallApp(
         self.isInteractiveMode = True
 
         # Initialize attributes that may be used later
+        self.slsLicenseFileLocal = None
+        self.db2LicenseFileLocal = None
         self.aiserviceTenantSchedulingConfigFileLocal = None
 
         if simplified:


### PR DESCRIPTION
### Description
When running in interactive mode, `db2LicenseFileLocal` is never initialized, so when `db2LicenseFile()` is called, the attribute doesn't exist on the instance, causing the `AttributeError`.

The fix is to initialize `db2LicenseFileLocal` (and `slsLicenseFileLocal`) in the `interactiveMode()` method.

### Linked issues
- https://github.com/ibm-mas/cli/issues/2259
- MASCORE-14091

### Tests
#### Pod templates
<img width="1203" height="602" alt="image" src="https://github.com/user-attachments/assets/7d770662-5d8c-4f20-88f8-b64aac2d70c9" />
<img width="1144" height="734" alt="image" src="https://github.com/user-attachments/assets/aa26f665-69b4-4314-871f-1c0f2cf0f8c3" />

#### External DB
<img width="1400" height="641" alt="image" src="https://github.com/user-attachments/assets/ac457942-b8d5-45cb-8cdd-cc24012e33be" />
<img width="836" height="936" alt="image" src="https://github.com/user-attachments/assets/d5ce550b-2e7f-4c76-ac73-4b11241f40f7" />

