### PR TITLE
[patch] remove/hide path based routing from the cli

### DIFF
--- a/python/src/mas/cli/install/app.py
+++ b/python/src/mas/cli/install/app.py
@@ -2593,6 +2593,22 @@ class InstallApp(
             ]
         )
 
+        # Currently no 9.2.x patch support path based routing as that changes this will need to change
+        # to filter on the specific patch version
+        if self.getParam("mas_routing_mode") == "path":
+            self.fatalError(
+                "\n".join(
+                    [
+                        "Path based routing mode not supported",
+                        "========================================================================",
+                        "Path based routing is not currently supported",
+                        "",
+                        "Use subdomain routing mode:",
+                        "   mas install --routing subdomain ...",
+                    ]
+                )
+            )
+
         # Validate IngressController configuration for path-based routing (non-interactive mode only)
         if not self.isInteractiveMode and self.getParam("mas_routing_mode") == "path":
             ingressControllerName = None

--- a/python/src/mas/cli/install/app.py
+++ b/python/src/mas/cli/install/app.py
@@ -660,7 +660,11 @@ class InstallApp(
         self.configOperationMode()
         self.configCATrust()
         self.configDNSAndCerts()
-        self.configRoutingMode()
+
+        # temporarily disabiliing configuring routing mode
+        # self.configRoutingMode()
+        self.setParam("mas_routing_mode", "subdomain")
+
         self.configServiceMesh()
         self.configSSOProperties()
         self.configSpecialCharacters()

--- a/python/tests/integration/install/test_arcgis_cluster_mode.py
+++ b/python/tests/integration/install/test_arcgis_cluster_mode.py
@@ -35,12 +35,14 @@ def test_install_arcgis_cluster_mode_success(tmpdir):
         ".*Select catalog.*": lambda msg: "v9-master-amd64",
         ".*Select channel.*": lambda msg: "9.2.x-dev",  # Use 9.2.x-dev channel
         # 4. Routing Mode Configuration - Select path-based routing
-        ".*Routing Mode.*": lambda msg: "1",  # Select path-based routing
+        # routing mode currently disabled
+        # ".*Routing Mode.*": lambda msg: "1",  # Select path-based routing
         # Note: IngressController selection prompt does NOT appear because there's only one controller
         # 5. Service Mesh Configuration
         ".*Enable OpenShift Service Mesh support for MAS.*": lambda msg: "y",
         # 6. Configure IngressController for path-based routing
-        ".*Configure ingress namespace ownership.*": lambda msg: "y",  # Agree to configure
+        # routing mode currently disabled
+        # ".*Configure ingress namespace ownership.*": lambda msg: "y",  # Agree to configure
         # 5. Storage classes
         ".*Use the auto-detected storage classes.*": lambda msg: "y",
         # 6. SLS configuration

--- a/python/tests/integration/install/test_dev_mode.py
+++ b/python/tests/integration/install/test_dev_mode.py
@@ -217,6 +217,7 @@ def test_install_master_dev_mode_existing_catalog(tmpdir):
     run_install_test(tmpdir, config)
 
 
+@pytest.mark.skip(reason="path based routing currently disabled")
 def test_install_master_dev_mode_with_path_routing(tmpdir):
     """Test interactive installation with 9.2.0 channel including path-based routing mode configuration.
 
@@ -504,7 +505,7 @@ def test_install_master_dev_mode_non_interactive(tmpdir):
     run_install_test(tmpdir, config)
 
 
-def test_install_master_dev_mode_non_interactive_with_path_routing(tmpdir):
+def test_install_master_dev_mode_non_interactive_with_path_routing(tmpdir, caplog):
     """Test non-interactive installation with path-based routing mode using CLI flags.
 
     This test verifies the complete non-interactive flow with path-based routing:
@@ -647,7 +648,16 @@ def test_install_master_dev_mode_non_interactive_with_path_routing(tmpdir):
         ],
     )
     # Run the test
-    run_install_test(tmpdir, config)
+    # Run the test and capture SystemExit to verify error message
+    with pytest.raises(SystemExit) as exc_info:
+        run_install_test(tmpdir, config)
+
+    # Verify the error message contains the expected text
+    assert exc_info.value.code != 0, "Expected non-zero exit code"
+
+    # Verify the error message was logged
+    error_message = "Path based routing mode not supported"
+    assert any(error_message in record.message for record in caplog.records), f"Expected error message '{error_message}' not found in logs"
 
 
 def test_install_master_dev_mode_non_interactive_with_slack(tmpdir):


### PR DESCRIPTION
In interactive mode we don't ask and set it to subdomain, and in non-interactive mode we fail if trying to use path based routing.