### PR TITLE
AI Service upgrade path 

### DIFF
--- a/python/src/mas/cli/cli.py
+++ b/python/src/mas/cli/cli.py
@@ -162,8 +162,6 @@ class BaseApp(PrintMixin, PromptMixin):
 
         self.compatibilityMatrix: Dict[str, Dict[str, List[str]]] = {
             "9.2.x": {
-                "aiservice_tenant": ["9.2.x", "9.2.x-feature"],
-                "aiservice": ["9.2.x", "9.2.x-feature", "9.1.x"],
                 "manage": ["9.2.x", "9.2.x-feature", "9.1.x"],
                 "optimizer": ["9.2.x", "9.2.x-feature", "9.1.x"],
                 "visualinspection": ["9.2.x", "9.2.x-feature", "9.1.x"],
@@ -173,7 +171,6 @@ class BaseApp(PrintMixin, PromptMixin):
                 "facilities": ["9.2.x", "9.2.x-feature", "9.1.x"],
             },
             "9.2.x-feature": {
-                "aibroker": ["9.2.x-feature", "9.1.x"],
                 "manage": ["9.2.x-feature", "9.1.x"],
                 "optimizer": ["9.2.x-feature", "9.1.x"],
                 "visualinspection": ["9.2.x-feature", "9.1.x"],
@@ -191,7 +188,6 @@ class BaseApp(PrintMixin, PromptMixin):
                 "optimizer": ["9.1.x", "9.1.x-feature", "9.0.x"],
                 "predict": ["9.1.x", "9.0.x"],
                 "visualinspection": ["9.1.x", "9.1.x-feature", "9.0.x"],
-                "aibroker": ["9.1.x", "9.0.x"],
             },
             "9.1.x-feature": {
                 "assist": ["9.0.x"],
@@ -201,7 +197,6 @@ class BaseApp(PrintMixin, PromptMixin):
                 "optimizer": ["9.1.x-feature", "9.0.x"],
                 "predict": ["9.0.x"],
                 "visualinspection": ["9.1.x-feature", "9.0.x"],
-                "aibroker": ["9.0.x"],
             },
             "9.0.x": {
                 "assist": ["9.0.x", "8.8.x"],
@@ -211,7 +206,6 @@ class BaseApp(PrintMixin, PromptMixin):
                 "optimizer": ["9.0.x", "8.5.x"],
                 "predict": ["9.0.x", "8.9.x"],
                 "visualinspection": ["9.0.x", "8.9.x"],
-                "aibroker": ["9.0.x"],
             },
             "8.11.x": {
                 "assist": ["8.8.x", "8.7.x"],

--- a/python/src/mas/cli/cli.py
+++ b/python/src/mas/cli/cli.py
@@ -246,7 +246,8 @@ class BaseApp(PrintMixin, PromptMixin):
         }
 
         self.upgrade_path: Dict[str, str] = {
-            "9.1.x": "9.2.x-feature",
+            "9.2.x-feature": "9.2.x",
+            "9.1.x": "9.2.x",
             "9.1.x-feature": "9.1.x",
             "9.0.x": "9.1.x",
             "8.11.x": "9.0.x",


### PR DESCRIPTION
## Description

- AI Service upgrade path


## Testing

### Upgrade from 9.1.x to 9.2.x
<img width="549" height="626" alt="Screenshot 2026-06-12 at 11 29 36 AM" src="https://github.com/user-attachments/assets/16e017e6-4070-498b-a6ee-70be67623e5b" />

### Upgrade from 9.2.x-feature to 9.2.x
<img width="558" height="799" alt="Screenshot 2026-06-12 at 4 24 44 PM" src="https://github.com/user-attachments/assets/6e2516be-112a-4bb7-b9cc-7d402782544a" />

## Related PR

- ibm-mas/ansible-devops#2313
