### PR TITLE
[patch] Civil COS pytest updates

### DIFF
--- a/tekton/src/pipelines/taskdefs/fvt-manage-is/phase1.yml.j2
+++ b/tekton/src/pipelines/taskdefs/fvt-manage-is/phase1.yml.j2
@@ -192,6 +192,8 @@
     {{ lookup('template', 'taskdefs/fvt-manage/api/params.yml.j2') | indent(4) }}
     - name: fvt_test_suite
       value: civil-api-defectdetection
+    - name: workspace_managedata_path
+      value: "/workspace/configs/managedata"
   when:
     - input: "civil"
       operator: in

--- a/tekton/src/tasks/fvt/mas-fvt-manage-pytest.yml.j2
+++ b/tekton/src/tasks/fvt/mas-fvt-manage-pytest.yml.j2
@@ -59,6 +59,10 @@ spec:
     - name: mas_instance_id
       type: string
       description: Instance ID of the target test environment
+    - name: workspace_managedata_path
+      type: string
+      description: Path where output data file will be placed. Defaults to value used in fvt shared workspace
+      default: ""
 
   stepTemplate:
     env:
@@ -194,6 +198,8 @@ spec:
             name: mas-fvt-manage
             key: LDAP_CRT
             optional: false
+      - name: WORKSPACE_MANAGEDATA_PATH
+        value: "$(params.workspace_managedata_path)"
 
 
   steps:

--- a/tekton/src/tasks/fvt/mas-fvt-manage-pytest.yml.j2
+++ b/tekton/src/tasks/fvt/mas-fvt-manage-pytest.yml.j2
@@ -121,7 +121,7 @@ spec:
       - name: IBMCLOUD_APIKEY
         valueFrom:
           secretKeyRef:
-            name: mas-devops
+            name: mas-fvt
             key: IBMCLOUD_APIKEY
             optional: true
 

--- a/tekton/src/tasks/fvt/mas-fvt-manage-pytest.yml.j2
+++ b/tekton/src/tasks/fvt/mas-fvt-manage-pytest.yml.j2
@@ -118,6 +118,12 @@ spec:
             name: mas-devops
             key: ARTIFACTORY_UPLOAD_DIR
             optional: true
+      - name: IBMCLOUD_APIKEY
+        valueFrom:
+          secretKeyRef:
+            name: mas-devops
+            key: IBMCLOUD_APIKEY
+            optional: true
 
       # Black and white listing
       - name: FVT_BLACKLIST


### PR DESCRIPTION
Updates the `mas-fvt-manage-pytest` task definition to support new Civil tests that work with images in IBM COS.
- New environment var with key to provide COS access to test
- New task param to override the default `workspace_managedata_path` so that test reads the correct `SetupProperties.data` file

Tested with tkn command in fyre cluster.
- Successful test overriding default `workspace_managedata_path`
<img width="755" height="662" alt="image" src="https://github.com/user-attachments/assets/0824d265-82c1-4da7-b95b-2adaa7e0ebeb" />


- Successful test using default `workspace_managedata_path` to make sure nothing breaks
<img width="757" height="646" alt="image" src="https://github.com/user-attachments/assets/bf8f74c8-d99f-4763-8d52-a64fb14a0897" />


