### PR TITLE
[patch] Collaborate should display in review settings while installing through cli

### DIFF
--- a/python/src/mas/cli/install/summarizer.py
+++ b/python/src/mas/cli/install/summarizer.py
@@ -267,6 +267,7 @@ class InstallSummarizerMixin:
                     ("ACM", "acm"),
                     ("Aviation", "aviation"),
                     ("Civil Infrastructure", "civil"),
+                    ("Collaborate", "collaborate"),
                     ("Envizi", "envizi"),
                     ("Health", "health"),
                     ("HSE", "hse"),


### PR DESCRIPTION
Collaborate should display in review settings while installing through cli.
I have tested it using mas install command and it is showing  `+ Collaborate ......................... Enabled`  while selecting collaborate addon. 
<img width="1728" height="1024" alt="image" src="https://github.com/user-attachments/assets/d4f94c7b-ffb5-4116-8de5-d9fe351e7ba9" />
