### PR TITLE
[minor] Add ibm-ca.yaml.j2 template for Cognos Analytics CP4D service in gitops

### DIFF
--- a/image/cli/mascli/templates/gitops/appset-configs/cluster/instance/ibm-ca.yaml.j2
+++ b/image/cli/mascli/templates/gitops/appset-configs/cluster/instance/ibm-ca.yaml.j2
@@ -1,0 +1,8 @@
+merge-key: "{{ ACCOUNT_ID }}/{{ CLUSTER_ID }}/{{ MAS_INSTANCE_ID }}"
+
+ibm_cognos_analytics:
+  cpd_product_version: "{{ CPD_PRODUCT_VERSION }}"
+  ccs_version: "<path:{{ SECRETS_PATH }}:{{ SECRET_KEY_CCS_VERSION }}>"
+  cpd_service_block_storage_class: "{{ CPD_SERVICE_BLOCK_STORAGE_CLASS }}"
+  cpd_service_scale_config: "{{ CPD_SERVICE_SCALE_CONFIG }}"
+  cpd_service_storage_class: "{{ CPD_SERVICE_STORAGE_CLASS }}"


### PR DESCRIPTION
## Issue
https://jsw.ibm.com/browse/MASCORE-15507
https://jsw.ibm.com/browse/MASCORE-15752
https://jsw.ibm.com/browse/MASCORE-16163

## Description

Adds the `ibm-ca.yaml.j2` Jinja2 template for Cognos Analytics, following the same pattern as existing CP4D service templates (WSL, WML, Spark, SPSS).

**File added:**
```
image/cli/mascli/templates/gitops/appset-configs/cluster/instance/ibm-ca.yaml.j2
```

**Template generates the following gitops-envs config** for a given account/cluster/instance:
```yaml
merge-key: "{account}/{cluster}/{instance}"

ibm_cognos_analytics:
  cpd_product_version: "{{ CPD_PRODUCT_VERSION }}"
  ccs_version: "<path:{{ SECRETS_PATH }}:{{ SECRET_KEY_CCS_VERSION }}>"
  cpd_service_block_storage_class: "{{ CPD_SERVICE_BLOCK_STORAGE_CLASS }}"
  cpd_service_scale_config: "{{ CPD_SERVICE_SCALE_CONFIG }}"
  cpd_service_storage_class: "{{ CPD_SERVICE_STORAGE_CLASS }}"
```

This config is consumed by the `gitops` repo's `120-ibm-cognos-analytics` Helm chart via the ArgoCD Vault Plugin, which uses these values to deploy the Cognos Analytics Helm charts on the target cluster.

## Test Results

Tested on noble8 cluster (CPD 5.3.1):
- `gitops-cp4d-cognos` pipeline task triggered with `cpd_service_name: ca`
- `ibm-ca.yaml.j2` rendered correctly and committed to `gitops-envs` repo under `fyre-noble8-dev/noble8/inst02/`
- ArgoCD Application `cognos.noble8.inst02` synced successfully
- `CAService ca-addon-cr` reached `100% Completed` 
- CP4D service catalog shows Cognos Analytics **"Ready to provision"** 
