### PR TITLE
[minor] Default to RHOAI and remove ODH/RHOAI interactive prompt

### DIFF
--- a/python/src/mas/cli/aiservice/install/app.py
+++ b/python/src/mas/cli/aiservice/install/app.py
@@ -313,14 +313,14 @@ class AiServiceInstallApp(BaseApp, aiServiceInstallArgBuilderMixin, aiServiceIns
                     self.setParam("environment_type", "production")
                     self.setParam("aiservice_odh_model_deployment_type", "raw")
                     self.setParam("aiservice_rhoai_model_deployment_type", "raw")
-                    self.setParam("rhoai", "false")
+                    self.setParam("rhoai", "true")
                 else:
                     self.operationalMode = 2
                     self.setParam("mas_annotations", "mas.ibm.com/operationalMode=nonproduction")
                     self.setParam("environment_type", "non-production")
                     self.setParam("aiservice_odh_model_deployment_type", "serverless")
                     self.setParam("aiservice_rhoai_model_deployment_type", "serverless")
-                    self.setParam("rhoai", "false")
+                    self.setParam("rhoai", "true")
 
             elif key == "additional_configs":
                 self.localConfigDir = value
@@ -673,23 +673,13 @@ class AiServiceInstallApp(BaseApp, aiServiceInstallArgBuilderMixin, aiServiceIns
             self.promptForString("Storage tenants bucket", "aiservice_s3_tenants_bucket")
             self.promptForString("Storage templates bucket", "aiservice_s3_templates_bucket")
 
-        # Configure AI Data Science Platform
-        self.printH2("Configure AI Data Science Platform")
-        self.printDescription(
-            [
-                "Choose which AI data science platform to install:",
-                " - <b>Note for 9.1.x</b>: Open Data Hub (ODH) is the supported platform for AI Service 9.1.x",
-                " - <b>Note for 9.2.x</b>: Red Hat OpenShift AI (RHOAI) is the recommended platform for AI Service 9.2.x",
-                "",
-                "  1. Red Hat OpenShift AI (RHOAI)",
-                "  2. Open Data Hub (ODH)",
-            ]
+        # AI Data Science Platform - defaults to Red Hat OpenShift AI (RHOAI)
+        self.setParam("rhoai", "true")
+        self.printWarning(
+            "Starting with AI Service 9.1.18, support for Open Data Hub (ODH) has been dropped. "
+            "Only Red Hat OpenShift AI (RHOAI) 2.25.10 or later is supported going forward. "
+            "If an existing ODH installation is detected, the installer will automatically migrate it to RHOAI."
         )
-        platformChoice = self.promptForInt("AI Data Science Platform", default=1, min=1, max=2)
-        if platformChoice == 2:
-            self.setParam("rhoai", "false")
-        else:
-            self.setParam("rhoai", "true")
 
         # Configure Certificate Issuer
         self.configCertIssuer()

--- a/python/src/mas/cli/install/app.py
+++ b/python/src/mas/cli/install/app.py
@@ -709,7 +709,7 @@ class InstallApp(
             self.setParam("aiservice_odh_model_deployment_type", "serverless")
             self.setParam("aiservice_rhoai_model_deployment_type", "serverless")
 
-        self.setParam("rhoai", "false")
+        self.setParam("rhoai", "true")
 
     @logMethodCall
     def configAdminMode(self):
@@ -1837,23 +1837,13 @@ class InstallApp(
                 self.promptForString("Storage tenants bucket", "aiservice_s3_tenants_bucket")
                 self.promptForString("Storage templates bucket", "aiservice_s3_templates_bucket")
 
-            # Configure AI Data Science Platform
-            self.printH2("Configure AI Data Science Platform")
-            self.printDescription(
-                [
-                    "Choose which AI data science platform to install:",
-                    " - <b>Note for 9.1.x</b>: Open Data Hub (ODH) is the supported platform for AI Service 9.1.x",
-                    " - <b>Note for 9.2.x</b>: Red Hat OpenShift AI (RHOAI) is the recommended platform for AI Service 9.2.x",
-                    "",
-                    "  1. Red Hat OpenShift AI (RHOAI)",
-                    "  2. Open Data Hub (ODH)",
-                ]
+            # AI Data Science Platform - defaults to Red Hat OpenShift AI (RHOAI)
+            self.setParam("rhoai", "true")
+            self.printWarning(
+                "Starting with AI Service 9.1.18, support for Open Data Hub (ODH) has been dropped. "
+                "Only Red Hat OpenShift AI (RHOAI) 2.25.10 or later is supported going forward. "
+                "If an existing ODH installation is detected, the installer will automatically migrate it to RHOAI."
             )
-            platformChoice = self.promptForInt("AI Data Science Platform", default=1, min=1, max=2)
-            if platformChoice == 2:
-                self.setParam("rhoai", "false")
-            else:
-                self.setParam("rhoai", "true")
 
             # Configure Certificate Issuer
             self.configAIServiceCertIssuer()

--- a/python/src/mas/cli/install/app.py
+++ b/python/src/mas/cli/install/app.py
@@ -2186,11 +2186,15 @@ class InstallApp(
                     self.operationalMode = 1
                     self.setParam("environment_type", "production")
                     self.setParam("aiservice_odh_model_deployment_type", "raw")
+                    self.setParam("aiservice_rhoai_model_deployment_type", "raw")
+                    self.setParam("rhoai", "true")
                 else:
                     self.operationalMode = 2
                     self.setParam("mas_annotations", "mas.ibm.com/operationalMode=nonproduction")
                     self.setParam("environment_type", "non-production")
                     self.setParam("aiservice_odh_model_deployment_type", "serverless")
+                    self.setParam("aiservice_rhoai_model_deployment_type", "serverless")
+                    self.setParam("rhoai", "true")
 
             elif key == "additional_configs":
                 self.localConfigDir = value

--- a/python/tests/integration/aiservice_install/test_app.py
+++ b/python/tests/integration/aiservice_install/test_app.py
@@ -287,8 +287,6 @@ def test_install_interactive_advanced(tmpdir):
                     return "username"
                 if re.match(".*minio root password.*", message):
                     return "password"
-                if re.match(".*AI Data Science Platform.*", message):
-                    return "1"
                 if re.match(r".*Configure certificate issuer\?.*", message):
                     return "y"
                 if re.match(".*Certificate issuer name.*", message):
@@ -445,8 +443,6 @@ def test_install_interactive_simplified(tmpdir):
                     return "username"
                 if re.match(".*minio root password.*", message):
                     return "password"
-                if re.match(".*AI Data Science Platform.*", message):
-                    return "1"
                 if re.match(".*Entitlement end date.*", message):
                     return "2027-02-16"
                 if re.match(".*Watsonxai api key.*", message):

--- a/python/tests/integration/aiservice_install/test_dev_mode.py
+++ b/python/tests/integration/aiservice_install/test_dev_mode.py
@@ -84,24 +84,22 @@ def test_aiservice_install_master_dev_mode(tmpdir):
         ".*Install Minio.*": lambda msg: "y",
         ".*minio root username.*": lambda msg: "miniouser",
         ".*minio root password.*": lambda msg: "miniopass",
-        # 11. AI Data Science Platform
-        ".*AI Data Science Platform.*": lambda msg: "1",
-        # 12. Tenant Settings
+        # 11. Tenant Settings
         ".*Entitlement end date.*": lambda msg: "2027-02-16",
-        # 13. WatsonX Integration
+        # 12. WatsonX Integration
         ".*Watsonxai api key.*": lambda msg: "testWxApiKey",
         ".*Watsonxai machine learning url.*": lambda msg: "https://us-south.ml.cloud.ibm.com",
         ".*Watsonxai project id.*": lambda msg: "testProjectId",
         ".*Does the Watsonxai AI use a self-signed certificate.*": lambda msg: "n",
         ".*Watsonxai Deployment ID.*": lambda msg: "",
         ".*Watsonxai Space ID.*": lambda msg: "",
-        # 14. RSL Integration
+        # 13. RSL Integration
         ".*Does the RSL API use a self-signed certificate.*": lambda msg: "n",
-        # 15. Database configuration
+        # 14. Database configuration
         ".*Do you want to use an external database.*": lambda msg: "n",
-        # 16. MongoDB configuration
+        # 15. MongoDB configuration
         ".*Create MongoDb cluster.*": lambda msg: "y",
-        # 17. Final confirmation
+        # 16. Final confirmation
         ".*Proceed with these settings.*": lambda msg: "y",
     }
 
@@ -157,24 +155,22 @@ def test_aiservice_install_master_dev_mode_existing_catalog(tmpdir):
         ".*Install Minio.*": lambda msg: "y",
         ".*minio root username.*": lambda msg: "miniouser",
         ".*minio root password.*": lambda msg: "miniopass",
-        # 11. AI Data Science Platform
-        ".*AI Data Science Platform.*": lambda msg: "1",
-        # 12. Tenant Settings
+        # 11. Tenant Settings
         ".*Entitlement end date.*": lambda msg: "2027-02-16",
-        # 13. WatsonX Integration
+        # 12. WatsonX Integration
         ".*Watsonxai api key.*": lambda msg: "testWxApiKey",
         ".*Watsonxai machine learning url.*": lambda msg: "https://us-south.ml.cloud.ibm.com",
         ".*Watsonxai project id.*": lambda msg: "testProjectId",
         ".*Does the Watsonxai AI use a self-signed certificate.*": lambda msg: "n",
         ".*Watsonxai Deployment ID.*": lambda msg: "",
         ".*Watsonxai Space ID.*": lambda msg: "",
-        # 14. RSL Integration
+        # 13. RSL Integration
         ".*Does the RSL API use a self-signed certificate.*": lambda msg: "n",
-        # 15. Database configuration
+        # 14. Database configuration
         ".*Do you want to use an external database.*": lambda msg: "n",
-        # 16. MongoDB configuration
+        # 15. MongoDB configuration
         ".*Create MongoDb cluster.*": lambda msg: "y",
-        # 17. Final confirmation
+        # 16. Final confirmation
         ".*Proceed with these settings.*": lambda msg: "y",
     }
 


### PR DESCRIPTION
## Summary

Removes the interactive "AI Data Science Platform" selection prompt from both `mas install` and `mas aiservice install`. Red Hat OpenShift AI(RHOAI) is now the default and only supported AI data science platform going forward.

## Changes

- **`mas install`** (`install/app.py`):
  - `configOperationMode()` now defaults `rhoai` param to `"true"`.
  - Removed the interactive ODH/RHOAI selection dialog in
    `aiServiceSettings()`; replaced with a warning notice.

- **`mas aiservice install`** (`aiservice/install/app.py`):
  - Non-interactive `non_prod` handler now sets `rhoai="true"` instead
    of `"false"` (RHOAI is now the default without needing `--rhoai`).
  - Removed the same interactive ODH/RHOAI selection dialog; replaced
    with the same warning notice.

## Testing
<img width="1728" height="264" alt="Screenshot 2026-08-24 at 2 57 42 PM" src="https://github.com/user-attachments/assets/4da8187f-6d7d-4350-9e9e-35eec46c2fb1" />
<img width="892" height="143" alt="Screenshot 2026-08-24 at 3 27 13 PM" src="https://github.com/user-attachments/assets/cd4e9765-4aae-4c05-b573-be77b58f2f6e" />

