### PR TITLE
[patch] Remove now-redundant KubectlCommandError

### DIFF
--- a/python/src/mas/cli/__main__.py
+++ b/python/src/mas/cli/__main__.py
@@ -12,7 +12,6 @@ import logging
 from sys import argv
 
 from jinja2.exceptions import TemplateNotFound
-from kubeconfig.exceptions import KubectlCommandError
 from kubernetes.client.exceptions import ApiException
 from prompt_toolkit import HTML, print_formatted_text
 from urllib3.exceptions import MaxRetryError
@@ -160,12 +159,6 @@ def main() -> None:
             app.fatalError("Could not find template", exception=exception)
         else:
             logger.error("Could not find template", exc_info=exception)
-            raise SystemExit(1) from exception
-    except KubectlCommandError as exception:
-        if app:
-            app.fatalError("Could not execute kubectl command", exception=exception)
-        else:
-            logger.error("Could not execute kubectl command", exc_info=exception)
             raise SystemExit(1) from exception
 
 


### PR DESCRIPTION
We have removed the `openshift` and `kubeconfig` libraries, so the import and handling of `KubectlCommandError` is no longer required/serves any purpose.