### PR TITLE
[patch] removed perl dependency from facilities db2 setup script

### DIFF
--- a/image/cli/mascli/db-scripts/facilities/external-db2/db2configinst.sh
+++ b/image/cli/mascli/db-scripts/facilities/external-db2/db2configinst.sh
@@ -35,7 +35,7 @@ DB2_HOME=${3}
 
 # validate instance user exist
 
-instHome=`perl -e "@user=getpwnam ${INST_USER};" -e "print @user[7];"`
+instHome=`getent passwd ${INST_USER} | cut -d: -f6`
 
 if [ -z "$instHome" ]; then
     echo "Error: The DB2 instance user $INST_USER does not exist!"

--- a/image/cli/mascli/db-scripts/facilities/external-db2/ssl-setup.sh
+++ b/image/cli/mascli/db-scripts/facilities/external-db2/ssl-setup.sh
@@ -8,10 +8,12 @@
 # 
 
 
-INSTANCE=${1}
+INST_USER=${1}
+
+instHome=`getent passwd ${INST_USER} | cut -d: -f6`
 
 # Add gskit libraries in the PATH
-export PATH="/home/$INSTANCE/sqllib/gskit/bin:$PATH"
+export PATH="$instHome/sqllib/gskit/bin:$PATH"
 
 # Generate Key Database and Certificate:
 mkdir dbcerts
@@ -21,13 +23,13 @@ gsk8capicmd_64 -cert -create -db "mydbserver.kdb" -pw "purisaab" -label "myselfs
 gsk8capicmd_64 -cert -extract -db "mydbserver.kdb" -pw "purisaab" -label "myselfsigned" -target "mydbserver.arm" -format ascii -fips
 
 # Update DB2 settings
-db2 update dbm cfg using SSL_SVR_KEYDB /home/$INSTANCE/dbcerts/mydbserver.kdb
-db2 update dbm cfg using SSL_SVR_STASH /home/$INSTANCE/dbcerts/mydbserver.sth
+db2 update dbm cfg using SSL_SVR_KEYDB $instHome/dbcerts/mydbserver.kdb
+db2 update dbm cfg using SSL_SVR_STASH $instHome/dbcerts/mydbserver.sth
 db2 update dbm cfg using SSL_SVR_LABEL myselfsigned
-db2 update dbm cfg using SVCENAME 50001
-db2 update dbm cfg using SSL_SVCENAME 50000
+db2 update dbm cfg using SVCENAME 50000
+db2 update dbm cfg using SSL_SVCENAME 50001
 db2 update dbm cfg using SSL_VERSIONS TLSV12
-db2set -i $INSTANCE DB2COMM=SSL
+db2set -i $INST_USER DB2COMM=SSL
 
 # Check DB2 configuration
 db2 get dbm config | grep SSL


### PR DESCRIPTION
## Description

The perl script was being used to fetch the user's home directory. This is the only one perl dependency, and perl does not come as part of the db2 image. This required installing perl just for something so small.
This change uses shell script to achieve the same without using perl.
Updated the script with correct db2 ports.

## Testing
1. Downloaded db2 image `icr.io/db2_community/db2:11.5.9.0` (that is the version the script is based on)
2. Ran it using docker
3. Executed all the scripts
4. Checked connectivity to the database