### PR TITLE
[patch] Made changes to use existing File Validator logic

### DIFF
--- a/python/src/mas/cli/install/app.py
+++ b/python/src/mas/cli/install/app.py
@@ -1551,11 +1551,10 @@ class InstallApp(
                             "If you choose not to upload a custom file, the default FACILITIES.properties will be used.",
                         ]
                     )
-                    facilitiesPropertiesFile = self.promptForString(
+                    self.promptForString(
                         "Path to FACILITIES.properties file", "mas_ws_facilities_properties_file_local", validator=FileExistsValidator()
                     )
 
-                    self.setParam("mas_ws_facilities_properties_file_local", facilitiesPropertiesFile)
                     self.setParam("mas_ws_facilities_custom_properties", "true")
 
                     # Prompt for custom secret name

--- a/python/src/mas/cli/install/app.py
+++ b/python/src/mas/cli/install/app.py
@@ -1551,9 +1551,7 @@ class InstallApp(
                             "If you choose not to upload a custom file, the default FACILITIES.properties will be used.",
                         ]
                     )
-                    self.promptForString(
-                        "Path to FACILITIES.properties file", "mas_ws_facilities_properties_file_local", validator=FileExistsValidator()
-                    )
+                    self.promptForString("Path to FACILITIES.properties file", "mas_ws_facilities_properties_file_local", validator=FileExistsValidator())
 
                     self.setParam("mas_ws_facilities_custom_properties", "true")
 

--- a/python/src/mas/cli/install/app.py
+++ b/python/src/mas/cli/install/app.py
@@ -1552,19 +1552,14 @@ class InstallApp(
                         ]
                     )
                     facilitiesPropertiesFile = self.promptForString(
-                        "Path to FACILITIES.properties file",
-                        "mas_ws_facilities_properties_file_local",
-                        validator=FileExistsValidator()
+                        "Path to FACILITIES.properties file", "mas_ws_facilities_properties_file_local", validator=FileExistsValidator()
                     )
-                    
+
                     self.setParam("mas_ws_facilities_properties_file_local", facilitiesPropertiesFile)
                     self.setParam("mas_ws_facilities_custom_properties", "true")
 
                     # Prompt for custom secret name
-                    customSecretName = self.promptForString(
-                        "Specify the custom secret name",
-                        "mas_ws_facilities_properties_secret_name"
-                    )
+                    customSecretName = self.promptForString("Specify the custom secret name", "mas_ws_facilities_properties_secret_name")
                     # Use default if not provided
                     if not customSecretName or customSecretName.strip() == "":
                         customSecretName = "custom-facilities-properties"

--- a/python/src/mas/cli/install/app.py
+++ b/python/src/mas/cli/install/app.py
@@ -46,6 +46,7 @@ from mas.cli.validators import (
     JsonValidator,
     OptimizerInstallPlanValidator,
     BucketPrefixValidator,
+    FileExistsValidator,
 )
 
 from mas.devops.ocp import (
@@ -1553,20 +1554,21 @@ class InstallApp(
                     facilitiesPropertiesFile = self.promptForString(
                         "Path to FACILITIES.properties file",
                         "mas_ws_facilities_properties_file_local",
+                        validator=FileExistsValidator()
                     )
-                    if facilitiesPropertiesFile and path.exists(facilitiesPropertiesFile):
-                        self.setParam("mas_ws_facilities_properties_file_local", facilitiesPropertiesFile)
-                        self.setParam("mas_ws_facilities_custom_properties", "true")
+                    
+                    self.setParam("mas_ws_facilities_properties_file_local", facilitiesPropertiesFile)
+                    self.setParam("mas_ws_facilities_custom_properties", "true")
 
-                        # Prompt for custom secret name (optional, with default)
-                        customSecretName = self.promptForString("Specify the custom secret name", "mas_ws_facilities_properties_secret_name")
-                        # Use default if not provided
-                        if not customSecretName or customSecretName.strip() == "":
-                            customSecretName = "custom-facilities-properties"
-                        self.setParam("mas_ws_facilities_properties_secret_name", customSecretName)
-                    else:
-                        print_formatted_text(HTML("<Red>File not found. Default FACILITIES.properties will be used.</Red>"))
-                        self.setParam("mas_ws_facilities_custom_properties", "false")
+                    # Prompt for custom secret name
+                    customSecretName = self.promptForString(
+                        "Specify the custom secret name",
+                        "mas_ws_facilities_properties_secret_name"
+                    )
+                    # Use default if not provided
+                    if not customSecretName or customSecretName.strip() == "":
+                        customSecretName = "custom-facilities-properties"
+                    self.setParam("mas_ws_facilities_properties_secret_name", customSecretName)
                 else:
                     self.setParam("mas_ws_facilities_custom_properties", "false")
 


### PR DESCRIPTION
Made changes to use existing File Validator logic based on review comments from PR: https://github.com/ibm-mas/cli/pull/2313#discussion_r3347796290

With Incorrect Path:
<img width="2800" height="490" alt="image" src="https://github.com/user-attachments/assets/15471e4e-82e9-4215-b020-947b0871593a" />

With Correct Path:
<img width="2800" height="490" alt="image" src="https://github.com/user-attachments/assets/eb6c065e-19c1-4cae-a175-4c280e515b87" />
