### PR TITLE
[doc] Update Cloud Pak for Data compatibility to v5.3.1

### DIFF
--- a/docs/catalogs/v9-260827-amd64.md
+++ b/docs/catalogs/v9-260827-amd64.md
@@ -48,7 +48,7 @@ The following packages from the `registry.redhat.io/redhat/redhat-operator-index
 
 IBM Cloud Pak for Data Compatibility
 -------------------------------------------------------------------------------
-This catalog is certified compatible with **IBM Cloud Pak for Data v5.2.0**.
+This catalog is certified compatible with **IBM Cloud Pak for Data v5.3.1**.
 
 For more information on Cloud Pak for Data's support policy review this [IBM Cloud Pak for Data Software Support Lifecycle Addendum](https://www.ibm.com/support/pages/node/6593147).
 


### PR DESCRIPTION
Updates the IBM Cloud Pak for Data certified compatibility version from v5.2.0 to v5.3.1 in the v9-260827-amd64 catalog documentation.