### PR TITLE
MASCORE-10022 Allow specification of any schema name in MREF SaaS - CLI support for facilities_db2_schema

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "build/bin/config/oscap/ssg-rhel9-ds.xml|^.secrets.baseline$|^docs/catalogs/",
     "lines": null
   },
-  "generated_at": "2026-08-20T08:19:14Z",
+  "generated_at": "2026-09-02T06:51:41Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -310,7 +310,7 @@
         "hashed_secret": "1459943ba5fd876f7ef6e48f566a40b448a2bf08",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 484,
+        "line_number": 488,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/image/cli/mascli/functions/gitops_db2u_database
+++ b/image/cli/mascli/functions/gitops_db2u_database
@@ -636,7 +636,7 @@ DB2_WORKLOAD: '${DB2_WORKLOAD}'"
   echo_reset_dim "skip-backup-notification ...................... ${COLOR_MAGENTA}${SKIP_BACKUP_NOTIFICATION}"
   echo_reset_dim "manually-set-enhanced-hadr .................... ${COLOR_MAGENTA}${MANUALLY_SET_ENHANCED_HADR}"
   echo_reset_dim "allow-list .................................... ${COLOR_MAGENTA}${ALLOW_LIST}"
-  echo_reset_dim "facilities-db2-schema ......................... ${COLOR_MAGENTA}${FACILITIES_DB2_SCHEMA}"
+  echo_reset_dim "facilities-db2-schema ......................... ${COLOR_MAGENTA}${FACILITIES_DB2_SCHEMA}" 
   echo_reset_dim "Cluster Domain ................................ ${COLOR_MAGENTA}${CLUSTER_DOMAIN}"
   reset_colors
 

--- a/image/cli/mascli/functions/gitops_db2u_database
+++ b/image/cli/mascli/functions/gitops_db2u_database
@@ -70,6 +70,7 @@ IBM DB2U:
       --auto-backup ${COLOR_YELLOW}AUTO_BACKUP${TEXT_RESET}                                                      Flag whether to install the Auto DB2 backup feature or not
       --manually-set-enhanced-hadr ${COLOR_YELLOW}MANUALLY_SET_ENHANCED_HADR${TEXT_RESET}                        Flag to indicate whether enhanced HADR was configured manually
       --allow-list ${COLOR_YELLOW}ALLOW_LIST${TEXT_RESET}                                                        List of IPs or CIDR range that will be whitelisted
+      --facilities-db2-schema ${COLOR_YELLOW}FACILITIES_DB2_SCHEMA${TEXT_RESET}                                  TRIRIGA schema name for Facilities (default: TRIDATA)
       --cluster-domain ${COLOR_YELLOW}CLUSTER_DOMAIN${TEXT_RESET}                                                Cluster domain if any tls route needs to be created. Only needed if redhat cert-manager is not installed.
 
 Secrets Manager:
@@ -310,6 +311,9 @@ function gitops_db2u_database_noninteractive() {
       --allow-list)
         export ALLOW_LIST=$1 && shift
         ;;
+      --facilities-db2-schema)
+        export FACILITIES_DB2_SCHEMA=$1 && shift
+        ;;
       --cluster-domain)
       export CLUSTER_DOMAIN=$1 && shift
         ;;
@@ -530,6 +534,9 @@ DB2_WORKLOAD: '${DB2_WORKLOAD}'"
   if [[ -z $MANUALLY_SET_ENHANCED_HADR ]]; then
     export MANUALLY_SET_ENHANCED_HADR=false
   fi
+  if [[ -z $FACILITIES_DB2_SCHEMA ]]; then
+    export FACILITIES_DB2_SCHEMA="TRIDATA"
+  fi
   export DB2_NAMESPACE="db2u-${MAS_INSTANCE_ID}"
   export DB2_DBNAME=${DB2_DBNAME:-"BLUDB"}
   export JDBC_ROUTE=${JDBC_ROUTE:-"default"}
@@ -629,6 +636,7 @@ DB2_WORKLOAD: '${DB2_WORKLOAD}'"
   echo_reset_dim "skip-backup-notification ...................... ${COLOR_MAGENTA}${SKIP_BACKUP_NOTIFICATION}"
   echo_reset_dim "manually-set-enhanced-hadr .................... ${COLOR_MAGENTA}${MANUALLY_SET_ENHANCED_HADR}"
   echo_reset_dim "allow-list .................................... ${COLOR_MAGENTA}${ALLOW_LIST}"
+  echo_reset_dim "facilities-db2-schema ......................... ${COLOR_MAGENTA}${FACILITIES_DB2_SCHEMA}"
   echo_reset_dim "Cluster Domain ................................ ${COLOR_MAGENTA}${CLUSTER_DOMAIN}"
   reset_colors
 

--- a/image/cli/mascli/templates/gitops/appset-configs/cluster/instance/db2-databases/ibm-db2u-database.yaml.j2
+++ b/image/cli/mascli/templates/gitops/appset-configs/cluster/instance/db2-databases/ibm-db2u-database.yaml.j2
@@ -137,3 +137,7 @@ db2_backup_icd_auth_key: <path:{{ SECRETS_PATH }}:{{ SECRET_KEY_DB2_BACKUP_ICD_A
 allow_list:
   ips: {{ ALLOW_LIST }}
 {% endif %}
+
+{% if MAS_APP_ID == 'facilities' and FACILITIES_DB2_SCHEMA is defined and FACILITIES_DB2_SCHEMA != '' %}
+facilities_db2_schema: {{ FACILITIES_DB2_SCHEMA }}
+{% endif %}


### PR DESCRIPTION
## Issue
https://jsw.ibm.com/browse/MASCORE-10022

## Description
There are some non-standard implementations of TRIRIGA in SaaS and on-prem 
that we will need to migrate into MREF. Previously the TRIRIGA schema name 
was hardcoded as `TRIDATA` in the DB2U database template, preventing customers 
with a non-standard schema name from using DB2 backup for migration (which 
would require an expensive TEL DB migration instead).

This change adds support for a configurable `facilities_db2_schema` value in 
the `ibm-db2u-database.yaml.j2` template:
- Only written when `MAS_APP_ID == 'facilities'`
- Only written when `FACILITIES_DB2_SCHEMA` is defined and non-empty
- Defaults to `TRIDATA` if not provided — all existing deployments are unaffected