### PR TITLE
[docs] Single definition for OCP support statement

### DIFF
--- a/docs/catalogs/v9-250109-amd64.md
+++ b/docs/catalogs/v9-250109-amd64.md
@@ -13,10 +13,6 @@ IBM Maximo Operator Catalog v9 (250109)
 
 Red Hat OpenShift Container Platform Support
 -------------------------------------------------------------------------------
-For more information about the OCP lifecycle refer to the [Red Hat OpenShift Container Platform Life Cycle Policy](https://access.redhat.com/support/policy/updates/openshift/).
-
-IBM Maximo Application Suite customers receive a standard Red Hat OpenShift Container Platform subscription as part of their purchase. This includes 18 months of maintenance support for each OpenShift minor release.  A further 6 months support is available to purchase as an Extended Update Support (EUS) Add-on to x86-64 versions of Red Hat OpenShift Kubernetes Engine, Red Hat OpenShift Container Platform, and Red Hat OpenShift Platform Plus Standard subscriptions.
-
 :::mas-catalog-ocp-compatibility-matrix
 
 ### Certified Operators

--- a/docs/catalogs/v9-250109-s390x.md
+++ b/docs/catalogs/v9-250109-s390x.md
@@ -19,10 +19,6 @@ IBM Maximo Operator Catalog v9 (250109)
 
 Red Hat OpenShift Container Platform Support
 -------------------------------------------------------------------------------
-For more information about the OCP lifecycle refer to the [Red Hat OpenShift Container Platform Life Cycle Policy](https://access.redhat.com/support/policy/updates/openshift/).
-
-IBM Maximo Application Suite customers receive a standard Red Hat OpenShift Container Platform subscription as part of their purchase. This includes 18 months of maintenance support for each OpenShift minor release.  A further 6 months support is available to purchase as an Extended Update Support (EUS) Add-on to x86-64 versions of Red Hat OpenShift Kubernetes Engine, Red Hat OpenShift Container Platform, and Red Hat OpenShift Platform Plus Standard subscriptions.
-
 :::mas-catalog-ocp-compatibility-matrix
 
 ### Certified Operators

--- a/docs/catalogs/v9-250206-amd64.md
+++ b/docs/catalogs/v9-250206-amd64.md
@@ -13,10 +13,6 @@ IBM Maximo Operator Catalog v9 (250206)
 
 Red Hat OpenShift Container Platform Support
 -------------------------------------------------------------------------------
-For more information about the OCP lifecycle refer to the [Red Hat OpenShift Container Platform Life Cycle Policy](https://access.redhat.com/support/policy/updates/openshift/).
-
-IBM Maximo Application Suite customers receive a standard Red Hat OpenShift Container Platform subscription as part of their purchase. This includes 18 months of maintenance support for each OpenShift minor release.  A further 6 months support is available to purchase as an Extended Update Support (EUS) Add-on to x86-64 versions of Red Hat OpenShift Kubernetes Engine, Red Hat OpenShift Container Platform, and Red Hat OpenShift Platform Plus Standard subscriptions.
-
 :::mas-catalog-ocp-compatibility-matrix
 
 ### Certified Operators

--- a/docs/catalogs/v9-250206-s390x.md
+++ b/docs/catalogs/v9-250206-s390x.md
@@ -19,10 +19,6 @@ IBM Maximo Operator Catalog v9 (250206)
 
 Red Hat OpenShift Container Platform Support
 -------------------------------------------------------------------------------
-For more information about the OCP lifecycle refer to the [Red Hat OpenShift Container Platform Life Cycle Policy](https://access.redhat.com/support/policy/updates/openshift/).
-
-IBM Maximo Application Suite customers receive a standard Red Hat OpenShift Container Platform subscription as part of their purchase. This includes 18 months of maintenance support for each OpenShift minor release.  A further 6 months support is available to purchase as an Extended Update Support (EUS) Add-on to x86-64 versions of Red Hat OpenShift Kubernetes Engine, Red Hat OpenShift Container Platform, and Red Hat OpenShift Platform Plus Standard subscriptions.
-
 :::mas-catalog-ocp-compatibility-matrix
 
 ### Certified Operators

--- a/docs/catalogs/v9-250306-amd64.md
+++ b/docs/catalogs/v9-250306-amd64.md
@@ -13,10 +13,6 @@ IBM Maximo Operator Catalog v9 (250306)
 
 Red Hat OpenShift Container Platform Support
 -------------------------------------------------------------------------------
-For more information about the OCP lifecycle refer to the [Red Hat OpenShift Container Platform Life Cycle Policy](https://access.redhat.com/support/policy/updates/openshift/).
-
-IBM Maximo Application Suite customers receive a standard Red Hat OpenShift Container Platform subscription as part of their purchase. This includes 18 months of maintenance support for each OpenShift minor release.  A further 6 months support is available to purchase as an Extended Update Support (EUS) Add-on to x86-64 versions of Red Hat OpenShift Kubernetes Engine, Red Hat OpenShift Container Platform, and Red Hat OpenShift Platform Plus Standard subscriptions.
-
 :::mas-catalog-ocp-compatibility-matrix
 
 ### Certified Operators

--- a/docs/catalogs/v9-250306-s390x.md
+++ b/docs/catalogs/v9-250306-s390x.md
@@ -19,10 +19,6 @@ IBM Maximo Operator Catalog v9 (250306)
 
 Red Hat OpenShift Container Platform Support
 -------------------------------------------------------------------------------
-For more information about the OCP lifecycle refer to the [Red Hat OpenShift Container Platform Life Cycle Policy](https://access.redhat.com/support/policy/updates/openshift/).
-
-IBM Maximo Application Suite customers receive a standard Red Hat OpenShift Container Platform subscription as part of their purchase. This includes 18 months of maintenance support for each OpenShift minor release.  A further 6 months support is available to purchase as an Extended Update Support (EUS) Add-on to x86-64 versions of Red Hat OpenShift Kubernetes Engine, Red Hat OpenShift Container Platform, and Red Hat OpenShift Platform Plus Standard subscriptions.
-
 :::mas-catalog-ocp-compatibility-matrix
 
 ### Certified Operators

--- a/docs/catalogs/v9-250403-amd64.md
+++ b/docs/catalogs/v9-250403-amd64.md
@@ -13,10 +13,6 @@ IBM Maximo Operator Catalog v9 (250403)
 
 Red Hat OpenShift Container Platform Support
 -------------------------------------------------------------------------------
-For more information about the OCP lifecycle refer to the [Red Hat OpenShift Container Platform Life Cycle Policy](https://access.redhat.com/support/policy/updates/openshift/).
-
-IBM Maximo Application Suite customers receive a standard Red Hat OpenShift Container Platform subscription as part of their purchase. This includes 18 months of maintenance support for each OpenShift minor release.  A further 6 months support is available to purchase as an Extended Update Support (EUS) Add-on to x86-64 versions of Red Hat OpenShift Kubernetes Engine, Red Hat OpenShift Container Platform, and Red Hat OpenShift Platform Plus Standard subscriptions.
-
 :::mas-catalog-ocp-compatibility-matrix
 
 ### Certified Operators

--- a/docs/catalogs/v9-250403-s390x.md
+++ b/docs/catalogs/v9-250403-s390x.md
@@ -19,10 +19,6 @@ IBM Maximo Operator Catalog v9 (250403)
 
 Red Hat OpenShift Container Platform Support
 -------------------------------------------------------------------------------
-For more information about the OCP lifecycle refer to the [Red Hat OpenShift Container Platform Life Cycle Policy](https://access.redhat.com/support/policy/updates/openshift/).
-
-IBM Maximo Application Suite customers receive a standard Red Hat OpenShift Container Platform subscription as part of their purchase. This includes 18 months of maintenance support for each OpenShift minor release.  A further 6 months support is available to purchase as an Extended Update Support (EUS) Add-on to x86-64 versions of Red Hat OpenShift Kubernetes Engine, Red Hat OpenShift Container Platform, and Red Hat OpenShift Platform Plus Standard subscriptions.
-
 :::mas-catalog-ocp-compatibility-matrix
 
 ### Certified Operators

--- a/docs/catalogs/v9-250501-amd64.md
+++ b/docs/catalogs/v9-250501-amd64.md
@@ -13,10 +13,6 @@ IBM Maximo Operator Catalog v9 (250501)
 
 Red Hat OpenShift Container Platform Support
 -------------------------------------------------------------------------------
-For more information about the OCP lifecycle refer to the [Red Hat OpenShift Container Platform Life Cycle Policy](https://access.redhat.com/support/policy/updates/openshift/).
-
-IBM Maximo Application Suite customers receive a standard Red Hat OpenShift Container Platform subscription as part of their purchase. This includes 18 months of maintenance support for each OpenShift minor release.  A further 6 months support is available to purchase as an Extended Update Support (EUS) Add-on to x86-64 versions of Red Hat OpenShift Kubernetes Engine, Red Hat OpenShift Container Platform, and Red Hat OpenShift Platform Plus Standard subscriptions.
-
 :::mas-catalog-ocp-compatibility-matrix
 
 ### Certified Operators

--- a/docs/catalogs/v9-250501-s390x.md
+++ b/docs/catalogs/v9-250501-s390x.md
@@ -19,10 +19,6 @@ IBM Maximo Operator Catalog v9 (250501)
 
 Red Hat OpenShift Container Platform Support
 -------------------------------------------------------------------------------
-For more information about the OCP lifecycle refer to the [Red Hat OpenShift Container Platform Life Cycle Policy](https://access.redhat.com/support/policy/updates/openshift/).
-
-IBM Maximo Application Suite customers receive a standard Red Hat OpenShift Container Platform subscription as part of their purchase. This includes 18 months of maintenance support for each OpenShift minor release.  A further 6 months support is available to purchase as an Extended Update Support (EUS) Add-on to x86-64 versions of Red Hat OpenShift Kubernetes Engine, Red Hat OpenShift Container Platform, and Red Hat OpenShift Platform Plus Standard subscriptions.
-
 :::mas-catalog-ocp-compatibility-matrix
 
 ### Certified Operators

--- a/docs/catalogs/v9-250624-amd64.md
+++ b/docs/catalogs/v9-250624-amd64.md
@@ -13,10 +13,6 @@ IBM Maximo Operator Catalog v9 (250624)
 
 Red Hat OpenShift Container Platform Support
 -------------------------------------------------------------------------------
-For more information about the OCP lifecycle refer to the [Red Hat OpenShift Container Platform Life Cycle Policy](https://access.redhat.com/support/policy/updates/openshift/).
-
-IBM Maximo Application Suite customers receive a standard Red Hat OpenShift Container Platform subscription as part of their purchase. This includes 18 months of maintenance support for each OpenShift minor release.  A further 6 months support is available to purchase as an Extended Update Support (EUS) Add-on to x86-64 versions of Red Hat OpenShift Kubernetes Engine, Red Hat OpenShift Container Platform, and Red Hat OpenShift Platform Plus Standard subscriptions.
-
 :::mas-catalog-ocp-compatibility-matrix
 
 ### Certified Operators

--- a/docs/catalogs/v9-250624-ppc64le.md
+++ b/docs/catalogs/v9-250624-ppc64le.md
@@ -14,10 +14,6 @@ IBM Maximo Operator Catalog v9 (250624)
 
 Red Hat OpenShift Container Platform Support
 -------------------------------------------------------------------------------
-For more information about the OCP lifecycle refer to the [Red Hat OpenShift Container Platform Life Cycle Policy](https://access.redhat.com/support/policy/updates/openshift/).
-
-IBM Maximo Application Suite customers receive a standard Red Hat OpenShift Container Platform subscription as part of their purchase. This includes 18 months of maintenance support for each OpenShift minor release.  A further 6 months support is available to purchase as an Extended Update Support (EUS) Add-on to x86-64 versions of Red Hat OpenShift Kubernetes Engine, Red Hat OpenShift Container Platform, and Red Hat OpenShift Platform Plus Standard subscriptions.
-
 :::mas-catalog-ocp-compatibility-matrix
 
 ### Certified Operators

--- a/docs/catalogs/v9-250624-s390x.md
+++ b/docs/catalogs/v9-250624-s390x.md
@@ -14,10 +14,6 @@ IBM Maximo Operator Catalog v9 (250624)
 
 Red Hat OpenShift Container Platform Support
 -------------------------------------------------------------------------------
-For more information about the OCP lifecycle refer to the [Red Hat OpenShift Container Platform Life Cycle Policy](https://access.redhat.com/support/policy/updates/openshift/).
-
-IBM Maximo Application Suite customers receive a standard Red Hat OpenShift Container Platform subscription as part of their purchase. This includes 18 months of maintenance support for each OpenShift minor release.  A further 6 months support is available to purchase as an Extended Update Support (EUS) Add-on to x86-64 versions of Red Hat OpenShift Kubernetes Engine, Red Hat OpenShift Container Platform, and Red Hat OpenShift Platform Plus Standard subscriptions.
-
 :::mas-catalog-ocp-compatibility-matrix
 
 ### Certified Operators

--- a/docs/catalogs/v9-250731-amd64.md
+++ b/docs/catalogs/v9-250731-amd64.md
@@ -13,10 +13,6 @@ IBM Maximo Operator Catalog v9 (250731)
 
 Red Hat OpenShift Container Platform Support
 -------------------------------------------------------------------------------
-For more information about the OCP lifecycle refer to the [Red Hat OpenShift Container Platform Life Cycle Policy](https://access.redhat.com/support/policy/updates/openshift/).
-
-IBM Maximo Application Suite customers receive a standard Red Hat OpenShift Container Platform subscription as part of their purchase. This includes 18 months of maintenance support for each OpenShift minor release.  A further 6 months support is available to purchase as an Extended Update Support (EUS) Add-on to x86-64 versions of Red Hat OpenShift Kubernetes Engine, Red Hat OpenShift Container Platform, and Red Hat OpenShift Platform Plus Standard subscriptions.
-
 :::mas-catalog-ocp-compatibility-matrix
 
 ### Certified Operators

--- a/docs/catalogs/v9-250731-ppc64le.md
+++ b/docs/catalogs/v9-250731-ppc64le.md
@@ -14,10 +14,6 @@ IBM Maximo Operator Catalog v9 (250731)
 
 Red Hat OpenShift Container Platform Support
 -------------------------------------------------------------------------------
-For more information about the OCP lifecycle refer to the [Red Hat OpenShift Container Platform Life Cycle Policy](https://access.redhat.com/support/policy/updates/openshift/).
-
-IBM Maximo Application Suite customers receive a standard Red Hat OpenShift Container Platform subscription as part of their purchase. This includes 18 months of maintenance support for each OpenShift minor release.  A further 6 months support is available to purchase as an Extended Update Support (EUS) Add-on to x86-64 versions of Red Hat OpenShift Kubernetes Engine, Red Hat OpenShift Container Platform, and Red Hat OpenShift Platform Plus Standard subscriptions.
-
 :::mas-catalog-ocp-compatibility-matrix
 
 ### Certified Operators

--- a/docs/catalogs/v9-250731-s390x.md
+++ b/docs/catalogs/v9-250731-s390x.md
@@ -14,10 +14,6 @@ IBM Maximo Operator Catalog v9 (250731)
 
 Red Hat OpenShift Container Platform Support
 -------------------------------------------------------------------------------
-For more information about the OCP lifecycle refer to the [Red Hat OpenShift Container Platform Life Cycle Policy](https://access.redhat.com/support/policy/updates/openshift/).
-
-IBM Maximo Application Suite customers receive a standard Red Hat OpenShift Container Platform subscription as part of their purchase. This includes 18 months of maintenance support for each OpenShift minor release.  A further 6 months support is available to purchase as an Extended Update Support (EUS) Add-on to x86-64 versions of Red Hat OpenShift Kubernetes Engine, Red Hat OpenShift Container Platform, and Red Hat OpenShift Platform Plus Standard subscriptions.
-
 :::mas-catalog-ocp-compatibility-matrix
 
 ### Certified Operators

--- a/docs/catalogs/v9-250828-amd64.md
+++ b/docs/catalogs/v9-250828-amd64.md
@@ -17,10 +17,6 @@ IBM Maximo Operator Catalog v9 (250828)
 
 Red Hat OpenShift Container Platform Support
 -------------------------------------------------------------------------------
-For more information about the OCP lifecycle refer to the [Red Hat OpenShift Container Platform Life Cycle Policy](https://access.redhat.com/support/policy/updates/openshift/).
-
-IBM Maximo Application Suite customers receive a standard Red Hat OpenShift Container Platform subscription as part of their purchase. This includes 18 months of maintenance support for each OpenShift minor release.  A further 6 months support is available to purchase as an Extended Update Support (EUS) Add-on to x86-64 versions of Red Hat OpenShift Kubernetes Engine, Red Hat OpenShift Container Platform, and Red Hat OpenShift Platform Plus Standard subscriptions.
-
 :::mas-catalog-ocp-compatibility-matrix
 
 ### Certified Operators

--- a/docs/catalogs/v9-250828-ppc64le.md
+++ b/docs/catalogs/v9-250828-ppc64le.md
@@ -14,10 +14,6 @@ IBM Maximo Operator Catalog v9 (250828)
 
 Red Hat OpenShift Container Platform Support
 -------------------------------------------------------------------------------
-For more information about the OCP lifecycle refer to the [Red Hat OpenShift Container Platform Life Cycle Policy](https://access.redhat.com/support/policy/updates/openshift/).
-
-IBM Maximo Application Suite customers receive a standard Red Hat OpenShift Container Platform subscription as part of their purchase. This includes 18 months of maintenance support for each OpenShift minor release.  A further 6 months support is available to purchase as an Extended Update Support (EUS) Add-on to x86-64 versions of Red Hat OpenShift Kubernetes Engine, Red Hat OpenShift Container Platform, and Red Hat OpenShift Platform Plus Standard subscriptions.
-
 :::mas-catalog-ocp-compatibility-matrix
 
 ### Certified Operators

--- a/docs/catalogs/v9-250828-s390x.md
+++ b/docs/catalogs/v9-250828-s390x.md
@@ -14,10 +14,6 @@ IBM Maximo Operator Catalog v9 (250828)
 
 Red Hat OpenShift Container Platform Support
 -------------------------------------------------------------------------------
-For more information about the OCP lifecycle refer to the [Red Hat OpenShift Container Platform Life Cycle Policy](https://access.redhat.com/support/policy/updates/openshift/).
-
-IBM Maximo Application Suite customers receive a standard Red Hat OpenShift Container Platform subscription as part of their purchase. This includes 18 months of maintenance support for each OpenShift minor release.  A further 6 months support is available to purchase as an Extended Update Support (EUS) Add-on to x86-64 versions of Red Hat OpenShift Kubernetes Engine, Red Hat OpenShift Container Platform, and Red Hat OpenShift Platform Plus Standard subscriptions.
-
 :::mas-catalog-ocp-compatibility-matrix
 
 ### Certified Operators

--- a/docs/catalogs/v9-250902-ppc64le.md
+++ b/docs/catalogs/v9-250902-ppc64le.md
@@ -14,10 +14,6 @@ IBM Maximo Operator Catalog v9 (250902)
 
 Red Hat OpenShift Container Platform Support
 -------------------------------------------------------------------------------
-For more information about the OCP lifecycle refer to the [Red Hat OpenShift Container Platform Life Cycle Policy](https://access.redhat.com/support/policy/updates/openshift/).
-
-IBM Maximo Application Suite customers receive a standard Red Hat OpenShift Container Platform subscription as part of their purchase. This includes 18 months of maintenance support for each OpenShift minor release.  A further 6 months support is available to purchase as an Extended Update Support (EUS) Add-on to x86-64 versions of Red Hat OpenShift Kubernetes Engine, Red Hat OpenShift Container Platform, and Red Hat OpenShift Platform Plus Standard subscriptions.
-
 :::mas-catalog-ocp-compatibility-matrix
 
 ### Red Hat Operators

--- a/docs/catalogs/v9-250902-s390x.md
+++ b/docs/catalogs/v9-250902-s390x.md
@@ -14,10 +14,6 @@ IBM Maximo Operator Catalog v9 (250902)
 
 Red Hat OpenShift Container Platform Support
 -------------------------------------------------------------------------------
-For more information about the OCP lifecycle refer to the [Red Hat OpenShift Container Platform Life Cycle Policy](https://access.redhat.com/support/policy/updates/openshift/).
-
-IBM Maximo Application Suite customers receive a standard Red Hat OpenShift Container Platform subscription as part of their purchase. This includes 18 months of maintenance support for each OpenShift minor release.  A further 6 months support is available to purchase as an Extended Update Support (EUS) Add-on to x86-64 versions of Red Hat OpenShift Kubernetes Engine, Red Hat OpenShift Container Platform, and Red Hat OpenShift Platform Plus Standard subscriptions.
-
 :::mas-catalog-ocp-compatibility-matrix
 
 ### Red Hat Operators

--- a/docs/catalogs/v9-250925-ppc64le.md
+++ b/docs/catalogs/v9-250925-ppc64le.md
@@ -19,10 +19,6 @@ IBM Maximo Operator Catalog v9 (250925)
 
 Red Hat OpenShift Container Platform Support
 -------------------------------------------------------------------------------
-For more information about the OCP lifecycle refer to the [Red Hat OpenShift Container Platform Life Cycle Policy](https://access.redhat.com/support/policy/updates/openshift/).
-
-IBM Maximo Application Suite customers receive a standard Red Hat OpenShift Container Platform subscription as part of their purchase. This includes 18 months of maintenance support for each OpenShift minor release.  A further 6 months support is available to purchase as an Extended Update Support (EUS) Add-on to x86-64 versions of Red Hat OpenShift Kubernetes Engine, Red Hat OpenShift Container Platform, and Red Hat OpenShift Platform Plus Standard subscriptions.
-
 :::mas-catalog-ocp-compatibility-matrix
 
 

--- a/docs/catalogs/v9-251010-ppc64le.md
+++ b/docs/catalogs/v9-251010-ppc64le.md
@@ -17,10 +17,6 @@ IBM Maximo Operator Catalog v9 (251010)
 
 Red Hat OpenShift Container Platform Support
 -------------------------------------------------------------------------------
-For more information about the OCP lifecycle refer to the [Red Hat OpenShift Container Platform Life Cycle Policy](https://access.redhat.com/support/policy/updates/openshift/).
-
-IBM Maximo Application Suite customers receive a standard Red Hat OpenShift Container Platform subscription as part of their purchase. This includes 18 months of maintenance support for each OpenShift minor release.  A further 6 months support is available to purchase as an Extended Update Support (EUS) Add-on to x86-64 versions of Red Hat OpenShift Kubernetes Engine, Red Hat OpenShift Container Platform, and Red Hat OpenShift Platform Plus Standard subscriptions.
-
 :::mas-catalog-ocp-compatibility-matrix
 
 

--- a/docs/catalogs/v9-251030-ppc64le.md
+++ b/docs/catalogs/v9-251030-ppc64le.md
@@ -14,10 +14,6 @@ IBM Maximo Operator Catalog v9 (251030)
 
 Red Hat OpenShift Container Platform Support
 -------------------------------------------------------------------------------
-For more information about the OCP lifecycle refer to the [Red Hat OpenShift Container Platform Life Cycle Policy](https://access.redhat.com/support/policy/updates/openshift/).
-
-IBM Maximo Application Suite customers receive a standard Red Hat OpenShift Container Platform subscription as part of their purchase. This includes 18 months of maintenance support for each OpenShift minor release.  A further 6 months support is available to purchase as an Extended Update Support (EUS) Add-on to x86-64 versions of Red Hat OpenShift Kubernetes Engine, Red Hat OpenShift Container Platform, and Red Hat OpenShift Platform Plus Standard subscriptions.
-
 :::mas-catalog-ocp-compatibility-matrix
 
 ### Red Hat Operators

--- a/docs/catalogs/v9-251030-s390x.md
+++ b/docs/catalogs/v9-251030-s390x.md
@@ -14,10 +14,6 @@ IBM Maximo Operator Catalog v9 (251030)
 
 Red Hat OpenShift Container Platform Support
 -------------------------------------------------------------------------------
-For more information about the OCP lifecycle refer to the [Red Hat OpenShift Container Platform Life Cycle Policy](https://access.redhat.com/support/policy/updates/openshift/).
-
-IBM Maximo Application Suite customers receive a standard Red Hat OpenShift Container Platform subscription as part of their purchase. This includes 18 months of maintenance support for each OpenShift minor release.  A further 6 months support is available to purchase as an Extended Update Support (EUS) Add-on to x86-64 versions of Red Hat OpenShift Kubernetes Engine, Red Hat OpenShift Container Platform, and Red Hat OpenShift Platform Plus Standard subscriptions.
-
 :::mas-catalog-ocp-compatibility-matrix
 
 ### Red Hat Operators

--- a/docs/catalogs/v9-251127-amd64.md
+++ b/docs/catalogs/v9-251127-amd64.md
@@ -17,10 +17,6 @@ IBM Maximo Operator Catalog v9 (251127)
 
 Red Hat OpenShift Container Platform Support
 -------------------------------------------------------------------------------
-For more information about the OCP lifecycle refer to the [Red Hat OpenShift Container Platform Life Cycle Policy](https://access.redhat.com/support/policy/updates/openshift/).
-
-IBM Maximo Application Suite customers receive a standard Red Hat OpenShift Container Platform subscription as part of their purchase. This includes 18 months of maintenance support for each OpenShift minor release.  A further 6 months support is available to purchase as an Extended Update Support (EUS) Add-on to x86-64 versions of Red Hat OpenShift Kubernetes Engine, Red Hat OpenShift Container Platform, and Red Hat OpenShift Platform Plus Standard subscriptions.
-
 :::mas-catalog-ocp-compatibility-matrix
 
 ### Certified Operators

--- a/docs/catalogs/v9-251127-ppc64le.md
+++ b/docs/catalogs/v9-251127-ppc64le.md
@@ -14,10 +14,6 @@ IBM Maximo Operator Catalog v9 (251127)
 
 Red Hat OpenShift Container Platform Support
 -------------------------------------------------------------------------------
-For more information about the OCP lifecycle refer to the [Red Hat OpenShift Container Platform Life Cycle Policy](https://access.redhat.com/support/policy/updates/openshift/).
-
-IBM Maximo Application Suite customers receive a standard Red Hat OpenShift Container Platform subscription as part of their purchase. This includes 18 months of maintenance support for each OpenShift minor release.  A further 6 months support is available to purchase as an Extended Update Support (EUS) Add-on to x86-64 versions of Red Hat OpenShift Kubernetes Engine, Red Hat OpenShift Container Platform, and Red Hat OpenShift Platform Plus Standard subscriptions.
-
 :::mas-catalog-ocp-compatibility-matrix
 
 ### Red Hat Operators

--- a/docs/catalogs/v9-251127-s390x.md
+++ b/docs/catalogs/v9-251127-s390x.md
@@ -14,10 +14,6 @@ IBM Maximo Operator Catalog v9 (251127)
 
 Red Hat OpenShift Container Platform Support
 -------------------------------------------------------------------------------
-For more information about the OCP lifecycle refer to the [Red Hat OpenShift Container Platform Life Cycle Policy](https://access.redhat.com/support/policy/updates/openshift/).
-
-IBM Maximo Application Suite customers receive a standard Red Hat OpenShift Container Platform subscription as part of their purchase. This includes 18 months of maintenance support for each OpenShift minor release.  A further 6 months support is available to purchase as an Extended Update Support (EUS) Add-on to x86-64 versions of Red Hat OpenShift Kubernetes Engine, Red Hat OpenShift Container Platform, and Red Hat OpenShift Platform Plus Standard subscriptions.
-
 :::mas-catalog-ocp-compatibility-matrix
 
 ### Red Hat Operators

--- a/docs/catalogs/v9-251224-amd64.md
+++ b/docs/catalogs/v9-251224-amd64.md
@@ -17,10 +17,6 @@ IBM Maximo Operator Catalog v9 (251224)
 
 Red Hat OpenShift Container Platform Support
 -------------------------------------------------------------------------------
-For more information about the OCP lifecycle refer to the [Red Hat OpenShift Container Platform Life Cycle Policy](https://access.redhat.com/support/policy/updates/openshift/).
-
-IBM Maximo Application Suite customers receive a standard Red Hat OpenShift Container Platform subscription as part of their purchase. This includes 18 months of maintenance support for each OpenShift minor release.  A further 6 months support is available to purchase as an Extended Update Support (EUS) Add-on to x86-64 versions of Red Hat OpenShift Kubernetes Engine, Red Hat OpenShift Container Platform, and Red Hat OpenShift Platform Plus Standard subscriptions.
-
 :::mas-catalog-ocp-compatibility-matrix
 
 ### Certified Operators

--- a/docs/catalogs/v9-251224-ppc64le.md
+++ b/docs/catalogs/v9-251224-ppc64le.md
@@ -14,10 +14,6 @@ IBM Maximo Operator Catalog v9 (251224)
 
 Red Hat OpenShift Container Platform Support
 -------------------------------------------------------------------------------
-For more information about the OCP lifecycle refer to the [Red Hat OpenShift Container Platform Life Cycle Policy](https://access.redhat.com/support/policy/updates/openshift/).
-
-IBM Maximo Application Suite customers receive a standard Red Hat OpenShift Container Platform subscription as part of their purchase. This includes 18 months of maintenance support for each OpenShift minor release.  A further 6 months support is available to purchase as an Extended Update Support (EUS) Add-on to x86-64 versions of Red Hat OpenShift Kubernetes Engine, Red Hat OpenShift Container Platform, and Red Hat OpenShift Platform Plus Standard subscriptions.
-
 :::mas-catalog-ocp-compatibility-matrix
 
 ### Red Hat Operators

--- a/docs/catalogs/v9-251224-s390x.md
+++ b/docs/catalogs/v9-251224-s390x.md
@@ -14,10 +14,6 @@ IBM Maximo Operator Catalog v9 (251224)
 
 Red Hat OpenShift Container Platform Support
 -------------------------------------------------------------------------------
-For more information about the OCP lifecycle refer to the [Red Hat OpenShift Container Platform Life Cycle Policy](https://access.redhat.com/support/policy/updates/openshift/).
-
-IBM Maximo Application Suite customers receive a standard Red Hat OpenShift Container Platform subscription as part of their purchase. This includes 18 months of maintenance support for each OpenShift minor release.  A further 6 months support is available to purchase as an Extended Update Support (EUS) Add-on to x86-64 versions of Red Hat OpenShift Kubernetes Engine, Red Hat OpenShift Container Platform, and Red Hat OpenShift Platform Plus Standard subscriptions.
-
 :::mas-catalog-ocp-compatibility-matrix
 
 ### Red Hat Operators

--- a/docs/catalogs/v9-251231-amd64.md
+++ b/docs/catalogs/v9-251231-amd64.md
@@ -17,10 +17,6 @@ IBM Maximo Operator Catalog v9 (251231)
 
 Red Hat OpenShift Container Platform Support
 -------------------------------------------------------------------------------
-For more information about the OCP lifecycle refer to the [Red Hat OpenShift Container Platform Life Cycle Policy](https://access.redhat.com/support/policy/updates/openshift/).
-
-IBM Maximo Application Suite customers receive a standard Red Hat OpenShift Container Platform subscription as part of their purchase. This includes 18 months of maintenance support for each OpenShift minor release.  A further 6 months support is available to purchase as an Extended Update Support (EUS) Add-on to x86-64 versions of Red Hat OpenShift Kubernetes Engine, Red Hat OpenShift Container Platform, and Red Hat OpenShift Platform Plus Standard subscriptions.
-
 :::mas-catalog-ocp-compatibility-matrix
 
 ### Certified Operators

--- a/docs/catalogs/v9-251231-ppc64le.md
+++ b/docs/catalogs/v9-251231-ppc64le.md
@@ -14,10 +14,6 @@ IBM Maximo Operator Catalog v9 (251231)
 
 Red Hat OpenShift Container Platform Support
 -------------------------------------------------------------------------------
-For more information about the OCP lifecycle refer to the [Red Hat OpenShift Container Platform Life Cycle Policy](https://access.redhat.com/support/policy/updates/openshift/).
-
-IBM Maximo Application Suite customers receive a standard Red Hat OpenShift Container Platform subscription as part of their purchase. This includes 18 months of maintenance support for each OpenShift minor release.  A further 6 months support is available to purchase as an Extended Update Support (EUS) Add-on to x86-64 versions of Red Hat OpenShift Kubernetes Engine, Red Hat OpenShift Container Platform, and Red Hat OpenShift Platform Plus Standard subscriptions.
-
 :::mas-catalog-ocp-compatibility-matrix
 
 ### Red Hat Operators

--- a/docs/catalogs/v9-251231-s390x.md
+++ b/docs/catalogs/v9-251231-s390x.md
@@ -14,10 +14,6 @@ IBM Maximo Operator Catalog v9 (251231)
 
 Red Hat OpenShift Container Platform Support
 -------------------------------------------------------------------------------
-For more information about the OCP lifecycle refer to the [Red Hat OpenShift Container Platform Life Cycle Policy](https://access.redhat.com/support/policy/updates/openshift/).
-
-IBM Maximo Application Suite customers receive a standard Red Hat OpenShift Container Platform subscription as part of their purchase. This includes 18 months of maintenance support for each OpenShift minor release.  A further 6 months support is available to purchase as an Extended Update Support (EUS) Add-on to x86-64 versions of Red Hat OpenShift Kubernetes Engine, Red Hat OpenShift Container Platform, and Red Hat OpenShift Platform Plus Standard subscriptions.
-
 :::mas-catalog-ocp-compatibility-matrix
 
 ### Red Hat Operators

--- a/docs/catalogs/v9-260129-amd64.md
+++ b/docs/catalogs/v9-260129-amd64.md
@@ -17,9 +17,6 @@ IBM Maximo Operator Catalog v9 (260129)
 
 Red Hat OpenShift Container Platform Support
 -------------------------------------------------------------------------------
-Note: Red Hat Extended Update Support Add-on Term 1 is included with the restricted use OCP subscription that comes with a MAS license. In the case of EUS denoted OCP releases, the support dates stated below refer to the EUS1 end dates. 
-For more information about the OCP lifecycle refer to the [Red Hat OpenShift Container Platform Life Cycle Policy](https://access.redhat.com/support/policy/updates/openshift/).
-
 :::mas-catalog-ocp-compatibility-matrix
 
 ### Certified Operators

--- a/docs/catalogs/v9-260129-ppc64le.md
+++ b/docs/catalogs/v9-260129-ppc64le.md
@@ -14,10 +14,6 @@ IBM Maximo Operator Catalog v9 (260129)
 
 Red Hat OpenShift Container Platform Support
 -------------------------------------------------------------------------------
-For more information about the OCP lifecycle refer to the [Red Hat OpenShift Container Platform Life Cycle Policy](https://access.redhat.com/support/policy/updates/openshift/).
-
-IBM Maximo Application Suite customers receive a standard Red Hat OpenShift Container Platform subscription as part of their purchase. This includes 18 months of maintenance support for each OpenShift minor release.  A further 6 months support is available to purchase as an Extended Update Support (EUS) Add-on to x86-64 versions of Red Hat OpenShift Kubernetes Engine, Red Hat OpenShift Container Platform, and Red Hat OpenShift Platform Plus Standard subscriptions.
-
 :::mas-catalog-ocp-compatibility-matrix
 
 ### Red Hat Operators

--- a/docs/catalogs/v9-260129-s390x.md
+++ b/docs/catalogs/v9-260129-s390x.md
@@ -14,10 +14,6 @@ IBM Maximo Operator Catalog v9 (260129)
 
 Red Hat OpenShift Container Platform Support
 -------------------------------------------------------------------------------
-For more information about the OCP lifecycle refer to the [Red Hat OpenShift Container Platform Life Cycle Policy](https://access.redhat.com/support/policy/updates/openshift/).
-
-IBM Maximo Application Suite customers receive a standard Red Hat OpenShift Container Platform subscription as part of their purchase. This includes 18 months of maintenance support for each OpenShift minor release.  A further 6 months support is available to purchase as an Extended Update Support (EUS) Add-on to x86-64 versions of Red Hat OpenShift Kubernetes Engine, Red Hat OpenShift Container Platform, and Red Hat OpenShift Platform Plus Standard subscriptions.
-
 :::mas-catalog-ocp-compatibility-matrix
 
 ### Red Hat Operators

--- a/docs/catalogs/v9-260216-amd64.md
+++ b/docs/catalogs/v9-260216-amd64.md
@@ -17,10 +17,6 @@ IBM Maximo Operator Catalog v9 (260216)
 
 Red Hat OpenShift Container Platform Support
 -------------------------------------------------------------------------------
-For more information about the OCP lifecycle refer to the [Red Hat OpenShift Container Platform Life Cycle Policy](https://access.redhat.com/support/policy/updates/openshift/).
-
-IBM Maximo Application Suite customers receive a standard Red Hat OpenShift Container Platform subscription as part of their purchase. This includes 18 months of maintenance support for each OpenShift minor release.  A further 6 months support is available to purchase as an Extended Update Support (EUS) Add-on to x86-64 versions of Red Hat OpenShift Kubernetes Engine, Red Hat OpenShift Container Platform, and Red Hat OpenShift Platform Plus Standard subscriptions.
-
 :::mas-catalog-ocp-compatibility-matrix
 
 ### Certified Operators

--- a/docs/catalogs/v9-260216-ppc64le.md
+++ b/docs/catalogs/v9-260216-ppc64le.md
@@ -14,10 +14,6 @@ IBM Maximo Operator Catalog v9 (260216)
 
 Red Hat OpenShift Container Platform Support
 -------------------------------------------------------------------------------
-For more information about the OCP lifecycle refer to the [Red Hat OpenShift Container Platform Life Cycle Policy](https://access.redhat.com/support/policy/updates/openshift/).
-
-IBM Maximo Application Suite customers receive a standard Red Hat OpenShift Container Platform subscription as part of their purchase. This includes 18 months of maintenance support for each OpenShift minor release.  A further 6 months support is available to purchase as an Extended Update Support (EUS) Add-on to x86-64 versions of Red Hat OpenShift Kubernetes Engine, Red Hat OpenShift Container Platform, and Red Hat OpenShift Platform Plus Standard subscriptions.
-
 :::mas-catalog-ocp-compatibility-matrix
 
 ### Red Hat Operators

--- a/docs/catalogs/v9-260216-s390x.md
+++ b/docs/catalogs/v9-260216-s390x.md
@@ -14,10 +14,6 @@ IBM Maximo Operator Catalog v9 (260216)
 
 Red Hat OpenShift Container Platform Support
 -------------------------------------------------------------------------------
-For more information about the OCP lifecycle refer to the [Red Hat OpenShift Container Platform Life Cycle Policy](https://access.redhat.com/support/policy/updates/openshift/).
-
-IBM Maximo Application Suite customers receive a standard Red Hat OpenShift Container Platform subscription as part of their purchase. This includes 18 months of maintenance support for each OpenShift minor release.  A further 6 months support is available to purchase as an Extended Update Support (EUS) Add-on to x86-64 versions of Red Hat OpenShift Kubernetes Engine, Red Hat OpenShift Container Platform, and Red Hat OpenShift Platform Plus Standard subscriptions.
-
 :::mas-catalog-ocp-compatibility-matrix
 
 ### Red Hat Operators

--- a/docs/catalogs/v9-260226-amd64.md
+++ b/docs/catalogs/v9-260226-amd64.md
@@ -17,9 +17,6 @@ IBM Maximo Operator Catalog v9 (260226)
 
 Red Hat OpenShift Container Platform Support
 -------------------------------------------------------------------------------
-Note: Red Hat Extended Update Support Add-on Term 1 is included with the restricted use OCP subscription that comes with a MAS license. In the case of EUS denoted OCP releases, the support dates stated below refer to the EUS1 end dates. 
-For more information about the OCP lifecycle refer to the [Red Hat OpenShift Container Platform Life Cycle Policy](https://access.redhat.com/support/policy/updates/openshift/).
-
 :::mas-catalog-ocp-compatibility-matrix
 
 ### Certified Operators

--- a/docs/catalogs/v9-260226-ppc64le.md
+++ b/docs/catalogs/v9-260226-ppc64le.md
@@ -14,10 +14,6 @@ IBM Maximo Operator Catalog v9 (260226)
 
 Red Hat OpenShift Container Platform Support
 -------------------------------------------------------------------------------
-For more information about the OCP lifecycle refer to the [Red Hat OpenShift Container Platform Life Cycle Policy](https://access.redhat.com/support/policy/updates/openshift/).
-
-IBM Maximo Application Suite customers receive a standard Red Hat OpenShift Container Platform subscription as part of their purchase. This includes 18 months of maintenance support for each OpenShift minor release.  A further 6 months support is available to purchase as an Extended Update Support (EUS) Add-on to x86-64 versions of Red Hat OpenShift Kubernetes Engine, Red Hat OpenShift Container Platform, and Red Hat OpenShift Platform Plus Standard subscriptions.
-
 :::mas-catalog-ocp-compatibility-matrix
 
 ### Red Hat Operators

--- a/docs/catalogs/v9-260226-s390x.md
+++ b/docs/catalogs/v9-260226-s390x.md
@@ -14,10 +14,6 @@ IBM Maximo Operator Catalog v9 (260226)
 
 Red Hat OpenShift Container Platform Support
 -------------------------------------------------------------------------------
-For more information about the OCP lifecycle refer to the [Red Hat OpenShift Container Platform Life Cycle Policy](https://access.redhat.com/support/policy/updates/openshift/).
-
-IBM Maximo Application Suite customers receive a standard Red Hat OpenShift Container Platform subscription as part of their purchase. This includes 18 months of maintenance support for each OpenShift minor release.  A further 6 months support is available to purchase as an Extended Update Support (EUS) Add-on to x86-64 versions of Red Hat OpenShift Kubernetes Engine, Red Hat OpenShift Container Platform, and Red Hat OpenShift Platform Plus Standard subscriptions.
-
 :::mas-catalog-ocp-compatibility-matrix
 
 ### Red Hat Operators

--- a/docs/catalogs/v9-260305-amd64.md
+++ b/docs/catalogs/v9-260305-amd64.md
@@ -17,10 +17,6 @@ IBM Maximo Operator Catalog v9 (260305)
 
 Red Hat OpenShift Container Platform Support
 -------------------------------------------------------------------------------
-For more information about the OCP lifecycle refer to the [Red Hat OpenShift Container Platform Life Cycle Policy](https://access.redhat.com/support/policy/updates/openshift/).
-
-IBM Maximo Application Suite customers receive a standard Red Hat OpenShift Container Platform subscription as part of their purchase. This includes 18 months of maintenance support for each OpenShift minor release.  A further 6 months support is available to purchase as an Extended Update Support (EUS) Add-on to x86-64 versions of Red Hat OpenShift Kubernetes Engine, Red Hat OpenShift Container Platform, and Red Hat OpenShift Platform Plus Standard subscriptions.
-
 :::mas-catalog-ocp-compatibility-matrix
 
 ### Certified Operators

--- a/docs/catalogs/v9-260305-ppc64le.md
+++ b/docs/catalogs/v9-260305-ppc64le.md
@@ -14,10 +14,6 @@ IBM Maximo Operator Catalog v9 (260305)
 
 Red Hat OpenShift Container Platform Support
 -------------------------------------------------------------------------------
-For more information about the OCP lifecycle refer to the [Red Hat OpenShift Container Platform Life Cycle Policy](https://access.redhat.com/support/policy/updates/openshift/).
-
-IBM Maximo Application Suite customers receive a standard Red Hat OpenShift Container Platform subscription as part of their purchase. This includes 18 months of maintenance support for each OpenShift minor release.  A further 6 months support is available to purchase as an Extended Update Support (EUS) Add-on to x86-64 versions of Red Hat OpenShift Kubernetes Engine, Red Hat OpenShift Container Platform, and Red Hat OpenShift Platform Plus Standard subscriptions.
-
 :::mas-catalog-ocp-compatibility-matrix
 
 ### Red Hat Operators

--- a/docs/catalogs/v9-260305-s390x.md
+++ b/docs/catalogs/v9-260305-s390x.md
@@ -14,10 +14,6 @@ IBM Maximo Operator Catalog v9 (260305)
 
 Red Hat OpenShift Container Platform Support
 -------------------------------------------------------------------------------
-For more information about the OCP lifecycle refer to the [Red Hat OpenShift Container Platform Life Cycle Policy](https://access.redhat.com/support/policy/updates/openshift/).
-
-IBM Maximo Application Suite customers receive a standard Red Hat OpenShift Container Platform subscription as part of their purchase. This includes 18 months of maintenance support for each OpenShift minor release.  A further 6 months support is available to purchase as an Extended Update Support (EUS) Add-on to x86-64 versions of Red Hat OpenShift Kubernetes Engine, Red Hat OpenShift Container Platform, and Red Hat OpenShift Platform Plus Standard subscriptions.
-
 :::mas-catalog-ocp-compatibility-matrix
 
 ### Red Hat Operators

--- a/docs/catalogs/v9-260313-amd64.md
+++ b/docs/catalogs/v9-260313-amd64.md
@@ -17,10 +17,6 @@ IBM Maximo Operator Catalog v9 (260313)
 
 Red Hat OpenShift Container Platform Support
 -------------------------------------------------------------------------------
-For more information about the OCP lifecycle refer to the [Red Hat OpenShift Container Platform Life Cycle Policy](https://access.redhat.com/support/policy/updates/openshift/).
-
-IBM Maximo Application Suite customers receive a standard Red Hat OpenShift Container Platform subscription as part of their purchase. This includes 18 months of maintenance support for each OpenShift minor release.  A further 6 months support is available to purchase as an Extended Update Support (EUS) Add-on to x86-64 versions of Red Hat OpenShift Kubernetes Engine, Red Hat OpenShift Container Platform, and Red Hat OpenShift Platform Plus Standard subscriptions.
-
 :::mas-catalog-ocp-compatibility-matrix
 
 ### Certified Operators

--- a/docs/catalogs/v9-260313-ppc64le.md
+++ b/docs/catalogs/v9-260313-ppc64le.md
@@ -14,10 +14,6 @@ IBM Maximo Operator Catalog v9 (260313)
 
 Red Hat OpenShift Container Platform Support
 -------------------------------------------------------------------------------
-For more information about the OCP lifecycle refer to the [Red Hat OpenShift Container Platform Life Cycle Policy](https://access.redhat.com/support/policy/updates/openshift/).
-
-IBM Maximo Application Suite customers receive a standard Red Hat OpenShift Container Platform subscription as part of their purchase. This includes 18 months of maintenance support for each OpenShift minor release.  A further 6 months support is available to purchase as an Extended Update Support (EUS) Add-on to x86-64 versions of Red Hat OpenShift Kubernetes Engine, Red Hat OpenShift Container Platform, and Red Hat OpenShift Platform Plus Standard subscriptions.
-
 :::mas-catalog-ocp-compatibility-matrix
 
 ### Red Hat Operators

--- a/docs/catalogs/v9-260313-s390x.md
+++ b/docs/catalogs/v9-260313-s390x.md
@@ -14,10 +14,6 @@ IBM Maximo Operator Catalog v9 (260313)
 
 Red Hat OpenShift Container Platform Support
 -------------------------------------------------------------------------------
-For more information about the OCP lifecycle refer to the [Red Hat OpenShift Container Platform Life Cycle Policy](https://access.redhat.com/support/policy/updates/openshift/).
-
-IBM Maximo Application Suite customers receive a standard Red Hat OpenShift Container Platform subscription as part of their purchase. This includes 18 months of maintenance support for each OpenShift minor release.  A further 6 months support is available to purchase as an Extended Update Support (EUS) Add-on to x86-64 versions of Red Hat OpenShift Kubernetes Engine, Red Hat OpenShift Container Platform, and Red Hat OpenShift Platform Plus Standard subscriptions.
-
 :::mas-catalog-ocp-compatibility-matrix
 
 ### Red Hat Operators

--- a/docs/catalogs/v9-260318-amd64.md
+++ b/docs/catalogs/v9-260318-amd64.md
@@ -17,10 +17,6 @@ IBM Maximo Operator Catalog v9 (260318)
 
 Red Hat OpenShift Container Platform Support
 -------------------------------------------------------------------------------
-For more information about the OCP lifecycle refer to the [Red Hat OpenShift Container Platform Life Cycle Policy](https://access.redhat.com/support/policy/updates/openshift/).
-
-IBM Maximo Application Suite customers receive a standard Red Hat OpenShift Container Platform subscription as part of their purchase. This includes 18 months of maintenance support for each OpenShift minor release.  A further 6 months support is available to purchase as an Extended Update Support (EUS) Add-on to x86-64 versions of Red Hat OpenShift Kubernetes Engine, Red Hat OpenShift Container Platform, and Red Hat OpenShift Platform Plus Standard subscriptions.
-
 :::mas-catalog-ocp-compatibility-matrix
 
 ### Certified Operators

--- a/docs/catalogs/v9-260318-ppc64le.md
+++ b/docs/catalogs/v9-260318-ppc64le.md
@@ -14,10 +14,6 @@ IBM Maximo Operator Catalog v9 (260318)
 
 Red Hat OpenShift Container Platform Support
 -------------------------------------------------------------------------------
-For more information about the OCP lifecycle refer to the [Red Hat OpenShift Container Platform Life Cycle Policy](https://access.redhat.com/support/policy/updates/openshift/).
-
-IBM Maximo Application Suite customers receive a standard Red Hat OpenShift Container Platform subscription as part of their purchase. This includes 18 months of maintenance support for each OpenShift minor release.  A further 6 months support is available to purchase as an Extended Update Support (EUS) Add-on to x86-64 versions of Red Hat OpenShift Kubernetes Engine, Red Hat OpenShift Container Platform, and Red Hat OpenShift Platform Plus Standard subscriptions.
-
 :::mas-catalog-ocp-compatibility-matrix
 
 ### Red Hat Operators

--- a/docs/catalogs/v9-260318-s390x.md
+++ b/docs/catalogs/v9-260318-s390x.md
@@ -14,10 +14,6 @@ IBM Maximo Operator Catalog v9 (260318)
 
 Red Hat OpenShift Container Platform Support
 -------------------------------------------------------------------------------
-For more information about the OCP lifecycle refer to the [Red Hat OpenShift Container Platform Life Cycle Policy](https://access.redhat.com/support/policy/updates/openshift/).
-
-IBM Maximo Application Suite customers receive a standard Red Hat OpenShift Container Platform subscription as part of their purchase. This includes 18 months of maintenance support for each OpenShift minor release.  A further 6 months support is available to purchase as an Extended Update Support (EUS) Add-on to x86-64 versions of Red Hat OpenShift Kubernetes Engine, Red Hat OpenShift Container Platform, and Red Hat OpenShift Platform Plus Standard subscriptions.
-
 :::mas-catalog-ocp-compatibility-matrix
 
 ### Red Hat Operators

--- a/docs/catalogs/v9-260326-amd64.md
+++ b/docs/catalogs/v9-260326-amd64.md
@@ -17,9 +17,6 @@ IBM Maximo Operator Catalog v9 (260326)
 
 Red Hat OpenShift Container Platform Support
 -------------------------------------------------------------------------------
-Note: Red Hat Extended Update Support Add-on Term 1 is included with the restricted use OCP subscription that comes with a MAS license. In the case of EUS denoted OCP releases, the support dates stated below refer to the EUS1 end dates. 
-For more information about the OCP lifecycle refer to the [Red Hat OpenShift Container Platform Life Cycle Policy](https://access.redhat.com/support/policy/updates/openshift/).
-
 :::mas-catalog-ocp-compatibility-matrix
 
 ### Certified Operators

--- a/docs/catalogs/v9-260326-ppc64le.md
+++ b/docs/catalogs/v9-260326-ppc64le.md
@@ -14,10 +14,6 @@ IBM Maximo Operator Catalog v9 (260326)
 
 Red Hat OpenShift Container Platform Support
 -------------------------------------------------------------------------------
-For more information about the OCP lifecycle refer to the [Red Hat OpenShift Container Platform Life Cycle Policy](https://access.redhat.com/support/policy/updates/openshift/).
-
-IBM Maximo Application Suite customers receive a standard Red Hat OpenShift Container Platform subscription as part of their purchase. This includes 18 months of maintenance support for each OpenShift minor release.  A further 6 months support is available to purchase as an Extended Update Support (EUS) Add-on to x86-64 versions of Red Hat OpenShift Kubernetes Engine, Red Hat OpenShift Container Platform, and Red Hat OpenShift Platform Plus Standard subscriptions.
-
 :::mas-catalog-ocp-compatibility-matrix
 
 ### Red Hat Operators

--- a/docs/catalogs/v9-260326-s390x.md
+++ b/docs/catalogs/v9-260326-s390x.md
@@ -14,10 +14,6 @@ IBM Maximo Operator Catalog v9 (260326)
 
 Red Hat OpenShift Container Platform Support
 -------------------------------------------------------------------------------
-For more information about the OCP lifecycle refer to the [Red Hat OpenShift Container Platform Life Cycle Policy](https://access.redhat.com/support/policy/updates/openshift/).
-
-IBM Maximo Application Suite customers receive a standard Red Hat OpenShift Container Platform subscription as part of their purchase. This includes 18 months of maintenance support for each OpenShift minor release.  A further 6 months support is available to purchase as an Extended Update Support (EUS) Add-on to x86-64 versions of Red Hat OpenShift Kubernetes Engine, Red Hat OpenShift Container Platform, and Red Hat OpenShift Platform Plus Standard subscriptions.
-
 :::mas-catalog-ocp-compatibility-matrix
 
 ### Red Hat Operators

--- a/docs/catalogs/v9-260430-amd64.md
+++ b/docs/catalogs/v9-260430-amd64.md
@@ -17,10 +17,6 @@ IBM Maximo Operator Catalog v9 (260430)
 
 Red Hat OpenShift Container Platform Support
 -------------------------------------------------------------------------------
-For more information about the OCP lifecycle refer to the [Red Hat OpenShift Container Platform Life Cycle Policy](https://access.redhat.com/support/policy/updates/openshift/).
-
-IBM Maximo Application Suite customers receive a standard Red Hat OpenShift Container Platform subscription as part of their purchase. This includes 18 months of maintenance support for each OpenShift minor release.  A further 6 months support is available to purchase as an Extended Update Support (EUS) Add-on to x86-64 versions of Red Hat OpenShift Kubernetes Engine, Red Hat OpenShift Container Platform, and Red Hat OpenShift Platform Plus Standard subscriptions.
-
 :::mas-catalog-ocp-compatibility-matrix
 
 ### Certified Operators

--- a/docs/catalogs/v9-260430-ppc64le.md
+++ b/docs/catalogs/v9-260430-ppc64le.md
@@ -14,10 +14,6 @@ IBM Maximo Operator Catalog v9 (260430)
 
 Red Hat OpenShift Container Platform Support
 -------------------------------------------------------------------------------
-For more information about the OCP lifecycle refer to the [Red Hat OpenShift Container Platform Life Cycle Policy](https://access.redhat.com/support/policy/updates/openshift/).
-
-IBM Maximo Application Suite customers receive a standard Red Hat OpenShift Container Platform subscription as part of their purchase. This includes 18 months of maintenance support for each OpenShift minor release.  A further 6 months support is available to purchase as an Extended Update Support (EUS) Add-on to x86-64 versions of Red Hat OpenShift Kubernetes Engine, Red Hat OpenShift Container Platform, and Red Hat OpenShift Platform Plus Standard subscriptions.
-
 :::mas-catalog-ocp-compatibility-matrix
 
 ### Red Hat Operators

--- a/docs/catalogs/v9-260430-s390x.md
+++ b/docs/catalogs/v9-260430-s390x.md
@@ -14,10 +14,6 @@ IBM Maximo Operator Catalog v9 (260430)
 
 Red Hat OpenShift Container Platform Support
 -------------------------------------------------------------------------------
-For more information about the OCP lifecycle refer to the [Red Hat OpenShift Container Platform Life Cycle Policy](https://access.redhat.com/support/policy/updates/openshift/).
-
-IBM Maximo Application Suite customers receive a standard Red Hat OpenShift Container Platform subscription as part of their purchase. This includes 18 months of maintenance support for each OpenShift minor release.  A further 6 months support is available to purchase as an Extended Update Support (EUS) Add-on to x86-64 versions of Red Hat OpenShift Kubernetes Engine, Red Hat OpenShift Container Platform, and Red Hat OpenShift Platform Plus Standard subscriptions.
-
 :::mas-catalog-ocp-compatibility-matrix
 
 ### Red Hat Operators

--- a/docs/catalogs/v9-260527-amd64.md
+++ b/docs/catalogs/v9-260527-amd64.md
@@ -17,10 +17,6 @@ IBM Maximo Operator Catalog v9 (260527)
 
 Red Hat OpenShift Container Platform Support
 -------------------------------------------------------------------------------
-For more information about the OCP lifecycle refer to the [Red Hat OpenShift Container Platform Life Cycle Policy](https://access.redhat.com/support/policy/updates/openshift/).
-
-IBM Maximo Application Suite customers receive a standard Red Hat OpenShift Container Platform subscription as part of their purchase. This includes 18 months of maintenance support for each OpenShift minor release.  A further 6 months support is available to purchase as an Extended Update Support (EUS) Add-on to x86-64 versions of Red Hat OpenShift Kubernetes Engine, Red Hat OpenShift Container Platform, and Red Hat OpenShift Platform Plus Standard subscriptions.
-
 :::mas-catalog-ocp-compatibility-matrix
 
 ### Certified Operators

--- a/docs/catalogs/v9-260527-ppc64le.md
+++ b/docs/catalogs/v9-260527-ppc64le.md
@@ -14,10 +14,6 @@ IBM Maximo Operator Catalog v9 (260527)
 
 Red Hat OpenShift Container Platform Support
 -------------------------------------------------------------------------------
-For more information about the OCP lifecycle refer to the [Red Hat OpenShift Container Platform Life Cycle Policy](https://access.redhat.com/support/policy/updates/openshift/).
-
-IBM Maximo Application Suite customers receive a standard Red Hat OpenShift Container Platform subscription as part of their purchase. This includes 18 months of maintenance support for each OpenShift minor release.  A further 6 months support is available to purchase as an Extended Update Support (EUS) Add-on to x86-64 versions of Red Hat OpenShift Kubernetes Engine, Red Hat OpenShift Container Platform, and Red Hat OpenShift Platform Plus Standard subscriptions.
-
 :::mas-catalog-ocp-compatibility-matrix
 
 ### Red Hat Operators

--- a/docs/catalogs/v9-260527-s390x.md
+++ b/docs/catalogs/v9-260527-s390x.md
@@ -14,10 +14,6 @@ IBM Maximo Operator Catalog v9 (260527)
 
 Red Hat OpenShift Container Platform Support
 -------------------------------------------------------------------------------
-For more information about the OCP lifecycle refer to the [Red Hat OpenShift Container Platform Life Cycle Policy](https://access.redhat.com/support/policy/updates/openshift/).
-
-IBM Maximo Application Suite customers receive a standard Red Hat OpenShift Container Platform subscription as part of their purchase. This includes 18 months of maintenance support for each OpenShift minor release.  A further 6 months support is available to purchase as an Extended Update Support (EUS) Add-on to x86-64 versions of Red Hat OpenShift Kubernetes Engine, Red Hat OpenShift Container Platform, and Red Hat OpenShift Platform Plus Standard subscriptions.
-
 :::mas-catalog-ocp-compatibility-matrix
 
 ### Red Hat Operators

--- a/docs/catalogs/v9-260625-amd64.md
+++ b/docs/catalogs/v9-260625-amd64.md
@@ -17,10 +17,6 @@ IBM Maximo Operator Catalog v9 (260625)
 
 Red Hat OpenShift Container Platform Support
 -------------------------------------------------------------------------------
-For more information about the OCP lifecycle refer to the [Red Hat OpenShift Container Platform Life Cycle Policy](https://access.redhat.com/support/policy/updates/openshift/).
-
-IBM Maximo Application Suite customers receive a standard Red Hat OpenShift Container Platform subscription as part of their purchase. This includes 18 months of maintenance support for each OpenShift minor release.  A further 6 months support is available to purchase as an Extended Update Support (EUS) Add-on to x86-64 versions of Red Hat OpenShift Kubernetes Engine, Red Hat OpenShift Container Platform, and Red Hat OpenShift Platform Plus Standard subscriptions.
-
 :::mas-catalog-ocp-compatibility-matrix
 
 ### Certified Operators

--- a/docs/catalogs/v9-260625-ppc64le.md
+++ b/docs/catalogs/v9-260625-ppc64le.md
@@ -14,10 +14,6 @@ IBM Maximo Operator Catalog v9 (260625)
 
 Red Hat OpenShift Container Platform Support
 -------------------------------------------------------------------------------
-For more information about the OCP lifecycle refer to the [Red Hat OpenShift Container Platform Life Cycle Policy](https://access.redhat.com/support/policy/updates/openshift/).
-
-IBM Maximo Application Suite customers receive a standard Red Hat OpenShift Container Platform subscription as part of their purchase. This includes 18 months of maintenance support for each OpenShift minor release.  A further 6 months support is available to purchase as an Extended Update Support (EUS) Add-on to x86-64 versions of Red Hat OpenShift Kubernetes Engine, Red Hat OpenShift Container Platform, and Red Hat OpenShift Platform Plus Standard subscriptions.
-
 :::mas-catalog-ocp-compatibility-matrix
 
 ### Red Hat Operators

--- a/docs/catalogs/v9-260625-s390x.md
+++ b/docs/catalogs/v9-260625-s390x.md
@@ -14,10 +14,6 @@ IBM Maximo Operator Catalog v9 (260625)
 
 Red Hat OpenShift Container Platform Support
 -------------------------------------------------------------------------------
-For more information about the OCP lifecycle refer to the [Red Hat OpenShift Container Platform Life Cycle Policy](https://access.redhat.com/support/policy/updates/openshift/).
-
-IBM Maximo Application Suite customers receive a standard Red Hat OpenShift Container Platform subscription as part of their purchase. This includes 18 months of maintenance support for each OpenShift minor release.  A further 6 months support is available to purchase as an Extended Update Support (EUS) Add-on to x86-64 versions of Red Hat OpenShift Kubernetes Engine, Red Hat OpenShift Container Platform, and Red Hat OpenShift Platform Plus Standard subscriptions.
-
 :::mas-catalog-ocp-compatibility-matrix
 
 ### Red Hat Operators

--- a/mkdocs_plugins/mkdocs_mas_catalogs/__init__.py
+++ b/mkdocs_plugins/mkdocs_mas_catalogs/__init__.py
@@ -171,14 +171,20 @@ spec:
 """
 
         # Build the table header
-        table_html = """<table class="compatabilityMatrix">
+        table_html = """The Red Hat Extended Update Support Add-on Term 1 offering is included with the OCP subscription that comes with a MAS license. In the case of EUS denoted OCP releases, any support dates stated refer to the EUS1 end dates.
+
+For more details refer to the [OCP lifecycle policy](https://access.redhat.com/support/policy/updates/openshift).  Also note that non-EUS release support expires before the extended support for the previous EUS release, for example extended support for OCP 4.18 expires on Feb 25, 2027, while standard support for OCP 4.17 expires on April 1, 2026.
+
+<table class="compatabilityMatrix">
   <tr>
     <th>OCP</th><td rowspan="{}" class="spacer"></td>
     <th>General Availability</th>
     <th>Standard Support</th>
     <th>Extended Support</th>
   </tr>
-""".format(len(ocp_versions) + 1)
+""".format(
+            len(ocp_versions) + 1
+        )
 
         # Add rows for each OCP version
         ocp_data = ocp_lifecycle_data.get("ocp_versions", {})


### PR DESCRIPTION
Move the OCP support doc string into a central location for easy maintenance.