### PR TITLE
[patch] update app id to ssp-secret for gitops

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 default_language_version:
-    python: python3
+    python: python
 repos:
   - repo: https://github.com/psf/black
     rev: 26.3.1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 default_language_version:
-    python: python
+    python: python3
 repos:
   - repo: https://github.com/psf/black
     rev: 26.3.1

--- a/image/cli/mascli/templates/gitops/appset-configs/cluster/instance/ibm-iac-rdsdb2.tf.j2
+++ b/image/cli/mascli/templates/gitops/appset-configs/cluster/instance/ibm-iac-rdsdb2.tf.j2
@@ -18,7 +18,7 @@ module "db2rds-{{RDS_APP}}" {
   sre_prefix                          = join("-", [var.cluster_name, var.instance_name, "{{RDS_APP}}"])
   secret_prefix                       = join("/", [var.name_prefix, var.cluster_name, var.instance_name, "jdbc",join("-", ["rds", var.instance_name, "{{RDS_APP}}"]) ])
   admin_secret_prefix                 = join("/", [var.name_prefix, var.cluster_name, var.instance_name, "admin",join("-", ["rds", var.instance_name, "{{RDS_APP}}"]) ])
-  ssp_secret_prefix                   = join("/", [var.name_prefix, var.cluster_name, var.instance_name, "db2rds-ssp"])
+  ssp_secret_prefix                   = join("/", [var.name_prefix, var.cluster_name, var.instance_name, "db2rds-ssp", "{{RDS_APP}}"])
   engine                              = "db2-ae"
   vpc_id                              = var.vpc_id
   ibm_customer_id                     = local.ibm_customer_id_{{RDS_APP}}


### PR DESCRIPTION
Jira: https://jsw.ibm.com/browse/MASCORE-14178
Description: Previously we were creating secret path without app id so we were getting secret already exist due to different app id db under same instance.
Fix: We added app id to the path to avoid this error.