### PR TITLE
[patch] add prepareAiServicePipelinesNamespace func back

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@ default_language_version:
     python: python
 repos:
   - repo: https://github.com/psf/black
-    rev: 26.3.1
+    rev: 26.5.1
     hooks:
       - id: black
   - repo: https://github.com/PyCQA/flake8

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "build/bin/config/oscap/ssg-rhel9-ds.xml|^.secrets.baseline$|^docs/catalogs/",
     "lines": null
   },
-  "generated_at": "2026-05-18T08:58:20Z",
+  "generated_at": "2026-05-19T12:05:11Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"

--- a/python/src/mas/cli/aiservice/install/app.py
+++ b/python/src/mas/cli/aiservice/install/app.py
@@ -51,7 +51,7 @@ from mas.devops.tekton import (
     prepareAiServicePipelinesNamespace,
     prepareInstallSecrets,
     testCLI,
-    launchInstallPipeline
+    launchInstallPipeline,
 )
 from mas.devops.pre_install import applyPreInstallMASRBAC, permissionCheckForRBAC
 from mas.devops.utils import isVersionEqualOrAfter
@@ -600,7 +600,7 @@ class AiServiceInstallApp(BaseApp, aiServiceInstallArgBuilderMixin, aiServiceIns
                     instanceId=self.getParam("aiservice_instance_id"),
                     storageClass=self.pipelineStorageClass,
                     accessMode=self.pipelineStorageAccessMode,
-                    configureRBAC=(self.getParam("service_account_name") == "")
+                    configureRBAC=(self.getParam("service_account_name") == ""),
                 )
                 prepareInstallSecrets(
                     dynClient=self.dynamicClient,

--- a/python/src/mas/cli/aiservice/install/app.py
+++ b/python/src/mas/cli/aiservice/install/app.py
@@ -55,6 +55,7 @@ from mas.devops.data import getCatalog, NoSuchCatalogError
 from mas.devops.tekton import (
     installOpenShiftPipelines,
     updateTektonDefinitions,
+    prepareAiServicePipelinesNamespace,
     prepareInstallSecrets,
     testCLI,
     launchInstallPipeline
@@ -581,6 +582,13 @@ class AiServiceInstallApp(BaseApp, aiServiceInstallArgBuilderMixin, aiServiceIns
 
             with Halo(text=f'Preparing namespace ({pipelinesNamespace})', spinner=self.spinner) as h:
                 createNamespace(self.dynamicClient, pipelinesNamespace)
+                prepareAiServicePipelinesNamespace(
+                    dynClient=self.dynamicClient,
+                    instanceId=self.getParam("aiservice_instance_id"),
+                    storageClass=self.pipelineStorageClass,
+                    accessMode=self.pipelineStorageAccessMode,
+                    configureRBAC=(self.getParam("service_account_name") == "")
+                )
                 prepareInstallSecrets(
                     dynClient=self.dynamicClient,
                     namespace=pipelinesNamespace,

--- a/python/test/aiservice/install/test_app.py
+++ b/python/test/aiservice/install/test_app.py
@@ -53,6 +53,7 @@ def test_install_noninteractive(tmpdir):
             mock.patch('mas.cli.aiservice.install.app.getCurrentCatalog') as get_current_catalog,
             mock.patch('mas.cli.aiservice.install.app.installOpenShiftPipelines'),
             mock.patch('mas.cli.aiservice.install.app.updateTektonDefinitions'),
+            mock.patch('mas.cli.aiservice.install.app.prepareAiServicePipelinesNamespace'),
             mock.patch('mas.cli.aiservice.install.app.launchInstallPipeline') as launch_ai_service_install_pipeline
         ):
             dynamic_client_class.return_value = dynamic_client
@@ -147,6 +148,7 @@ def test_install_interactive_advanced(tmpdir):
             mock.patch('mas.cli.aiservice.install.app.getCurrentCatalog') as get_current_catalog,
             mock.patch('mas.cli.aiservice.install.app.installOpenShiftPipelines'),
             mock.patch('mas.cli.aiservice.install.app.updateTektonDefinitions'),
+            mock.patch('mas.cli.aiservice.install.app.prepareAiServicePipelinesNamespace'),
             mock.patch('mas.cli.aiservice.install.app.launchInstallPipeline') as launch_ai_service_install_pipeline,
             mock.patch('mas.cli.cli.isSNO') as is_sno,
             mock.patch('mas.cli.displayMixins.prompt') as mixins_prompt,
@@ -278,6 +280,7 @@ def test_install_interactive_simplified(tmpdir):
             mock.patch('mas.cli.aiservice.install.app.getCurrentCatalog') as get_current_catalog,
             mock.patch('mas.cli.aiservice.install.app.installOpenShiftPipelines'),
             mock.patch('mas.cli.aiservice.install.app.updateTektonDefinitions'),
+            mock.patch('mas.cli.aiservice.install.app.prepareAiServicePipelinesNamespace'),
             mock.patch('mas.cli.aiservice.install.app.launchInstallPipeline') as launch_ai_service_install_pipeline,
             mock.patch('mas.cli.cli.isSNO') as is_sno,
             mock.patch('mas.cli.displayMixins.prompt') as mixins_prompt,

--- a/python/test/aiservice/install/test_app.py
+++ b/python/test/aiservice/install/test_app.py
@@ -54,14 +54,14 @@ def test_install_noninteractive(tmpdir):
         routes_api.get.return_value = route
         catalog_api.get.side_effect = NotFoundError(ApiException(status="404"))
         with (
-            mock.patch('mas.cli.cli.DynamicClient') as dynamic_client_class,
-            mock.patch('mas.cli.cli.getNodes') as get_nodes,
-            mock.patch('mas.cli.cli.isAirgapInstall') as is_airgap_install,
-            mock.patch('mas.cli.aiservice.install.app.getCurrentCatalog') as get_current_catalog,
-            mock.patch('mas.cli.aiservice.install.app.installOpenShiftPipelines'),
-            mock.patch('mas.cli.aiservice.install.app.updateTektonDefinitions'),
-            mock.patch('mas.cli.aiservice.install.app.prepareAiServicePipelinesNamespace'),
-            mock.patch('mas.cli.aiservice.install.app.launchInstallPipeline') as launch_ai_service_install_pipeline
+            mock.patch("mas.cli.cli.DynamicClient") as dynamic_client_class,
+            mock.patch("mas.cli.cli.getNodes") as get_nodes,
+            mock.patch("mas.cli.cli.isAirgapInstall") as is_airgap_install,
+            mock.patch("mas.cli.aiservice.install.app.getCurrentCatalog") as get_current_catalog,
+            mock.patch("mas.cli.aiservice.install.app.installOpenShiftPipelines"),
+            mock.patch("mas.cli.aiservice.install.app.updateTektonDefinitions"),
+            mock.patch("mas.cli.aiservice.install.app.prepareAiServicePipelinesNamespace"),
+            mock.patch("mas.cli.aiservice.install.app.launchInstallPipeline") as launch_ai_service_install_pipeline,
         ):
             dynamic_client_class.return_value = dynamic_client
             get_nodes.return_value = [{"status": {"nodeInfo": {"architecture": "amd64"}}}]
@@ -206,18 +206,18 @@ def test_install_interactive_advanced(tmpdir):
         routes_api.get.return_value = route
         catalog_api.get.side_effect = NotFoundError(ApiException(status="404"))
         with (
-            mock.patch('mas.cli.cli.DynamicClient') as dynamic_client_class,
-            mock.patch('mas.cli.cli.getNodes') as get_nodes,
-            mock.patch('mas.cli.cli.isAirgapInstall') as is_airgap_install,
-            mock.patch('mas.cli.aiservice.install.app.getCurrentCatalog') as get_current_catalog,
-            mock.patch('mas.cli.aiservice.install.app.installOpenShiftPipelines'),
-            mock.patch('mas.cli.aiservice.install.app.updateTektonDefinitions'),
-            mock.patch('mas.cli.aiservice.install.app.prepareAiServicePipelinesNamespace'),
-            mock.patch('mas.cli.aiservice.install.app.launchInstallPipeline') as launch_ai_service_install_pipeline,
-            mock.patch('mas.cli.cli.isSNO') as is_sno,
-            mock.patch('mas.cli.displayMixins.prompt') as mixins_prompt,
-            mock.patch('mas.cli.aiservice.install.app.prompt') as app_prompt,
-            mock.patch('mas.cli.aiservice.install.app.getStorageClasses') as get_storage_classes
+            mock.patch("mas.cli.cli.DynamicClient") as dynamic_client_class,
+            mock.patch("mas.cli.cli.getNodes") as get_nodes,
+            mock.patch("mas.cli.cli.isAirgapInstall") as is_airgap_install,
+            mock.patch("mas.cli.aiservice.install.app.getCurrentCatalog") as get_current_catalog,
+            mock.patch("mas.cli.aiservice.install.app.installOpenShiftPipelines"),
+            mock.patch("mas.cli.aiservice.install.app.updateTektonDefinitions"),
+            mock.patch("mas.cli.aiservice.install.app.prepareAiServicePipelinesNamespace"),
+            mock.patch("mas.cli.aiservice.install.app.launchInstallPipeline") as launch_ai_service_install_pipeline,
+            mock.patch("mas.cli.cli.isSNO") as is_sno,
+            mock.patch("mas.cli.displayMixins.prompt") as mixins_prompt,
+            mock.patch("mas.cli.aiservice.install.app.prompt") as app_prompt,
+            mock.patch("mas.cli.aiservice.install.app.getStorageClasses") as get_storage_classes,
         ):
             dynamic_client_class.return_value = dynamic_client
             get_nodes.return_value = [{"status": {"nodeInfo": {"architecture": "amd64"}}}]
@@ -348,18 +348,18 @@ def test_install_interactive_simplified(tmpdir):
         routes_api.get.return_value = route
         catalog_api.get.side_effect = NotFoundError(ApiException(status="404"))
         with (
-            mock.patch('mas.cli.cli.DynamicClient') as dynamic_client_class,
-            mock.patch('mas.cli.cli.getNodes') as get_nodes,
-            mock.patch('mas.cli.cli.isAirgapInstall') as is_airgap_install,
-            mock.patch('mas.cli.aiservice.install.app.getCurrentCatalog') as get_current_catalog,
-            mock.patch('mas.cli.aiservice.install.app.installOpenShiftPipelines'),
-            mock.patch('mas.cli.aiservice.install.app.updateTektonDefinitions'),
-            mock.patch('mas.cli.aiservice.install.app.prepareAiServicePipelinesNamespace'),
-            mock.patch('mas.cli.aiservice.install.app.launchInstallPipeline') as launch_ai_service_install_pipeline,
-            mock.patch('mas.cli.cli.isSNO') as is_sno,
-            mock.patch('mas.cli.displayMixins.prompt') as mixins_prompt,
-            mock.patch('mas.cli.aiservice.install.app.prompt') as app_prompt,
-            mock.patch('mas.cli.aiservice.install.app.getStorageClasses') as get_storage_classes
+            mock.patch("mas.cli.cli.DynamicClient") as dynamic_client_class,
+            mock.patch("mas.cli.cli.getNodes") as get_nodes,
+            mock.patch("mas.cli.cli.isAirgapInstall") as is_airgap_install,
+            mock.patch("mas.cli.aiservice.install.app.getCurrentCatalog") as get_current_catalog,
+            mock.patch("mas.cli.aiservice.install.app.installOpenShiftPipelines"),
+            mock.patch("mas.cli.aiservice.install.app.updateTektonDefinitions"),
+            mock.patch("mas.cli.aiservice.install.app.prepareAiServicePipelinesNamespace"),
+            mock.patch("mas.cli.aiservice.install.app.launchInstallPipeline") as launch_ai_service_install_pipeline,
+            mock.patch("mas.cli.cli.isSNO") as is_sno,
+            mock.patch("mas.cli.displayMixins.prompt") as mixins_prompt,
+            mock.patch("mas.cli.aiservice.install.app.prompt") as app_prompt,
+            mock.patch("mas.cli.aiservice.install.app.getStorageClasses") as get_storage_classes,
         ):
             dynamic_client_class.return_value = dynamic_client
             get_nodes.return_value = [{"status": {"nodeInfo": {"architecture": "amd64"}}}]

--- a/python/test/utils/install_test_helper.py
+++ b/python/test/utils/install_test_helper.py
@@ -275,12 +275,12 @@ class InstallTestHelper:
             from mas.cli.aiservice.install.app import AiServiceInstallApp
 
             app_class = AiServiceInstallApp
-            app_module = 'mas.cli.aiservice.install.app'
-            prepare_namespace_func = 'prepareAiServicePipelinesNamespace'
+            app_module = "mas.cli.aiservice.install.app"
+            prepare_namespace_func = "prepareAiServicePipelinesNamespace"
         else:
             app_class = InstallApp
-            app_module = 'mas.cli.install.app'
-            prepare_namespace_func = 'preparePipelinesNamespace'
+            app_module = "mas.cli.install.app"
+            prepare_namespace_func = "preparePipelinesNamespace"
 
         self.setup_test_files()
         self.start_watchdog()
@@ -292,22 +292,22 @@ class InstallTestHelper:
             dynamic_client, resource_apis = self.setup_mocks()
 
             with (
-                mock.patch('mas.cli.cli.DynamicClient') as dynamic_client_class,
-                mock.patch('mas.cli.cli.getNodes') as get_nodes,
-                mock.patch('mas.cli.cli.isAirgapInstall') as is_airgap_install,
-                mock.patch(f'{app_module}.getCurrentCatalog') as get_current_catalog,
-                mock.patch(f'{app_module}.installOpenShiftPipelines'),
-                mock.patch(f'{app_module}.updateTektonDefinitions'),
-                mock.patch(f'{app_module}.createNamespace'),
-                mock.patch(f'{app_module}.{prepare_namespace_func}'),
-                mock.patch(f'{app_module}.launchInstallPipeline') as launch_install_pipeline,
-                mock.patch('mas.cli.install.app.configureIngressForPathBasedRouting') as configure_ingress,
-                mock.patch('mas.cli.cli.isSNO') as is_sno,
-                mock.patch('mas.cli.displayMixins.prompt') as mixins_prompt,
-                mock.patch('mas.cli.displayMixins.PromptSession') as prompt_session_class,
-                mock.patch(f'{app_module}.prompt') as app_prompt,
-                mock.patch(f'{app_module}.getStorageClasses') as get_storage_classes,
-                mock.patch(f'{app_module}.getDefaultStorageClasses') as get_default_storage_classes,
+                mock.patch("mas.cli.cli.DynamicClient") as dynamic_client_class,
+                mock.patch("mas.cli.cli.getNodes") as get_nodes,
+                mock.patch("mas.cli.cli.isAirgapInstall") as is_airgap_install,
+                mock.patch(f"{app_module}.getCurrentCatalog") as get_current_catalog,
+                mock.patch(f"{app_module}.installOpenShiftPipelines"),
+                mock.patch(f"{app_module}.updateTektonDefinitions"),
+                mock.patch(f"{app_module}.createNamespace"),
+                mock.patch(f"{app_module}.{prepare_namespace_func}"),
+                mock.patch(f"{app_module}.launchInstallPipeline") as launch_install_pipeline,
+                mock.patch("mas.cli.install.app.configureIngressForPathBasedRouting") as configure_ingress,
+                mock.patch("mas.cli.cli.isSNO") as is_sno,
+                mock.patch("mas.cli.displayMixins.prompt") as mixins_prompt,
+                mock.patch("mas.cli.displayMixins.PromptSession") as prompt_session_class,
+                mock.patch(f"{app_module}.prompt") as app_prompt,
+                mock.patch(f"{app_module}.getStorageClasses") as get_storage_classes,
+                mock.patch(f"{app_module}.getDefaultStorageClasses") as get_default_storage_classes,
             ):
 
                 # Configure mock return values

--- a/python/test/utils/install_test_helper.py
+++ b/python/test/utils/install_test_helper.py
@@ -282,9 +282,11 @@ class InstallTestHelper:
             from mas.cli.aiservice.install.app import AiServiceInstallApp
             app_class = AiServiceInstallApp
             app_module = 'mas.cli.aiservice.install.app'
+            prepare_namespace_func = 'prepareAiServicePipelinesNamespace'
         else:
             app_class = InstallApp
             app_module = 'mas.cli.install.app'
+            prepare_namespace_func = 'preparePipelinesNamespace'
 
         self.setup_test_files()
         self.start_watchdog()
@@ -303,6 +305,7 @@ class InstallTestHelper:
                 mock.patch(f'{app_module}.installOpenShiftPipelines'),
                 mock.patch(f'{app_module}.updateTektonDefinitions'),
                 mock.patch(f'{app_module}.createNamespace'),
+                mock.patch(f'{app_module}.{prepare_namespace_func}'),
                 mock.patch(f'{app_module}.launchInstallPipeline') as launch_install_pipeline,
                 mock.patch('mas.cli.install.app.configureIngressForPathBasedRouting') as configure_ingress,
                 mock.patch('mas.cli.cli.isSNO') as is_sno,


### PR DESCRIPTION
removal of prepareAiServicePipelinesNamespace func was a mistake in PR: https://github.com/ibm-mas/cli/pull/2232

adding back,

Tests:
https://dashboard.ibmmas.com/tests/pfvtaisvc

<img width="578" height="951" alt="image" src="https://github.com/user-attachments/assets/d2bdc531-71f7-47c8-926c-fd658112318e" />

<img width="498" height="657" alt="image" src="https://github.com/user-attachments/assets/27b8e73f-3c35-4f6c-b0a6-57994b295e00" />

https://ibm-mas.slack.com/archives/C0AUGE6J4HY/p1779169482507959
