### PR TITLE
[patch] Removed RSL validation secret and ibm_entitlement validation outside of FVT flow in gitops

### DIFF
--- a/image/cli/mascli/functions/gitops_aiservice_tenant
+++ b/image/cli/mascli/functions/gitops_aiservice_tenant
@@ -509,8 +509,8 @@ fi
 
   # check for those variables present into the aws sm 
 
+  sm_verify_secret_exists ${SECRETS_PREFIX}ibm_entitlement "image_pull_secret_b64,entitlement_key"
   if [[ "${IS_GITOPS_FVT_ENV}" != "true" ]]; then
-    sm_verify_secret_exists ${SECRETS_PREFIX}ibm_entitlement "image_pull_secret_b64,entitlement_key"
     sm_verify_secret_exists ${SECRETS_PREFIX}dro "dro_api_token,dro_ca_b64enc"
     if [ -z "$STANDALONE_SLS_SERVICE" ]; then
       # In GitOps FVT environment, skip SLS secret verification as they will be created by postSync job
@@ -518,7 +518,6 @@ fi
     else
       sm_verify_secret_exists ${SLS_SECRETS_PREFIX}sls "registration_key,ca_b64,sls_url"
     fi
-    sm_verify_secret_exists ${SECRETS_PREFIX}rsl "rsl_org_id,rsl_token"
     sm_verify_secret_exists ${SECRETS_PREFIX}watsonx "watsonxai_apikey,watsonxai_project_id"
   else
       echo "GitOps FVT Environment: Skipping SLS secret verification (will be created by postSync job)"


### PR DESCRIPTION
[MASAIB-2563](https://jsw.ibm.com/browse/MASAIB-2563)

I noticed that Bhautik Vala removed the RSL validation from this function a few days ago. However, after the SaaS FVT flow changes, that code appears to have been reverted, and the function is validating the RSL secret again.

FVT PR has been merge yesterday: https://github.com/ibm-mas/cli/pull/2310/changes#diff-72acec02435f86be0864e61eec5559227fb5f78bebcfa567c50c9cc7829a1c0bR521

Bhautik's PR: https://github.com/ibm-mas/cli/commit/915c748444e5b95a3db1bf8159674616fd4bdd79#diff-72acec02435f86be0864e61eec5559227fb5f78bebcfa567c50c9cc7829a1c0bL486

Remove ibm_entitlement key validation from the skipped validation logic.