### PR TITLE
[patch] Fix reloadDynamicClient()

### DIFF
--- a/python/src/mas/cli/cli.py
+++ b/python/src/mas/cli/cli.py
@@ -424,8 +424,24 @@ class BaseApp(PrintMixin, PromptMixin):
                 self._apiClient = ApiClient(configuration=k8s_config)
                 self._dynClient = DynamicClient(self._apiClient)
             else:
-                config.load_kube_config()
-                self._apiClient = ApiClient()
+                # Determine kubeconfig path to force fresh load
+                kubeconfig_path = environ.get("KUBECONFIG")
+                if not kubeconfig_path:
+                    from pathlib import Path
+
+                    kubeconfig_path = path.join(Path.home(), ".kube", "config")
+
+                logger.debug(f"Loading kubeconfig from {kubeconfig_path}")
+
+                # Clear any cached configuration to ensure fresh load
+                Configuration.set_default(None)
+
+                # Load the configuration from the kubeconfig file
+                config.load_kube_config(config_file=kubeconfig_path)
+
+                # Create new API client with the fresh configuration
+                k8s_config = Configuration.get_default_copy()
+                self._apiClient = ApiClient(configuration=k8s_config)
                 self._dynClient = DynamicClient(self._apiClient)
             return self._dynClient
         except Exception as e:


### PR DESCRIPTION
Working with a temporary kubeconfig doesn't have the desired effect, we need to work with the actual kubeconfig file, just like we did when using the old library (that was basically a shim directly running `kubectl` commands)

- See also: https://github.com/ibm-mas/python-devops/pull/415