### PR TITLE
[patch] Make built-in templates portable

### DIFF
--- a/python/src/mas/cli/install/app.py
+++ b/python/src/mas/cli/install/app.py
@@ -2111,11 +2111,13 @@ class InstallApp(
             elif key == "pod_templates":
                 # For the named configurations we will convert into the path
                 if value in ["best-effort", "guaranteed"]:
+                    self.podTemplatesKeyword = value
                     self.setParam(
                         "mas_pod_templates_dir",
                         path.join(self.templatesDir, "pod-templates", value),
                     )
                 else:
+                    self.podTemplatesKeyword = None
                     self.setParam("mas_pod_templates_dir", value)
 
             # We check for both None and "" values for the application channel parameters

--- a/python/src/mas/cli/install/argBuilder.py
+++ b/python/src/mas/cli/install/argBuilder.py
@@ -87,8 +87,12 @@ class installArgBuilderMixin:
 
         if self.localConfigDir is not None:
             command += f'  --additional-configs "{self.localConfigDir}"{newline}'
-        if self.getParam("pod_templates") != "":
-            command += f"  --pod-templates \"{self.getParam('pod_templates')}\"{newline}"
+        if self.getParam("mas_pod_templates_dir") != "":
+            # Use keyword for built-in templates, otherwise use the full path
+            if hasattr(self, "podTemplatesKeyword") and self.podTemplatesKeyword is not None:
+                command += f'  --pod-templates "{self.podTemplatesKeyword}"{newline}'
+            else:
+                command += f"  --pod-templates \"{self.getParam('mas_pod_templates_dir')}\"{newline}"
 
         if self.operationalMode == 2:
             command += f"  --non-prod{newline}"

--- a/python/src/mas/cli/install/argParser.py
+++ b/python/src/mas/cli/install/argParser.py
@@ -124,7 +124,7 @@ masAdvancedArgGroup.add_argument(
 masAdvancedArgGroup.add_argument(
     "--pod-templates",
     required=False,
-    help="Path to directory containing custom podTemplates configuration files to be applied",
+    help="Pod templates to apply. Use 'guaranteed' or 'best-effort' for built-in templates, or provide a path to a directory containing custom podTemplates configuration files",
 )
 masAdvancedArgGroup.add_argument(
     "--non-prod",

--- a/python/src/mas/cli/install/settings/additionalConfigs.py
+++ b/python/src/mas/cli/install/settings/additionalConfigs.py
@@ -137,10 +137,13 @@ class AdditionalConfigsMixin:
             podTemplateChoice = self.promptForInt("Select pod templates profile")
 
             if podTemplateChoice == 1:
+                self.podTemplatesKeyword = "guaranteed"
                 self.setParam("mas_pod_templates_dir", path.join(self.templatesDir, "pod-templates", "guaranteed"))
             elif podTemplateChoice == 2:
+                self.podTemplatesKeyword = "best-effort"
                 self.setParam("mas_pod_templates_dir", path.join(self.templatesDir, "pod-templates", "best-effort"))
             elif podTemplateChoice == 3:
+                self.podTemplatesKeyword = None
                 self.setParam("mas_pod_templates_dir", self.promptForDir("Pod templates directory", mustExist=True))
             else:
                 self.fatalError(f"Invalid selection: {podTemplateChoice}")

--- a/python/src/mas/cli/install/summarizer.py
+++ b/python/src/mas/cli/install/summarizer.py
@@ -200,7 +200,12 @@ class InstallSummarizerMixin:
         else:
             self.printSummary("Additional Config", "Not Configured")
         if "mas_pod_templates_dir" in self.params:
-            self.printParamSummary("Pod Templates", "mas_pod_templates_dir")
+            # Display the keyword if it's a built-in template, otherwise show the path
+            podTemplatesKeyword = getattr(self, "podTemplatesKeyword", None)
+            if podTemplatesKeyword:
+                self.printSummary("Pod Templates", podTemplatesKeyword.title())
+            else:
+                self.printParamSummary("Pod Templates", "mas_pod_templates_dir")
         else:
             self.printSummary("Pod Templates", "Not Configured")
 


### PR DESCRIPTION
Simple change to ensure `--pod-templates` are portable when using the built-in ones.

Fixes #2369