### PR TITLE
[patch] Add Route collection as a standard resource

### DIFF
--- a/python/src/mas/cli/must_gather/common/task_generation.py
+++ b/python/src/mas/cli/must_gather/common/task_generation.py
@@ -87,6 +87,7 @@ def generateNamespaceCollectionTasks(
         ("v1", "ServiceAccount"),
         ("rbac.authorization.k8s.io/v1", "Role"),
         ("rbac.authorization.k8s.io/v1", "RoleBinding"),
+        ("route.openshift.io/v1", "Route"),
         ("networking.k8s.io/v1", "NetworkPolicy"),
         ("networking.k8s.io/v1", "Ingress"),
         ("operators.coreos.com/v1alpha1", "Subscription"),


### PR DESCRIPTION
In the re-write of must-gather to Python, we lost the collection of Routes, this update corrects that:

- https://github.com/ibm-mas/cli/issues/2429
