### PR TITLE
[patch] Preserve old digest for master

### DIFF
--- a/.github/workflows/build-cli.yml
+++ b/.github/workflows/build-cli.yml
@@ -490,6 +490,13 @@ jobs:
           else
             echo "Publishing quay.io/ibmmas/cli:$GITHUB_REF_NAME alias"
             docker buildx imagetools create -t quay.io/ibmmas/cli:$GITHUB_REF_NAME quay.io/ibmmas/cli:${{ env.DOCKER_TAG }}
+            
+            # Preserve digests for master and monthlyupdate branches with build-specific tags
+            if [[ "$GITHUB_REF_NAME" == "master" ]] || [[ "$GITHUB_REF_NAME" == "fix-branch-tag" ]]; then
+              BUILD_TAG="${GITHUB_REF_NAME}-${{ github.run_number }}"
+              echo "Publishing quay.io/ibmmas/cli:${BUILD_TAG} for digest preservation"
+              docker buildx imagetools create -t quay.io/ibmmas/cli:${BUILD_TAG} quay.io/ibmmas/cli:${{ env.DOCKER_TAG }}
+            fi
           fi
 
 

--- a/.github/workflows/build-cli.yml
+++ b/.github/workflows/build-cli.yml
@@ -492,7 +492,7 @@ jobs:
             docker buildx imagetools create -t quay.io/ibmmas/cli:$GITHUB_REF_NAME quay.io/ibmmas/cli:${{ env.DOCKER_TAG }}
             
             # Preserve digests for master and monthlyupdate branches with build-specific tags
-            if [[ "$GITHUB_REF_NAME" == "master" ]] || [[ "$GITHUB_REF_NAME" == "fix-branch-tag" ]]; then
+            if [[ "$GITHUB_REF_NAME" == "master" ]] || [[ "$GITHUB_REF_NAME" == "monthlyupdate" ]]; then
               BUILD_TAG="${GITHUB_REF_NAME}-${{ github.run_number }}"
               echo "Publishing quay.io/ibmmas/cli:${BUILD_TAG} for digest preservation"
               docker buildx imagetools create -t quay.io/ibmmas/cli:${BUILD_TAG} quay.io/ibmmas/cli:${{ env.DOCKER_TAG }}


### PR DESCRIPTION
### Problem 
Based on the previous changes https://github.com/ibm-mas/cli/pull/2316 now we are using specific digest in MAS install command itself

However, during Personal fvt ongoing run (pointing to my cli branch) I updated my cli changes which initiated the new github actions. This has impacted the FVT run and one of my task failed with below error -

```
status:
  completionTime: '2026-06-04T11:04:18Z'
  conditions:
    - lastTransitionTime: '2026-06-04T11:04:18Z'
      message: 'the step "app-config" in TaskRun "usfvt-install-260604-0641-app-install-iot-after-monitor" failed to pull the image "". The pod errored with the message: "Back-off pulling image "quay.io/ibmmas/cli@sha256:1820014d22381a008ced042f0ce36fe2ad8b8586ded8d8dcd6d997169b160b29": ErrImagePull: unable to pull image or OCI artifact: pull image err: initializing source docker://quay.io/ibmmas/cli@sha256:1820014d22381a008ced042f0ce36fe2ad8b8586ded8d8dcd6d997169b160b29: reading manifest sha256:1820014d22381a008ced042f0ce36fe2ad8b8586ded8d8dcd6d997169b160b29 in quay.io/ibmmas/cli: manifest unknown; artifact err: get manifest: build image source: reading manifest sha256:1820014d22381a008ced042f0ce36fe2ad8b8586ded8d8dcd6d997169b160b29 in quay.io/ibmmas/cli: manifest unknown."'
      reason: TaskRunImagePullFailed
      status: 'False'
      type: Succeeded
```

Slack discussion - https://ibm-mas.slack.com/archives/C0A6RLMP614/p1780571924845539?thread_ts=1779362627.213809&cid=C0A6RLMP614

### Solution
Generate extra branch_buildnum label on important branches so that we preserve the old digests. 

Note: Its not applicable for personal branches, assuming that we don't need any changes in mid way when FVT is running 