### PR TITLE
[patch] Fix AppConfig (MAF) not deprovisioned when maf block is removed or instance is deprovisioned in gitops

### DIFF
--- a/tekton/src/pipelines/gitops/gitops-deprovision-mas-instance.yml.j2
+++ b/tekton/src/pipelines/gitops/gitops-deprovision-mas-instance.yml.j2
@@ -63,6 +63,12 @@ spec:
     - name: smtp_use_sendgrid
       type: string
       default: ""
+
+    # maf parameters
+    # -------------------------------------------------------------------------
+    - name: maf_enabled
+      type: string
+      default: ""
   tasks:
     # Deprovision workspace
     # -------------------------------------------------------------------------
@@ -275,6 +281,31 @@ spec:
       taskRef:
         kind: Task
         name: gitops-deprovision-suite-watson-studio-config
+      workspaces:
+        - name: configs
+          workspace: configs
+
+    # Deprovision AppConfig (MAF)
+    # -------------------------------------------------------------------------
+    - name: gitops-deprovision-maf-app-config
+      runAfter:
+        - gitops-deprovision-suite-workspace
+      params:
+        {{ lookup('template', pipeline_src_dir ~ '/taskdefs/gitops/common/gitops-params.yml.j2') | indent(8) }}
+        {{ lookup('template', pipeline_src_dir ~ '/taskdefs/gitops/common/secrets-params.yml.j2') | indent(8) }}
+        {{ lookup('template', pipeline_src_dir ~ '/taskdefs/gitops/common/git-params.yml.j2') | indent(8) }}
+
+        - name: mas_instance_id
+          value: $(params.mas_instance_id)
+        - name: maf_enabled
+          value: $(params.maf_enabled)
+      taskRef:
+        kind: Task
+        name: gitops-delete-app-config
+      when:
+        - input: "$(params.maf_enabled)"
+          operator: in
+          values: ["true"]
       workspaces:
         - name: configs
           workspace: configs

--- a/tekton/src/pipelines/gitops/gitops-mas-instance.yml.j2
+++ b/tekton/src/pipelines/gitops/gitops-mas-instance.yml.j2
@@ -263,7 +263,7 @@ spec:
       type: string
     - name: application_configuration
       type: string
-      default: "true"
+      default: ""
     - name: additional_resources_instances
       type: string
       default: ""
@@ -1003,6 +1003,8 @@ spec:
     # 3. Deprovision app config
     # -------------------------------------------------------------------------
     - name: gitops-deprovision-maf-app-config
+      runAfter:
+        - gitops-suite-config
       params:
         {{ lookup('template', pipeline_src_dir ~ '/taskdefs/gitops/common/gitops-params.yml.j2') | indent(8) }}
         {{ lookup('template', pipeline_src_dir ~ '/taskdefs/gitops/common/secrets-params.yml.j2') | indent(8) }}


### PR DESCRIPTION
## Issue
https://jira.swg-devops.com/browse/MASCORE-17756

## Description
AppConfig (MAF) deprovision was silently skipped in two scenarios:

### Scenario 1 — Removing the `maf` block from `mas-instance-params.yaml`
When the `maf`/`application_configuration` block is removed from `mas-instance-params.yaml`, the launcher classifies this as a positive instance-level change and triggers the `gitops-mas-instance` pipeline. The `gitops-deprovision-maf-app-config` task exists in this pipeline but had two problems:

1. **Race condition** — no `runAfter` was set, so `gitops-deprovision-maf-app-config` started at T=0 in parallel with `gitops-suite` and `gitops-suite-config`. Because `application_configuration` had a hardcoded default of `"true"`, `gitops-suite` would re-provision AppConfig and overwrite the deletion made by the deprovision task in the same git commit window.
2. **Silent re-provision** — the `application_configuration` param defaulted to `"true"`, meaning `gitops-suite` always treated AppConfig as enabled even after the `maf` block was removed from params.

**Fixes:**
- Added `runAfter: - gitops-suite-config` to `gitops-deprovision-maf-app-config` so it only runs after the full provisioning path has completed, eliminating the race.
- Changed `application_configuration` default from `"true"` to `""` so that removing the key from params correctly propagates as absent instead of silently defaulting to enabled.

### Scenario 2 — Full instance deprovision
When `mas-instance-params.yaml` is deleted entirely (full instance deprovision), the `gitops-deprovision-mas-instance` pipeline is triggered. This pipeline had **no** `gitops-deprovision-maf-app-config` task and no `maf_enabled` param — so AppConfig was never cleaned up regardless of whether MAF was enabled.

**Fixes:**
- Added `maf_enabled` param (default `""`) to `gitops-deprovision-mas-instance` pipeline.
- Added `gitops-deprovision-maf-app-config` task referencing `gitops-delete-app-config`, with `runAfter: gitops-deprovision-suite-workspace` and `when: maf_enabled in ["true"]` so it only fires when MAF was actually provisioned.
- Added `maf_enabled` to the `mas-instance-deprovision-listener` TriggerTemplate, TriggerBinding (`$(event.merged_params.maf.enabled)`), and PipelineRun params so the value flows through from the event payload.

## Test Results
Tested by reverting the `maf` block from `mas-instance-params.yaml` in `fyre-noble8-dev/us-east-2/noble8/inst01` and verifying:
- The `gitops-mas-instance` pipeline runs with `gitops-deprovision-maf-app-config` executing after `gitops-suite-config` completes (no race).
- AppConfig gitops file is removed from the repo and not re-created by `gitops-suite`.

Full instance deprovision with `maf.enabled: true` should be verified against a cluster with MAF provisioned.

## Related Pull Requests
<!-- Please list any related pull requests in other repositories. -->
- saas-tekton: <link to saas-tekton PR>

<hr/>

### :warning: Notes for Reviewers
* Ensure you have understood the [guidelines](https://pages.github.ibm.com/maximoappsuite/playbook/tools/github/#guidelines) before proceeding with a review.
* Ensure all sections in the PR template are appropriately completed.