### PR TITLE
[patch] auto-sanitize registry prefix to comply with RFC 1123

### DIFF
--- a/image/cli/mascli/functions/configure_airgap
+++ b/image/cli/mascli/functions/configure_airgap
@@ -96,6 +96,7 @@ function configure_ocp_for_mirror_noninteractive() {
   [[ -z "$REGISTRY_PRIVATE_CA_FILE" ]] && configure_ocp_for_mirror_help "REGISTRY_PRIVATE_CA_FILE is not set"
   [[ -z "$REGISTRY_USERNAME" ]] && configure_ocp_for_mirror_help "REGISTRY_USERNAME is not set"
   [[ -z "$REGISTRY_PASSWORD" ]] && configure_ocp_for_mirror_help "REGISTRY_PASSWORD is not set"
+  REGISTRY_PREFIX=$(sanitize_registry_prefix "$REGISTRY_PREFIX")
   validate_registry_prefix "$REGISTRY_PREFIX"
   if [[ ! -e $REGISTRY_PRIVATE_CA_FILE ]]; then
     echo_warning "Certificate file '$REGISTRY_PRIVATE_CA_FILE' does not exist"
@@ -115,6 +116,7 @@ function configure_ocp_for_mirror_interactive() {
   prompt_for_input "Mirror Registry Host" REGISTRY_PRIVATE_HOST && export REGISTRY_PRIVATE_HOST
   prompt_for_input "Mirror Registry Port" REGISTRY_PRIVATE_PORT && export REGISTRY_PRIVATE_PORT
   prompt_for_input "Mirror Registry Prefix" REGISTRY_PREFIX && export REGISTRY_PREFIX
+  REGISTRY_PREFIX=$(sanitize_registry_prefix "$REGISTRY_PREFIX")
   validate_registry_prefix "$REGISTRY_PREFIX"
   prompt_for_input "Mirror Registry CA File" REGISTRY_PRIVATE_CA_FILE && export REGISTRY_PRIVATE_CA_FILE
   if [[ ! -e $REGISTRY_PRIVATE_CA_FILE ]]; then
@@ -123,11 +125,11 @@ function configure_ocp_for_mirror_interactive() {
   fi
 
   if [[ "$REGISTRY_PRIVATE_PORT" != "" ]]; then
-    REGISTRY_PRIVATE_URL = "${REGISTRY_PRIVATE_HOST}:${REGISTRY_PRIVATE_PORT}"
+    REGISTRY_PRIVATE_URL="${REGISTRY_PRIVATE_HOST}:${REGISTRY_PRIVATE_PORT}"
   fi
 
   if [[ "$REGISTRY_PREFIX" != "" ]]; then
-    REGISTRY_PRIVATE_URL_WITH_PATH = "${REGISTRY_PRIVATE_URL}/${REGISTRY_PREFIX}"
+    REGISTRY_PRIVATE_URL_WITH_PATH="${REGISTRY_PRIVATE_URL}/${REGISTRY_PREFIX}"
   fi
 
   echo

--- a/image/cli/mascli/functions/internal/utils
+++ b/image/cli/mascli/functions/internal/utils
@@ -202,6 +202,31 @@ function prompt_for_secret(){
 }
 
 
+function sanitize_registry_prefix() {
+  local original=$1
+  if [[ -z "$original" ]]; then
+    echo ""
+    return 0
+  fi
+  local prefix=$original
+  # Convert uppercase to lowercase
+  prefix=$(echo "$prefix" | tr '[:upper:]' '[:lower:]')
+  # Replace any character that is not lowercase alphanumeric, '-', or '.' with '-'
+  prefix=$(echo "$prefix" | sed 's/[^a-z0-9.-]/-/g')
+  # Collapse multiple consecutive hyphens into one
+  prefix=$(echo "$prefix" | sed 's/-\{2,\}/-/g')
+  # Strip leading and trailing hyphens or dots
+  prefix=$(echo "$prefix" | sed 's/^[.-]*//;s/[.-]*$//')
+  # Notify the user if the value was changed so they know what will actually be used
+  # Redirect to stderr so the message is not captured when function is used in $(...) substitution
+  if [[ "$prefix" != "$original" ]]; then
+    echo -e "${COLOR_YELLOW}Note: Registry prefix '$original' is not RFC 1123 compliant and has been automatically changed to '$prefix'${TEXT_RESET}" >&2
+    echo -e "${COLOR_YELLOW}      Make sure your images were also mirrored using '$prefix'${TEXT_RESET}" >&2
+    echo -e "Note: Registry prefix '$original' auto-sanitized to '$prefix'" >> $LOGFILE
+  fi
+  echo "$prefix"
+}
+
 function validate_registry_prefix() {
   registryPrefix=$1
 

--- a/image/cli/mascli/functions/mirror_images
+++ b/image/cli/mascli/functions/mirror_images
@@ -273,6 +273,7 @@ function mirror_to_registry_noninteractive() {
   [[ -z "$IBM_ENTITLEMENT_KEY" ]] && mirror_to_registry_help "IBM_ENTITLEMENT_KEY is not set"
 
   [[ -z "$REGISTRY_PUBLIC_HOST" ]] && mirror_to_registry_help "REGISTRY_PUBLIC_HOST is not set"
+  REGISTRY_PREFIX=$(sanitize_registry_prefix "$REGISTRY_PREFIX")
   validate_registry_prefix "$REGISTRY_PREFIX"
 
   if [[ $MIRROR_MODE != "to-filesystem" && $REGISTRY_IS_ECR == "true" ]]; then

--- a/image/cli/mascli/functions/mirror_images_common
+++ b/image/cli/mascli/functions/mirror_images_common
@@ -71,6 +71,7 @@ function mirror_to_registry_interactive_common() {
   prompt_for_input "Mirror Registry Host" REGISTRY_PUBLIC_HOST
   prompt_for_input "Mirror Registry Port" REGISTRY_PUBLIC_PORT
   prompt_for_input "Mirror Registry Prefix" REGISTRY_PREFIX
+  REGISTRY_PREFIX=$(sanitize_registry_prefix "$REGISTRY_PREFIX")
   validate_registry_prefix "$REGISTRY_PREFIX"
 
   if [[ $MIRROR_MODE != "to-filesystem" ]]; then

--- a/image/cli/mascli/functions/mirror_redhat
+++ b/image/cli/mascli/functions/mirror_redhat
@@ -89,6 +89,7 @@ function mirror_redhat_noninteractive() {
   # Check all args have been set
   [[ -z "$MIRROR_MODE" ]] && mirror_redhat_help "MIRROR_MODE is not set"
   [[ -z "$MIRROR_WORKING_DIR" ]] && mirror_redhat_help "MIRROR_WORKING_DIR is not set"
+  REGISTRY_PREFIX_REDHAT=$(sanitize_registry_prefix "$REGISTRY_PREFIX_REDHAT")
   validate_registry_prefix "$REGISTRY_PREFIX_REDHAT"
 
   if [[ $MIRROR_MODE != "to-filesystem" && $REGISTRY_IS_ECR == "true" ]]; then
@@ -194,6 +195,7 @@ function mirror_redhat_interactive() {
     prompt_for_input "Mirror Registry Host" REGISTRY_PUBLIC_HOST
     prompt_for_input "Mirror Registry Port" REGISTRY_PUBLIC_PORT
     prompt_for_input "Mirror Registry Prefix" REGISTRY_PREFIX_REDHAT
+    REGISTRY_PREFIX_REDHAT=$(sanitize_registry_prefix "$REGISTRY_PREFIX_REDHAT")
     validate_registry_prefix "$REGISTRY_PREFIX_REDHAT"
     prompt_for_input "Mirror Registry Username" REGISTRY_USERNAME
     prompt_for_secret "Mirror Registry Password" REGISTRY_PASSWORD "Re-use saved registry password?"


### PR DESCRIPTION
## Summary

Auto-sanitize the registry prefix to comply with RFC 1123 naming rules, preventing validation errors and OpenShift API rejections caused by invalid characters in the prefix.

---

## Problem

When users run `mas configure-airgap`, `mas mirror-images`, or `mas mirror-redhat` with a registry prefix containing characters such as `/`, `\`, uppercase letters, or spaces, one of two failures occurs:

**1. CLI validation failure** — `validate_registry_prefix` rejects the prefix with `exit 1`:
```
Invalid registry prefix 'test/test'
REGISTRY_PREFIX must be a lowercase RFC 1123 subdomain...
```

**2. OpenShift API failure** — if validation is bypassed, the `ocp_idms` Ansible role builds an invalid IDMS resource name which OpenShift rejects:
```
Invalid value: "mas-ibm-catalog-test/test": a lowercase RFC 1123 subdomain must consist of
lower case alphanumeric characters, '-', or '.', and must start and end with an alphanumeric character
```

---

## Solution

Introduce a new `sanitize_registry_prefix()` function in `image/cli/mascli/functions/internal/utils` that automatically normalises the prefix **before** validation:

| Input | Output | Transformation |
|---|---|---|
| `test/test` | `test-test` | `/` replaced with `-` |
| `test_test` | `test-test` | `_` replaced with `-` |
| `MyPrefix` | `myprefix` | uppercase converted to lowercase |
| `test--test` | `test-test` | consecutive dashes collapsed |
| `-test-` | `test` | leading/trailing `-` stripped |
| `MY/folder/path` | `my-folder-path` | combined transformations |

If the value changes during sanitization, a **yellow informational note** is printed:
```
Note: Registry prefix 'test/test' is not RFC 1123 compliant and has been automatically changed to 'test-test'
      Make sure your images were also mirrored using 'test-test'
```

Valid prefixes pass through unchanged with no output.

---

## Also Fixed

Pre-existing bash syntax bug in `configure_airgap` — spaces around `=` in variable assignments caused `command not found` errors in interactive mode:

```bash
# Before (broken)
REGISTRY_PRIVATE_URL = "${REGISTRY_PRIVATE_HOST}:${REGISTRY_PRIVATE_PORT}"

# After (fixed)
REGISTRY_PRIVATE_URL="${REGISTRY_PRIVATE_HOST}:${REGISTRY_PRIVATE_PORT}"
```

---

## Files Changed

| File | Change |
|---|---|
| `image/cli/mascli/functions/internal/utils` | Added `sanitize_registry_prefix()` |
| `image/cli/mascli/functions/configure_airgap` | Sanitize before validate (x2), fix assignment bug (x2) |
| `image/cli/mascli/functions/mirror_images` | Sanitize before validate |
| `image/cli/mascli/functions/mirror_images_common` | Sanitize before validate |
| `image/cli/mascli/functions/mirror_redhat` | Sanitize before validate (x2) |

---

## Testing

Manually tested end-to-end on an OCP cluster with a local Docker registry:

- `mas mirror-images --prefix "test/test"` → sanitized to `test-test`, mirroring proceeded with correct target path `host:5000/test-test/cpopen/...` 
- `mas configure-airgap --prefix "test/jeel123"` → sanitized to `test-jeel123`, IDMS resource created as `mas-ibm-catalog-test-jeel123` 
- Valid prefixes (`test-test`, `abc.123`) → pass through unchanged, no warning printed 
- Empty prefix → no change, no warning 
---
<img width="1728" height="823" alt="Screenshot 2026-07-13 at 16 20 11" src="https://github.com/user-attachments/assets/1d3180d7-8dab-4fd6-b965-08bf48dc18dc" />

<img width="1722" height="987" alt="Screenshot 2026-07-13 at 16 38 23" src="https://github.com/user-attachments/assets/65e6f76d-cae3-496d-8f86-50971ce105f3" />

<img width="1726" height="980" alt="Screenshot 2026-07-13 at 16 38 35" src="https://github.com/user-attachments/assets/70a75676-aa13-491d-af5a-cee362a21930" />

<img width="1722" height="989" alt="Screenshot 2026-07-13 at 16 39 35" src="https://github.com/user-attachments/assets/ec2aaf74-bc2a-41db-b7ac-ad401dd5b907" />

<img width="1722" height="986" alt="Screenshot 2026-07-13 at 16 45 15" src="https://github.com/user-attachments/assets/0a2c363d-9b3b-4a6e-a50f-65fcc85a1aa3" />

<img width="1699" height="966" alt="Screenshot 2026-07-13 at 20 23 19" src="https://github.com/user-attachments/assets/b5445ced-569a-4ed7-8147-f655609d96b4" />
