### PR TITLE
[patch] added facilities to finalizer

### DIFF
--- a/image/cli/app-root/src/finalizer.py
+++ b/image/cli/app-root/src/finalizer.py
@@ -286,6 +286,12 @@ if __name__ == "__main__":
             "apiVersion": "apps.mas.ibm.com/v1",
             "kind": "ManageApp",
         },
+        "ibm-mas-facilities": {
+            "deployment": "ibm-mas-facilities-operator",
+            "namespace": f"mas-{instanceId}-facilities",
+            "apiVersion": "apps.mas.ibm.com/v1",
+            "kind": "FacilitiesApp",
+        },
         "ibm-mas-monitor": {
             "deployment": "ibm-mas-monitor-operator",
             "namespace": f"mas-{instanceId}-monitor",
@@ -326,6 +332,7 @@ if __name__ == "__main__":
         "ibm-mas-assist": "S04PPFYUJG5",
         "ibm-mas-iot": "S04PBTG77JB",
         "ibm-mas-manage": "S05QB03HNTU",
+        "ibm-mas-facilities": "S08U8MQTZKP",
         "ibm-mas-monitor": "S04QG3R30SC",
         "ibm-mas-optimizer": "S04PSB1R8DR",
         "ibm-mas-predict": "S04Q53TT5S5",


### PR DESCRIPTION
Facilities was missing in few places in finalizer, because of which versions were not being stored.

We ran the finalizer pipeline and the dashboard now shows the version:
<img width="1233" height="333" alt="image" src="https://github.com/user-attachments/assets/a93a9834-452d-4b46-83fd-9267de2f7f09" />