### PR TITLE
[patch] Update catalog digests for June 25, 2026 release

### DIFF
--- a/catalogs/v9-260625-amd64.yaml
+++ b/catalogs/v9-260625-amd64.yaml
@@ -1,0 +1,12 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: CatalogSource
+metadata:
+  name: ibm-operator-catalog
+  namespace: openshift-marketplace
+spec:
+  displayName: IBM Maximo Operators (v9-260625-amd64)
+  publisher: IBM
+  description: Static Catalog Source for IBM Maximo Application Suite
+  sourceType: grpc
+  image: icr.io/cpopen/ibm-maximo-operator-catalog@sha256:29f96e5e36bfb8594c8747043d72a662206a2836959ed3c76ed6fc62462d8241
+  priority: 90

--- a/catalogs/v9-260625-ppc64le.yaml
+++ b/catalogs/v9-260625-ppc64le.yaml
@@ -1,0 +1,12 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: CatalogSource
+metadata:
+  name: ibm-operator-catalog
+  namespace: openshift-marketplace
+spec:
+  displayName: IBM Maximo Operators (v9-260625-ppc64le)
+  publisher: IBM
+  description: Static Catalog Source for IBM Maximo Application Suite
+  sourceType: grpc
+  image: icr.io/cpopen/ibm-maximo-operator-catalog@sha256:44b82c3e8c618fe8d34849c5c080401c33753939ccdcc0ee51708bb026610b2d
+  priority: 90

--- a/catalogs/v9-260625-s390x.yaml
+++ b/catalogs/v9-260625-s390x.yaml
@@ -1,0 +1,12 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: CatalogSource
+metadata:
+  name: ibm-operator-catalog
+  namespace: openshift-marketplace
+spec:
+  displayName: IBM Maximo Operators (v9-260625-s390x)
+  publisher: IBM
+  description: Static Catalog Source for IBM Maximo Application Suite
+  sourceType: grpc
+  image: icr.io/cpopen/ibm-maximo-operator-catalog@sha256:6850fe15ea49526c61616f389181608a173587d63407d321fdbd3d6c13634648
+  priority: 90


### PR DESCRIPTION
This PR updates the CLI catalog files with new digests for the June 25, 2026 release (v9-260625).

## Changes
- Created v9-260625-amd64.yaml with updated digest
- Created v9-260625-ppc64le.yaml with updated digest
- Created v9-260625-s390x.yaml with updated digest

## Digests
- amd64: sha256:29f96e5e36bfb8594c8747043d72a662206a2836959ed3c76ed6fc62462d8241
- ppc64le: sha256:44b82c3e8c618fe8d34849c5c080401c33753939ccdcc0ee51708bb026610b2d
- s390x: sha256:6850fe15ea49526c61616f389181608a173587d63407d321fdbd3d6c13634648

## Related
- Python-devops PR: https://github.com/ibm-mas/python-devops/pull/358