### PR TITLE
[patch] Fix the spaghetti code of the fvt-launcher

### DIFF
--- a/tekton/generate-pipeline.sh
+++ b/tekton/generate-pipeline.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+# Quick script to generate a single pipeline
+# Usage: ./generate-pipeline.sh mas-fvt-launcher
+
+if [ -z "$1" ]; then
+    echo "Usage: $0 <pipeline-name>"
+    echo ""
+    echo "Examples:"
+    echo "  $0 mas-fvt-launcher"
+    echo "  $0 mas-install"
+    echo "  $0 mas-fvt-core"
+    echo ""
+    echo "To generate all pipelines, run:"
+    echo "  ansible-playbook generate-tekton-pipelines.yml"
+    exit 1
+fi
+
+ansible-playbook generate-tekton-pipelines.yml -e pipeline_name=$1

--- a/tekton/generate-tekton-pipelines.yml
+++ b/tekton/generate-tekton-pipelines.yml
@@ -9,6 +9,50 @@
 
     pipeline_src_dir: src/pipelines
     pipeline_target_dir: target/pipelines
+
+    # Optional: specify a single pipeline to generate (e.g., -e pipeline_name=mas-fvt-launcher)
+    pipeline_name: ""
+
+    # Define all pipelines
+    all_pipelines:
+      # MAS Pipelines
+      - mas-backup
+      - mas-restore
+      - mas-install
+      - mas-update
+      - mas-upgrade
+      - mas-rollback
+      - mas-uninstall
+      # MAS FVT Pipelines
+      - mas-fvt-assist
+      - mas-fvt-core
+      - mas-fvt-deprovision-after
+      - mas-fvt-iot
+      - mas-fvt-finally
+      - mas-fvt-manage
+      - mas-fvt-manage-ai
+      - mas-fvt-manage-is
+      - mas-fvt-manage-regr
+      - mas-fvt-mobile-pytest
+      - mas-fvt-mobile-requests
+      - mas-fvt-mobile-testng
+      - mas-fvt-monitor
+      - mas-fvt-optimizer
+      - mas-fvt-predict
+      - mas-fvt-sls
+      - mas-fvt-visualinspection
+      - mas-fvt-launcher
+      - mas-ivt-manage
+      - mas-fvt-facilities
+      # AI Service Pipelines
+      - aiservice-upgrade
+      # AI Service FVT Pipelines
+      - aiservice-fvt-launcher
+      - aiservice-fvt
+
+    # Determine which pipelines to generate
+    pipelines_to_generate: "{{ [pipeline_name] if pipeline_name != '' else all_pipelines }}"
+
   tasks:
 
     # 1. Prepare tmp and target directory for the pipeline build
@@ -26,41 +70,7 @@
       ansible.builtin.template:
         src: "{{ pipeline_src_dir }}/{{ item }}.yml.j2"
         dest: "{{ pipeline_target_dir }}/{{ item }}.yaml"
-      with_items:
-        # MAS Pipelines
-        - mas-backup
-        - mas-restore
-        - mas-install
-        - mas-update
-        - mas-upgrade
-        - mas-rollback
-        - mas-uninstall
-        # MAS FVT Pipelines
-        - mas-fvt-assist
-        - mas-fvt-core
-        - mas-fvt-deprovision-after
-        - mas-fvt-iot
-        - mas-fvt-finally
-        - mas-fvt-manage
-        - mas-fvt-manage-ai
-        - mas-fvt-manage-is
-        - mas-fvt-manage-regr
-        - mas-fvt-mobile-pytest
-        - mas-fvt-mobile-requests
-        - mas-fvt-mobile-testng
-        - mas-fvt-monitor
-        - mas-fvt-optimizer
-        - mas-fvt-predict
-        - mas-fvt-sls
-        - mas-fvt-visualinspection
-        - mas-fvt-launcher
-        - mas-ivt-manage
-        - mas-fvt-facilities
-        # AI Service Pipelines
-        - aiservice-upgrade
-        # AI Service FVT Pipelines
-        - aiservice-fvt-launcher
-        - aiservice-fvt
+      with_items: "{{ pipelines_to_generate }}"
 
     # 2. Generate Pipelines
     # -------------------------------------------------------------------------
@@ -74,6 +84,7 @@
         # TODO: Get rid of this, integrate this into main FVT launcher like
         # we do for update, upgrade, & uninstall testing
         - mas-rollback
+      when: pipeline_name == '' or pipeline_name == 'mas-rollback'
 
     # 3. Generate Gitops Pipelines
     # -------------------------------------------------------------------------
@@ -103,6 +114,7 @@
         - gitops-deprovision-aiservice-pipeline
         - gitops-deprovision-aiservice-tenant-pipeline
         - gitops-iac-pipeline
+      when: pipeline_name == ''
 
     # 4. Generate Gitops Pipelines with waits
     # -------------------------------------------------------------------------
@@ -116,6 +128,7 @@
         - provision-bootstrap-cluster
         - deprovision-cluster
         - deprovision-mas-deps
+      when: pipeline_name == ''
 
     # 5. Generate Gitops Pipelines with waits
     # -------------------------------------------------------------------------
@@ -128,5 +141,4 @@
       with_items:
         - gitops-mas-deps
         - gitops-mas-initiator
-
-        
+      when: pipeline_name == ''

--- a/tekton/src/params/common.yml.j2
+++ b/tekton/src/params/common.yml.j2
@@ -20,6 +20,7 @@
 - name: custom_labels
   type: string
   default: ""
+  description: Optional custom labels, comma separated list of key=value pairs
 
 # Slack Notifications
 - name: slack_token
@@ -30,7 +31,6 @@
   type: string
   default: ""
   description: Slack channel(s) for notifications (comma-separated for multiple channels)
-  description: Optional custom labels, comma separated list of key=value pairs
 
 {% if application is not defined %}
 

--- a/tekton/src/pipelines/mas-fvt-launcher.yml.j2
+++ b/tekton/src/pipelines/mas-fvt-launcher.yml.j2
@@ -87,10 +87,6 @@ spec:
       type: string
       default: "false"
       description: "Set this to 'true' to enable launch of the Monitor FVT pipeline after app-cfg-monitor completes"
-    - name: mas_monitor_install_order
-      type: string
-      default: "after-iot"
-      description: "Monitor installation order relative to IoT: 'before-iot' for Monitor >= 9.2.0, 'after-iot' for Monitor < 9.2.0"
     - name: launchfvt_optimizer
       type: string
       default: "false"
@@ -334,7 +330,6 @@ spec:
           operator: in
           values: ["true", "True"]
       runAfter:
-        - approval-suite-verify
         - approval-manage
 
     - name: launchfvt-assist
@@ -377,8 +372,7 @@ spec:
     # 3. Application FVT - IoT
     # -------------------------------------------------------------------------
     # Wait for IoT installation to complete before launching IoT FVT
-    # For Monitor < 9.2.0 (after-iot): IoT installs before Monitor (legacy behavior)
-    # IoT does not depend on Manage, it can start right after Core is verified
+    # Runs after Manage approval to ensure proper sequencing
     - name: waitfor-iot
       timeout: "0"
       taskRef:
@@ -410,92 +404,8 @@ spec:
         - input: $(params.sync_with_install)
           operator: in
           values: ["true", "True"]
-        - input: $(params.mas_monitor_install_order)
-          operator: in
-          values: ["after-iot"]
       runAfter:
-        - approval-suite-verify
-
-    # Wait for IoT (before-iot scenario) - runs after Monitor approval
-    # For Monitor >= 9.2.0: Monitor installs first, then IoT installs after Monitor
-    # So we wait for Monitor approval first, then wait for IoT approval
-    - name: waitfor-iot-after-monitor
-      timeout: "0"
-      taskRef:
-        kind: Task
-        name: mas-devops-wait-for-configmap
-      params:
-        - name: image_pull_policy
-          value: $(params.image_pull_policy)
-        - name: namespace
-          value: $(context.taskRun.namespace)
-        - name: configmap_name
-          value: approval-app-cfg-iot
-        - name: configmap_target_value
-          value: pending
-        # Escape route
-        - name: escape_configmap_name
-          value: sync-install
-        # 88 retries at 5 minute intervals = 7.3 hours (increased by 4 hours)
-        - name: delay
-          value: "300"
-        - name: max_retries
-          value: "88"
-        - name: ignore_failure
-          value: "False"
-      when:
-        - input: $(params.sync_with_install)
-          operator: in
-          values: ["true", "True"]
-        - input: $(params.mas_monitor_install_order)
-          operator: in
-          values: ["before-iot"]
-      runAfter:
-        - approval-monitor-before-iot
-
-    # Launch IoT FVT (Monitor < 9.2.0 - after IoT)
-    # For pre-9.2 installations, IoT installs before Monitor and can run independently
-    - name: launchfvt-iot
-      timeout: "0"
-      params:
-        - name: image_pull_policy
-          value: $(params.image_pull_policy)
-        - name: pipelinerun_name
-          value: "$(params.mas_instance_id)-fvt-iot"
-      taskRef:
-        kind: Task
-        name: mas-launchfvt-iot
-      when:
-        - input: $(params.launchfvt_iot)
-          operator: in
-          values: ["true", "True"]
-        - input: $(params.mas_monitor_install_order)
-          operator: in
-          values: ["after-iot"]
-      runAfter:
-        - waitfor-iot
-
-    # Launch IoT FVT (Monitor >= 9.2.0 - before IoT)
-    # For post-9.2 installations, IoT installs after Monitor, so wait for Monitor approval first
-    - name: launchfvt-iot-after-monitor
-      timeout: "0"
-      params:
-        - name: image_pull_policy
-          value: $(params.image_pull_policy)
-        - name: pipelinerun_name
-          value: "$(params.mas_instance_id)-fvt-iot"
-      taskRef:
-        kind: Task
-        name: mas-launchfvt-iot
-      when:
-        - input: $(params.launchfvt_iot)
-          operator: in
-          values: ["true", "True"]
-        - input: $(params.mas_monitor_install_order)
-          operator: in
-          values: ["before-iot"]
-      runAfter:
-        - waitfor-iot-after-monitor
+        - approval-manage
 
     - name: approval-iot
       timeout: "0"
@@ -513,35 +423,8 @@ spec:
         - input: $(params.sync_with_install)
           operator: in
           values: ["true", "True"]
-        - input: $(params.mas_monitor_install_order)
-          operator: in
-          values: ["after-iot"]
       runAfter:
         - waitfor-iot
-
-    # Approve IoT (before-iot scenario) - only after both Monitor and IoT FVT complete
-    # For Monitor >= 9.2.0: IoT installs after Monitor, so approval happens after both FVTs
-    - name: approval-iot-after-monitor
-      timeout: "0"
-      taskRef:
-        kind: Task
-        name: mas-devops-update-configmap
-      params:
-        - name: image_pull_policy
-          value: $(params.image_pull_policy)
-        - name: configmap_name
-          value: approval-app-cfg-iot
-        - name: configmap_value
-          value: approved
-      when:
-        - input: $(params.sync_with_install)
-          operator: in
-          values: ["true", "True"]
-        - input: $(params.mas_monitor_install_order)
-          operator: in
-          values: ["before-iot"]
-      runAfter:
-        - waitfor-iot-after-monitor
 
 
     # 5. Application FVT - Manage
@@ -674,8 +557,6 @@ spec:
           values: ["true", "True"]
       runAfter:
         - manage-setup
-        - launchfvt-core-pre92
-        - launchfvt-core-post92
 
     - name: launchfvt-manage-ai
       timeout: "0"
@@ -752,9 +633,7 @@ spec:
     # 7. Application FVT - Monitor
     # -------------------------------------------------------------------------
     # Wait for Monitor installation to complete before launching Monitor FVT
-    # For Monitor >= 9.2.0 (before-iot): runs in parallel with waitfor-iot
-    # For Monitor < 9.2.0 (after-iot): runs after both manage approval and waitfor-iot
-    # Note: Monitor installation depends on manage completing, so we must wait for manage approval
+    # Runs after Manage approval to ensure proper sequencing
     - name: waitfor-monitor
       timeout: "0"
       taskRef:
@@ -786,96 +665,9 @@ spec:
         - input: $(params.sync_with_install)
           operator: in
           values: ["true", "True"]
-        - input: $(params.mas_monitor_install_order)
-          operator: in
-          values: ["after-iot"]
-      runAfter:
-        - waitfor-iot
-        - approval-manage
-
-    # Wait for Monitor (before-iot scenario) - runs in parallel with IoT
-    - name: waitfor-monitor-before-iot
-      timeout: "0"
-      taskRef:
-        kind: Task
-        name: mas-devops-wait-for-configmap
-      params:
-        - name: image_pull_policy
-          value: $(params.image_pull_policy)
-        - name: namespace
-          value: $(context.taskRun.namespace)
-        - name: configmap_name
-          value: approval-app-cfg-monitor
-        - name: configmap_target_value
-          value: pending
-        # Escape route
-        - name: escape_configmap_name
-          value: sync-install
-        # 98 retries at 5 minute intervals = 8.17 hours (increased by 4 hours)
-        - name: delay
-          value: "300"
-        - name: max_retries
-          value: "98"
-        - name: ignore_failure
-          value: "False"
-      when:
-        - input: $(params.launchfvt_monitor)
-          operator: in
-          values: ["true", "True"]
-        - input: $(params.sync_with_install)
-          operator: in
-          values: ["true", "True"]
-        - input: $(params.mas_monitor_install_order)
-          operator: in
-          values: ["before-iot"]
       runAfter:
         - approval-manage
 
-    # Launch Monitor FVT (Monitor < 9.2.0 - after IoT)
-    - name: launchfvt-monitor
-      timeout: "0"
-      params:
-        - name: image_pull_policy
-          value: $(params.image_pull_policy)
-        - name: pipelinerun_name
-          value: "$(params.mas_instance_id)-fvt-monitor"
-      taskRef:
-        kind: Task
-        name: mas-launchfvt-monitor
-      when:
-        - input: $(params.launchfvt_monitor)
-          operator: in
-          values: ["true", "True"]
-        - input: $(params.mas_monitor_install_order)
-          operator: in
-          values: ["after-iot"]
-      runAfter:
-        - waitfor-monitor
-
-    # Launch Monitor FVT (Monitor >= 9.2.0 - before IoT)
-    # Waits for both Monitor and IoT installations to complete before launching
-    - name: launchfvt-monitor-before-iot
-      timeout: "0"
-      params:
-        - name: image_pull_policy
-          value: $(params.image_pull_policy)
-        - name: pipelinerun_name
-          value: "$(params.mas_instance_id)-fvt-monitor"
-      taskRef:
-        kind: Task
-        name: mas-launchfvt-monitor
-      when:
-        - input: $(params.launchfvt_monitor)
-          operator: in
-          values: ["true", "True"]
-        - input: $(params.mas_monitor_install_order)
-          operator: in
-          values: ["before-iot"]
-      runAfter:
-        - waitfor-monitor-before-iot
-        - waitfor-iot-after-monitor
-
-    # Approve Monitor for Monitor < 9.2.0 (after-iot scenario)
     - name: approval-monitor
       timeout: "0"
       taskRef:
@@ -892,35 +684,45 @@ spec:
         - input: $(params.sync_with_install)
           operator: in
           values: ["true", "True"]
-        - input: $(params.mas_monitor_install_order)
-          operator: in
-          values: ["after-iot"]
       runAfter:
         - waitfor-monitor
 
-    # Approve Monitor for Monitor >= 9.2.0 (before-iot scenario)
-    # This runs immediately after Monitor installation completes, allowing IoT to start
-    - name: approval-monitor-before-iot
+    # Launch IoT FVT after both IoT and Monitor approvals
+    - name: launchfvt-iot
       timeout: "0"
-      taskRef:
-        kind: Task
-        name: mas-devops-update-configmap
       params:
         - name: image_pull_policy
           value: $(params.image_pull_policy)
-        - name: configmap_name
-          value: approval-app-cfg-monitor
-        - name: configmap_value
-          value: approved
+        - name: pipelinerun_name
+          value: "$(params.mas_instance_id)-fvt-iot"
+      taskRef:
+        kind: Task
+        name: mas-launchfvt-iot
       when:
-        - input: $(params.sync_with_install)
+        - input: $(params.launchfvt_iot)
           operator: in
           values: ["true", "True"]
-        - input: $(params.mas_monitor_install_order)
-          operator: in
-          values: ["before-iot"]
       runAfter:
-        - waitfor-monitor-before-iot
+        - approval-iot
+        - approval-monitor
+
+    # Launch Monitor FVT after IoT FVT
+    - name: launchfvt-monitor
+      timeout: "0"
+      params:
+        - name: image_pull_policy
+          value: $(params.image_pull_policy)
+        - name: pipelinerun_name
+          value: "$(params.mas_instance_id)-fvt-monitor"
+      taskRef:
+        kind: Task
+        name: mas-launchfvt-monitor
+      when:
+        - input: $(params.launchfvt_monitor)
+          operator: in
+          values: ["true", "True"]
+      runAfter:
+        - launchfvt-iot
 
 
     # 8. Application FVT - Optimizer
@@ -1033,9 +835,7 @@ spec:
           values: ["true", "True"]
       runAfter:
         - approval-monitor
-        - approval-manage
         - approval-iot
-        - approval-iot-after-monitor
 
     - name: launchfvt-predict
       timeout: "0"
@@ -1108,7 +908,6 @@ spec:
           operator: in
           values: ["true", "True"]
       runAfter:
-        - approval-suite-verify
         - approval-manage
 
     - name: launchfvt-visualinspection
@@ -1183,7 +982,6 @@ spec:
           operator: in
           values: ["true", "True"]
       runAfter:
-        - approval-suite-verify
         - waitfor-manage
 
     - name: launchfvt-facilities
@@ -1239,8 +1037,8 @@ spec:
           operator: in
           values: ["true", "True"]
       runAfter:
-        - approval-manage
-        - approval-monitor
+        - approval-visualinspection
+        - launchfvt-monitor
         - launchfvt-mobile
 
     # Install Sync Point
@@ -1271,16 +1069,13 @@ spec:
           operator: in
           values: ["true", "True"]
       runAfter:
-        - launchfvt-mobile
         - approval-assist
         - approval-optimizer
         - approval-predict
-        - approval-iot # Ensure IoT FVT completes before Day2 (pre-9.2)
-        - approval-iot-after-monitor # Ensure IoT FVT completes before Day2 (post-9.2)
-        - approval-monitor # Ensure Monitor FVT completes before Day2 (pre-9.2)
-        - approval-monitor-before-iot # Ensure Monitor FVT completes before Day2 (post-9.2)
-        - approval-visualinspection
-        - launchivt-manage
+        # Note: IoT and Monitor FVT works differently.  We grant approval for the install pipeline to proceed before the
+        # FVT for these applications starts, so when the FVT for Monitor completes we know that we have already
+        # granted approval for the install to progress, and both IoT and Monitor FVT is complete.
+        - launchivt-manage  # Also ensures completion of launchfvt-mobile, launchfvt-monitor, & approval-visualinspection
         - approval-facilities
 
     # Day 2 activity FVT


### PR DESCRIPTION
Three main highlights:
- Fixes AI Agent introduced bugs in the pipeline
- Sort out the IoT/Monitor FVT ordering mess
- Clean up redundant `runAfter` clauses