### PR TITLE
[patch] Revert Fix Monitor FVT to wait for IoT installation completi…

### DIFF
--- a/tekton/src/pipelines/mas-fvt-launcher.yml.j2
+++ b/tekton/src/pipelines/mas-fvt-launcher.yml.j2
@@ -373,7 +373,6 @@ spec:
     # -------------------------------------------------------------------------
     # Wait for IoT installation to complete before launching IoT FVT
     # Runs after Manage approval to ensure proper sequencing
-    # Also waits when Monitor FVT is enabled to ensure IoT installation completes before Monitor FVT starts
     - name: waitfor-iot
       timeout: "0"
       taskRef:
@@ -399,9 +398,9 @@ spec:
         - name: ignore_failure
           value: "False"
       when:
-        - input: $(params.launchfvt_iot)$(params.launchfvt_monitor)
-          operator: notin
-          values: ["falsefalse", "FalseFalse"]
+        - input: $(params.launchfvt_iot)
+          operator: in
+          values: ["true", "True"]
         - input: $(params.sync_with_install)
           operator: in
           values: ["true", "True"]
@@ -635,7 +634,6 @@ spec:
     # -------------------------------------------------------------------------
     # Wait for Monitor installation to complete before launching Monitor FVT
     # Runs after Manage approval to ensure proper sequencing
-    # Also waits when IoT FVT is enabled to ensure Monitor installation completes before IoT FVT starts
     - name: waitfor-monitor
       timeout: "0"
       taskRef:
@@ -661,9 +659,9 @@ spec:
         - name: ignore_failure
           value: "False"
       when:
-        - input: $(params.launchfvt_iot)$(params.launchfvt_monitor)
-          operator: notin
-          values: ["falsefalse", "FalseFalse"]
+        - input: $(params.launchfvt_monitor)
+          operator: in
+          values: ["true", "True"]
         - input: $(params.sync_with_install)
           operator: in
           values: ["true", "True"]
@@ -708,8 +706,7 @@ spec:
         - approval-iot
         - approval-monitor
 
-    # Launch Monitor FVT after both IoT and Monitor installations complete
-    # Waits for IoT FVT if enabled, otherwise waits for IoT approval
+    # Launch Monitor FVT after IoT FVT
     - name: launchfvt-monitor
       timeout: "0"
       params:
@@ -726,7 +723,6 @@ spec:
           values: ["true", "True"]
       runAfter:
         - launchfvt-iot
-        - approval-iot
 
 
     # 8. Application FVT - Optimizer


### PR DESCRIPTION


This reverts commit 5957d36579afe01105cd82a8645d4c4a95196c77.

Reverted changes:
- Removed Monitor FVT dependency on IoT installation completion
- Restored original waitfor-iot condition to only check launchfvt_iot
- Restored original waitfor-monitor condition to only check launchfvt_monitor
- Removed approval-iot from launchfvt-monitor runAfter dependencies
- Updated comments to reflect original behavior