### PR TITLE
[patch] corrected the pods-only parameter in doc example

### DIFF
--- a/docs/commands/must-gather.md
+++ b/docs/commands/must-gather.md
@@ -194,7 +194,7 @@ mas must-gather -d /mnt/home/must-gather --no-ocp --no-dependencies --no-sls --m
 mas must-gather -d /mnt/home/must-gather --no-ocp --no-dependencies --no-sls --mas-instance-ids "inst2" --mas-app-ids "core,manage"
 
 # Target Manage pods only in inst3
-mas must-gather -d /mnt/home/must-gather --no-ocp --no-dependencies --no-sls --mas-instance-ids "inst3" --mas-app-ids "manage" --pods_only
+mas must-gather -d /mnt/home/must-gather --no-ocp --no-dependencies --no-sls --mas-instance-ids "inst3" --mas-app-ids "manage" --pods-only
 ```
 
 **Generate MAS quick summary report for specific MAS instance:**  By default, must-gather includes a MAS quick summary report in the `mas-quick-summary` folder, providing compiled information to help identify common issues in the environment. When used with the flags `--summary-only`, `--no-ocp`, `--no-dependencies`, `--no-sls`, and `--mas-instance-ids` to target a specific namespace or MAS application, must-gather focuses the collection for faster execution while still including the MAS quick summary.


### PR DESCRIPTION
The parameter is `--pods-only`, as mentioned in the [doc](https://github.com/ibm-mas/cli/blob/f02864d64f6a6463852a709b9797fa21b661e9df/docs/commands/must-gather.md#L16) and in the [code](https://github.com/ibm-mas/cli/blob/f02864d64f6a6463852a709b9797fa21b661e9df/image/cli/mascli/functions/must_gather#L159)

However, the example in the doc called it `--pods_only`. I have corrected it.