### PR TITLE
[patch] skip_pre_check param should not skip post install verification

### DIFF
--- a/tekton/src/pipelines/taskdefs/cluster-setup/ocp-verify.yml.j2
+++ b/tekton/src/pipelines/taskdefs/cluster-setup/ocp-verify.yml.j2
@@ -22,7 +22,9 @@
       value: {{ verify_ingress | default("True") }}
     - name: ocp_ingress_tls_secret_name
       value: $(params.ocp_ingress_tls_secret_name)
+{% if name != "post-install-verify" %}
   when:
     - input: "$(params.skip_pre_check)"
       operator: notin
       values: ["True", "true"]
+{% endif %}


### PR DESCRIPTION
Due to re-use of the same taskdef template, when we added support for `--skip-pre-check` we have also unintentionally disabled the post install verification (which is pretty important all things considered!).

This update makes the inclusion of the `when skip_pre_check == true` clause in the template conditional,