### PR TITLE
[patch] Extending OCP support to version 4.22

### DIFF
--- a/docs/commands/mirror-redhat-images.md
+++ b/docs/commands/mirror-redhat-images.md
@@ -22,7 +22,7 @@ Usage
 - `--pullsecret REDHAT_PULLSECRET` [Red Hat OpenShift Pull Secret](https://console.redhat.com/openshift/install/pull-secret)
 
 ### Content Selection (Optional):
-- `--release OCP_RELEASE` OCP Release to mirror content for (e.g. 4.16,4.17,4.18,4.19,4.20,4.21)
+- `--release OCP_RELEASE` OCP Release to mirror content for (e.g. 4.16,4.17,4.18,4.19,4.20,4.21,4.22)
 
 ### Platform Version Range (Optional):
 - `--min-version OCP_MIN_VERSION` Minimum version of the OCP release to mirror

--- a/image/cli/mascli/functions/mirror_redhat
+++ b/image/cli/mascli/functions/mirror_redhat
@@ -150,12 +150,13 @@ function mirror_redhat_interactive() {
   echo "${TEXT_DIM}Select the release to mirror content for:"
 
   echo "Supported OCP Releases:"
-  echo "  1) 4.21"
-  echo "  2) 4.20"
-  echo "  3) 4.19"
-  echo "  4) 4.18"
-  echo "  5) 4.17"
-  echo "  6) 4.16"
+  echo "  1) 4.22"
+  echo "  2) 4.21"
+  echo "  3) 4.20"
+  echo "  4) 4.19"
+  echo "  5) 4.18"
+  echo "  6) 4.17"
+  echo "  7) 4.16"
   reset_colors
 
   echo
@@ -163,21 +164,24 @@ function mirror_redhat_interactive() {
 
   case $OCP_RELEASE_SELECTION in
     1)
-      OCP_RELEASE=4.21
+      OCP_RELEASE=4.22
       ;;
     2)
-      OCP_RELEASE=4.20
+      OCP_RELEASE=4.21
       ;;
     3)
-      OCP_RELEASE=4.19
+      OCP_RELEASE=4.20
       ;;
     4)
-      OCP_RELEASE=4.18
+      OCP_RELEASE=4.19
       ;;
     5)
-      OCP_RELEASE=4.17
+      OCP_RELEASE=4.18
       ;;
     6)
+      OCP_RELEASE=4.17
+      ;;
+    7)
       OCP_RELEASE=4.16
       ;;
     *)

--- a/image/cli/mascli/functions/provision_aws
+++ b/image/cli/mascli/functions/provision_aws
@@ -153,31 +153,35 @@ function provision_aws_interactive() {
   # prompt_ocp_version                  # OCP_VERSION
   echo
   echo "OCP Version:"
-  echo "  1. 4.21 (MAS 8.10-9.2)"
-  echo "  2. 4.20 (MAS 8.10-9.2)" 
-  echo "  3. 4.19 (MAS 8.10-9.2)"  
-  echo "  4. 4.18 (MAS 8.10-9.1)"
-  echo "  5. 4.17 (MAS 8.10-9.1)"
-  echo "  6. 4.16 (MAS 8.10-9.1)"
+  echo "  1. 4.22 (MAS 8.10-9.3)"
+  echo "  2. 4.21 (MAS 8.10-9.2)"
+  echo "  3. 4.20 (MAS 8.10-9.2)" 
+  echo "  4. 4.19 (MAS 8.10-9.2)"  
+  echo "  5. 4.18 (MAS 8.10-9.1)"
+  echo "  6. 4.17 (MAS 8.10-9.1)"
+  echo "  7. 4.16 (MAS 8.10-9.1)"
   prompt_for_input "Select Version" OCP_VERSION_SELECTION "1"
 
   case $OCP_VERSION_SELECTION in
-    1|4.21)
+    1|4.22)
+      export OCP_VERSION=latest-4.22
+      ;;
+    2|4.21)
       export OCP_VERSION=latest-4.21
       ;;
-    2|4.20)
+    3|4.20)
       export OCP_VERSION=latest-4.20
       ;;
-    3|4.19)
+    4|4.19)
       export OCP_VERSION=latest-4.19
       ;;
-    4|4.18)
+    5|4.18)
       export OCP_VERSION=latest-4.18
       ;;
-    5|4.17)
+    6|4.17)
       export OCP_VERSION=latest-4.17
       ;;
-    6|4.16)
+    7|4.16)
       export OCP_VERSION=latest-4.16
       ;;
     *)

--- a/image/cli/mascli/functions/provision_fyre
+++ b/image/cli/mascli/functions/provision_fyre
@@ -219,31 +219,35 @@ function provision_fyre_interactive() {
 
   echo
   echo "OCP Version:"
-  echo "  1. 4.21"
-  echo "  2. 4.20"
-  echo "  3. 4.19"
-  echo "  4. 4.18"
-  echo "  5. 4.17"
-  echo "  6. 4.16"
+  echo "  1. 4.22"
+  echo "  2. 4.21"
+  echo "  3. 4.20"
+  echo "  4. 4.19"
+  echo "  5. 4.18"
+  echo "  6. 4.17"
+  echo "  7. 4.16"
   prompt_for_input "Select Version" OCP_VERSION_SELECTION "1"
 
   case $OCP_VERSION_SELECTION in
-    1|4.21)
+    1|4.22)
+      export OCP_VERSION=4.22
+      ;;
+    2|4.21)
       export OCP_VERSION=4.21
       ;;
-    2|4.20)
+    3|4.20)
       export OCP_VERSION=4.20
       ;;
-    3|4.19)
+    4|4.19)
       export OCP_VERSION=4.19
       ;;
-    4|4.18)
+    5|4.18)
       export OCP_VERSION=4.18
       ;;
-    5|4.17)
+    6|4.17)
       export OCP_VERSION=4.17
       ;;
-    6|4.16)
+    7|4.16)
       export OCP_VERSION=4.16
       ;;
     *)


### PR DESCRIPTION
Adding OCP 4.22 changes
files changed
docs/commands/mirror-redhat-images.md
image/cli/mascli/functions/mirror_redhat
image/cli/mascli/functions/provision_aws
image/cli/mascli/functions/provision_fyre

OCP 4.22 changes are made only on fyre and AWS.
OCP 4.22 is not yet released on IBM CLoud (ROKS) hence 4.22 is not enabled in ROKS.