### PR TITLE
[patch] remove warning message for ai assistant for 9.1

### DIFF
--- a/python/src/mas/cli/install/settings/aiSettings.py
+++ b/python/src/mas/cli/install/settings/aiSettings.py
@@ -80,7 +80,8 @@ class AiSettingsMixin:
             except (ValueError, IndexError):
                 pass
 
-        # If MAS 9.1 or earlier, force disable AiCfg regardless of user input
+        # Skip AiCfg configuration silently for MAS 9.1 and earlier
+        # Do not display any warnings, messages, or step numbers
         if not is_mas_92_or_later:
             return
 


### PR DESCRIPTION
This change is to remove warning message on 9.1 installation
before this PR
<img width="404" height="397" alt="image" src="https://github.com/user-attachments/assets/c30a7e1f-5fb7-4f24-a760-bf223fb1f0dc" />

after this PR, it will ignore warning 
<img width="188" height="432" alt="image" src="https://github.com/user-attachments/assets/588acfff-41d7-47ba-a14b-e4aba60f2609" />
