### PR TITLE
[patch] Fix mustgather test by adding runtime parser wrapper

### DIFF
--- a/python/src/mas/cli/must_gather/arg_parser.py
+++ b/python/src/mas/cli/must_gather/arg_parser.py
@@ -12,6 +12,7 @@
 
 import argparse
 import os
+from typing import Callable, Optional
 
 
 class EnvDefault(argparse.Action):
@@ -43,10 +44,10 @@ class EnvDefault(argparse.Action):
 
 def _get_env_default(parser, namespace):
     """Apply environment variable defaults after parsing.
-    
+
     This is called as a post-processing step to apply environment variable
     defaults for arguments that weren't provided on the command line.
-    
+
     Args:
         parser: ArgumentParser instance
         namespace: Parsed namespace object
@@ -60,11 +61,12 @@ def _get_env_default(parser, namespace):
 
 
 # Wrap parse_args to apply environment defaults
-_original_parse_args = None
+_original_parse_args: Optional[Callable] = None
 
 
 def _parse_args_wrapper(args=None, namespace=None):
     """Wrapper for parse_args that applies environment variable defaults."""
+    assert _original_parse_args is not None, "parse_args must be initialized before calling wrapper"
     parsed = _original_parse_args(args, namespace)
     return _get_env_default(mustGatherArgParser, parsed)
 

--- a/python/src/mas/cli/must_gather/arg_parser.py
+++ b/python/src/mas/cli/must_gather/arg_parser.py
@@ -13,6 +13,38 @@
 import argparse
 import os
 
+
+class EnvDefault(argparse.Action):
+    """Custom action to use environment variable as default if argument not provided."""
+
+    def __init__(self, envvar, required=False, default=None, **kwargs):
+        """Initialize action with environment variable name.
+        
+        Args:
+            envvar (str): Name of environment variable to use as default
+            required (bool, optional): Whether argument is required. Defaults to False.
+            default: Default value if env var not set. Defaults to None.
+            **kwargs: Additional arguments passed to Action
+        """
+        if envvar:
+            if envvar in os.environ:
+                default = os.environ[envvar]
+        if required and default:
+            required = False
+        super(EnvDefault, self).__init__(default=default, required=required, **kwargs)
+
+    def __call__(self, parser, namespace, values, option_string=None):
+        """Set the attribute value.
+        
+        Args:
+            parser: ArgumentParser instance
+            namespace: Namespace object to populate
+            values: Parsed values
+            option_string: Option string used
+        """
+        setattr(namespace, self.dest, values)
+
+
 # Define all available collectors
 ALL_COLLECTORS = ["ocp", "db2", "kafka", "mongodb", "cp4d", "cert-manager", "grafana", "sls", "mas", "aiservice"]
 
@@ -107,14 +139,16 @@ additionalGroup.add_argument("--extra-namespaces", type=str, default=None, help=
 artifactoryGroup = mustGatherArgParser.add_argument_group("Artifactory Upload")
 artifactoryGroup.add_argument(
     "--artifactory-token",
+    action=EnvDefault,
+    envvar="ARTIFACTORY_TOKEN",
     type=str,
-    default=os.environ.get("ARTIFACTORY_TOKEN"),
     help="Provide a token for Artifactory to automatically upload the file (can also be set via ARTIFACTORY_TOKEN environment variable)",
 )
 artifactoryGroup.add_argument(
     "--artifactory-upload-dir",
+    action=EnvDefault,
+    envvar="ARTIFACTORY_UPLOAD_DIR",
     type=str,
-    default=os.environ.get("ARTIFACTORY_UPLOAD_DIR"),
     help="Working URL to the root directory in Artifactory where the must-gather file should be uploaded (can also be set via ARTIFACTORY_UPLOAD_DIR environment variable)",
 )
 

--- a/python/src/mas/cli/must_gather/arg_parser.py
+++ b/python/src/mas/cli/must_gather/arg_parser.py
@@ -26,11 +26,7 @@ class EnvDefault(argparse.Action):
             default: Default value if env var not set. Defaults to None.
             **kwargs: Additional arguments passed to Action
         """
-        if envvar:
-            if envvar in os.environ:
-                default = os.environ[envvar]
-        if required and default:
-            required = False
+        self.envvar = envvar
         super(EnvDefault, self).__init__(default=default, required=required, **kwargs)
 
     def __call__(self, parser, namespace, values, option_string=None):
@@ -43,6 +39,34 @@ class EnvDefault(argparse.Action):
             option_string: Option string used
         """
         setattr(namespace, self.dest, values)
+
+
+def _get_env_default(parser, namespace):
+    """Apply environment variable defaults after parsing.
+    
+    This is called as a post-processing step to apply environment variable
+    defaults for arguments that weren't provided on the command line.
+    
+    Args:
+        parser: ArgumentParser instance
+        namespace: Parsed namespace object
+    """
+    for action in parser._actions:
+        if isinstance(action, EnvDefault) and getattr(namespace, action.dest) is None:
+            env_value = os.environ.get(action.envvar)
+            if env_value is not None:
+                setattr(namespace, action.dest, env_value)
+    return namespace
+
+
+# Wrap parse_args to apply environment defaults
+_original_parse_args = None
+
+
+def _parse_args_wrapper(args=None, namespace=None):
+    """Wrapper for parse_args that applies environment variable defaults."""
+    parsed = _original_parse_args(args, namespace)
+    return _get_env_default(mustGatherArgParser, parsed)
 
 
 # Define all available collectors
@@ -157,3 +181,7 @@ subparsers = mustGatherArgParser.add_subparsers(dest="command", help="Available 
 serveParser = subparsers.add_parser("serve", help="Serve web viewer for existing must-gather output", formatter_class=argparse.RawTextHelpFormatter)
 serveParser.add_argument("-d", "--dir", type=str, required=True, help="Path to must-gather output directory")
 serveParser.add_argument("--port", type=int, default=8000, help="Port for HTTP server (default: 8000)")
+
+# Wrap parse_args to apply environment variable defaults at parse time
+_original_parse_args = mustGatherArgParser.parse_args
+mustGatherArgParser.parse_args = _parse_args_wrapper

--- a/python/src/mas/cli/must_gather/arg_parser.py
+++ b/python/src/mas/cli/must_gather/arg_parser.py
@@ -19,7 +19,7 @@ class EnvDefault(argparse.Action):
 
     def __init__(self, envvar, required=False, default=None, **kwargs):
         """Initialize action with environment variable name.
-        
+
         Args:
             envvar (str): Name of environment variable to use as default
             required (bool, optional): Whether argument is required. Defaults to False.
@@ -35,7 +35,7 @@ class EnvDefault(argparse.Action):
 
     def __call__(self, parser, namespace, values, option_string=None):
         """Set the attribute value.
-        
+
         Args:
             parser: ArgumentParser instance
             namespace: Namespace object to populate


### PR DESCRIPTION
The mustgather tests are failing that was added in https://github.com/ibm-mas/cli/pull/2387 due to the envvar being read at the time of import rather than at runtime when the monkeypatch was used to set the envvar.

This change allows the envvar to be read at runtime