### PR TITLE
[patch] Add reconcile logs for core and monitor

### DIFF
--- a/python/src/mas/cli/must_gather/mas/apps.py
+++ b/python/src/mas/cli/must_gather/mas/apps.py
@@ -108,6 +108,12 @@ def _getReconcileLogsOperatorsForApp(namespace: str, appId: str) -> List[Tuple[s
             (namespace, "operator", "ibm-truststore-mgr"),
             (namespace, "mas.ibm.com/appType", "serverBundle"),
         ]
+    elif appId == "monitor":
+        operators = [
+            (namespace, "control-plane", "ibm-mas-monitor"),
+            (namespace, "mas.ibm.com/appType", "entitymgr-ws-operator"),
+            (namespace, "operator", "ibm-truststore-mgr"),
+        ]
     elif appId == "iot":
         operators = [
             (namespace, "control-plane", "ibm-iot-operator"),

--- a/python/src/mas/cli/must_gather/mas/core.py
+++ b/python/src/mas/cli/must_gather/mas/core.py
@@ -22,8 +22,8 @@ from typing import Set, Optional, List
 from kubernetes.dynamic import DynamicClient
 from kubernetes import client
 
+from mas.cli.must_gather.common import generateReconcileLogsCollectionTasks
 from mas.cli.must_gather.common.task_generation import generateNamespaceCollectionTasks
-from mas.cli.must_gather.common.reconcile_logs import collectReconcileLogs
 from mas.cli.must_gather.common.pod_exec import execCurlInPod
 from .network_tests import testCoreToManageConnectivity
 from .version import isMAS91OrLater
@@ -249,16 +249,24 @@ def _generateMASCoreCollectionTasks(
         )
 
         # Add MAS Core-specific task: Collect reconcile logs from MAS operator
-        tasks.append(
-            (
-                "reconcile_logs_mas_operator",
-                collectReconcileLogs,
-                namespace,
-                "app.kubernetes.io/name",
-                "ibm-mas-operator",
-                outputDir,
-            )
-        )
+        operators = [
+            (namespace, "control-plane", "ibm-mas"),
+            (namespace, "control-plane", "ibm-mas-ws"),
+            (namespace, "control-plane", "ibm-mas-coreidp"),
+            (namespace, "control-plane", "ibm-mas-addons"),
+            (namespace, "control-plane", "ibm-mas-cfg-ai"),
+            (namespace, "control-plane", "ibm-mas-cfg-app"),
+            (namespace, "control-plane", "ibm-mas-cfg-bas"),
+            (namespace, "control-plane", "ibm-mas-cfg-idp"),
+            (namespace, "control-plane", "ibm-mas-cfg-scim"),
+            (namespace, "control-plane", "ibm-mas-cfg-jdbc"),
+            (namespace, "control-plane", "ibm-mas-cfg-mongo"),
+            (namespace, "control-plane", "ibm-mas-cfg-kafka"),
+            (namespace, "control-plane", "ibm-mas-cfg-objectstorage"),
+            (namespace, "control-plane", "ibm-mas-cfg-smtp"),
+            (namespace, "operator", "ibm-truststore-mgr"),
+        ]
+        tasks.extend(generateReconcileLogsCollectionTasks(operators, outputDir))
 
         # Add network connectivity test (Core to Manage)
         tasks.append(


### PR DESCRIPTION
Analyzing must-gather from FVT systems we can see that the reconcile logs we used to have for core are absent, and that the monitor reconcile logs were never added to the original must-gather scripts so are also absent.  This update ensures both are added to the collectors.