### PR TITLE
[patch] Add re-ordering to fix race conditions

### DIFF
--- a/tekton/src/pipelines/mas-fvt-core.yml.j2
+++ b/tekton/src/pipelines/mas-fvt-core.yml.j2
@@ -96,6 +96,17 @@ spec:
           value: coreidp-auth
       runAfter:
         - kyverno
+    
+    # We're getting concurrent problems on manage since we're running a lot of creation/deletion at the same time
+    # as this test is pretty fast, it can be runned independently to not cause race conditions.
+    - name: coreapi-scimv2
+      {{ lookup('template', 'taskdefs/fvt-core/common/taskref.yml.j2') | indent(6) }}
+      params:
+        {{ lookup('template', 'taskdefs/fvt-core/common/params.yml.j2') | indent(8) }}
+        - name: fvt_test_suite
+          value: coreapi-scimv2
+      runAfter:
+        - coreidp-auth
 
     # Phase 1
     # -------------------------------------------------------------------------

--- a/tekton/src/pipelines/taskdefs/fvt-core/phase1-under5min.yml.j2
+++ b/tekton/src/pipelines/taskdefs/fvt-core/phase1-under5min.yml.j2
@@ -157,17 +157,6 @@
     {{ lookup('template', 'taskdefs/fvt-core/common/params.yml.j2') | indent(4) }}
   runAfter: {{ runAfter }}
 
-# coreapi-scimv2 ~1m
-# -----------------------------------------------------------------------------
-- name: coreapi-scimv2
-  {{ lookup('template', 'taskdefs/fvt-core/common/taskref.yml.j2') | indent(2) }}
-  params:
-    {{ lookup('template', 'taskdefs/fvt-core/common/params.yml.j2') | indent(4) }}
-    - name: fvt_test_suite
-      value: coreapi-scimv2
-  runAfter:
-    - coreapi-selfreg
-
 # masprovisioner ~5m
 # -----------------------------------------------------------------------------
 - name: masprovisioner

--- a/tekton/src/pipelines/taskdefs/fvt-core/phase4-disruptive.yml.j2
+++ b/tekton/src/pipelines/taskdefs/fvt-core/phase4-disruptive.yml.j2
@@ -11,37 +11,7 @@
 # - operatormaturity: non-disruptive, we just want it to be the last thing that runs
 
 
-# 1. smtp
-# -------------------------------------------------------------------------
-- name: smtp
-  {{ lookup('template', 'taskdefs/fvt-core/common/taskref.yml.j2') | indent(2) }}
-  params:
-    - name: fvt_test_suite
-      value: smtp
-    {{ lookup('template', 'taskdefs/fvt-core/common/params.yml.j2') | indent(4) }}
-  runAfter: {{ runAfter }}
-
-# 2. core-trustcas
-# -------------------------------------------------------------------------
-- name: core-trustcas
-  {{ lookup('template', 'taskdefs/fvt-core/common/taskref.yml.j2') | indent(2) }}
-  params:
-    - name: fvt_test_suite
-      value: core-trustcas
-    {{ lookup('template', 'taskdefs/fvt-core/common/params.yml.j2') | indent(4) }}
-  runAfter: {{ runAfter }}
-
-# 3. adoptionusagemetering
-# -------------------------------------------------------------------------
-- name: adoptionusagemetering
-  {{ lookup('template', 'taskdefs/fvt-core/common/taskref.yml.j2') | indent(2) }}
-  params:
-    - name: fvt_test_suite
-      value: adoptionusagemetering
-    {{ lookup('template', 'taskdefs/fvt-core/common/params.yml.j2') | indent(4) }}
-  runAfter: {{ runAfter }}
-
-# 4. authservice ~3m
+# 1. authservice ~3m
 # -----------------------------------------------------------------------------
 - name: authservice
   {{ lookup('template', 'taskdefs/fvt-core/common/taskref.yml.j2') | indent(2) }}
@@ -49,10 +19,40 @@
     {{ lookup('template', 'taskdefs/fvt-core/common/params.yml.j2') | indent(4) }}
     - name: fvt_test_suite
       value: authservice
+  runAfter: {{ runAfter }}
+
+# 2. smtp
+# -------------------------------------------------------------------------
+- name: smtp
+  {{ lookup('template', 'taskdefs/fvt-core/common/taskref.yml.j2') | indent(2) }}
+  params:
+    - name: fvt_test_suite
+      value: smtp
+    {{ lookup('template', 'taskdefs/fvt-core/common/params.yml.j2') | indent(4) }}
   runAfter:
-    - smtp
-    - core-trustcas
-    - adoptionusagemetering
+    - authservice
+
+# 3. core-trustcas
+# -------------------------------------------------------------------------
+- name: core-trustcas
+  {{ lookup('template', 'taskdefs/fvt-core/common/taskref.yml.j2') | indent(2) }}
+  params:
+    - name: fvt_test_suite
+      value: core-trustcas
+    {{ lookup('template', 'taskdefs/fvt-core/common/params.yml.j2') | indent(4) }}
+  runAfter:
+    - authservice
+
+# 4. adoptionusagemetering
+# -------------------------------------------------------------------------
+- name: adoptionusagemetering
+  {{ lookup('template', 'taskdefs/fvt-core/common/taskref.yml.j2') | indent(2) }}
+  params:
+    - name: fvt_test_suite
+      value: adoptionusagemetering
+    {{ lookup('template', 'taskdefs/fvt-core/common/params.yml.j2') | indent(4) }}
+  runAfter:
+    - authservice
 
 # 5. coreidp-ldap
 # -------------------------------------------------------------------------
@@ -63,7 +63,9 @@
       value: coreidp-ldap
     {{ lookup('template', 'taskdefs/fvt-core/common/params.yml.j2') | indent(4) }}
   runAfter:
-    - authservice
+    - smtp
+    - core-trustcas
+    - adoptionusagemetering
 
 # 6. coreidp-saml
 # -------------------------------------------------------------------------


### PR DESCRIPTION
# Summary

This PR reorganizes the execution order of FVT (Functional Verification Tests) in the MAS core pipeline to address race conditions caused by concurrent test execution. The key changes include:

1. Moving `coreapi-scimv2` out of the parallel `phase1-under5min` task group and into the main pipeline as a sequential step after `coreidp-auth`, preventing concurrent create/delete operations that were causing race conditions with Manage.
2. Reordering the `phase4-disruptive` tests so that `authservice` runs **first** (as the entry point), with `smtp`, `core-trustcas`, and `adoptionusagemetering` running after it, and `coreidp-ldap`/`coreidp-saml` running after those — rather than `authservice` running last.

# Files Changed

📄 `tekton/src/pipelines/mas-fvt-core.yml.j2`

Adds `coreapi-scimv2` as an explicit pipeline step that runs sequentially after `coreidp-auth`. This moves the test out of the parallel phase1 group to avoid race conditions caused by simultaneous resource creation and deletion operations conflicting with Manage.

---

📄 `tekton/src/pipelines/taskdefs/fvt-core/phase1-under5min.yml.j2`

Removes the `coreapi-scimv2` task definition from the phase1 parallel task group. Since this test has been relocated to the main pipeline as a sequential step, it no longer needs to be defined here.

---

📄 `tekton/src/pipelines/taskdefs/fvt-core/phase4-disruptive.yml.j2`

Restructures the execution order of disruptive tests in phase 4. `authservice` is promoted to be the **first** test to run (using `runAfter: {{ runAfter }}`), while `smtp`, `core-trustcas`, and `adoptionusagemetering` are changed to run **after** `authservice`. Subsequently, `coreidp-ldap` (and implicitly `coreidp-saml`) are updated to run after `smtp`, `core-trustcas`, and `adoptionusagemetering` complete — effectively reversing the previous dependency chain where `authservice` was the last step.