### PR TITLE
[minor] Support bash auto-completion

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -77,4 +77,4 @@ tekton/target:
 
 .PHONY: run
 run:
-	podman run --rm -it quay.io/ibmmas/cli:k8sclient -- bash
+	podman run --rm -it -e IBM_ENTITLEMENT_KEY --pull Always quay.io/ibmmas/cli:master bash

--- a/image/cli/app-root/src/.bashrc
+++ b/image/cli/app-root/src/.bashrc
@@ -16,6 +16,9 @@ TEXT_UNDERLINE=$(tput smul)
 TEXT_RESET=$(tput sgr0)
 arch=$(uname -i)
 
+# Enable bash auto-completion
+. /etc/profile.d/bash_completion.sh
+
 echo "${TEXT_UNDERLINE}IBM Maximo Application Suite CLI Container ${TEXT_BOLD}v${VERSION}${TEXT_RESET}"
 echo
 echo "${COLOR_CYAN}${TEXT_UNDERLINE}https://github.com/ibm-mas/ansible-devops${TEXT_RESET}"

--- a/python/src/mas/cli/validators.py
+++ b/python/src/mas/cli/validators.py
@@ -231,14 +231,17 @@ class BucketPrefixValidator(Validator):
         bucketPrefix = document.text
 
         if not match(r"^.{1,4}$", bucketPrefix):
-            raise ValidationError(message='Bucket prefix does not meet the requirement', cursor_position=len(bucketPrefix))
+            raise ValidationError(message="Bucket prefix does not meet the requirement", cursor_position=len(bucketPrefix))
 
 
 class CustomizationArchiveNameValidator(Validator):
     def validate(self, document: Document) -> None:
         name = document.text
         if not match(r"^[0-9a-zA-Z][0-9a-zA-Z\-_.]+$", name):
-            raise ValidationError(message='Customization archive name must start with a letter or digit, and contain only letters, digits, hyphens, underscores, and dots', cursor_position=len(name))
+            raise ValidationError(
+                message="Customization archive name must start with a letter or digit, and contain only letters, digits, hyphens, underscores, and dots",
+                cursor_position=len(name),
+            )
 
 
 class NotEmptyValidator(Validator):

--- a/python/tests/unit/must_gather/test_arg_parser.py
+++ b/python/tests/unit/must_gather/test_arg_parser.py
@@ -294,7 +294,7 @@ class TestCollectorsFlag:
         """
         parser = mustGatherArgParser
         args = parser.parse_args([])
-        expected = "ocp,db2,kafka,mongodb,cp4d,cert-manager,grafana,sls,mas,aiservice"
+        expected = "ocp,db2,kafka,mongodb,cp4d,cert-manager,grafana,sls,mas,aiservice,lic"
         assert args.collectors == expected
 
     def test_parser_collectors_single_collector(self):
@@ -389,7 +389,7 @@ class TestCollectorsFlag:
         THEN all collectors are accepted.
         """
         parser = mustGatherArgParser
-        all_collectors = "ocp,db2,kafka,mongodb,cp4d,cert-manager,grafana,sls,mas,aiservice"
+        all_collectors = "ocp,db2,kafka,mongodb,cp4d,cert-manager,grafana,sls,mas,aiservice,lic"
         args = parser.parse_args(["--collectors", all_collectors])
         assert args.collectors == all_collectors
 


### PR DESCRIPTION
Adds support for bash auto-complete in `oc`, `kubectl`, `aws`, `helm`, and `argocd` tools:

- See: https://github.com/ibm-mas/cli/issues/1916