### PR TITLE
[patch] Revert "remove ibm_entitlement_key from Tekton param flow and…

### DIFF
--- a/python/src/mas/cli/aiservice/install/app.py
+++ b/python/src/mas/cli/aiservice/install/app.py
@@ -547,7 +547,6 @@ class AiServiceInstallApp(BaseApp, aiServiceInstallArgBuilderMixin, aiServiceIns
                     aiserviceConfig=self.aiserviceConfigSecret,
                     slack_token=self.getParam("slack_token"),
                     slack_channel=self.getParam("slack_channel"),
-                    ibm_entitlement_key=self.getParam("ibm_entitlement_key"),
                 )
 
                 self.setupApprovals(pipelinesNamespace)

--- a/python/src/mas/cli/install/app.py
+++ b/python/src/mas/cli/install/app.py
@@ -2867,7 +2867,6 @@ class InstallApp(
                     aiserviceConfig=self.aiserviceConfigSecret,
                     slack_token=self.getParam("slack_token"),
                     slack_channel=self.getParam("slack_channel"),
-                    ibm_entitlement_key=self.getParam("ibm_entitlement_key"),
                 )
 
                 self.setupApprovals(pipelinesNamespace)

--- a/python/src/mas/cli/restore/app.py
+++ b/python/src/mas/cli/restore/app.py
@@ -332,12 +332,7 @@ class RestoreApp(BaseApp):
                 )
 
                 # Apply config file secrets to the namespace
-                prepareRestoreSecrets(
-                    dynClient=self.dynamicClient,
-                    namespace=pipelinesNamespace,
-                    restoreConfigs=self.configSecret,
-                    ibm_entitlement_key=self.getParam("ibm_entitlement_key"),
-                )
+                prepareRestoreSecrets(dynClient=self.dynamicClient, namespace=pipelinesNamespace, restoreConfigs=self.configSecret)
 
                 h.stop_and_persist(symbol=self.successIcon, text=f"Namespace is ready ({pipelinesNamespace})")
 

--- a/tekton/src/params/backup.yml.j2
+++ b/tekton/src/params/backup.yml.j2
@@ -194,6 +194,11 @@
   default: ""
   description: Required for DRO installation during restore
 
+- name: ibm_entitlement_key
+  type: string
+  default: ""
+  description: Required for DRO installation during restore
+
 # Restore-specific Configuration
 # -----------------------------------------------------------------------------
 - name: mas_domain_on_restore

--- a/tekton/src/params/install-common.yml.j2
+++ b/tekton/src/params/install-common.yml.j2
@@ -9,6 +9,12 @@
   default: ""
   description: ReadWriteMany storage class
 
+# Entitlement
+# -----------------------------------------------------------------------------
+- name: ibm_entitlement_key
+  type: string
+  description: IBM Entitlement Key
+
 # Pipeline config
 # -----------------------------------------------------------------------------
 - name: skip_pre_check

--- a/tekton/src/pipelines/mas-restore.yml.j2
+++ b/tekton/src/pipelines/mas-restore.yml.j2
@@ -9,8 +9,6 @@ spec:
     - name: shared-backups
     # Configs to restore like slscfg and drocfg
     - name: restore-configurations
-    # Any pre-generated configs that contain IBM_ENTITLEMENT_KEY
-    - name: shared-additional-configs
 
   params:
     # 1. Common Parameters
@@ -299,10 +297,6 @@ spec:
       workspaces:
         - name: backups
           workspace: shared-backups
-        - name: additional-configs
-          workspace: shared-additional-configs
-        - name: configs
-          workspace: restore-configurations
       runAfter:
         - mongodb
 
@@ -331,6 +325,8 @@ spec:
           value: "$(params.dro_contact_firstname)"
         - name: dro_contact_lastname
           value: "$(params.dro_contact_lastname)"
+        - name: ibm_entitlement_key
+          value: $(params.ibm_entitlement_key)
         - name: dro_namespace
           value: $(params.dro_namespace)
         - name: dro_storage_class

--- a/tekton/src/pipelines/taskdefs/aiservice/aiservice.yml.j2
+++ b/tekton/src/pipelines/taskdefs/aiservice/aiservice.yml.j2
@@ -10,6 +10,8 @@
     - name: artifactory_token
       value: $(params.artifactory_token)
 
+    - name: ibm_entitlement_key
+      value: $(params.ibm_entitlement_key)
 
     - name: custom_labels
       value: $(params.custom_labels)
@@ -103,7 +105,5 @@
   workspaces:
     - name: configs
       workspace: shared-configs
-    - name: additional-configs
-      workspace: shared-additional-configs
     - name: aiservice
       workspace: shared-aiservice-config

--- a/tekton/src/pipelines/taskdefs/aiservice/minio.yml.j2
+++ b/tekton/src/pipelines/taskdefs/aiservice/minio.yml.j2
@@ -14,6 +14,8 @@
       value: $(params.artifactory_token)
     - name: mas_app_channel
       value: "$(params.aiservice_channel)"
+    - name: ibm_entitlement_key
+      value: $(params.ibm_entitlement_key)
     - name: minio_root_user
       value: $(params.minio_root_user)
     - name: minio_root_password
@@ -22,9 +24,6 @@
   taskRef:
     name: mas-devops-minio
     kind: Task
-  workspaces:
-    - name: configs
-      workspace: shared-additional-configs
   when:
     - input: "$(params.minio_root_user)"
       operator: notin

--- a/tekton/src/pipelines/taskdefs/aiservice/odh.yml.j2
+++ b/tekton/src/pipelines/taskdefs/aiservice/odh.yml.j2
@@ -16,6 +16,8 @@
       value: $(params.artifactory_token)
     - name: aiservice_channel
       value: "$(params.aiservice_channel)"
+    - name: ibm_entitlement_key
+      value: $(params.ibm_entitlement_key)
     - name: custom_labels
       value: $(params.custom_labels)
     - name: aiservice_odh_model_deployment_type
@@ -26,9 +28,6 @@
   taskRef:
     name: mas-devops-aiservice-odh
     kind: Task
-  workspaces:
-    - name: configs
-      workspace: shared-additional-configs
   when:
     - input: "$(params.aiservice_channel)"
       operator: notin

--- a/tekton/src/pipelines/taskdefs/aiservice/rhoai.yml.j2
+++ b/tekton/src/pipelines/taskdefs/aiservice/rhoai.yml.j2
@@ -16,6 +16,8 @@
       value: $(params.artifactory_token)
     - name: aiservice_channel
       value: "$(params.aiservice_channel)"
+    - name: ibm_entitlement_key
+      value: $(params.ibm_entitlement_key)
     - name: custom_labels
       value: $(params.custom_labels)
     - name: aiservice_rhoai_model_deployment_type
@@ -26,9 +28,6 @@
   taskRef:
     name: mas-devops-aiservice-rhoai
     kind: Task
-  workspaces:
-    - name: configs
-      workspace: shared-additional-configs
   when:
     - input: "$(params.aiservice_channel)"
       operator: notin

--- a/tekton/src/pipelines/taskdefs/apps/assist-app.yml.j2
+++ b/tekton/src/pipelines/taskdefs/apps/assist-app.yml.j2
@@ -13,6 +13,8 @@
       value: $(params.artifactory_token)
     - name: mas_app_channel
       value: "$(params.mas_app_channel_assist)"
+    - name: ibm_entitlement_key
+      value: $(params.ibm_entitlement_key)
     - name: custom_labels
       value: $(params.custom_labels)
     - name: mas_use_service_mesh

--- a/tekton/src/pipelines/taskdefs/apps/db2-setup-facilities.yml.j2
+++ b/tekton/src/pipelines/taskdefs/apps/db2-setup-facilities.yml.j2
@@ -11,6 +11,8 @@
       value: "mas-$(params.mas_instance_id)-$(params.mas_workspace_id)-facilities"
 
     # Entitlement
+    - name: ibm_entitlement_key
+      value: $(params.ibm_entitlement_key)
 
     # Operator Subscription
     - name: db2_channel

--- a/tekton/src/pipelines/taskdefs/apps/facilities-app.yml.j2
+++ b/tekton/src/pipelines/taskdefs/apps/facilities-app.yml.j2
@@ -16,6 +16,8 @@
       value: facilities
     - name: mas_app_channel
       value: "$(params.mas_app_channel_facilities)"
+    - name: ibm_entitlement_key
+      value: $(params.ibm_entitlement_key)
     - name: custom_labels
       value: $(params.custom_labels)
     - name: mas_use_service_mesh

--- a/tekton/src/pipelines/taskdefs/apps/iot-app.yml.j2
+++ b/tekton/src/pipelines/taskdefs/apps/iot-app.yml.j2
@@ -15,6 +15,8 @@
       value: iot
     - name: mas_app_channel
       value: "$(params.mas_app_channel_iot)"
+    - name: ibm_entitlement_key
+      value: $(params.ibm_entitlement_key)
     - name: custom_labels
       value: $(params.custom_labels)
     - name: mas_use_service_mesh

--- a/tekton/src/pipelines/taskdefs/apps/manage-app.yml.j2
+++ b/tekton/src/pipelines/taskdefs/apps/manage-app.yml.j2
@@ -23,6 +23,8 @@
       value: $(params.artifactory_token)
     - name: mas_app_channel
       value: "$(params.mas_app_channel_manage)"
+    - name: ibm_entitlement_key
+      value: $(params.ibm_entitlement_key)
     - name: custom_labels
       value: $(params.custom_labels)
     - name: mas_use_service_mesh

--- a/tekton/src/pipelines/taskdefs/apps/monitor-app.yml.j2
+++ b/tekton/src/pipelines/taskdefs/apps/monitor-app.yml.j2
@@ -15,6 +15,8 @@
       value: monitor
     - name: mas_app_channel
       value: "$(params.mas_app_channel_monitor)"
+    - name: ibm_entitlement_key
+      value: $(params.ibm_entitlement_key)
     - name: custom_labels
       value: $(params.custom_labels)
     - name: mas_use_service_mesh

--- a/tekton/src/pipelines/taskdefs/apps/optimizer-app.yml.j2
+++ b/tekton/src/pipelines/taskdefs/apps/optimizer-app.yml.j2
@@ -17,6 +17,8 @@
       value: "$(params.mas_app_channel_optimizer)"
     - name: mas_app_plan
       value: "$(params.mas_app_plan_optimizer)"
+    - name: ibm_entitlement_key
+      value: $(params.ibm_entitlement_key)
     - name: custom_labels
       value: $(params.custom_labels)
     - name: mas_use_service_mesh

--- a/tekton/src/pipelines/taskdefs/apps/predict-app.yml.j2
+++ b/tekton/src/pipelines/taskdefs/apps/predict-app.yml.j2
@@ -15,6 +15,8 @@
       value: $(params.artifactory_token)
     - name: mas_app_channel
       value: "$(params.mas_app_channel_predict)"
+    - name: ibm_entitlement_key
+      value: $(params.ibm_entitlement_key)
     - name: custom_labels
       value: $(params.custom_labels)
     - name: mas_use_service_mesh

--- a/tekton/src/pipelines/taskdefs/apps/visualinspection-app.yml.j2
+++ b/tekton/src/pipelines/taskdefs/apps/visualinspection-app.yml.j2
@@ -17,6 +17,8 @@
       value: "$(params.mas_app_channel_visualinspection)"
     - name: mas_app_settings_visualinspection_storage_class
       value: $(params.storage_class_rwx)
+    - name: ibm_entitlement_key
+      value: $(params.ibm_entitlement_key)
     - name: custom_labels
       value: $(params.custom_labels)
     - name: mas_use_service_mesh

--- a/tekton/src/pipelines/taskdefs/core/suite-install.yml.j2
+++ b/tekton/src/pipelines/taskdefs/core/suite-install.yml.j2
@@ -36,6 +36,8 @@
       value: $(params.mas_icr_cp)
     - name: mas_icr_cpopen
       value: $(params.mas_icr_cpopen)
+    - name: ibm_entitlement_key
+      value: $(params.ibm_entitlement_key)
     - name: idle_timeout
       value: $(params.idle_timeout)
     - name: idp_session_timeout

--- a/tekton/src/pipelines/taskdefs/cp4d/cp4d-platform.yml.j2
+++ b/tekton/src/pipelines/taskdefs/cp4d/cp4d-platform.yml.j2
@@ -5,6 +5,8 @@
     - name: devops_suite_name
       value: setup-cp4d
 
+    - name: ibm_entitlement_key
+      value: $(params.ibm_entitlement_key)
     - name: cpd_product_version
       value: $(params.cpd_product_version)
     - name: cpd_primary_storage_class

--- a/tekton/src/pipelines/taskdefs/dependencies/arcgis.yml.j2
+++ b/tekton/src/pipelines/taskdefs/dependencies/arcgis.yml.j2
@@ -17,6 +17,8 @@
       value: "$(params.mas_app_channel_manage)"
     - name: mas_app_channel_facilities
       value: "$(params.mas_app_channel_facilities)"
+    - name: ibm_entitlement_key
+      value: $(params.ibm_entitlement_key)
     - name: custom_labels
       value: $(params.custom_labels)
     - name: mas_arcgis_channel

--- a/tekton/src/pipelines/taskdefs/dependencies/db2.yml.j2
+++ b/tekton/src/pipelines/taskdefs/dependencies/db2.yml.j2
@@ -13,6 +13,8 @@
 {% endif %}
 
     # Entitlement
+    - name: ibm_entitlement_key
+      value: $(params.ibm_entitlement_key)
 
     # Operator Subscription
     - name: db2_channel

--- a/tekton/src/pipelines/taskdefs/dependencies/dro.yml.j2
+++ b/tekton/src/pipelines/taskdefs/dependencies/dro.yml.j2
@@ -22,6 +22,8 @@
       value: "$(params.dro_contact_firstname)"
     - name: dro_contact_lastname
       value: "$(params.dro_contact_lastname)"
+    - name: ibm_entitlement_key
+      value: $(params.ibm_entitlement_key)
     - name: dro_namespace
       value: $(params.dro_namespace)
     - name: dro_storage_class

--- a/tekton/src/pipelines/taskdefs/dependencies/sls.yml.j2
+++ b/tekton/src/pipelines/taskdefs/dependencies/sls.yml.j2
@@ -33,6 +33,8 @@
     - name: sls_entitlement_file
       value: $(params.sls_entitlement_file)
 
+    - name: ibm_entitlement_key
+      value: $(params.ibm_entitlement_key)
     - name: custom_labels
       value: $(params.custom_labels)
   taskRef:

--- a/tekton/src/tasks/aiservice/aiservice.yml.j2
+++ b/tekton/src/tasks/aiservice/aiservice.yml.j2
@@ -17,6 +17,10 @@ spec:
       type: string
       description: Required to use development MAS builds
 
+    # Entitlement
+    - name: ibm_entitlement_key
+      type: string
+
     # AI Service Details
     - name: aiservice_instance_id
       type: string
@@ -162,10 +166,7 @@ spec:
 
       # Entitlement
       - name: IBM_ENTITLEMENT_KEY
-        valueFrom:
-          secretKeyRef:
-            name: pipeline-additional-configs
-            key: IBM_ENTITLEMENT_KEY
+        value: $(params.ibm_entitlement_key)
 
       # AI Service Details
       - name: AISERVICE_INSTANCE_ID
@@ -309,8 +310,6 @@ spec:
 
   workspaces:
     - name: configs
-      optional: true
-    - name: additional-configs
       optional: true
     - name: aiservice
       optional: true

--- a/tekton/src/tasks/aiservice/minio.yml.j2
+++ b/tekton/src/tasks/aiservice/minio.yml.j2
@@ -17,6 +17,10 @@ spec:
       type: string
       description: Required to use development MAS builds
 
+    # Entitlement
+    - name: ibm_entitlement_key
+      type: string
+
     # MAS Details
     - name: mas_instance_id
       type: string
@@ -42,10 +46,7 @@ spec:
 
       # Entitlement
       - name: IBM_ENTITLEMENT_KEY
-        valueFrom:
-          secretKeyRef:
-            name: pipeline-additional-configs
-            key: IBM_ENTITLEMENT_KEY
+        value: $(params.ibm_entitlement_key)
 
       # MAS Details
       - name: MAS_INSTANCE_ID
@@ -62,10 +63,6 @@ spec:
 
       - name: MINIO_ROOT_PASSWORD
         value: $(params.minio_root_password)
-
-  workspaces:
-    - name: configs
-      optional: true
 
   steps:
     - name: minio

--- a/tekton/src/tasks/aiservice/odh.yml.j2
+++ b/tekton/src/tasks/aiservice/odh.yml.j2
@@ -17,6 +17,10 @@ spec:
       type: string
       description: Required to use development MAS builds
 
+    # Entitlement
+    - name: ibm_entitlement_key
+      type: string
+
     # MAS Details
     - name: mas_instance_id
       type: string
@@ -60,10 +64,7 @@ spec:
 
       # Entitlement
       - name: IBM_ENTITLEMENT_KEY
-        valueFrom:
-          secretKeyRef:
-            name: pipeline-additional-configs
-            key: IBM_ENTITLEMENT_KEY
+        value: $(params.ibm_entitlement_key)
 
       # MAS Details
       - name: MAS_INSTANCE_ID
@@ -80,10 +81,6 @@ spec:
       # Model deployment type
       - name: AISERVICE_ODH_MODEL_DEPLOYMENT_TYPE
         value: $(params.aiservice_odh_model_deployment_type)
-
-  workspaces:
-    - name: configs
-      optional: true
 
   steps:
     - name: aiservice-odh

--- a/tekton/src/tasks/aiservice/rhoai.yml.j2
+++ b/tekton/src/tasks/aiservice/rhoai.yml.j2
@@ -17,6 +17,10 @@ spec:
       type: string
       description: Required to use development MAS builds
 
+    # Entitlement
+    - name: ibm_entitlement_key
+      type: string
+
     # MAS Details
     - name: mas_instance_id
       type: string
@@ -60,10 +64,7 @@ spec:
 
       # Entitlement
       - name: IBM_ENTITLEMENT_KEY
-        valueFrom:
-          secretKeyRef:
-            name: pipeline-additional-configs
-            key: IBM_ENTITLEMENT_KEY
+        value: $(params.ibm_entitlement_key)
 
       # MAS Details
       - name: MAS_INSTANCE_ID
@@ -80,10 +81,6 @@ spec:
       # Model deployment type
       - name: AISERVICE_RHOAI_MODEL_DEPLOYMENT_TYPE
         value: $(params.aiservice_rhoai_model_deployment_type)
-
-  workspaces:
-    - name: configs
-      optional: true
 
   steps:
     - name: aiservice-rhoai

--- a/tekton/src/tasks/dependencies/appconnect.yml.j2
+++ b/tekton/src/tasks/dependencies/appconnect.yml.j2
@@ -17,6 +17,10 @@ spec:
       description: Optional MAS custom labels, comma separated list of key=value pairs
       default: ""
     # Entitlement
+    - name: ibm_entitlement_key
+      type: string
+      description: "IBM Entitlement Key"
+      default: ""
     # Subscription Channel
     - name: appconnect_channel
       type: string
@@ -50,10 +54,7 @@ spec:
         value: $(params.custom_labels)
       # Entitlement
       - name: IBM_ENTITLEMENT_KEY
-        valueFrom:
-          secretKeyRef:
-            name: pipeline-additional-configs
-            key: IBM_ENTITLEMENT_KEY
+        value: $(params.ibm_entitlement_key)
       # Channel
       - name: APPCONNECT_CHANNEL
         value: $(params.appconnect_channel)

--- a/tekton/src/tasks/dependencies/arcgis.yml.j2
+++ b/tekton/src/tasks/dependencies/arcgis.yml.j2
@@ -17,6 +17,10 @@ spec:
       type: string
       description: Required to use development MAS builds
 
+    # Entitlement
+    - name: ibm_entitlement_key
+      type: string
+
     # MAS Details
     - name: mas_instance_id
       type: string
@@ -54,10 +58,7 @@ spec:
 
       # Entitlement
       - name: IBM_ENTITLEMENT_KEY
-        valueFrom:
-          secretKeyRef:
-            name: pipeline-additional-configs
-            key: IBM_ENTITLEMENT_KEY
+        value: $(params.ibm_entitlement_key)
 
       # MAS Details
       - name: MAS_INSTANCE_ID

--- a/tekton/src/tasks/dependencies/cp4d.yml.j2
+++ b/tekton/src/tasks/dependencies/cp4d.yml.j2
@@ -29,6 +29,8 @@ spec:
       default: ""
 
     # Entitlement
+    - name: ibm_entitlement_key
+      type: string
     - name: skip_entitlement_key_flag
       type: string
       default: ""
@@ -55,10 +57,7 @@ spec:
 
       # Entitlement
       - name: IBM_ENTITLEMENT_KEY
-        valueFrom:
-          secretKeyRef:
-            name: pipeline-additional-configs
-            key: IBM_ENTITLEMENT_KEY
+        value: $(params.ibm_entitlement_key)
       - name: SKIP_ENTITLEMENT_KEY_FLAG
         value: $(params.skip_entitlement_key_flag)
   steps:

--- a/tekton/src/tasks/dependencies/db2.yml.j2
+++ b/tekton/src/tasks/dependencies/db2.yml.j2
@@ -8,6 +8,9 @@ spec:
     {{ lookup('template', task_src_dir ~ '/common/cli-params.yml.j2') | indent(4) }}
 
     # Entitlement
+    - name: ibm_entitlement_key
+      type: string
+      default: ""
     - name: db2_license_file
       type: string
       description: Db2 activation license file
@@ -222,10 +225,7 @@ spec:
 
       # Entitlement
       - name: IBM_ENTITLEMENT_KEY
-        valueFrom:
-          secretKeyRef:
-            name: pipeline-additional-configs
-            key: IBM_ENTITLEMENT_KEY
+        value: $(params.ibm_entitlement_key)
       - name: DB2_LICENSE_FILE
         value: $(params.db2_license_file)
 

--- a/tekton/src/tasks/dependencies/dro.yml.j2
+++ b/tekton/src/tasks/dependencies/dro.yml.j2
@@ -29,6 +29,9 @@ spec:
       description: config directory path
       default: "/workspace/configs"
 
+    - name: ibm_entitlement_key
+      type: string
+      default: ""
     - name: dro_namespace
       type: string
       default: "redhat-marketplace"
@@ -83,10 +86,7 @@ spec:
         - name: CUSTOM_LABELS
           value: $(params.custom_labels)
         - name: IBM_ENTITLEMENT_KEY
-          valueFrom:
-            secretKeyRef:
-              name: pipeline-additional-configs
-              key: IBM_ENTITLEMENT_KEY
+          value: $(params.ibm_entitlement_key)
         - name: DRO_CONTACT_EMAIL
           value: $(params.dro_contact_email)
         - name: DRO_CONTACT_FIRSTNAME

--- a/tekton/src/tasks/dependencies/sls.yml.j2
+++ b/tekton/src/tasks/dependencies/sls.yml.j2
@@ -48,6 +48,11 @@ spec:
       type: string
       default: ""
 
+    # Entitlement (only used for artifactory auth since 3.8.0)
+    - name: ibm_entitlement_key
+      type: string
+      default: ""
+
     - name: artifactory_username
       default: ""
       type: string
@@ -103,13 +108,8 @@ spec:
         value: $(params.sls_entitlement_file)
 
       # Entitlement (only used for artifactory auth since 3.8.0)
-      {% if sls_channel is defined and sls_channel|string|replace('.', '')|int <= 370 %}
       - name: IBM_ENTITLEMENT_KEY
-        valueFrom:
-          secretKeyRef:
-            name: pipeline-additional-configs
-            key: IBM_ENTITLEMENT_KEY
-      {% endif %}
+        value: $(params.ibm_entitlement_key)
 
       - name: ARTIFACTORY_USERNAME
         value: $(params.artifactory_username)

--- a/tekton/src/tasks/suite-app-install.yml.j2
+++ b/tekton/src/tasks/suite-app-install.yml.j2
@@ -52,6 +52,10 @@ spec:
       type: string
       description: Required to use development MAS builds
 
+    # Entitlement
+    - name: ibm_entitlement_key
+      type: string
+
     # Application - Operator
     - name: mas_app_channel
       type: string
@@ -453,10 +457,7 @@ spec:
 
         # Entitlement
         - name: IBM_ENTITLEMENT_KEY
-          valueFrom:
-            secretKeyRef:
-              name: pipeline-additional-configs
-              key: IBM_ENTITLEMENT_KEY
+          value: $(params.ibm_entitlement_key)
 
         - name: MAS_USE_SERVICE_MESH
           value: $(params.mas_use_service_mesh)

--- a/tekton/src/tasks/suite-db2-setup-for-facilities.yml.j2
+++ b/tekton/src/tasks/suite-db2-setup-for-facilities.yml.j2
@@ -7,6 +7,11 @@ spec:
   params:
     {{ lookup('template', task_src_dir ~ '/common/cli-params.yml.j2') | indent(4) }}
 
+    # Entitlement
+    - name: ibm_entitlement_key
+      type: string
+      default: ""
+
     - name: db2_action_facilities
       type: string
       description: Set to 'install' to set up Db2 instance for Facilities
@@ -178,10 +183,7 @@ spec:
 
       # Entitlement
       - name: IBM_ENTITLEMENT_KEY
-        valueFrom:
-          secretKeyRef:
-            name: pipeline-additional-configs
-            key: IBM_ENTITLEMENT_KEY
+        value: $(params.ibm_entitlement_key)
 
       # Db2u Operator
       - name: DB2_CHANNEL

--- a/tekton/src/tasks/suite-install.yml.j2
+++ b/tekton/src/tasks/suite-install.yml.j2
@@ -99,6 +99,9 @@ spec:
       description: Certificate issuer kind for MAS Suite CR (Issuer or ClusterIssuer)
       default: ""
 
+    - name: ibm_entitlement_key
+      type: string
+
     - name: artifactory_username
       default: ''
       type: string
@@ -219,10 +222,7 @@ spec:
         value: $(params.mas_issuer_kind)
 
       - name: IBM_ENTITLEMENT_KEY
-        valueFrom:
-          secretKeyRef:
-            name: pipeline-additional-configs
-            key: IBM_ENTITLEMENT_KEY
+        value: $(params.ibm_entitlement_key)
 
       - name: MAS_POD_TEMPLATES_DIR
         value: /workspace/pod-templates


### PR DESCRIPTION
… source from secrets (#2405)"

This reverts commit c58cc38262e73b2f38ab265417211ea632e12968 due to the error in the update pipeline:
```
mas-update-260702-1633-update-db2-pod
CreateContainerConfigError
Error: secret "pipeline-additional-configs" not found
```

Needs PR https://github.com/ibm-mas/python-devops/pull/416 to be merged in as well