### PR TITLE
[patch] Monitor FVT suite segregation — replace fvt_91x with parallel suites (9.1+/9.2+)

### DIFF
--- a/image/cli/masfvt/fvt-monitor.yml
+++ b/image/cli/masfvt/fvt-monitor.yml
@@ -16,25 +16,9 @@
     fvt_digest_ctf: "{{ lookup('env', 'FVT_DIGEST_CTF') }}"
     fvt_digest_monitor: "{{ lookup('env', 'FVT_DIGEST_MONITOR') }}"
     ivt_digest_core: "{{ lookup('env', 'IVT_DIGEST_CORE') }}"
-    # Black and white listing
-    fvt_blacklist: "{{ lookup('env', 'FVT_BLACKLIST') }}"
-    fvt_whitelist: "{{ lookup('env', 'FVT_WHITELIST') }}"
     # Data Dictionary FVT is only supported for Release versions 8.10, 8.11, and 9.0
     # For any other version (including 9.1+), the digest will be empty and the task will be skipped
     fvt_digest_data_dictionary: "{% if '8.10' in mas_app_channel_monitor or '8.11' in mas_app_channel_monitor or '9.0' in mas_app_channel_monitor %}{{ lookup('env', 'FVT_DIGEST_DATA_DICTIONARY') }}{% endif %}"
-    # Control the Monitor suite based on Monitor version and presence/absence of Manage
-    # For Monitor 9.1.x and above, use version-specific test suites (fvt_91x, fvt_92x)
-    # For Monitor 8.x and 9.0.x, use legacy suites based on Manage presence
-    fvt_test_suite: >-
-      {%- if '9.1' in mas_app_channel_monitor -%}
-        fvt_91x
-      {%- elif '9.2' in mas_app_channel_monitor -%}
-        fvt_91x
-      {%- elif mas_app_channel_manage == '' -%}
-        monitor_fvt
-      {%- else -%}
-        monitor_fvt_with_manage
-      {%- endif -%}
     # Pipeline Run Info
     devops_build_number: "{{ lookup('env', 'DEVOPS_BUILD_NUMBER') | default('0', True) }}"
     pipelinerun_name: "{{ lookup('env', 'PIPELINERUN_NAME') | default('mas-fvt-monitor', True) }}-{{ devops_build_number }}"
@@ -59,11 +43,6 @@
           - "fvt_digest_monitor .............. {{ fvt_digest_monitor }}"
           - "ivt_digest_core ................. {{ ivt_digest_core }}"
           - "fvt_digest_data_dictionary ...... {{ fvt_digest_data_dictionary }}"
-          - ""
-          - "fvt_test_suite .................. {{ fvt_test_suite }}"
-          - ""
-          - "fvt_blacklist ............... {{ fvt_blacklist }}"
-          - "fvt_whitelist ............... {{ fvt_whitelist }}"
 
     - name: "Start fvt-monitor pipeline"
       kubernetes.core.k8s:

--- a/image/cli/masfvt/fvt-monitor.yml
+++ b/image/cli/masfvt/fvt-monitor.yml
@@ -16,6 +16,9 @@
     fvt_digest_ctf: "{{ lookup('env', 'FVT_DIGEST_CTF') }}"
     fvt_digest_monitor: "{{ lookup('env', 'FVT_DIGEST_MONITOR') }}"
     ivt_digest_core: "{{ lookup('env', 'IVT_DIGEST_CORE') }}"
+    # Black and white listing
+    fvt_blacklist: "{{ lookup('env', 'FVT_BLACKLIST') }}"
+    fvt_whitelist: "{{ lookup('env', 'FVT_WHITELIST') }}"
     # Data Dictionary FVT is only supported for Release versions 8.10, 8.11, and 9.0
     # For any other version (including 9.1+), the digest will be empty and the task will be skipped
     fvt_digest_data_dictionary: "{% if '8.10' in mas_app_channel_monitor or '8.11' in mas_app_channel_monitor or '9.0' in mas_app_channel_monitor %}{{ lookup('env', 'FVT_DIGEST_DATA_DICTIONARY') }}{% endif %}"
@@ -43,6 +46,9 @@
           - "fvt_digest_monitor .............. {{ fvt_digest_monitor }}"
           - "ivt_digest_core ................. {{ ivt_digest_core }}"
           - "fvt_digest_data_dictionary ...... {{ fvt_digest_data_dictionary }}"
+          - ""
+          - "fvt_blacklist ............... {{ fvt_blacklist }}"
+          - "fvt_whitelist ............... {{ fvt_whitelist }}"
 
     - name: "Start fvt-monitor pipeline"
       kubernetes.core.k8s:

--- a/image/cli/masfvt/fvt-monitor.yml
+++ b/image/cli/masfvt/fvt-monitor.yml
@@ -22,6 +22,20 @@
     # Data Dictionary FVT is only supported for Release versions 8.10, 8.11, and 9.0
     # For any other version (including 9.1+), the digest will be empty and the task will be skipped
     fvt_digest_data_dictionary: "{% if '8.10' in mas_app_channel_monitor or '8.11' in mas_app_channel_monitor or '9.0' in mas_app_channel_monitor %}{{ lookup('env', 'FVT_DIGEST_DATA_DICTIONARY') }}{% endif %}"
+    # Determine which Monitor FVT suite to run based on Monitor version and presence of Manage:
+    #   - 8.10.x / 8.11.x: legacy suite (monitor_fvt_with_manage only, no health check)
+    #   - 9.0.x:            legacy suite + health check (fvt_90x)
+    #   - 9.1.x / 9.2.x+:  new parallel suites (fvt_91x)
+    fvt_test_suite: >-
+      {%- if '9.1' in mas_app_channel_monitor -%}
+        fvt_91x
+      {%- elif '9.2' in mas_app_channel_monitor -%}
+        fvt_91x
+      {%- elif '9.0' in mas_app_channel_monitor -%}
+        fvt_90x
+      {%- else -%}
+        monitor_fvt_with_manage
+      {%- endif -%}
     # Pipeline Run Info
     devops_build_number: "{{ lookup('env', 'DEVOPS_BUILD_NUMBER') | default('0', True) }}"
     pipelinerun_name: "{{ lookup('env', 'PIPELINERUN_NAME') | default('mas-fvt-monitor', True) }}-{{ devops_build_number }}"
@@ -46,6 +60,8 @@
           - "fvt_digest_monitor .............. {{ fvt_digest_monitor }}"
           - "ivt_digest_core ................. {{ ivt_digest_core }}"
           - "fvt_digest_data_dictionary ...... {{ fvt_digest_data_dictionary }}"
+          - ""
+          - "fvt_test_suite .................. {{ fvt_test_suite }}"
           - ""
           - "fvt_blacklist ............... {{ fvt_blacklist }}"
           - "fvt_whitelist ............... {{ fvt_whitelist }}"

--- a/image/cli/masfvt/templates/mas-fvt-monitor.yml.j2
+++ b/image/cli/masfvt/templates/mas-fvt-monitor.yml.j2
@@ -22,8 +22,6 @@ spec:
     # MAS Info
     - name: mas_app_channel_monitor
       value: "{{ mas_app_channel_monitor }}"
-    - name: mas_app_channel_manage
-      value: "{{ mas_app_channel_manage }}"
     - name: mas_instance_id
       value: "{{ mas_instance_id }}"
     - name: mas_workspace_id
@@ -44,9 +42,6 @@ spec:
       value: "{{ ivt_digest_core }}"
     - name: fvt_digest_data_dictionary
       value: "{{ fvt_digest_data_dictionary }}"
-    # Product channel for version-specific test suite selection
-    - name: product_channel
-      value: "{{ mas_app_channel_monitor }}"
 
   workspaces:
     # The generated configuration files

--- a/image/cli/masfvt/templates/mas-fvt-monitor.yml.j2
+++ b/image/cli/masfvt/templates/mas-fvt-monitor.yml.j2
@@ -44,9 +44,6 @@ spec:
       value: "{{ ivt_digest_core }}"
     - name: fvt_digest_data_dictionary
       value: "{{ fvt_digest_data_dictionary }}"
-    # Which FVT suite to run ('monitor_fvt' or 'monitor_fvt_with_manage')
-    - name: fvt_test_suite
-      value: "{{ fvt_test_suite }}"
     # Product channel for version-specific test suite selection
     - name: product_channel
       value: "{{ mas_app_channel_monitor }}"

--- a/image/cli/masfvt/templates/mas-fvt-monitor.yml.j2
+++ b/image/cli/masfvt/templates/mas-fvt-monitor.yml.j2
@@ -42,6 +42,12 @@ spec:
       value: "{{ ivt_digest_core }}"
     - name: fvt_digest_data_dictionary
       value: "{{ fvt_digest_data_dictionary }}"
+    # Which FVT suite to run - computed from Monitor channel + Manage presence
+    # monitor_fvt_with_manage: 8.10.x, 8.11.x
+    # fvt_90x:                 9.0.x (monitor_fvt_with_manage + health check)
+    # fvt_91x:                 9.1.x and above (new parallel suites + health check)
+    - name: fvt_test_suite
+      value: "{{ fvt_test_suite }}"
 
   workspaces:
     # The generated configuration files

--- a/tekton/src/pipelines/mas-fvt-monitor.yml.j2
+++ b/tekton/src/pipelines/mas-fvt-monitor.yml.j2
@@ -21,6 +21,9 @@ spec:
     - name: mas_app_channel_monitor
       type: string
       default: ""
+    - name: mas_app_channel_manage
+      type: string
+      default: ""
     - name: mas_instance_id
       type: string
       default: ""
@@ -57,9 +60,9 @@ spec:
       description: Data Dictionary Digest
       default: ""
 
-    - name: fvt_test_suite
+    # Product channel (used for version-specific suite selection)
+    - name: product_channel
       type: string
-      description: Which Monitor FVT suite to run [monitor_fvt, monitor_fvt_with_manage, fvt_91x]
       default: ""
 
   tasks:
@@ -80,16 +83,23 @@ spec:
         - name: pipelinerun_namespace
           value: $(context.pipelineRun.namespace)
 
-    # 1. Core x Monitor
+    # 1. Core x Monitor (Kyverno + IVT Core)
     # -------------------------------------------------------------------------
     - name: kyverno-monitor
       {{ lookup('template', 'taskdefs/ivt-core/common/taskref.yml.j2') | indent(6) }}
       params:
-        {{ lookup('template', 'taskdefs/ivt-core/common/params.yml.j2') | indent(8) }}
-        - name: product_id
-          value: ibm-mas-monitor
+        - name: mas_instance_id
+          value: $(params.mas_instance_id)
+        - name: mas_workspace_id
+          value: $(params.mas_workspace_id)
         - name: product_channel
           value: $(params.mas_app_channel_monitor)
+        - name: fvt_image_registry
+          value: $(params.fvt_image_registry)
+        - name: fvt_image_digest
+          value: $(params.ivt_digest_core)
+        - name: product_id
+          value: ibm-mas-monitor
         - name: fvt_test_suite
           value: kyverno
       when:
@@ -105,11 +115,18 @@ spec:
     - name: ivtcore-monitor
       {{ lookup('template', 'taskdefs/ivt-core/common/taskref.yml.j2') | indent(6) }}
       params:
-        {{ lookup('template', 'taskdefs/ivt-core/common/params.yml.j2') | indent(8) }}
-        - name: product_id
-          value: ibm-mas-monitor
+        - name: mas_instance_id
+          value: $(params.mas_instance_id)
+        - name: mas_workspace_id
+          value: $(params.mas_workspace_id)
         - name: product_channel
           value: $(params.mas_app_channel_monitor)
+        - name: fvt_image_registry
+          value: $(params.fvt_image_registry)
+        - name: fvt_image_digest
+          value: $(params.ivt_digest_core)
+        - name: product_id
+          value: ibm-mas-monitor
         - name: fvt_test_suite
           value: coreivt
       runAfter:
@@ -122,30 +139,21 @@ spec:
           operator: notin
           values: [""]
 
-    # 2. Monitor FVT (with or without Manage Integration)
-    # -----------------------------------------------------------------------------
-    # When Manage is installed in the cluster, many Monitor APIs are disabled, this
-    # prevents the standard Monitor FVT suite from running so this IVT suite must run instead
-    #
-    # fvt_test_suite should be set to one of the following:
-    # - monitor_fvt
-    # - monitor_fvt_with_manage
-    #
-    # These testsuites are mutually exclusive
-    - name: fvt-monitor
+    # 2. Legacy Monitor FVT - monitor_fvt_with_manage
+    # -------------------------------------------------------------------------
+    # Kept unchanged - runs when Manage is installed alongside Monitor.
+    - name: fvt-monitor-with-manage
       params:
         - name: mas_instance_id
           value: $(params.mas_instance_id)
         - name: mas_workspace_id
           value: $(params.mas_workspace_id)
-
         - name: fvt_image_registry
           value: $(params.fvt_image_registry)
         - name: fvt_image_digest
           value: $(params.fvt_digest_monitor)
-
         - name: fvt_test_suite
-          value: $(params.fvt_test_suite) # pytest_marker in Monitor Test Framework
+          value: monitor_fvt_with_manage
         - name: product_channel
           value: $(params.mas_app_channel_monitor)
       timeout: "0"
@@ -156,20 +164,391 @@ spec:
         - input: "$(params.fvt_digest_monitor)"
           operator: notin
           values: [""]
-        - input: "$(params.fvt_test_suite)"
-          operator: in
-          values: ["monitor_fvt", "monitor_fvt_with_manage", "fvt_91x"]
+        - input: "$(params.mas_app_channel_manage)"
+          operator: notin
+          values: [""]
       runAfter:
         - ivtcore-monitor
       workspaces:
         - name: configs
           workspace: shared-configs
 
-    # 3. Data Dictionary FVT
+    # 3. New Parallel Monitor FVT Suites (9.1.x and above, no Manage)
+    # -------------------------------------------------------------------------
+    # All 11 suites run in parallel immediately after ivtcore-monitor completes.
+    # Each suite is fully self-contained with its own setup and cleanup phases.
+    # The when condition (mas_app_channel_manage == "") ensures these only run
+    # when Manage is NOT installed (mutually exclusive with fvt-monitor-with-manage).
+    # -------------------------------------------------------------------------
+
+    # fvt_monitoronly - File ingest and basic monitor-only verification
+    - name: fvt-monitoronly
+      params:
+        - name: mas_instance_id
+          value: $(params.mas_instance_id)
+        - name: mas_workspace_id
+          value: $(params.mas_workspace_id)
+        - name: fvt_image_registry
+          value: $(params.fvt_image_registry)
+        - name: fvt_image_digest
+          value: $(params.fvt_digest_monitor)
+        - name: fvt_test_suite
+          value: fvt_monitoronly
+        - name: product_channel
+          value: $(params.mas_app_channel_monitor)
+      timeout: "0"
+      taskRef:
+        kind: Task
+        name: mas-fvt-monitor
+      when:
+        - input: "$(params.fvt_digest_monitor)"
+          operator: notin
+          values: [""]
+        - input: "$(params.mas_app_channel_manage)"
+          operator: in
+          values: [""]
+      runAfter:
+        - ivtcore-monitor
+      workspaces:
+        - name: configs
+          workspace: shared-configs
+
+    # fvt_core_devicetype - Device type management APIs
+    - name: fvt-core-devicetype
+      params:
+        - name: mas_instance_id
+          value: $(params.mas_instance_id)
+        - name: mas_workspace_id
+          value: $(params.mas_workspace_id)
+        - name: fvt_image_registry
+          value: $(params.fvt_image_registry)
+        - name: fvt_image_digest
+          value: $(params.fvt_digest_monitor)
+        - name: fvt_test_suite
+          value: fvt_core_devicetype
+        - name: product_channel
+          value: $(params.mas_app_channel_monitor)
+      timeout: "0"
+      taskRef:
+        kind: Task
+        name: mas-fvt-monitor
+      when:
+        - input: "$(params.fvt_digest_monitor)"
+          operator: notin
+          values: [""]
+        - input: "$(params.mas_app_channel_manage)"
+          operator: in
+          values: [""]
+      runAfter:
+        - ivtcore-monitor
+      workspaces:
+        - name: configs
+          workspace: shared-configs
+
+    # fvt_core_device - Device management APIs
+    - name: fvt-core-device
+      params:
+        - name: mas_instance_id
+          value: $(params.mas_instance_id)
+        - name: mas_workspace_id
+          value: $(params.mas_workspace_id)
+        - name: fvt_image_registry
+          value: $(params.fvt_image_registry)
+        - name: fvt_image_digest
+          value: $(params.fvt_digest_monitor)
+        - name: fvt_test_suite
+          value: fvt_core_device
+        - name: product_channel
+          value: $(params.mas_app_channel_monitor)
+      timeout: "0"
+      taskRef:
+        kind: Task
+        name: mas-fvt-monitor
+      when:
+        - input: "$(params.fvt_digest_monitor)"
+          operator: notin
+          values: [""]
+        - input: "$(params.mas_app_channel_manage)"
+          operator: in
+          values: [""]
+      runAfter:
+        - ivtcore-monitor
+      workspaces:
+        - name: configs
+          workspace: shared-configs
+
+    # fvt_core_gateway - Gateway management APIs
+    - name: fvt-core-gateway
+      params:
+        - name: mas_instance_id
+          value: $(params.mas_instance_id)
+        - name: mas_workspace_id
+          value: $(params.mas_workspace_id)
+        - name: fvt_image_registry
+          value: $(params.fvt_image_registry)
+        - name: fvt_image_digest
+          value: $(params.fvt_digest_monitor)
+        - name: fvt_test_suite
+          value: fvt_core_gateway
+        - name: product_channel
+          value: $(params.mas_app_channel_monitor)
+      timeout: "0"
+      taskRef:
+        kind: Task
+        name: mas-fvt-monitor
+      when:
+        - input: "$(params.fvt_digest_monitor)"
+          operator: notin
+          values: [""]
+        - input: "$(params.mas_app_channel_manage)"
+          operator: in
+          values: [""]
+      runAfter:
+        - ivtcore-monitor
+      workspaces:
+        - name: configs
+          workspace: shared-configs
+
+    # fvt_core_workspace - Workspace-level APIs
+    - name: fvt-core-workspace
+      params:
+        - name: mas_instance_id
+          value: $(params.mas_instance_id)
+        - name: mas_workspace_id
+          value: $(params.mas_workspace_id)
+        - name: fvt_image_registry
+          value: $(params.fvt_image_registry)
+        - name: fvt_image_digest
+          value: $(params.fvt_digest_monitor)
+        - name: fvt_test_suite
+          value: fvt_core_workspace
+        - name: product_channel
+          value: $(params.mas_app_channel_monitor)
+      timeout: "0"
+      taskRef:
+        kind: Task
+        name: mas-fvt-monitor
+      when:
+        - input: "$(params.fvt_digest_monitor)"
+          operator: notin
+          values: [""]
+        - input: "$(params.mas_app_channel_manage)"
+          operator: in
+          values: [""]
+      runAfter:
+        - ivtcore-monitor
+      workspaces:
+        - name: configs
+          workspace: shared-configs
+
+    # fvt_iot - IoT device data ingestion and certificate tests
+    - name: fvt-iot
+      params:
+        - name: mas_instance_id
+          value: $(params.mas_instance_id)
+        - name: mas_workspace_id
+          value: $(params.mas_workspace_id)
+        - name: fvt_image_registry
+          value: $(params.fvt_image_registry)
+        - name: fvt_image_digest
+          value: $(params.fvt_digest_monitor)
+        - name: fvt_test_suite
+          value: fvt_iot
+        - name: product_channel
+          value: $(params.mas_app_channel_monitor)
+      timeout: "0"
+      taskRef:
+        kind: Task
+        name: mas-fvt-monitor
+      when:
+        - input: "$(params.fvt_digest_monitor)"
+          operator: notin
+          values: [""]
+        - input: "$(params.mas_app_channel_manage)"
+          operator: in
+          values: [""]
+      runAfter:
+        - ivtcore-monitor
+      workspaces:
+        - name: configs
+          workspace: shared-configs
+
+    # fvt_pipeline_devicetype - Device type pipeline (KPI bootstrap + data lake validation)
+    - name: fvt-pipeline-devicetype
+      params:
+        - name: mas_instance_id
+          value: $(params.mas_instance_id)
+        - name: mas_workspace_id
+          value: $(params.mas_workspace_id)
+        - name: fvt_image_registry
+          value: $(params.fvt_image_registry)
+        - name: fvt_image_digest
+          value: $(params.fvt_digest_monitor)
+        - name: fvt_test_suite
+          value: fvt_pipeline_devicetype
+        - name: product_channel
+          value: $(params.mas_app_channel_monitor)
+      timeout: "0"
+      taskRef:
+        kind: Task
+        name: mas-fvt-monitor
+      when:
+        - input: "$(params.fvt_digest_monitor)"
+          operator: notin
+          values: [""]
+        - input: "$(params.mas_app_channel_manage)"
+          operator: in
+          values: [""]
+      runAfter:
+        - ivtcore-monitor
+      workspaces:
+        - name: configs
+          workspace: shared-configs
+
+    # fvt_pipeline_hierarchy - Hierarchy (asset/location/system/site/org) pipeline validation
+    - name: fvt-pipeline-hierarchy
+      params:
+        - name: mas_instance_id
+          value: $(params.mas_instance_id)
+        - name: mas_workspace_id
+          value: $(params.mas_workspace_id)
+        - name: fvt_image_registry
+          value: $(params.fvt_image_registry)
+        - name: fvt_image_digest
+          value: $(params.fvt_digest_monitor)
+        - name: fvt_test_suite
+          value: fvt_pipeline_hierarchy
+        - name: product_channel
+          value: $(params.mas_app_channel_monitor)
+      timeout: "0"
+      taskRef:
+        kind: Task
+        name: mas-fvt-monitor
+      when:
+        - input: "$(params.fvt_digest_monitor)"
+          operator: notin
+          values: [""]
+        - input: "$(params.mas_app_channel_manage)"
+          operator: in
+          values: [""]
+      runAfter:
+        - ivtcore-monitor
+      workspaces:
+        - name: configs
+          workspace: shared-configs
+
+    # fvt_edc - Edge Data Collector device library and protocol integration
+    - name: fvt-edc
+      params:
+        - name: mas_instance_id
+          value: $(params.mas_instance_id)
+        - name: mas_workspace_id
+          value: $(params.mas_workspace_id)
+        - name: fvt_image_registry
+          value: $(params.fvt_image_registry)
+        - name: fvt_image_digest
+          value: $(params.fvt_digest_monitor)
+        - name: fvt_test_suite
+          value: fvt_edc
+        - name: product_channel
+          value: $(params.mas_app_channel_monitor)
+      timeout: "0"
+      taskRef:
+        kind: Task
+        name: mas-fvt-monitor
+      when:
+        - input: "$(params.fvt_digest_monitor)"
+          operator: notin
+          values: [""]
+        - input: "$(params.mas_app_channel_manage)"
+          operator: in
+          values: [""]
+      runAfter:
+        - ivtcore-monitor
+      workspaces:
+        - name: configs
+          workspace: shared-configs
+
+    # fvt_int_mref - MREF (TRIRIGA, Webex, DNA Spaces) integration
+    - name: fvt-int-mref
+      params:
+        - name: mas_instance_id
+          value: $(params.mas_instance_id)
+        - name: mas_workspace_id
+          value: $(params.mas_workspace_id)
+        - name: fvt_image_registry
+          value: $(params.fvt_image_registry)
+        - name: fvt_image_digest
+          value: $(params.fvt_digest_monitor)
+        - name: fvt_test_suite
+          value: fvt_int_mref
+        - name: product_channel
+          value: $(params.mas_app_channel_monitor)
+      timeout: "0"
+      taskRef:
+        kind: Task
+        name: mas-fvt-monitor
+      when:
+        - input: "$(params.fvt_digest_monitor)"
+          operator: notin
+          values: [""]
+        - input: "$(params.mas_app_channel_manage)"
+          operator: in
+          values: [""]
+      runAfter:
+        - ivtcore-monitor
+      workspaces:
+        - name: configs
+          workspace: shared-configs
+
+    # fvt_int_scada - SCADA connector integration
+    - name: fvt-int-scada
+      params:
+        - name: mas_instance_id
+          value: $(params.mas_instance_id)
+        - name: mas_workspace_id
+          value: $(params.mas_workspace_id)
+        - name: fvt_image_registry
+          value: $(params.fvt_image_registry)
+        - name: fvt_image_digest
+          value: $(params.fvt_digest_monitor)
+        - name: fvt_test_suite
+          value: fvt_int_scada
+        - name: product_channel
+          value: $(params.mas_app_channel_monitor)
+      timeout: "0"
+      taskRef:
+        kind: Task
+        name: mas-fvt-monitor
+      when:
+        - input: "$(params.fvt_digest_monitor)"
+          operator: notin
+          values: [""]
+        - input: "$(params.mas_app_channel_manage)"
+          operator: in
+          values: [""]
+      runAfter:
+        - ivtcore-monitor
+      workspaces:
+        - name: configs
+          workspace: shared-configs
+
+    # 4. Data Dictionary FVT
     # -------------------------------------------------------------------------
     {{ lookup('template', 'taskdefs/fvt-data-dictionary/data-dictionary.yml.j2') | indent(4) }}
       runAfter:
-        - fvt-monitor
+        - fvt-monitoronly
+        - fvt-core-devicetype
+        - fvt-core-device
+        - fvt-core-gateway
+        - fvt-core-workspace
+        - fvt-iot
+        - fvt-pipeline-devicetype
+        - fvt-pipeline-hierarchy
+        - fvt-edc
+        - fvt-int-mref
+        - fvt-int-scada
+        - fvt-monitor-with-manage
 
   finally:
     # 1. Run CV
@@ -177,11 +556,18 @@ spec:
     - name: cv-monitor
       {{ lookup('template', 'taskdefs/ivt-core/common/taskref.yml.j2') | indent(6) }}
       params:
-        {{ lookup('template', 'taskdefs/ivt-core/common/params.yml.j2') | indent(8) }}
-        - name: product_id
-          value: ibm-mas-monitor
+        - name: mas_instance_id
+          value: $(params.mas_instance_id)
+        - name: mas_workspace_id
+          value: $(params.mas_workspace_id)
         - name: product_channel
           value: $(params.mas_app_channel_monitor)
+        - name: fvt_image_registry
+          value: $(params.fvt_image_registry)
+        - name: fvt_image_digest
+          value: $(params.ivt_digest_core)
+        - name: product_id
+          value: ibm-mas-monitor
         - name: fvt_test_suite
           value: contentverification
       when:
@@ -201,8 +587,6 @@ spec:
         - name: image_pull_policy
           value: $(params.image_pull_policy)
         - name: pipeline_status
-          # An aggregate status of all the pipelineTasks under the tasks section (excluding the finally section).
-          # This variable is only available in the finally tasks and can have any one of the values (Succeeded, Failed, Completed, or None)
           value: $(tasks.status)
         - name: pipeline_name
           value: $(context.pipeline.name)

--- a/tekton/src/pipelines/mas-fvt-monitor.yml.j2
+++ b/tekton/src/pipelines/mas-fvt-monitor.yml.j2
@@ -21,9 +21,6 @@ spec:
     - name: mas_app_channel_monitor
       type: string
       default: ""
-    - name: mas_app_channel_manage
-      type: string
-      default: ""
     - name: mas_instance_id
       type: string
       default: ""
@@ -54,15 +51,10 @@ spec:
       description: IVT Digest - Core
       default: ""
 
-    # Data Dictionary Digest
+    # Data Dictionary Digest (only populated for 8.10, 8.11, 9.0)
     - name: fvt_digest_data_dictionary
       type: string
       description: Data Dictionary Digest
-      default: ""
-
-    # Product channel (used for version-specific suite selection)
-    - name: product_channel
-      type: string
       default: ""
 
   tasks:
@@ -139,9 +131,10 @@ spec:
           operator: notin
           values: [""]
 
-    # 2. Legacy Monitor FVT - monitor_fvt_with_manage
+    # 2. Legacy Monitor FVT - monitor_fvt_with_manage (8.10, 8.11, 9.0 only)
     # -------------------------------------------------------------------------
-    # Kept unchanged - runs when Manage is installed alongside Monitor.
+    # Runs for Monitor versions 8.10, 8.11, and 9.0 only.
+    # Skipped for 9.1 and above where the new parallel suites are used instead.
     - name: fvt-monitor-with-manage
       params:
         - name: mas_instance_id
@@ -164,21 +157,20 @@ spec:
         - input: "$(params.fvt_digest_monitor)"
           operator: notin
           values: [""]
-        - input: "$(params.mas_app_channel_manage)"
-          operator: notin
-          values: [""]
+        - input: "$(params.mas_app_channel_monitor)"
+          operator: in
+          values: ["8.10.x-stable", "8.11.x-stable", "9.0.x-stable"]
       runAfter:
         - ivtcore-monitor
       workspaces:
         - name: configs
           workspace: shared-configs
 
-    # 3. New Parallel Monitor FVT Suites (9.1.x and above, no Manage)
+    # 3. New Parallel Monitor FVT Suites (9.1 and above)
     # -------------------------------------------------------------------------
     # All 11 suites run in parallel immediately after ivtcore-monitor completes.
     # Each suite is fully self-contained with its own setup and cleanup phases.
-    # The when condition (mas_app_channel_manage == "") ensures these only run
-    # when Manage is NOT installed (mutually exclusive with fvt-monitor-with-manage).
+    # Gated on mas_app_channel_monitor containing "9.1" or "9.2" (or later).
     # -------------------------------------------------------------------------
 
     # fvt_monitoronly - File ingest and basic monitor-only verification
@@ -204,9 +196,9 @@ spec:
         - input: "$(params.fvt_digest_monitor)"
           operator: notin
           values: [""]
-        - input: "$(params.mas_app_channel_manage)"
-          operator: in
-          values: [""]
+        - input: "$(params.mas_app_channel_monitor)"
+          operator: notin
+          values: ["", "8.10.x-stable", "8.11.x-stable", "9.0.x-stable"]
       runAfter:
         - ivtcore-monitor
       workspaces:
@@ -236,9 +228,9 @@ spec:
         - input: "$(params.fvt_digest_monitor)"
           operator: notin
           values: [""]
-        - input: "$(params.mas_app_channel_manage)"
-          operator: in
-          values: [""]
+        - input: "$(params.mas_app_channel_monitor)"
+          operator: notin
+          values: ["", "8.10.x-stable", "8.11.x-stable", "9.0.x-stable"]
       runAfter:
         - ivtcore-monitor
       workspaces:
@@ -268,9 +260,9 @@ spec:
         - input: "$(params.fvt_digest_monitor)"
           operator: notin
           values: [""]
-        - input: "$(params.mas_app_channel_manage)"
-          operator: in
-          values: [""]
+        - input: "$(params.mas_app_channel_monitor)"
+          operator: notin
+          values: ["", "8.10.x-stable", "8.11.x-stable", "9.0.x-stable"]
       runAfter:
         - ivtcore-monitor
       workspaces:
@@ -300,9 +292,9 @@ spec:
         - input: "$(params.fvt_digest_monitor)"
           operator: notin
           values: [""]
-        - input: "$(params.mas_app_channel_manage)"
-          operator: in
-          values: [""]
+        - input: "$(params.mas_app_channel_monitor)"
+          operator: notin
+          values: ["", "8.10.x-stable", "8.11.x-stable", "9.0.x-stable"]
       runAfter:
         - ivtcore-monitor
       workspaces:
@@ -332,9 +324,9 @@ spec:
         - input: "$(params.fvt_digest_monitor)"
           operator: notin
           values: [""]
-        - input: "$(params.mas_app_channel_manage)"
-          operator: in
-          values: [""]
+        - input: "$(params.mas_app_channel_monitor)"
+          operator: notin
+          values: ["", "8.10.x-stable", "8.11.x-stable", "9.0.x-stable"]
       runAfter:
         - ivtcore-monitor
       workspaces:
@@ -364,9 +356,9 @@ spec:
         - input: "$(params.fvt_digest_monitor)"
           operator: notin
           values: [""]
-        - input: "$(params.mas_app_channel_manage)"
-          operator: in
-          values: [""]
+        - input: "$(params.mas_app_channel_monitor)"
+          operator: notin
+          values: ["", "8.10.x-stable", "8.11.x-stable", "9.0.x-stable"]
       runAfter:
         - ivtcore-monitor
       workspaces:
@@ -396,9 +388,9 @@ spec:
         - input: "$(params.fvt_digest_monitor)"
           operator: notin
           values: [""]
-        - input: "$(params.mas_app_channel_manage)"
-          operator: in
-          values: [""]
+        - input: "$(params.mas_app_channel_monitor)"
+          operator: notin
+          values: ["", "8.10.x-stable", "8.11.x-stable", "9.0.x-stable"]
       runAfter:
         - ivtcore-monitor
       workspaces:
@@ -428,9 +420,9 @@ spec:
         - input: "$(params.fvt_digest_monitor)"
           operator: notin
           values: [""]
-        - input: "$(params.mas_app_channel_manage)"
-          operator: in
-          values: [""]
+        - input: "$(params.mas_app_channel_monitor)"
+          operator: notin
+          values: ["", "8.10.x-stable", "8.11.x-stable", "9.0.x-stable"]
       runAfter:
         - ivtcore-monitor
       workspaces:
@@ -460,9 +452,9 @@ spec:
         - input: "$(params.fvt_digest_monitor)"
           operator: notin
           values: [""]
-        - input: "$(params.mas_app_channel_manage)"
-          operator: in
-          values: [""]
+        - input: "$(params.mas_app_channel_monitor)"
+          operator: notin
+          values: ["", "8.10.x-stable", "8.11.x-stable", "9.0.x-stable"]
       runAfter:
         - ivtcore-monitor
       workspaces:
@@ -492,9 +484,9 @@ spec:
         - input: "$(params.fvt_digest_monitor)"
           operator: notin
           values: [""]
-        - input: "$(params.mas_app_channel_manage)"
-          operator: in
-          values: [""]
+        - input: "$(params.mas_app_channel_monitor)"
+          operator: notin
+          values: ["", "8.10.x-stable", "8.11.x-stable", "9.0.x-stable"]
       runAfter:
         - ivtcore-monitor
       workspaces:
@@ -524,19 +516,20 @@ spec:
         - input: "$(params.fvt_digest_monitor)"
           operator: notin
           values: [""]
-        - input: "$(params.mas_app_channel_manage)"
-          operator: in
-          values: [""]
+        - input: "$(params.mas_app_channel_monitor)"
+          operator: notin
+          values: ["", "8.10.x-stable", "8.11.x-stable", "9.0.x-stable"]
       runAfter:
         - ivtcore-monitor
       workspaces:
         - name: configs
           workspace: shared-configs
 
-    # 4. Data Dictionary FVT
+    # 4. Data Dictionary FVT (8.10, 8.11, 9.0 only - digest is empty for 9.1+)
     # -------------------------------------------------------------------------
     {{ lookup('template', 'taskdefs/fvt-data-dictionary/data-dictionary.yml.j2') | indent(4) }}
       runAfter:
+        - fvt-monitor-with-manage
         - fvt-monitoronly
         - fvt-core-devicetype
         - fvt-core-device
@@ -548,7 +541,6 @@ spec:
         - fvt-edc
         - fvt-int-mref
         - fvt-int-scada
-        - fvt-monitor-with-manage
 
   finally:
     # 1. Run CV

--- a/tekton/src/pipelines/mas-fvt-monitor.yml.j2
+++ b/tekton/src/pipelines/mas-fvt-monitor.yml.j2
@@ -168,8 +168,8 @@ spec:
 
     # 3. New Parallel Monitor FVT Suites (9.1 and above)
     # -------------------------------------------------------------------------
-    # All 11 suites run in parallel immediately after ivtcore-monitor completes.
-    # Each suite is fully self-contained with its own setup and cleanup phases.
+    # fvt_monitoronly runs first (creates default hierarchy: D_ORG, D_SITE_1, D_ASSET_1, D_LOCATION_1).
+    # Once it completes, the remaining 10 suites fan out in parallel (runAfter: fvt-monitoronly).
     # Gated on mas_app_channel_monitor containing "9.1" or "9.2" (or later).
     # -------------------------------------------------------------------------
 
@@ -232,7 +232,7 @@ spec:
           operator: notin
           values: ["", "8.10.x-stable", "8.11.x-stable", "9.0.x-stable"]
       runAfter:
-        - ivtcore-monitor
+        - fvt-monitoronly
       workspaces:
         - name: configs
           workspace: shared-configs
@@ -264,7 +264,7 @@ spec:
           operator: notin
           values: ["", "8.10.x-stable", "8.11.x-stable", "9.0.x-stable"]
       runAfter:
-        - ivtcore-monitor
+        - fvt-monitoronly
       workspaces:
         - name: configs
           workspace: shared-configs
@@ -296,7 +296,7 @@ spec:
           operator: notin
           values: ["", "8.10.x-stable", "8.11.x-stable", "9.0.x-stable"]
       runAfter:
-        - ivtcore-monitor
+        - fvt-monitoronly
       workspaces:
         - name: configs
           workspace: shared-configs
@@ -328,7 +328,7 @@ spec:
           operator: notin
           values: ["", "8.10.x-stable", "8.11.x-stable", "9.0.x-stable"]
       runAfter:
-        - ivtcore-monitor
+        - fvt-monitoronly
       workspaces:
         - name: configs
           workspace: shared-configs
@@ -360,7 +360,7 @@ spec:
           operator: notin
           values: ["", "8.10.x-stable", "8.11.x-stable", "9.0.x-stable"]
       runAfter:
-        - ivtcore-monitor
+        - fvt-monitoronly
       workspaces:
         - name: configs
           workspace: shared-configs
@@ -392,7 +392,7 @@ spec:
           operator: notin
           values: ["", "8.10.x-stable", "8.11.x-stable", "9.0.x-stable"]
       runAfter:
-        - ivtcore-monitor
+        - fvt-monitoronly
       workspaces:
         - name: configs
           workspace: shared-configs
@@ -424,7 +424,7 @@ spec:
           operator: notin
           values: ["", "8.10.x-stable", "8.11.x-stable", "9.0.x-stable"]
       runAfter:
-        - ivtcore-monitor
+        - fvt-monitoronly
       workspaces:
         - name: configs
           workspace: shared-configs
@@ -456,7 +456,7 @@ spec:
           operator: notin
           values: ["", "8.10.x-stable", "8.11.x-stable", "9.0.x-stable"]
       runAfter:
-        - ivtcore-monitor
+        - fvt-monitoronly
       workspaces:
         - name: configs
           workspace: shared-configs
@@ -488,7 +488,7 @@ spec:
           operator: notin
           values: ["", "8.10.x-stable", "8.11.x-stable", "9.0.x-stable"]
       runAfter:
-        - ivtcore-monitor
+        - fvt-monitoronly
       workspaces:
         - name: configs
           workspace: shared-configs
@@ -520,7 +520,7 @@ spec:
           operator: notin
           values: ["", "8.10.x-stable", "8.11.x-stable", "9.0.x-stable"]
       runAfter:
-        - ivtcore-monitor
+        - fvt-monitoronly
       workspaces:
         - name: configs
           workspace: shared-configs
@@ -552,7 +552,7 @@ spec:
           operator: notin
           values: ["", "8.10.x-stable", "8.11.x-stable", "9.0.x-stable"]
       runAfter:
-        - ivtcore-monitor
+        - fvt-monitoronly
       workspaces:
         - name: configs
           workspace: shared-configs

--- a/tekton/src/pipelines/mas-fvt-monitor.yml.j2
+++ b/tekton/src/pipelines/mas-fvt-monitor.yml.j2
@@ -57,6 +57,15 @@ spec:
       description: Data Dictionary Digest
       default: ""
 
+    # Computed suite selector (set by fvt-monitor.yml Ansible playbook):
+    #   monitor_fvt_with_manage : Monitor 8.10.x and 8.11.x (legacy, no health check)
+    #   fvt_90x                 : Monitor 9.0.x (monitor_fvt_with_manage + fvt_health_check)
+    #   fvt_91x                 : Monitor 9.1.x and 9.2.x+ (new parallel suites + fvt_health_check)
+    - name: fvt_test_suite
+      type: string
+      description: Which Monitor FVT suite grouping to run
+      default: ""
+
   tasks:
     - name: pipeline-start
       timeout: "0"
@@ -131,10 +140,11 @@ spec:
           operator: notin
           values: [""]
 
-    # 2. Legacy Monitor FVT - monitor_fvt_with_manage (8.10, 8.11, 9.0 only)
+    # 2. Legacy Monitor FVT - monitor_fvt_with_manage (8.10.x, 8.11.x, 9.0.x)
     # -------------------------------------------------------------------------
-    # Runs for Monitor versions 8.10, 8.11, and 9.0 only.
-    # Skipped for 9.1 and above where the new parallel suites are used instead.
+    # Runs for Monitor 8.10.x and 8.11.x (fvt_test_suite=monitor_fvt_with_manage)
+    # and Monitor 9.0.x (fvt_test_suite=fvt_90x).
+    # Skipped for 9.1+ where the new parallel suites are used instead.
     - name: fvt-monitor-with-manage
       params:
         - name: mas_instance_id
@@ -157,17 +167,18 @@ spec:
         - input: "$(params.fvt_digest_monitor)"
           operator: notin
           values: [""]
-        - input: "$(params.mas_app_channel_monitor)"
+        - input: "$(params.fvt_test_suite)"
           operator: in
-          values: ["8.10.x", "8.11.x", "9.0.x"]
+          values: ["monitor_fvt_with_manage", "fvt_90x"]
       runAfter:
         - ivtcore-monitor
       workspaces:
         - name: configs
           workspace: shared-configs
 
-    # 2b. Health-check suite - runs on Monitor 9.0, 9.1, 9.2+ (NOT 8.10 or 8.11)
-    # Validates /healthcheck/ready and /healthcheck/live. Acts as gate before fvt-monitoronly.
+    # 2b. Health-check suite - runs on Monitor 9.0.x, 9.1.x, 9.2.x+
+    # (NOT 8.10 or 8.11 — gated by fvt_test_suite being fvt_90x or fvt_91x)
+    # Validates /healthcheck/ready and /healthcheck/live.
     - name: fvt-health-check
       timeout: "0"
       taskRef:
@@ -190,29 +201,25 @@ spec:
         - input: "$(params.fvt_digest_monitor)"
           operator: notin
           values: [""]
-        - input: "$(params.mas_app_channel_monitor)"
-          operator: notin
-          values: ["", "8.10.x", "8.11.x"]
+        - input: "$(params.fvt_test_suite)"
+          operator: in
+          values: ["fvt_90x", "fvt_91x"]
       runAfter:
         - ivtcore-monitor
       workspaces:
         - name: configs
           workspace: shared-configs
 
-    # 3. New Parallel Monitor FVT Suites (9.1 and above)
+    # 3. New Parallel Monitor FVT Suites (9.1.x and 9.2.x+)
     # -------------------------------------------------------------------------
-    # fvt_hierarchy_setup runs first on ALL versions (9.1 and 9.2+).
-    # It creates Default + Pipeline hierarchies and device types so that all
-    # dependent suites find everything ready.
-    #
-    # Once fvt_hierarchy_setup completes, all other suites fan out in parallel
-    # (runAfter: fvt-hierarchy-setup), including fvt-monitoronly which is gated
-    # to 9.2+ only (@afterMON920) and handles CSV file ingest verification.
+    # All tasks in this section are gated on fvt_test_suite == "fvt_91x".
+    # fvt_hierarchy_setup runs first and creates Default + Pipeline hierarchies
+    # and device types so that all dependent suites find everything ready.
+    # Once fvt_hierarchy_setup completes, all other suites fan out in parallel.
     # -------------------------------------------------------------------------
 
-    # fvt_hierarchy_setup - Version-agnostic hierarchy bootstrap (9.1 and 9.2+)
+    # fvt_hierarchy_setup - Hierarchy bootstrap for 9.1+ parallel suites
     # Creates Default + Pipeline hierarchies, device types, devices, and assignments.
-    # Runs on ALL 9.1+ versions — no version gate.
     - name: fvt-hierarchy-setup
       params:
         - name: mas_instance_id
@@ -235,9 +242,9 @@ spec:
         - input: "$(params.fvt_digest_monitor)"
           operator: notin
           values: [""]
-        - input: "$(params.mas_app_channel_monitor)"
-          operator: notin
-          values: ["", "8.10.x", "8.11.x", "9.0.x"]
+        - input: "$(params.fvt_test_suite)"
+          operator: in
+          values: ["fvt_91x"]
       runAfter:
         - fvt-health-check
       workspaces:
@@ -268,9 +275,9 @@ spec:
         - input: "$(params.fvt_digest_monitor)"
           operator: notin
           values: [""]
-        - input: "$(params.mas_app_channel_monitor)"
-          operator: notin
-          values: ["", "8.10.x", "8.11.x", "9.0.x"]
+        - input: "$(params.fvt_test_suite)"
+          operator: in
+          values: ["fvt_91x"]
       runAfter:
         - fvt-hierarchy-setup
       workspaces:
@@ -300,9 +307,9 @@ spec:
         - input: "$(params.fvt_digest_monitor)"
           operator: notin
           values: [""]
-        - input: "$(params.mas_app_channel_monitor)"
-          operator: notin
-          values: ["", "8.10.x", "8.11.x", "9.0.x"]
+        - input: "$(params.fvt_test_suite)"
+          operator: in
+          values: ["fvt_91x"]
       runAfter:
         - fvt-hierarchy-setup
       workspaces:
@@ -332,9 +339,9 @@ spec:
         - input: "$(params.fvt_digest_monitor)"
           operator: notin
           values: [""]
-        - input: "$(params.mas_app_channel_monitor)"
-          operator: notin
-          values: ["", "8.10.x", "8.11.x", "9.0.x"]
+        - input: "$(params.fvt_test_suite)"
+          operator: in
+          values: ["fvt_91x"]
       runAfter:
         - fvt-hierarchy-setup
       workspaces:
@@ -364,9 +371,9 @@ spec:
         - input: "$(params.fvt_digest_monitor)"
           operator: notin
           values: [""]
-        - input: "$(params.mas_app_channel_monitor)"
-          operator: notin
-          values: ["", "8.10.x", "8.11.x", "9.0.x"]
+        - input: "$(params.fvt_test_suite)"
+          operator: in
+          values: ["fvt_91x"]
       runAfter:
         - fvt-hierarchy-setup
       workspaces:
@@ -396,9 +403,9 @@ spec:
         - input: "$(params.fvt_digest_monitor)"
           operator: notin
           values: [""]
-        - input: "$(params.mas_app_channel_monitor)"
-          operator: notin
-          values: ["", "8.10.x", "8.11.x", "9.0.x"]
+        - input: "$(params.fvt_test_suite)"
+          operator: in
+          values: ["fvt_91x"]
       runAfter:
         - fvt-hierarchy-setup
       workspaces:
@@ -428,9 +435,9 @@ spec:
         - input: "$(params.fvt_digest_monitor)"
           operator: notin
           values: [""]
-        - input: "$(params.mas_app_channel_monitor)"
-          operator: notin
-          values: ["", "8.10.x", "8.11.x", "9.0.x"]
+        - input: "$(params.fvt_test_suite)"
+          operator: in
+          values: ["fvt_91x"]
       runAfter:
         - fvt-hierarchy-setup
       workspaces:
@@ -460,9 +467,9 @@ spec:
         - input: "$(params.fvt_digest_monitor)"
           operator: notin
           values: [""]
-        - input: "$(params.mas_app_channel_monitor)"
-          operator: notin
-          values: ["", "8.10.x", "8.11.x", "9.0.x"]
+        - input: "$(params.fvt_test_suite)"
+          operator: in
+          values: ["fvt_91x"]
       runAfter:
         - fvt-hierarchy-setup
       workspaces:
@@ -492,9 +499,9 @@ spec:
         - input: "$(params.fvt_digest_monitor)"
           operator: notin
           values: [""]
-        - input: "$(params.mas_app_channel_monitor)"
-          operator: notin
-          values: ["", "8.10.x", "8.11.x", "9.0.x"]
+        - input: "$(params.fvt_test_suite)"
+          operator: in
+          values: ["fvt_91x"]
       runAfter:
         - fvt-hierarchy-setup
       workspaces:
@@ -524,9 +531,9 @@ spec:
         - input: "$(params.fvt_digest_monitor)"
           operator: notin
           values: [""]
-        - input: "$(params.mas_app_channel_monitor)"
-          operator: notin
-          values: ["", "8.10.x", "8.11.x", "9.0.x"]
+        - input: "$(params.fvt_test_suite)"
+          operator: in
+          values: ["fvt_91x"]
       runAfter:
         - fvt-hierarchy-setup
       workspaces:
@@ -556,9 +563,9 @@ spec:
         - input: "$(params.fvt_digest_monitor)"
           operator: notin
           values: [""]
-        - input: "$(params.mas_app_channel_monitor)"
-          operator: notin
-          values: ["", "8.10.x", "8.11.x", "9.0.x"]
+        - input: "$(params.fvt_test_suite)"
+          operator: in
+          values: ["fvt_91x"]
       runAfter:
         - fvt-hierarchy-setup
       workspaces:
@@ -588,9 +595,9 @@ spec:
         - input: "$(params.fvt_digest_monitor)"
           operator: notin
           values: [""]
-        - input: "$(params.mas_app_channel_monitor)"
-          operator: notin
-          values: ["", "8.10.x", "8.11.x", "9.0.x"]
+        - input: "$(params.fvt_test_suite)"
+          operator: in
+          values: ["fvt_91x"]
       runAfter:
         - fvt-hierarchy-setup
       workspaces:
@@ -620,9 +627,9 @@ spec:
         - input: "$(params.fvt_digest_monitor)"
           operator: notin
           values: [""]
-        - input: "$(params.mas_app_channel_monitor)"
-          operator: notin
-          values: ["", "8.10.x", "8.11.x", "9.0.x"]
+        - input: "$(params.fvt_test_suite)"
+          operator: in
+          values: ["fvt_91x"]
       runAfter:
         - fvt-hierarchy-setup
       workspaces:

--- a/tekton/src/pipelines/mas-fvt-monitor.yml.j2
+++ b/tekton/src/pipelines/mas-fvt-monitor.yml.j2
@@ -333,7 +333,39 @@ spec:
         - name: configs
           workspace: shared-configs
 
-    # fvt_iot - IoT device data ingestion and certificate tests
+    # fvt_core_hierarchy - Core hierarchy (asset/location/system/site/org) management APIs
+    - name: fvt-core-hierarchy
+      params:
+        - name: mas_instance_id
+          value: $(params.mas_instance_id)
+        - name: mas_workspace_id
+          value: $(params.mas_workspace_id)
+        - name: fvt_image_registry
+          value: $(params.fvt_image_registry)
+        - name: fvt_image_digest
+          value: $(params.fvt_digest_monitor)
+        - name: fvt_test_suite
+          value: fvt_core_hierarchy
+        - name: product_channel
+          value: $(params.mas_app_channel_monitor)
+      timeout: "0"
+      taskRef:
+        kind: Task
+        name: mas-fvt-monitor
+      when:
+        - input: "$(params.fvt_digest_monitor)"
+          operator: notin
+          values: [""]
+        - input: "$(params.mas_app_channel_monitor)"
+          operator: notin
+          values: ["", "8.10.x-stable", "8.11.x-stable", "9.0.x-stable"]
+      runAfter:
+        - ivtcore-monitor
+      workspaces:
+        - name: configs
+          workspace: shared-configs
+
+        # fvt_iot - IoT device data ingestion and certificate tests
     - name: fvt-iot
       params:
         - name: mas_instance_id
@@ -535,6 +567,7 @@ spec:
         - fvt-core-device
         - fvt-core-gateway
         - fvt-core-workspace
+        - fvt-core-hierarchy
         - fvt-iot
         - fvt-pipeline-devicetype
         - fvt-pipeline-hierarchy

--- a/tekton/src/pipelines/mas-fvt-monitor.yml.j2
+++ b/tekton/src/pipelines/mas-fvt-monitor.yml.j2
@@ -166,6 +166,39 @@ spec:
         - name: configs
           workspace: shared-configs
 
+    # 2b. Health-check suite - runs on ALL Monitor versions (9.0, 9.1, 9.2+)
+    # Validates /healthcheck/ready and /healthcheck/live. Acts as gate before fvt-monitoronly.
+    - name: fvt-health-check
+      timeout: "0"
+      taskRef:
+        kind: Task
+        name: mas-fvt-monitor
+      params:
+        - name: mas_instance_id
+          value: $(params.mas_instance_id)
+        - name: mas_workspace_id
+          value: $(params.mas_workspace_id)
+        - name: fvt_image_registry
+          value: $(params.fvt_image_registry)
+        - name: fvt_image_digest
+          value: $(params.fvt_digest_monitor)
+        - name: fvt_test_suite
+          value: fvt_health_check
+        - name: product_channel
+          value: $(params.mas_app_channel_monitor)
+      when:
+        - input: "$(params.fvt_digest_monitor)"
+          operator: notin
+          values: [""]
+        - input: "$(params.mas_app_channel_monitor)"
+          operator: notin
+          values: [""]
+      runAfter:
+        - ivtcore-monitor
+      workspaces:
+        - name: configs
+          workspace: shared-configs
+
     # 3. New Parallel Monitor FVT Suites (9.1 and above)
     # -------------------------------------------------------------------------
     # fvt_monitoronly runs first (creates default hierarchy: D_ORG, D_SITE_1, D_ASSET_1, D_LOCATION_1).
@@ -200,7 +233,7 @@ spec:
           operator: notin
           values: ["", "8.10.x-stable", "8.11.x-stable", "9.0.x-stable"]
       runAfter:
-        - ivtcore-monitor
+        - fvt-health-check
       workspaces:
         - name: configs
           workspace: shared-configs
@@ -561,6 +594,7 @@ spec:
     # -------------------------------------------------------------------------
     {{ lookup('template', 'taskdefs/fvt-data-dictionary/data-dictionary.yml.j2') | indent(4) }}
       runAfter:
+        - fvt-health-check
         - fvt-monitor-with-manage
         - fvt-monitoronly
         - fvt-core-devicetype

--- a/tekton/src/pipelines/mas-fvt-monitor.yml.j2
+++ b/tekton/src/pipelines/mas-fvt-monitor.yml.j2
@@ -201,12 +201,51 @@ spec:
 
     # 3. New Parallel Monitor FVT Suites (9.1 and above)
     # -------------------------------------------------------------------------
-    # fvt_monitoronly runs first (creates default hierarchy: D_ORG, D_SITE_1, D_ASSET_1, D_LOCATION_1).
-    # Once it completes, the remaining 10 suites fan out in parallel (runAfter: fvt-monitoronly).
-    # Gated on mas_app_channel_monitor containing "9.1" or "9.2" (or later).
+    # fvt_hierarchy_setup runs first on ALL versions (9.1 and 9.2+).
+    # It creates Default + Pipeline hierarchies and device types so that all
+    # dependent suites find everything ready.
+    #
+    # Once fvt_hierarchy_setup completes, all other suites fan out in parallel
+    # (runAfter: fvt-hierarchy-setup), including fvt-monitoronly which is gated
+    # to 9.2+ only (@afterMON920) and handles CSV file ingest verification.
     # -------------------------------------------------------------------------
 
-    # fvt_monitoronly - File ingest and basic monitor-only verification
+    # fvt_hierarchy_setup - Version-agnostic hierarchy bootstrap (9.1 and 9.2+)
+    # Creates Default + Pipeline hierarchies, device types, devices, and assignments.
+    # Runs on ALL 9.1+ versions — no version gate.
+    - name: fvt-hierarchy-setup
+      params:
+        - name: mas_instance_id
+          value: $(params.mas_instance_id)
+        - name: mas_workspace_id
+          value: $(params.mas_workspace_id)
+        - name: fvt_image_registry
+          value: $(params.fvt_image_registry)
+        - name: fvt_image_digest
+          value: $(params.fvt_digest_monitor)
+        - name: fvt_test_suite
+          value: fvt_hierarchy_setup
+        - name: product_channel
+          value: $(params.mas_app_channel_monitor)
+      timeout: "0"
+      taskRef:
+        kind: Task
+        name: mas-fvt-monitor
+      when:
+        - input: "$(params.fvt_digest_monitor)"
+          operator: notin
+          values: [""]
+        - input: "$(params.mas_app_channel_monitor)"
+          operator: notin
+          values: ["", "8.10.x-stable", "8.11.x-stable", "9.0.x-stable"]
+      runAfter:
+        - fvt-health-check
+      workspaces:
+        - name: configs
+          workspace: shared-configs
+
+    # fvt_monitoronly - CSV file ingest and 9.2-specific monitor-only verification
+    # Runs on Monitor 9.2+ only (gated by @afterMON920 inside the suite).
     - name: fvt-monitoronly
       params:
         - name: mas_instance_id
@@ -233,7 +272,7 @@ spec:
           operator: notin
           values: ["", "8.10.x-stable", "8.11.x-stable", "9.0.x-stable"]
       runAfter:
-        - fvt-health-check
+        - fvt-hierarchy-setup
       workspaces:
         - name: configs
           workspace: shared-configs
@@ -265,7 +304,7 @@ spec:
           operator: notin
           values: ["", "8.10.x-stable", "8.11.x-stable", "9.0.x-stable"]
       runAfter:
-        - fvt-monitoronly
+        - fvt-hierarchy-setup
       workspaces:
         - name: configs
           workspace: shared-configs
@@ -297,7 +336,7 @@ spec:
           operator: notin
           values: ["", "8.10.x-stable", "8.11.x-stable", "9.0.x-stable"]
       runAfter:
-        - fvt-monitoronly
+        - fvt-hierarchy-setup
       workspaces:
         - name: configs
           workspace: shared-configs
@@ -329,7 +368,7 @@ spec:
           operator: notin
           values: ["", "8.10.x-stable", "8.11.x-stable", "9.0.x-stable"]
       runAfter:
-        - fvt-monitoronly
+        - fvt-hierarchy-setup
       workspaces:
         - name: configs
           workspace: shared-configs
@@ -361,7 +400,7 @@ spec:
           operator: notin
           values: ["", "8.10.x-stable", "8.11.x-stable", "9.0.x-stable"]
       runAfter:
-        - fvt-monitoronly
+        - fvt-hierarchy-setup
       workspaces:
         - name: configs
           workspace: shared-configs
@@ -393,7 +432,7 @@ spec:
           operator: notin
           values: ["", "8.10.x-stable", "8.11.x-stable", "9.0.x-stable"]
       runAfter:
-        - fvt-monitoronly
+        - fvt-hierarchy-setup
       workspaces:
         - name: configs
           workspace: shared-configs
@@ -425,7 +464,7 @@ spec:
           operator: notin
           values: ["", "8.10.x-stable", "8.11.x-stable", "9.0.x-stable"]
       runAfter:
-        - fvt-monitoronly
+        - fvt-hierarchy-setup
       workspaces:
         - name: configs
           workspace: shared-configs
@@ -457,7 +496,7 @@ spec:
           operator: notin
           values: ["", "8.10.x-stable", "8.11.x-stable", "9.0.x-stable"]
       runAfter:
-        - fvt-monitoronly
+        - fvt-hierarchy-setup
       workspaces:
         - name: configs
           workspace: shared-configs
@@ -489,7 +528,7 @@ spec:
           operator: notin
           values: ["", "8.10.x-stable", "8.11.x-stable", "9.0.x-stable"]
       runAfter:
-        - fvt-monitoronly
+        - fvt-hierarchy-setup
       workspaces:
         - name: configs
           workspace: shared-configs
@@ -521,7 +560,7 @@ spec:
           operator: notin
           values: ["", "8.10.x-stable", "8.11.x-stable", "9.0.x-stable"]
       runAfter:
-        - fvt-monitoronly
+        - fvt-hierarchy-setup
       workspaces:
         - name: configs
           workspace: shared-configs
@@ -553,7 +592,7 @@ spec:
           operator: notin
           values: ["", "8.10.x-stable", "8.11.x-stable", "9.0.x-stable"]
       runAfter:
-        - fvt-monitoronly
+        - fvt-hierarchy-setup
       workspaces:
         - name: configs
           workspace: shared-configs
@@ -585,7 +624,7 @@ spec:
           operator: notin
           values: ["", "8.10.x-stable", "8.11.x-stable", "9.0.x-stable"]
       runAfter:
-        - fvt-monitoronly
+        - fvt-hierarchy-setup
       workspaces:
         - name: configs
           workspace: shared-configs
@@ -596,6 +635,7 @@ spec:
       runAfter:
         - fvt-health-check
         - fvt-monitor-with-manage
+        - fvt-hierarchy-setup
         - fvt-monitoronly
         - fvt-core-devicetype
         - fvt-core-device

--- a/tekton/src/pipelines/mas-fvt-monitor.yml.j2
+++ b/tekton/src/pipelines/mas-fvt-monitor.yml.j2
@@ -159,14 +159,14 @@ spec:
           values: [""]
         - input: "$(params.mas_app_channel_monitor)"
           operator: in
-          values: ["8.10.x-stable", "8.11.x-stable", "9.0.x-stable"]
+          values: ["8.10.x", "8.11.x", "9.0.x"]
       runAfter:
         - ivtcore-monitor
       workspaces:
         - name: configs
           workspace: shared-configs
 
-    # 2b. Health-check suite - runs on ALL Monitor versions (9.0, 9.1, 9.2+)
+    # 2b. Health-check suite - runs on Monitor 9.0, 9.1, 9.2+ (NOT 8.10 or 8.11)
     # Validates /healthcheck/ready and /healthcheck/live. Acts as gate before fvt-monitoronly.
     - name: fvt-health-check
       timeout: "0"
@@ -192,7 +192,7 @@ spec:
           values: [""]
         - input: "$(params.mas_app_channel_monitor)"
           operator: notin
-          values: [""]
+          values: ["", "8.10.x", "8.11.x"]
       runAfter:
         - ivtcore-monitor
       workspaces:
@@ -237,7 +237,7 @@ spec:
           values: [""]
         - input: "$(params.mas_app_channel_monitor)"
           operator: notin
-          values: ["", "8.10.x-stable", "8.11.x-stable", "9.0.x-stable"]
+          values: ["", "8.10.x", "8.11.x", "9.0.x"]
       runAfter:
         - fvt-health-check
       workspaces:
@@ -270,7 +270,7 @@ spec:
           values: [""]
         - input: "$(params.mas_app_channel_monitor)"
           operator: notin
-          values: ["", "8.10.x-stable", "8.11.x-stable", "9.0.x-stable"]
+          values: ["", "8.10.x", "8.11.x", "9.0.x"]
       runAfter:
         - fvt-hierarchy-setup
       workspaces:
@@ -302,7 +302,7 @@ spec:
           values: [""]
         - input: "$(params.mas_app_channel_monitor)"
           operator: notin
-          values: ["", "8.10.x-stable", "8.11.x-stable", "9.0.x-stable"]
+          values: ["", "8.10.x", "8.11.x", "9.0.x"]
       runAfter:
         - fvt-hierarchy-setup
       workspaces:
@@ -334,7 +334,7 @@ spec:
           values: [""]
         - input: "$(params.mas_app_channel_monitor)"
           operator: notin
-          values: ["", "8.10.x-stable", "8.11.x-stable", "9.0.x-stable"]
+          values: ["", "8.10.x", "8.11.x", "9.0.x"]
       runAfter:
         - fvt-hierarchy-setup
       workspaces:
@@ -366,7 +366,7 @@ spec:
           values: [""]
         - input: "$(params.mas_app_channel_monitor)"
           operator: notin
-          values: ["", "8.10.x-stable", "8.11.x-stable", "9.0.x-stable"]
+          values: ["", "8.10.x", "8.11.x", "9.0.x"]
       runAfter:
         - fvt-hierarchy-setup
       workspaces:
@@ -398,7 +398,7 @@ spec:
           values: [""]
         - input: "$(params.mas_app_channel_monitor)"
           operator: notin
-          values: ["", "8.10.x-stable", "8.11.x-stable", "9.0.x-stable"]
+          values: ["", "8.10.x", "8.11.x", "9.0.x"]
       runAfter:
         - fvt-hierarchy-setup
       workspaces:
@@ -430,7 +430,7 @@ spec:
           values: [""]
         - input: "$(params.mas_app_channel_monitor)"
           operator: notin
-          values: ["", "8.10.x-stable", "8.11.x-stable", "9.0.x-stable"]
+          values: ["", "8.10.x", "8.11.x", "9.0.x"]
       runAfter:
         - fvt-hierarchy-setup
       workspaces:
@@ -462,7 +462,7 @@ spec:
           values: [""]
         - input: "$(params.mas_app_channel_monitor)"
           operator: notin
-          values: ["", "8.10.x-stable", "8.11.x-stable", "9.0.x-stable"]
+          values: ["", "8.10.x", "8.11.x", "9.0.x"]
       runAfter:
         - fvt-hierarchy-setup
       workspaces:
@@ -494,7 +494,7 @@ spec:
           values: [""]
         - input: "$(params.mas_app_channel_monitor)"
           operator: notin
-          values: ["", "8.10.x-stable", "8.11.x-stable", "9.0.x-stable"]
+          values: ["", "8.10.x", "8.11.x", "9.0.x"]
       runAfter:
         - fvt-hierarchy-setup
       workspaces:
@@ -526,7 +526,7 @@ spec:
           values: [""]
         - input: "$(params.mas_app_channel_monitor)"
           operator: notin
-          values: ["", "8.10.x-stable", "8.11.x-stable", "9.0.x-stable"]
+          values: ["", "8.10.x", "8.11.x", "9.0.x"]
       runAfter:
         - fvt-hierarchy-setup
       workspaces:
@@ -558,7 +558,7 @@ spec:
           values: [""]
         - input: "$(params.mas_app_channel_monitor)"
           operator: notin
-          values: ["", "8.10.x-stable", "8.11.x-stable", "9.0.x-stable"]
+          values: ["", "8.10.x", "8.11.x", "9.0.x"]
       runAfter:
         - fvt-hierarchy-setup
       workspaces:
@@ -590,7 +590,7 @@ spec:
           values: [""]
         - input: "$(params.mas_app_channel_monitor)"
           operator: notin
-          values: ["", "8.10.x-stable", "8.11.x-stable", "9.0.x-stable"]
+          values: ["", "8.10.x", "8.11.x", "9.0.x"]
       runAfter:
         - fvt-hierarchy-setup
       workspaces:
@@ -622,7 +622,7 @@ spec:
           values: [""]
         - input: "$(params.mas_app_channel_monitor)"
           operator: notin
-          values: ["", "8.10.x-stable", "8.11.x-stable", "9.0.x-stable"]
+          values: ["", "8.10.x", "8.11.x", "9.0.x"]
       runAfter:
         - fvt-hierarchy-setup
       workspaces:

--- a/tekton/src/tasks/fvt-launcher/mas-launchfvt-monitor.yml.j2
+++ b/tekton/src/tasks/fvt-launcher/mas-launchfvt-monitor.yml.j2
@@ -73,18 +73,11 @@ spec:
 
         # Lookups from mas-fvt-monitor
         # -----------------------------------------------------------------------
-        # Framework Information
         - name: MAS_APP_CHANNEL_MONITOR
           valueFrom:
             secretKeyRef:
               name: mas-fvt-monitor
               key: MAS_APP_CHANNEL_MONITOR
-              optional: false
-        - name: MAS_APP_CHANNEL_MANAGE
-          valueFrom:
-            secretKeyRef:
-              name: mas-fvt-monitor
-              key: MAS_APP_CHANNEL_MANAGE
               optional: false
         - name: MAS_WORKSPACE_ID
           valueFrom:

--- a/tekton/src/tasks/fvt-launcher/mas-launchfvt-monitor.yml.j2
+++ b/tekton/src/tasks/fvt-launcher/mas-launchfvt-monitor.yml.j2
@@ -79,6 +79,12 @@ spec:
               name: mas-fvt-monitor
               key: MAS_APP_CHANNEL_MONITOR
               optional: false
+        - name: MAS_APP_CHANNEL_MANAGE
+          valueFrom:
+            secretKeyRef:
+              name: mas-fvt-monitor
+              key: MAS_APP_CHANNEL_MANAGE
+              optional: false
         - name: MAS_WORKSPACE_ID
           valueFrom:
             secretKeyRef:

--- a/tekton/src/tasks/fvt/mas-fvt-monitor.yml.j2
+++ b/tekton/src/tasks/fvt/mas-fvt-monitor.yml.j2
@@ -40,17 +40,23 @@ spec:
       default: "true"
     - name: fvt_test_suite
       type: string
-      description: Which Monitor FVT suite to run ('monitor_fvt' or 'monitor_fvt_with_manage')
+      description: >-
+        Which Monitor FVT suite to run. Valid values:
+          Legacy suites  : monitor_fvt_with_manage
+          New suites     : fvt_monitoronly, fvt_core_devicetype, fvt_core_device,
+                           fvt_core_gateway, fvt_core_workspace, fvt_iot,
+                           fvt_pipeline_devicetype, fvt_pipeline_hierarchy,
+                           fvt_edc, fvt_int_mref, fvt_int_scada
     - name: ctf_is_local
       type: string
-      description: Boolean value to check if tests are runninng locally or on fvt
+      description: Boolean value to check if tests are running locally or on fvt
       default: "false"
 
   steps:
     - name: fvt-monitor
       image: '$(params.fvt_image_registry)/fvt-monitor/fvt-ibm-mas-monitor@$(params.fvt_image_digest)'
       imagePullPolicy: $(params.image_pull_policy)
-      timeout: 6h # Ensure bad FVTs don't run forever .. want this to be smaller, but urgh, teams have already created huge suites that run for hours instead of multiple smaller suites
+      timeout: 6h # Ensure bad FVTs don't run forever
       onError: continue # Ensure bad FVTs don't break the pipeline
       workingDir: /opt/ibm/test
       env:
@@ -66,7 +72,7 @@ spec:
         - name: WORKSPACE_ID
           value: "$(params.mas_workspace_id)"
 
-       # Enable results to be saved
+        # Enable results to be saved
         - name: DEVOPS_MONGO_URI
           valueFrom:
             secretKeyRef:
@@ -93,7 +99,6 @@ spec:
               name: mas-fvt-monitor
               key: FVT_WHITELIST
               optional: false
-
 
         # Test Data
         - name: FVT_TEST_SUITE

--- a/tekton/src/tasks/fvt/mas-fvt-monitor.yml.j2
+++ b/tekton/src/tasks/fvt/mas-fvt-monitor.yml.j2
@@ -43,7 +43,8 @@ spec:
       description: >-
         Which Monitor FVT suite to run. Valid values:
           Legacy suites  : monitor_fvt_with_manage
-          New suites     : fvt_monitoronly, fvt_core_devicetype, fvt_core_device,
+          New suites     : fvt_health_check, fvt_hierarchy_setup,
+                           fvt_monitoronly, fvt_core_devicetype, fvt_core_device,
                            fvt_core_gateway, fvt_core_workspace, fvt_iot,
                            fvt_pipeline_devicetype, fvt_pipeline_hierarchy,
                            fvt_edc, fvt_int_mref, fvt_int_scada


### PR DESCRIPTION
## Summary

Replaces the monolithic `fvt_91x` test suite with 14 purpose-built parallel suites for Monitor 9.1+ and 9.2+, while preserving the legacy `monitor_fvt_with_manage` path for Monitor 8.10, 8.11 and 9.0. Routing is now done via a computed `fvt_test_suite` parameter using Jinja2 substring matching, making it immune to channel suffix variants like `-dev`, `-feature` or `-stable`.

---

## Optimisation of Tests through Suite Segregation

The old `fvt_91x` suite was a large sequential monolith. All tests ran one after another covering end to end flow of monitor in a single run. This prevented parallel execution and made failure isolation difficult. This PR segregates it into independent suites that run concurrently after a shared hierarchy bootstrap step, significantly reducing wall-clock time.

---

## What Changed

### `image/cli/masfvt/fvt-monitor.yml`
Computes `fvt_test_suite` at launch time via Jinja2 substring matching on `MAS_APP_CHANNEL_MONITOR`:

| Channel pattern | `fvt_test_suite` | Effect |
|---|---|---|
| `8.10.x*` / `8.11.x*` | `monitor_fvt_with_manage` | Legacy suite only |
| `9.0.x*` | `fvt_90x` | Legacy suite + health check |
| `9.1.x*` / `9.2.x*`+ | `fvt_91x` | All new parallel suites + health check |

### `image/cli/masfvt/templates/mas-fvt-monitor.yml.j2`
Passes the computed `fvt_test_suite` as a PipelineRun parameter so the Tekton pipeline can gate tasks on it.

### `tekton/src/pipelines/mas-fvt-monitor.yml.j2` — main pipeline rewrite
Adds `fvt_test_suite` as a pipeline param. All `when` conditions now gate on the suite name, not raw channel strings:

- **`fvt-monitor-with-manage`** — `operator: in ["monitor_fvt_with_manage", "fvt_90x"]` → runs on 8.10, 8.11, 9.0
- **`fvt-health-check`** — `operator: in ["fvt_90x", "fvt_91x"]` → runs on 9.0, 9.1, 9.2+
- **`fvt-hierarchy-setup`** — `operator: in ["fvt_91x"]` → runs on 9.1, 9.2+ only; acts as fan-out gate for all parallel suites
- **14 parallel suites** — all gate on `operator: in ["fvt_91x"]` and run concurrently after `fvt-hierarchy-setup`:
  `fvt_monitoronly`, `fvt_core_devicetype`, `fvt_core_device`, `fvt_core_gateway`, `fvt_core_workspace`, `fvt_core_hierarchy`, `fvt_iot`, `fvt_pipeline_devicetype`, `fvt_pipeline_hierarchy`, `fvt_edc`, `fvt_int_mref`, `fvt_int_scada`

Each parallel task hardcodes its own `fvt_test_suite` param value so the container executes `suites/<suite_name>/` — the old `fvt_91x` directory is never invoked.

---

## Execution Matrix

| Monitor version | Suites executed |
|---|---|
| `8.10.x*`, `8.11.x*` | `monitor_fvt_with_manage` |
| `9.0.x*` | `monitor_fvt_with_manage` + `fvt_health_check` |
| `9.1.x*`, `9.2.x*`+ | `fvt_health_check` + `fvt_hierarchy_setup` → 13 parallel suites |

---

## Pipeline Flow (9.1+)

```
pipeline-start
    └─ kyverno-monitor → ivtcore-monitor
            ├─ fvt-health-check
            └─ fvt-hierarchy-setup
                    ├─ fvt-monitoronly
                    ├─ fvt-core-devicetype
                    ├─ fvt-core-device
                    ├─ fvt-core-gateway
                    ├─ fvt-core-workspace
                    ├─ fvt-core-hierarchy
                    ├─ fvt-iot
                    ├─ fvt-pipeline-devicetype
                    ├─ fvt-pipeline-hierarchy
                    ├─ fvt-edc
                    ├─ fvt-int-mref
                    └─ fvt-int-scada
```

---

## Related PFVT runs
For 9.0 : https://dashboard.ibmmas.com/tests/pfvtjd1290/testsuite/ibm-mas-monitor/monitor_fvt_with_manage
For 9.1 : https://dashboard.ibmmas.com/tests/pfvtjd1291
Foe 9.2 : https://dashboard.ibmmas.com/tests/pfvtjd1692