### PR TITLE
[patch] Extend Monitor FVT 9.3.x support 

### DIFF
--- a/image/cli/masfvt/fvt-monitor.yml
+++ b/image/cli/masfvt/fvt-monitor.yml
@@ -25,11 +25,13 @@
     # Determine which Monitor FVT suite to run based on Monitor version and presence of Manage:
     #   - 8.10.x / 8.11.x: legacy suite (monitor_fvt_with_manage only, no health check)
     #   - 9.0.x:            legacy suite + health check (fvt_90x)
-    #   - 9.1.x / 9.2.x+:  new parallel suites (fvt_91x)
+    #   - 9.1.x / 9.2.x+ / 9.3.x+:  new parallel suites (fvt_91x)
     fvt_test_suite: >-
       {%- if '9.1' in mas_app_channel_monitor -%}
         fvt_91x
       {%- elif '9.2' in mas_app_channel_monitor -%}
+        fvt_91x
+      {%- elif '9.3' in mas_app_channel_monitor -%}
         fvt_91x
       {%- elif '9.0' in mas_app_channel_monitor -%}
         fvt_90x

--- a/image/cli/masfvt/templates/mas-fvt-monitor.yml.j2
+++ b/image/cli/masfvt/templates/mas-fvt-monitor.yml.j2
@@ -45,7 +45,7 @@ spec:
     # Which FVT suite to run - computed from Monitor channel + Manage presence
     # monitor_fvt_with_manage: 8.10.x, 8.11.x
     # fvt_90x:                 9.0.x (monitor_fvt_with_manage + health check)
-    # fvt_91x:                 9.1.x and above (new parallel suites + health check)
+    # fvt_91x:                 9.1.x and above, incl. 9.3.x+ (new parallel suites + health check)
     - name: fvt_test_suite
       value: "{{ fvt_test_suite }}"
 

--- a/tekton/src/pipelines/mas-fvt-monitor.yml.j2
+++ b/tekton/src/pipelines/mas-fvt-monitor.yml.j2
@@ -60,7 +60,7 @@ spec:
     # Computed suite selector (set by fvt-monitor.yml Ansible playbook):
     #   monitor_fvt_with_manage : Monitor 8.10.x and 8.11.x (legacy, no health check)
     #   fvt_90x                 : Monitor 9.0.x (monitor_fvt_with_manage + fvt_health_check)
-    #   fvt_91x                 : Monitor 9.1.x and 9.2.x+ (new parallel suites + fvt_health_check)
+    #   fvt_91x                 : Monitor 9.1.x, 9.2.x+ and 9.3.x+ (new parallel suites + fvt_health_check)
     - name: fvt_test_suite
       type: string
       description: Which Monitor FVT suite grouping to run
@@ -176,7 +176,7 @@ spec:
         - name: configs
           workspace: shared-configs
 
-    # 2b. Health-check suite - runs on Monitor 9.0.x, 9.1.x, 9.2.x+
+    # 2b. Health-check suite - runs on Monitor 9.0.x, 9.1.x, 9.2.x+, 9.3.x+
     # (NOT 8.10 or 8.11 — gated by fvt_test_suite being fvt_90x or fvt_91x)
     # Validates /healthcheck/ready and /healthcheck/live.
     - name: fvt-health-check
@@ -210,7 +210,7 @@ spec:
         - name: configs
           workspace: shared-configs
 
-    # 3. New Parallel Monitor FVT Suites (9.1.x and 9.2.x+)
+    # 3. New Parallel Monitor FVT Suites (9.1.x, 9.2.x+, 9.3.x+)
     # -------------------------------------------------------------------------
     # All tasks in this section are gated on fvt_test_suite == "fvt_91x".
     # fvt_hierarchy_setup runs first and creates Default + Pipeline hierarchies


### PR DESCRIPTION
Updated  mas-fvt-monitor.yml.j2 (template) and tekton/src/pipelines/mas-fvt-monitor.yml.j2 to reflect that monitor FVT covers 9.1.x, 9.2.x+, and 9.3.x+.

PFVT for 93: https://dashboard.ibmmas.com/tests/pfvtijkl93
PFVT for 92 : https://dashboard.ibmmas.com/tests/pfvtjvmnpd92
PFVT for 91 : https://dashboard.ibmmas.com/tests/pfvtmp9116
