### PR TITLE
[patch] Add interactive ODH/RHOAI platform selection prompt for AI Service installation

### DIFF
--- a/python/src/mas/cli/aiservice/install/app.py
+++ b/python/src/mas/cli/aiservice/install/app.py
@@ -668,6 +668,24 @@ class AiServiceInstallApp(BaseApp, aiServiceInstallArgBuilderMixin, aiServiceIns
             self.promptForString("Storage tenants bucket", "aiservice_s3_tenants_bucket")
             self.promptForString("Storage templates bucket", "aiservice_s3_templates_bucket")
 
+        # Configure AI Data Science Platform
+        self.printH2("Configure AI Data Science Platform")
+        self.printDescription(
+            [
+                "Choose which AI data science platform to install:",
+                " - <b>Note for 9.1.x</b>: Open Data Hub (ODH) is the supported platform for AI Service 9.1.x",
+                " - <b>Note for 9.2.x</b>: Red Hat OpenShift AI (RHOAI) is the recommended platform for AI Service 9.2.x",
+                "",
+                "  1. Red Hat OpenShift AI (RHOAI)",
+                "  2. Open Data Hub (ODH)",
+            ]
+        )
+        platformChoice = self.promptForInt("AI Data Science Platform", default=1, min=1, max=2)
+        if platformChoice == 2:
+            self.setParam("rhoai", "false")
+        else:
+            self.setParam("rhoai", "true")
+
         # Configure Certificate Issuer
         self.configCertIssuer()
 
@@ -1085,21 +1103,3 @@ class AiServiceInstallApp(BaseApp, aiServiceInstallArgBuilderMixin, aiServiceIns
             self.setParam("environment_type", "non-production")
             self.setParam("aiservice_odh_model_deployment_type", "serverless")
             self.setParam("aiservice_rhoai_model_deployment_type", "serverless")
-
-        # Prompt user to choose AI data science platform
-        self.printH2("Configure AI Data Science Platform")
-        self.printDescription(
-            [
-                "Choose which AI data science platform to install:",
-                " - <b>Note for 9.1.x</b>: Open Data Hub (ODH) is the supported platform for AI Service 9.1.x",
-                " - <b>Note for 9.2.x</b>: Red Hat OpenShift AI (RHOAI) is the recommended platform for AI Service 9.2.x",
-                "",
-                "  1. Open Data Hub (ODH)",
-                "  2. Red Hat OpenShift AI (RHOAI)",
-            ]
-        )
-        platformChoice = self.promptForInt("AI Data Science Platform", default=1, min=1, max=2)
-        if platformChoice == 2:
-            self.setParam("rhoai", "true")
-        else:
-            self.setParam("rhoai", "false")

--- a/python/src/mas/cli/aiservice/install/app.py
+++ b/python/src/mas/cli/aiservice/install/app.py
@@ -1081,9 +1081,25 @@ class AiServiceInstallApp(BaseApp, aiServiceInstallArgBuilderMixin, aiServiceIns
             self.setParam("environment_type", "production")
             self.setParam("aiservice_odh_model_deployment_type", "raw")
             self.setParam("aiservice_rhoai_model_deployment_type", "raw")
-            self.setParam("rhoai", "false")
         else:
             self.setParam("environment_type", "non-production")
             self.setParam("aiservice_odh_model_deployment_type", "serverless")
             self.setParam("aiservice_rhoai_model_deployment_type", "serverless")
+
+        # Prompt user to choose AI data science platform
+        self.printH2("Configure AI Data Science Platform")
+        self.printDescription(
+            [
+                "Choose which AI data science platform to install:",
+                " - <b>Note for 9.1.x</b>: Open Data Hub (ODH) is the supported platform for AI Service 9.1.x",
+                " - <b>Note for 9.2.x</b>: Red Hat OpenShift AI (RHOAI) is the recommended platform for AI Service 9.2.x",
+                "",
+                "  1. Open Data Hub (ODH)",
+                "  2. Red Hat OpenShift AI (RHOAI)",
+            ]
+        )
+        platformChoice = self.promptForInt("AI Data Science Platform", default=1, min=1, max=2)
+        if platformChoice == 2:
+            self.setParam("rhoai", "true")
+        else:
             self.setParam("rhoai", "false")

--- a/python/src/mas/cli/aiservice/install/summarizer.py
+++ b/python/src/mas/cli/aiservice/install/summarizer.py
@@ -46,6 +46,7 @@ class aiServiceInstallSummarizerMixin:
         self.printParamSummary("Release", "aiservice_channel")
         self.printParamSummary("Instance ID", "aiservice_instance_id")
         self.printParamSummary("Environment Type", "environment_type")
+        self.printSummary("AI Data Science Platform", "Red Hat OpenShift AI (RHOAI)" if self.getParam("rhoai") == "true" else "Open Data Hub (ODH)")
 
         if "aiservice_certificate_issuer" in self.params:
             self.printParamSummary("Certificate Issuer", "aiservice_certificate_issuer")

--- a/python/src/mas/cli/install/app.py
+++ b/python/src/mas/cli/install/app.py
@@ -1734,24 +1734,6 @@ class InstallApp(
         )
         self.params["aiservice_channel"] = prompt(HTML("<Yellow>Custom channel for AI Service</Yellow> "))
 
-        # Prompt user to choose AI data science platform
-        self.printH2("Configure AI Data Science Platform")
-        self.printDescription(
-            [
-                "Choose which AI data science platform to install:",
-                " - <b>Note for 9.1.x</b>: Open Data Hub (ODH) is the supported platform for AI Service 9.1.x",
-                " - <b>Note for 9.2.x</b>: Red Hat OpenShift AI (RHOAI) is the recommended platform for AI Service 9.2.x",
-                "",
-                "  1. Open Data Hub (ODH)",
-                "  2. Red Hat OpenShift AI (RHOAI)",
-            ]
-        )
-        platformChoice = self.promptForInt("AI Data Science Platform", default=1, min=1, max=2)
-        if platformChoice == 2:
-            self.setParam("rhoai", "true")
-        else:
-            self.setParam("rhoai", "false")
-
     @logMethodCall
     def configAIServiceDatabase(self):
         """Configure database for AI Service - either in-cluster DB2 or external database"""
@@ -1854,6 +1836,24 @@ class InstallApp(
                 )
                 self.promptForString("Storage tenants bucket", "aiservice_s3_tenants_bucket")
                 self.promptForString("Storage templates bucket", "aiservice_s3_templates_bucket")
+
+            # Configure AI Data Science Platform
+            self.printH2("Configure AI Data Science Platform")
+            self.printDescription(
+                [
+                    "Choose which AI data science platform to install:",
+                    " - <b>Note for 9.1.x</b>: Open Data Hub (ODH) is the supported platform for AI Service 9.1.x",
+                    " - <b>Note for 9.2.x</b>: Red Hat OpenShift AI (RHOAI) is the recommended platform for AI Service 9.2.x",
+                    "",
+                    "  1. Red Hat OpenShift AI (RHOAI)",
+                    "  2. Open Data Hub (ODH)",
+                ]
+            )
+            platformChoice = self.promptForInt("AI Data Science Platform", default=1, min=1, max=2)
+            if platformChoice == 2:
+                self.setParam("rhoai", "false")
+            else:
+                self.setParam("rhoai", "true")
 
             # Configure Certificate Issuer
             self.configAIServiceCertIssuer()

--- a/python/src/mas/cli/install/app.py
+++ b/python/src/mas/cli/install/app.py
@@ -704,12 +704,12 @@ class InstallApp(
             self.setParam("environment_type", "production")
             self.setParam("aiservice_odh_model_deployment_type", "raw")
             self.setParam("aiservice_rhoai_model_deployment_type", "raw")
-            self.setParam("rhoai", "false")
         else:
             self.setParam("environment_type", "non-production")
             self.setParam("aiservice_odh_model_deployment_type", "serverless")
             self.setParam("aiservice_rhoai_model_deployment_type", "serverless")
-            self.setParam("rhoai", "false")
+
+        self.setParam("rhoai", "false")
 
     @logMethodCall
     def configAdminMode(self):
@@ -1733,6 +1733,24 @@ class InstallApp(
             validator=InstanceIDFormatValidator(),
         )
         self.params["aiservice_channel"] = prompt(HTML("<Yellow>Custom channel for AI Service</Yellow> "))
+
+        # Prompt user to choose AI data science platform
+        self.printH2("Configure AI Data Science Platform")
+        self.printDescription(
+            [
+                "Choose which AI data science platform to install:",
+                " - <b>Note for 9.1.x</b>: Open Data Hub (ODH) is the supported platform for AI Service 9.1.x",
+                " - <b>Note for 9.2.x</b>: Red Hat OpenShift AI (RHOAI) is the recommended platform for AI Service 9.2.x",
+                "",
+                "  1. Open Data Hub (ODH)",
+                "  2. Red Hat OpenShift AI (RHOAI)",
+            ]
+        )
+        platformChoice = self.promptForInt("AI Data Science Platform", default=1, min=1, max=2)
+        if platformChoice == 2:
+            self.setParam("rhoai", "true")
+        else:
+            self.setParam("rhoai", "false")
 
     @logMethodCall
     def configAIServiceDatabase(self):

--- a/python/src/mas/cli/install/summarizer.py
+++ b/python/src/mas/cli/install/summarizer.py
@@ -367,6 +367,7 @@ class InstallSummarizerMixin:
             self.printParamSummary("Release", "aiservice_channel")
             self.printParamSummary("Instance ID", "aiservice_instance_id")
             self.printParamSummary("Environment Type", "environment_type")
+            self.printSummary("AI Data Science Platform", "Red Hat OpenShift AI (RHOAI)" if self.getParam("rhoai") == "true" else "Open Data Hub (ODH)")
 
             if "aiservice_certificate_issuer" in self.params:
                 self.printParamSummary("Certificate Issuer", "aiservice_certificate_issuer")

--- a/python/tests/integration/aiservice_install/test_app.py
+++ b/python/tests/integration/aiservice_install/test_app.py
@@ -273,6 +273,8 @@ def test_install_interactive_advanced(tmpdir):
                     return ""
                 if re.match(".*Operational Mode.*", message):
                     return "1"
+                if re.match(".*AI Data Science Platform.*", message):
+                    return "1"
                 if re.match(".*Install Minio.*", message):
                     return "y"
                 if re.match(".*minio root username.*", message):
@@ -428,6 +430,8 @@ def test_install_interactive_simplified(tmpdir):
                 if re.match(".*Instance ID.*", message):
                     return "apmdevops"
                 if re.match(".*Operational Mode.*", message):
+                    return "1"
+                if re.match(".*AI Data Science Platform.*", message):
                     return "1"
                 if re.match(".*Install Minio.*", message):
                     return "y"

--- a/python/tests/integration/aiservice_install/test_app.py
+++ b/python/tests/integration/aiservice_install/test_app.py
@@ -273,14 +273,14 @@ def test_install_interactive_advanced(tmpdir):
                     return ""
                 if re.match(".*Operational Mode.*", message):
                     return "1"
-                if re.match(".*AI Data Science Platform.*", message):
-                    return "1"
                 if re.match(".*Install Minio.*", message):
                     return "y"
                 if re.match(".*minio root username.*", message):
                     return "username"
                 if re.match(".*minio root password.*", message):
                     return "password"
+                if re.match(".*AI Data Science Platform.*", message):
+                    return "1"
                 if re.match(r".*Configure certificate issuer\?.*", message):
                     return "y"
                 if re.match(".*Certificate issuer name.*", message):
@@ -431,14 +431,14 @@ def test_install_interactive_simplified(tmpdir):
                     return "apmdevops"
                 if re.match(".*Operational Mode.*", message):
                     return "1"
-                if re.match(".*AI Data Science Platform.*", message):
-                    return "1"
                 if re.match(".*Install Minio.*", message):
                     return "y"
                 if re.match(".*minio root username.*", message):
                     return "username"
                 if re.match(".*minio root password.*", message):
                     return "password"
+                if re.match(".*AI Data Science Platform.*", message):
+                    return "1"
                 if re.match(".*Entitlement end date.*", message):
                     return "2027-02-16"
                 if re.match(".*Watsonxai api key.*", message):

--- a/python/tests/integration/aiservice_install/test_dev_mode.py
+++ b/python/tests/integration/aiservice_install/test_dev_mode.py
@@ -80,12 +80,12 @@ def test_aiservice_install_master_dev_mode(tmpdir):
         ".*Instance ID.*": lambda msg: "testinst",
         # 9. Operational mode
         ".*Operational Mode.*": lambda msg: "1",
-        # 10. AI Data Science Platform
-        ".*AI Data Science Platform.*": lambda msg: "1",
-        # 11. Storage Configuration (MinIO)
+        # 10. Storage Configuration (MinIO)
         ".*Install Minio.*": lambda msg: "y",
         ".*minio root username.*": lambda msg: "miniouser",
         ".*minio root password.*": lambda msg: "miniopass",
+        # 11. AI Data Science Platform
+        ".*AI Data Science Platform.*": lambda msg: "1",
         # 12. Tenant Settings
         ".*Entitlement end date.*": lambda msg: "2027-02-16",
         # 13. WatsonX Integration
@@ -153,12 +153,12 @@ def test_aiservice_install_master_dev_mode_existing_catalog(tmpdir):
         ".*Instance ID.*": lambda msg: "testinst",
         # 9. Operational mode
         ".*Operational Mode.*": lambda msg: "1",
-        # 10. AI Data Science Platform
-        ".*AI Data Science Platform.*": lambda msg: "1",
-        # 11. Storage Configuration (MinIO)
+        # 10. Storage Configuration (MinIO)
         ".*Install Minio.*": lambda msg: "y",
         ".*minio root username.*": lambda msg: "miniouser",
         ".*minio root password.*": lambda msg: "miniopass",
+        # 11. AI Data Science Platform
+        ".*AI Data Science Platform.*": lambda msg: "1",
         # 12. Tenant Settings
         ".*Entitlement end date.*": lambda msg: "2027-02-16",
         # 13. WatsonX Integration

--- a/python/tests/integration/aiservice_install/test_dev_mode.py
+++ b/python/tests/integration/aiservice_install/test_dev_mode.py
@@ -80,26 +80,28 @@ def test_aiservice_install_master_dev_mode(tmpdir):
         ".*Instance ID.*": lambda msg: "testinst",
         # 9. Operational mode
         ".*Operational Mode.*": lambda msg: "1",
-        # 10. Storage Configuration (MinIO)
+        # 10. AI Data Science Platform
+        ".*AI Data Science Platform.*": lambda msg: "1",
+        # 11. Storage Configuration (MinIO)
         ".*Install Minio.*": lambda msg: "y",
         ".*minio root username.*": lambda msg: "miniouser",
         ".*minio root password.*": lambda msg: "miniopass",
-        # 11. Tenant Settings
+        # 12. Tenant Settings
         ".*Entitlement end date.*": lambda msg: "2027-02-16",
-        # 12. WatsonX Integration
+        # 13. WatsonX Integration
         ".*Watsonxai api key.*": lambda msg: "testWxApiKey",
         ".*Watsonxai machine learning url.*": lambda msg: "https://us-south.ml.cloud.ibm.com",
         ".*Watsonxai project id.*": lambda msg: "testProjectId",
         ".*Does the Watsonxai AI use a self-signed certificate.*": lambda msg: "n",
         ".*Watsonxai Deployment ID.*": lambda msg: "",
         ".*Watsonxai Space ID.*": lambda msg: "",
-        # 13. RSL Integration
+        # 14. RSL Integration
         ".*Does the RSL API use a self-signed certificate.*": lambda msg: "n",
-        # 14. Database configuration
+        # 15. Database configuration
         ".*Do you want to use an external database.*": lambda msg: "n",
-        # 15. MongoDB configuration
+        # 16. MongoDB configuration
         ".*Create MongoDb cluster.*": lambda msg: "y",
-        # 16. Final confirmation
+        # 17. Final confirmation
         ".*Proceed with these settings.*": lambda msg: "y",
     }
 
@@ -151,26 +153,28 @@ def test_aiservice_install_master_dev_mode_existing_catalog(tmpdir):
         ".*Instance ID.*": lambda msg: "testinst",
         # 9. Operational mode
         ".*Operational Mode.*": lambda msg: "1",
-        # 10. Storage Configuration (MinIO)
+        # 10. AI Data Science Platform
+        ".*AI Data Science Platform.*": lambda msg: "1",
+        # 11. Storage Configuration (MinIO)
         ".*Install Minio.*": lambda msg: "y",
         ".*minio root username.*": lambda msg: "miniouser",
         ".*minio root password.*": lambda msg: "miniopass",
-        # 11. Tenant Settings
+        # 12. Tenant Settings
         ".*Entitlement end date.*": lambda msg: "2027-02-16",
-        # 12. WatsonX Integration
+        # 13. WatsonX Integration
         ".*Watsonxai api key.*": lambda msg: "testWxApiKey",
         ".*Watsonxai machine learning url.*": lambda msg: "https://us-south.ml.cloud.ibm.com",
         ".*Watsonxai project id.*": lambda msg: "testProjectId",
         ".*Does the Watsonxai AI use a self-signed certificate.*": lambda msg: "n",
         ".*Watsonxai Deployment ID.*": lambda msg: "",
         ".*Watsonxai Space ID.*": lambda msg: "",
-        # 13. RSL Integration
+        # 14. RSL Integration
         ".*Does the RSL API use a self-signed certificate.*": lambda msg: "n",
-        # 14. Database configuration
+        # 15. Database configuration
         ".*Do you want to use an external database.*": lambda msg: "n",
-        # 15. MongoDB configuration
+        # 16. MongoDB configuration
         ".*Create MongoDb cluster.*": lambda msg: "y",
-        # 16. Final confirmation
+        # 17. Final confirmation
         ".*Proceed with these settings.*": lambda msg: "y",
     }
 


### PR DESCRIPTION
## Summary

Adds an interactive prompt to the AI Service installation flow asking users to choose between **Red Hat OpenShift AI (RHOAI)** and **Open Data Hub (ODH)** as the AI data science platform.

Previously, interactive mode always defaulted to ODH silently. Non-interactive mode already supported \`--rhoai\` flag.

## Testing Snapshots
- Standalone AIService pipeline:
<img width="954" height="195" alt="Screenshot 2026-07-31 at 12 18 30 PM" src="https://github.com/user-attachments/assets/e8029c23-c9b4-4332-8410-f75afeb85a10" />

- Mas install pipeline:
<img width="1460" height="448" alt="Screenshot 2026-07-31 at 3 46 21 PM" src="https://github.com/user-attachments/assets/769aea62-3028-46da-82c6-b89c8664427b" />
