### PR TITLE
[patch] Fix 9.0 to 9.1 upgrade

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,7 +85,12 @@ max-line-length = 160
 
 [tool.basedpyright]
 # Only check must-gather module during gradual rollout
-include = ["python/tests/unit/must_gather"]
+include = [
+  "python/src/mas/cli/must_gather",
+  "python/src/mas/cli/update",
+  "python/src/mas/cli/upgrade",
+  "python/tests/unit/must_gather"
+]
 
 # Use "basic" mode - focuses on our code, lenient with untyped dependencies
 # Options: "off", "basic", "standard", "strict"

--- a/python/src/mas/cli/install/settings/db2Settings.py
+++ b/python/src/mas/cli/install/settings/db2Settings.py
@@ -12,6 +12,8 @@ from os import path
 from typing import TYPE_CHECKING, Dict, List, Any
 from prompt_toolkit import print_formatted_text
 
+from mas.devops.utils import isVersionEqualOrAfter
+
 if TYPE_CHECKING:
     # Type hints for methods and attributes provided by other mixins
     # These are only used during type checking and have no runtime cost
@@ -25,6 +27,7 @@ class Db2SettingsMixin:
         params: Dict[str, str]
         devMode: bool
         installIoT: bool
+        installMonitor: bool
         installManage: bool
         installFacilities: bool
         manageAppName: str
@@ -100,8 +103,6 @@ class Db2SettingsMixin:
         # Determine which application requires the system database based on Monitor version
         # For Monitor >= 9.2.0: Monitor requires system Db2
         # For Monitor < 9.2.0: IoT requires system Db2 (original behavior)
-        from mas.devops.utils import isVersionEqualOrAfter
-
         monitorChannel = self.getParam("mas_app_channel_monitor")
         useNewDependency = monitorChannel and isVersionEqualOrAfter("9.2.0", monitorChannel)
         instanceId = self.getParam("mas_instance_id")

--- a/python/src/mas/cli/update/app.py
+++ b/python/src/mas/cli/update/app.py
@@ -196,7 +196,8 @@ class UpdateApp(BaseApp, AdditionalConfigsMixin):
                 if key in requiredParams:
                     if value is None:
                         self.fatalError(f"{key} must be set")
-                    self.setParam(key, value)
+                    else:
+                        self.setParam(key, value)
 
                 # These fields we just pass straight through to the parameters
                 elif key in optionalParams:
@@ -290,6 +291,7 @@ class UpdateApp(BaseApp, AdditionalConfigsMixin):
         self.printDescription(["Connected to:", f" - <u>{getConsoleURL(self.dynamicClient)}</u>"])
 
         self.printH2("IBM Maximo Operator Catalog")
+        assert self.installedCatalogId is not None, "Catalog ID is not set"
         self.printSummary("Installed Catalog", self.installedCatalogId)
         self.printSummary("Updated Catalog", self.getParam("mas_catalog_version"))
 

--- a/python/src/mas/cli/upgrade/app.py
+++ b/python/src/mas/cli/upgrade/app.py
@@ -269,24 +269,27 @@ class UpgradeApp(BaseApp, UpgradeSettingsMixin):
             self.manageAppName = "Manage foundation"
             self.showAdvancedOptions = False
             self.installIoT = False
+            self.installMonitor = False
             self.installFacilities = False
             self.installManage = True
             self.isManageFoundation = True
             self.printDescription(
                 [f"{self.manageAppName} installs the following capabilities: User, Security groups, Application configurator and Mobile configurator."]
             )
+
+            # TODO: Why do we need to ask the user from their entitlement key, we should look it up from the cluster.
             self.printH1("Configure IBM Container Registry")
             self.promptForEntitlementKey("IBM entitlement key", "ibm_entitlement_key")
             if self.devMode:
                 self.promptForString("Artifactory username", "artifactory_username")
                 self.promptForString("Artifactory token", "artifactory_token", isPassword=True)
+
             self.setParam("should_install_manage_foundation", "true")
             self.setParam("mas_appws_components", "")
             self.setParam("mas_app_settings_aio_flag", "false")
             self.setParam("mas_app_channel_manage", self.nextChannel)
             self.setParam("mas_workspace_id", getWorkspaceId(self.dynamicClient, instanceId))
-            # It has been decided that we don't need to ask for any specific Manage Settings
-            # self.manageSettings()
+
             self.configDb2(silentMode=True)
 
         # Compute Monitor install order for upgrade


### PR DESCRIPTION
Monitor 9.2 changes broke 9.0 - 9.1 upgrade

```
Traceback (most recent call last):
  File "/home/david/python312/bin/mas-cli", line 8, in <module>
    sys.exit(main())
             ^^^^^^
  File "/mnt/c/Users/097891866/Documents/GitHub/ibm-mas/cli/python/src/mas/cli/__main__.py", line 96, in main
    app.upgrade(argv[2:])
  File "/mnt/c/Users/097891866/Documents/GitHub/ibm-mas/cli/python/src/mas/cli/upgrade/app.py", line 290, in upgrade
    self.configDb2(silentMode=True)
  File "/mnt/c/Users/097891866/Documents/GitHub/ibm-mas/cli/python/src/mas/cli/install/settings/db2Settings.py", line 82, in configDb2
    if not self.installMonitor and not self.installIoT and not self.installManage and not self.installFacilities:
           ^^^^^^^^^^^^^^^^^^^
AttributeError: 'UpgradeApp' object has no attribute 'installMonitor'. Did you mean: 'installManage'?
```