### PR TITLE
[patch] add service mesh install options to provision_fyre

### DIFF
--- a/image/cli/mascli/functions/provision_fyre
+++ b/image/cli/mascli/functions/provision_fyre
@@ -47,6 +47,10 @@ Turbonomic Integration:
       --turbonomic-username ${COLOR_YELLOW}TURBONOMIC_USERNAME${TEXT_RESET}              Turbonomic username
       --turbonomic-password ${COLOR_YELLOW}TURBONOMIC_PASSWORD${TEXT_RESET}              Turbonomic password
 
+Service Mesh Installation:
+      --install-service-mesh       Install Redhat Openshift Service Mesh to handle cluster networking
+      --install-kiali              Install Kiali as a monitoring UI for Redhat Openshift Service Mesh
+
 Other Commands:
       --no-confirm        Provision the cluster without prompting for confirmation
   -h, --help              Show this help message
@@ -149,6 +153,14 @@ function provision_fyre_noninteractive() {
         ;;
       --turbonomic-password)
         TURBONOMIC_PASSWORD=$1 && shift
+        ;;
+
+      # Service Mesh
+      --install-service-mesh)
+        INSTALL_SERVICE_MESH=true
+        ;;
+      --install-kiali)
+        INSTALL_KIALI=true
         ;;
 
       # Other options
@@ -329,6 +341,13 @@ function provision_fyre_interactive() {
     prompt_for_secret "Password" TURBONOMIC_PASSWORD
   fi
 
+  echo
+  echo_h2 "Service Mesh Installation:"
+  prompt_for_confirm "Install Service Mesh" && export INSTALL_SERVICE_MESH=true
+  if [[ "$INSTALL_SERVICE_MESH" == "true" ]]; then
+    prompt_for_confirm "Install Kiali" && export INSTALL_KIALI=true
+  fi
+
 }
 
 function provision_fyre() {
@@ -378,6 +397,9 @@ function provision_fyre() {
   export TURBONOMIC_USERNAME
   export TURBONOMIC_PASSWORD
 
+  export INSTALL_SERVICE_MESH
+  export INSTALL_KIALI
+
   echo
   reset_colors
   echo_h2 "Review Settings"
@@ -425,6 +447,12 @@ function provision_fyre() {
     echo_reset_dim "Server URL .................. ${COLOR_MAGENTA}${TURBONOMIC_SERVER_URL}"
     echo_reset_dim "Server Version .............. ${COLOR_MAGENTA}${TURBONOMIC_SERVER_VERSION}"
   fi
+
+  reset_colors
+  echo "${TEXT_DIM}"
+  echo_h2 "Service Mesh Integration" "    "
+  echo_reset_dim "Install Service Mesh ........ ${COLOR_MAGENTA}${INSTALL_SERVICE_MESH:-false}"
+  echo_reset_dim "Install Kiali................ ${COLOR_MAGENTA}${INSTALL_KIALI:-false}"
 
   echo
   reset_colors


### PR DESCRIPTION
## Description
Modify the provision-fyre command to install Redhat Service Mesh. 

## Related Issues
https://jsw.ibm.com/browse/MASCORE-12035

## Test Results
Tested by reprovisioning ServiceMesh fyre cluster, confirmed that service mesh was installed

