### PR TITLE
[patch] Include MCPI in the collection of reconcile logs for mustgather

### DIFF
--- a/python/src/mas/cli/must_gather/mas/core.py
+++ b/python/src/mas/cli/must_gather/mas/core.py
@@ -258,6 +258,7 @@ def _generateMASCoreCollectionTasks(
             (namespace, "control-plane", "ibm-mas-cfg-app"),
             (namespace, "control-plane", "ibm-mas-cfg-bas"),
             (namespace, "control-plane", "ibm-mas-cfg-idp"),
+            (namespace, "control-plane", "ibm-mas-cfg-mcpi"),
             (namespace, "control-plane", "ibm-mas-cfg-scim"),
             (namespace, "control-plane", "ibm-mas-cfg-jdbc"),
             (namespace, "control-plane", "ibm-mas-cfg-mongo"),


### PR DESCRIPTION
Include MCPI in the collection of reconcile logs from MAS operator