### PR TITLE
[patch] Error while trying to add cluster in Argo

### DIFF
--- a/image/cli/mascli/functions/gitops_bootstrap
+++ b/image/cli/mascli/functions/gitops_bootstrap
@@ -340,7 +340,7 @@ function gitops_bootstrap() {
     echo "argocd cluster add failed with $rc, try again"
     echo
     sleep 10
-    argocd cluster add $K8S_AUTH_CONTEXT -y
+    argocd cluster add $K8S_AUTH_CONTEXT --system-namespace ${ARGOCLUSTER_NAMESPACE} -y
   fi
 
   echo "${COLOR_GREEN}ArgoCD is now available at https://${ARGOCD_URL} username is: admin and password: ${ARGOCD_PASSWORD} ${COLOR_RESET}"


### PR DESCRIPTION
## Description
While trying to add cluster in Argo, getting below error
`{"level":"fatal","msg":"failed to create service account \"argocd-manager\" in namespace \"kube-system\": admission webhook \"serviceaccount-validation.managed.openshift.io\" denied the request: Creating service accounts in managed namespace kube-system is not allowed","time":"2026-06-12T12:18:40+05:30"}`