### PR TITLE
[patch] Add AICfg Test Suite to Tekton Phase 1 Pipeline

### DIFF
--- a/tekton/src/pipelines/taskdefs/fvt-core/phase1-under5min.yml.j2
+++ b/tekton/src/pipelines/taskdefs/fvt-core/phase1-under5min.yml.j2
@@ -166,3 +166,13 @@
     - name: fvt_test_suite
       value: masprovisioner
   runAfter: {{ runAfter }}
+
+# aicfg ~5m
+# -----------------------------------------------------------------------------
+- name: aicfg
+  {{ lookup('template', 'taskdefs/fvt-core/common/taskref.yml.j2') | indent(2) }}
+  params:
+    {{ lookup('template', 'taskdefs/fvt-core/common/params.yml.j2') | indent(4) }}
+    - name: fvt_test_suite
+      value: aicfg
+  runAfter: {{ runAfter }}


### PR DESCRIPTION
This PR adds the AICfg FVT suite to the Phase 1 Tekton pipeline (phase1-under5min.yml.j2).AICfg FVT tests are executed as part of the Phase 1 Tekton pipeline.



<img width="971" height="219" alt="image" src="https://github.com/user-attachments/assets/4f9a5278-2789-49cb-89a1-6716c5d557e2" />
