### PR TITLE
[patch] Mobile FVT tasks reorder

### DIFF
--- a/tekton/src/pipelines/mas-fvt-mobile-pytest.yml.j2
+++ b/tekton/src/pipelines/mas-fvt-mobile-pytest.yml.j2
@@ -88,6 +88,7 @@ spec:
     {{ lookup('template', 'taskdefs/fvt-mobile/pytest/phase3-apps.yml.j2') | indent(4) }}
     {{ lookup('template', 'taskdefs/fvt-mobile/pytest/phase4-apps.yml.j2') | indent(4) }}
     {{ lookup('template', 'taskdefs/fvt-mobile/pytest/phase5-apps.yml.j2') | indent(4) }}
+    {{ lookup('template', 'taskdefs/fvt-mobile/pytest/phase6-apps.yml.j2') | indent(4) }}
   
   # Finally
   # ---------------------------------------------------------------------------

--- a/tekton/src/pipelines/taskdefs/fvt-mobile/pytest/phase1-setup.yml.j2
+++ b/tekton/src/pipelines/taskdefs/fvt-mobile/pytest/phase1-setup.yml.j2
@@ -33,16 +33,6 @@
   runAfter:
     - fvt-component
 
-
-- name: mobile-pytest-requests
-  {{ lookup('template', 'taskdefs/fvt-mobile/common/taskref-pytest.yml.j2') | indent(2) }}
-  params:
-    {{ lookup('template', 'taskdefs/fvt-mobile/common/params-pytest.yml.j2') | indent(4) }}
-    - name: fvt_test_suite
-      value: mobile-api-requests
-  runAfter:
-    - mobile-setup-pytest
-
 - name: mobile-pytest-asset-image
   {{ lookup('template', 'taskdefs/fvt-mobile/common/taskref-pytest.yml.j2') | indent(2) }}
   params:

--- a/tekton/src/pipelines/taskdefs/fvt-mobile/pytest/phase4-apps.yml.j2
+++ b/tekton/src/pipelines/taskdefs/fvt-mobile/pytest/phase4-apps.yml.j2
@@ -30,3 +30,14 @@
     - mobile-pytest-calibration
     - mobile-pytest-civil-defects
     - mobile-pytest-location
+
+- name: mobile-pytest-sr
+  {{ lookup('template', 'taskdefs/fvt-mobile/common/taskref-pytest.yml.j2') | indent(2) }}
+  params:
+    {{ lookup('template', 'taskdefs/fvt-mobile/common/params-pytest.yml.j2') | indent(4) }}
+    - name: fvt_test_suite
+      value: mobile-api-sr
+  runAfter:
+    - mobile-pytest-calibration
+    - mobile-pytest-civil-defects
+    - mobile-pytest-location

--- a/tekton/src/pipelines/taskdefs/fvt-mobile/pytest/phase5-apps.yml.j2
+++ b/tekton/src/pipelines/taskdefs/fvt-mobile/pytest/phase5-apps.yml.j2
@@ -1,13 +1,14 @@
-- name: mobile-pytest-sr
+- name: mobile-pytest-crew
   {{ lookup('template', 'taskdefs/fvt-mobile/common/taskref-pytest.yml.j2') | indent(2) }}
   params:
     {{ lookup('template', 'taskdefs/fvt-mobile/common/params-pytest.yml.j2') | indent(4) }}
     - name: fvt_test_suite
-      value: mobile-api-sr
+      value: mobile-api-crew
   runAfter:
     - mobile-pytest-ic
     - mobile-pytest-ir
     - mobile-pytest-it
+    - mobile-pytest-sr
 
 - name: mobile-pytest-insp
   {{ lookup('template', 'taskdefs/fvt-mobile/common/taskref-pytest.yml.j2') | indent(2) }}
@@ -19,6 +20,7 @@
     - mobile-pytest-ic
     - mobile-pytest-ir
     - mobile-pytest-it
+    - mobile-pytest-sr
 
 - name: mobile-pytest-collaborate
   taskRef:
@@ -33,6 +35,7 @@
     - mobile-pytest-ic
     - mobile-pytest-ir
     - mobile-pytest-it
+    - mobile-pytest-sr
   workspaces:
     - name: configs
       workspace: shared-configs

--- a/tekton/src/pipelines/taskdefs/fvt-mobile/pytest/phase6-apps.yml.j2
+++ b/tekton/src/pipelines/taskdefs/fvt-mobile/pytest/phase6-apps.yml.j2
@@ -1,31 +1,32 @@
-
-
-- name: mobile-pytest-assetmanager
+- name: mobile-pytest-timesheet
   {{ lookup('template', 'taskdefs/fvt-mobile/common/taskref-pytest.yml.j2') | indent(2) }}
   params:
     {{ lookup('template', 'taskdefs/fvt-mobile/common/params-pytest.yml.j2') | indent(4) }}
     - name: fvt_test_suite
-      value: mobile-api-assetm
+      value: mobile-api-timesheet
   runAfter:
-    - mobile-pytest-asset-image
-    - mobile-pytest-download
-    
-- name: mobile-pytest-tech
-  {{ lookup('template', 'taskdefs/fvt-mobile/common/taskref-pytest.yml.j2') | indent(2) }}
-  params:
-    {{ lookup('template', 'taskdefs/fvt-mobile/common/params-pytest.yml.j2') | indent(4) }}
-    - name: fvt_test_suite
-      value: mobile-api-tech
-  runAfter:
-    - mobile-pytest-asset-image
-    - mobile-pytest-download
+    - mobile-pytest-crew
+    - mobile-pytest-insp
+    - mobile-pytest-collaborate
 
-- name: mobile-pytest-supervisor
+- name: mobile-pytest-materialrequest
   {{ lookup('template', 'taskdefs/fvt-mobile/common/taskref-pytest.yml.j2') | indent(2) }}
   params:
     {{ lookup('template', 'taskdefs/fvt-mobile/common/params-pytest.yml.j2') | indent(4) }}
     - name: fvt_test_suite
-      value: mobile-api-supervisor
+      value: mobile-api-materialrequest
   runAfter:
-    - mobile-pytest-asset-image
-    - mobile-pytest-download
+    - mobile-pytest-crew
+    - mobile-pytest-insp
+    - mobile-pytest-collaborate
+
+- name: mobile-pytest-requests
+  {{ lookup('template', 'taskdefs/fvt-mobile/common/taskref-pytest.yml.j2') | indent(2) }}
+  params:
+    {{ lookup('template', 'taskdefs/fvt-mobile/common/params-pytest.yml.j2') | indent(4) }}
+    - name: fvt_test_suite
+      value: mobile-api-requests
+  runAfter:
+    - mobile-pytest-crew
+    - mobile-pytest-insp
+    - mobile-pytest-collaborate


### PR DESCRIPTION
- Reordering tasks so that mobile-pytest-requests is executed at the end of the pytest pipeline in order to give more time for required permissions to reflect in manage.
- Including 3 new mobile suites for the following mobile apps:
  - Mobile Crew
  - Material Request
  - Time Sheet

Pipelinerun Test Evidence in dev environment:
<img width="1601" height="794" alt="image" src="https://github.com/user-attachments/assets/16d74b4c-0b0a-4c44-9a83-cdca00465556" />

Tasks reorder and new additions
<img width="1444" height="678" alt="image" src="https://github.com/user-attachments/assets/9c5e62c7-79b9-4284-9a86-798411afaf35" />
