### PR TITLE
[patch] set db2_channel earlier in update flow for same-major-version…

### DIFF
--- a/python/src/mas/cli/update/app.py
+++ b/python/src/mas/cli/update/app.py
@@ -847,6 +847,11 @@ class UpdateApp(BaseApp, AdditionalConfigsMixin):
 
                 kindString = "/".join([kind + "s" for kind in kinds])
                 if len(instances) > 0:
+                    # Set db2_channel immediately after confirming instances exist and target version is available
+                    if targetDb2uVersion:
+                        self.setParam("db2_channel", targetDb2uVersion)
+                        logger.debug(f"Setting db2_channel to {targetDb2uVersion}")
+
                     # If the user provided the namespace using --db2-namespace then we don't have any work to do here
                     if self.getParam(paramName) == "":
                         namespaces = set()
@@ -879,7 +884,6 @@ class UpdateApp(BaseApp, AdditionalConfigsMixin):
                             for index, ns in enumerate(sorted(namespaces), start=1):
                                 self.printDescription([f"{index}. {ns}"])
                             self.promptForListSelect("Select namespace", sorted(namespaces), paramName)
-                            self.setParam("db2_channel", self.chosenCatalog["db2_channel_default"])
 
                     # Version comparison logic - check if Db2u needs major version upgrade
                     if len(instances) > 0:
@@ -984,8 +988,6 @@ class UpdateApp(BaseApp, AdditionalConfigsMixin):
                                                     "Path to a valid Db2 v12 license file", envVar="DB2_LICENSE_FILE", default="", mustExist=False
                                                 )
 
-                                        # Set db2_channel when upgrade is confirmed (either via flag or user prompt)
-                                        self.setParam("db2_channel", targetDb2uVersion)
                                         logger.debug(f"Db2u major version upgrade required: {minMajorVersion} -> {targetMajorVersion}")
                                     else:
                                         self.setParam(f"db2_v{targetMajorVersion}_upgrade", "false")

--- a/python/tests/integration/update/test_db2u_non_interactive.py
+++ b/python/tests/integration/update/test_db2u_non_interactive.py
@@ -9,7 +9,7 @@
 #
 # *****************************************************************************
 
-from utils import UpdateTestConfig, run_update_test
+from utils import UpdateTestConfig, UpdateTestHelper, run_update_test
 import sys
 import os
 import pytest
@@ -318,6 +318,35 @@ def test_db2u_same_version_no_upgrade(tmpdir, resource_kind):
     )
 
     run_update_test(tmpdir, config)
+
+
+@pytest.mark.parametrize("resource_kind", ["Db2uCluster", "Db2uInstance"])
+def test_db2u_same_major_version_sets_db2_channel(tmpdir, resource_kind):
+    """Test that same-major-version updates still set db2_channel.
+
+    GIVEN a Db2 instance already on the target major version
+    WHEN update runs in non-interactive mode
+    THEN db2_channel is set to the catalog default channel.
+    """
+
+    config = UpdateTestConfig(
+        prompt_handlers={},
+        installed_catalog_id="v9-251231-amd64",
+        target_catalog_version="v9-260129-amd64",
+        db2u_namespaces=["db2u-system"],
+        db2u_resource_kind=resource_kind,
+        db2u_version="11.5.9.0",
+        db2u_target_version="v11.5",
+        mas_instances=[{"metadata": {"name": "inst1"}, "status": {"versions": {"reconciled": "9.1.7"}}}],
+        argv=["--catalog", "v9-260129-amd64", "--no-confirm"],
+        timeout_seconds=30,
+    )
+
+    helper = UpdateTestHelper(tmpdir, config)
+    helper.run_update_test()
+
+    assert helper.app is not None
+    assert helper.app.getParam("db2_channel") == "v11.5"
 
 
 @pytest.mark.parametrize("resource_kind", ["Db2uCluster", "Db2uInstance"])


### PR DESCRIPTION
## Description
`db2_channel` was not being parsed correctly to the pipelines during `update` scenario. The parameter `db2_channel` has been moved to the top of the function `detectDb2u()` meeting the following criteria:
- It has Db2 instances (Db2uCluster or Db2uInstance)
- It has a default channel in the catalog.

**Previous behavior**
<img width="558" height="415" alt="image" src="https://github.com/user-attachments/assets/0c7f234b-d2fa-4e44-868b-181fc55774a9" />


## Test Results
Tested locally
<img width="1396" height="178" alt="image" src="https://github.com/user-attachments/assets/3711a7ed-0366-4bc5-b405-b75ac736ab55" />

<hr/>

### :warning: Notes for Reviewers
* Ensure you have understood the PR guidelines in the Playbook before proceeding with a review.
* Ensure all sections in the PR template are appropriately completed.
