### PR TITLE
[patch] fvt - Unable to run Mustgather from saas toolchain pipeline

### DIFF
--- a/tekton/src/tasks/gitops/gitops-mas-fvt-preparer.yml.j2
+++ b/tekton/src/tasks/gitops/gitops-mas-fvt-preparer.yml.j2
@@ -342,7 +342,7 @@ spec:
       - |-
 
         set -o pipefail
-        trap '[[ $? -eq 1 ]] && mas must-gather --directory /workspace/mustgather --mas-instance-ids ${MAS_INSTANCE_ID} --extra-namespaces selenium,mas-${MAS_INSTANCE_ID}-syncres,mas-${MAS_INSTANCE_ID}-postsyncjobs' ERR EXIT
+        trap '[[ $? -eq 1 ]] && env -u KUBERNETES_SERVICE_HOST mas must-gather --directory /workspace/mustgather --mas-instance-ids ${MAS_INSTANCE_ID} --extra-namespaces selenium,mas-${MAS_INSTANCE_ID}-syncres,mas-${MAS_INSTANCE_ID}-postsyncjobs' ERR EXIT
 
 
         get_trailing_number() {


### PR DESCRIPTION
Issue: [MASCORE-15582](https://jsw.ibm.com/browse/MASCORE-15582)

## Description
Mustgather process was not connected to oc cluster as the new logic checks for service account if KUBERNETES_SERVICE_HOST var is set. So we need to unset the env var for the mustgather to use the KUBE config file

## Testing
Tested in an existing fvtsaastran run and ensured that mustgather logs are taken
https://cloud.ibm.com/devops/pipelines/tekton/a9b62902-737f-4f72-8288-ba7e67cf706b/runs/1ffd2e59-0486-4f3a-9ac0-e8007a2921e4/mas-launchfvt?env_id=ibm:yp:us-south&view=logs

(Saas Tekton PR: https://github.ibm.com/maximoappsuite/saas-tekton/pull/264)