### PR TITLE
[patch] Add scim_v2 right after the coreidp-auth

### DIFF
--- a/tekton/src/pipelines/mas-fvt-core.yml.j2
+++ b/tekton/src/pipelines/mas-fvt-core.yml.j2
@@ -111,7 +111,7 @@ spec:
     # Phase 1
     # -------------------------------------------------------------------------
     # Only suites that take less than 5 minutes
-    {{ lookup('template', 'taskdefs/fvt-core/phase1-under5min.yml.j2', template_vars={'runAfter': ['coreidp-auth']}) | indent(4) }}
+    {{ lookup('template', 'taskdefs/fvt-core/phase1-under5min.yml.j2', template_vars={'runAfter': ['coreapi-scimv2']}) | indent(4) }}
 
     # Phase 2
     # -------------------------------------------------------------------------


### PR DESCRIPTION
# Summary

Updates the task dependency in the MAS FVT Core pipeline to change the `runAfter` condition for the Phase 1 task suite. The Phase 1 tasks (suites taking less than 5 minutes) will now run after the `coreapi-scimv2` task instead of the `coreidp-auth` task, adjusting the execution order within the pipeline.

# Files Changed

📄 `tekton/src/pipelines/mas-fvt-core.yml.j2`

Updates the `runAfter` dependency for the Phase 1 task definition (`phase1-under5min.yml.j2`) from `coreidp-auth` to `coreapi-scimv2`. This change modifies the pipeline's task execution order, ensuring that the Phase 1 short-running test suites are triggered only after the `coreapi-scimv2` task completes, rather than waiting on `coreidp-auth`.