### PR TITLE
[patch] Increase MAX_RETRIES for launchfvt-predict from 50 to 72

### DIFF
--- a/tekton/src/tasks/fvt-launcher/mas-launchfvt-predict.yml.j2
+++ b/tekton/src/tasks/fvt-launcher/mas-launchfvt-predict.yml.j2
@@ -117,7 +117,7 @@ spec:
     - name: wait-for-pipelinerun
       image: "quay.io/ibmmas/cli:latest"
       imagePullPolicy: $(params.image_pull_policy)
-      # 50 retries at 5 minute intervals = 4 hours
+      # 72 retries at 5 minute intervals = 6 hours
       command:
         - /opt/app-root/src/wait-for-tekton.sh
       env:
@@ -136,6 +136,6 @@ spec:
         - name: DELAY
           value: "300"
         - name: MAX_RETRIES
-          value: "50"
+          value: "72"
         - name: IGNORE_FAILURE
           value: "True"


### PR DESCRIPTION
The predict FVT suite executes long-running Watson Studio notebook jobs and routinely takes well over 4 hours to complete. The wait-for-pipelinerun step in mas-launchfvt-predict was configured with MAX_RETRIES=50 (50 x 5 min = 4h 10m), which is shorter than both the 6h step timeout and the 8h pipeline timeout set on the predict PipelineRun itself.

When the watcher exhausted its retries while predict was still running, IGNORE_FAILURE=True caused the step to exit 0, making the launcher believe predict had finished. This triggered the mas-fvt-finally pipeline (deprovision, must-gather) while predict tests were still actively executing, cutting the suite short.

Increase MAX_RETRIES to 72 (72 x 5 min = 6h), aligning the launcher's watch window with the 6h step timeout on the fvt-predict task so the watcher does not give up before the tests can legitimately complete.

Root-cause reference: build 8295, instance pfvtjdmnp92, 2026-08-14.
FVT Dashboard :https://dashboard.ibmmas.com/tests/pfvtjdmnp92/8295