### PR TITLE
[patch] AIS remove rhoai catalog source from deployment

### DIFF
--- a/image/cli/mascli/templates/gitops/appset-configs/cluster/instance/ibm-mas-rhoai-install.yaml.j2
+++ b/image/cli/mascli/templates/gitops/appset-configs/cluster/instance/ibm-mas-rhoai-install.yaml.j2
@@ -15,7 +15,6 @@ ibm_rhoai:
   serverless_channel: {{ SERVERLESS_CHANNEL }}
   authorino_catalog_source: {{ AUTHORINO_CATALOG_SOURCE }}
   rhoai_channel: {{ RHOAI_CHANNEL }}
-  rhoai_catalog_source: {{ RHOAI_CATALOG_SOURCE }}
   rhoai_operator_version: {{ RHOAI_OPERATOR_VERSION }}
   rhoai_namespace: {{ RHOAI_NAMESPACE }}
 


### PR DESCRIPTION
https://jsw.ibm.com/browse/MASAIB-2450
For Air gap we specify catalog source for RHOAI - but this is making issue on aigap. To fix this we need to remove var rhoai_catalog_source

<img width="221" height="624" alt="image" src="https://github.com/user-attachments/assets/04520305-2557-4f68-9a47-f909d30242c9" />
