### PR TITLE
[patch] Remove 9.1-feature column from install catalog version table

### DIFF
--- a/python/src/mas/cli/install/app.py
+++ b/python/src/mas/cli/install/app.py
@@ -273,11 +273,8 @@ class InstallApp(
 
         # Generate catalogTable
         for application, key in applications.items():
-            # Add 9.1-feature channel based off 9.0 to those apps that have not onboarded yet
             if key in self.chosenCatalog:
                 tempChosenCatalog = self.chosenCatalog[key].copy()
-                if "9.1.x-feature" not in tempChosenCatalog and "9.0.x" in tempChosenCatalog:
-                    tempChosenCatalog.update({"9.1.x-feature": tempChosenCatalog["9.0.x"]})
 
                 self.catalogTable.append({"": application} | {key.replace(".x", ""): value for key, value in sorted(tempChosenCatalog.items(), reverse=True)})
 


### PR DESCRIPTION
The 9.1-feature column was displayed in the version table but was not available in the release dropdown selection, causing user confusion.

## test

<img width="2332" height="1000" alt="image" src="https://github.com/user-attachments/assets/bd176b5a-47c2-477d-afe8-a2de71b83ba4" />
