### PR TITLE
[patch] update channel env var name to AISERVICE_CHANNEL in rhoai.yml.j2

### DIFF
--- a/tekton/src/tasks/aiservice/rhoai.yml.j2
+++ b/tekton/src/tasks/aiservice/rhoai.yml.j2
@@ -71,7 +71,7 @@ spec:
         value: $(params.mas_instance_id)
 
       # Application - Operator
-      - name: MAS_APP_CHANNEL
+      - name: AISERVICE_CHANNEL
         value: $(params.aiservice_channel)
 
       # Custom Label Support


### PR DESCRIPTION
Renamed env var from `MAS_APP_CHANNEL` to `AISERVICE_CHANNEL` in the rhoai Tekton task.
