### PR TITLE
feat(MASR-10793): wire fvt_gitops block into ibm-mas-instance-base template

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "build/bin/config/oscap/ssg-rhel9-ds.xml|^.secrets.baseline$|^docs/catalogs/",
     "lines": null
   },
-  "generated_at": "2026-08-20T08:19:14Z",
+  "generated_at": "2026-09-08T11:11:17Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -502,7 +502,7 @@
         "hashed_secret": "b2817467154949a61f8e9ad31d1eeaf03221cbfa",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 674,
+        "line_number": 684,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/image/cli/mascli/functions/gitops_suite
+++ b/image/cli/mascli/functions/gitops_suite
@@ -446,6 +446,14 @@ function gitops_suite_noninteractive() {
         export PRODUCTION_DATABASE_ACCESS_TYPE=$1 && shift
         ;;
 
+      --fvt-gitops-enabled)
+        export FVT_GITOPS_ENABLED=$1 && shift
+        ;;
+
+      --fvt-gitops-enabled-apps)
+        export FVT_GITOPS_ENABLED_APPS=$1 && shift
+        ;;
+
       # Other Commands
       -h|--help)
         gitops_suite_help
@@ -662,6 +670,8 @@ function gitops_suite() {
   fi
   echo_reset_dim "Default welcome message .................... ${COLOR_MAGENTA}${WELCOME_MESSAGE}"
   echo_reset_dim "Production Database Access Type ............ ${COLOR_MAGENTA}${PRODUCTION_DATABASE_ACCESS_TYPE}"
+  echo_reset_dim "FVT GitOps Enabled ......................... ${COLOR_MAGENTA}${FVT_GITOPS_ENABLED}"
+  echo_reset_dim "FVT GitOps Enabled Apps .................... ${COLOR_MAGENTA}${FVT_GITOPS_ENABLED_APPS}"
   reset_colors
 
   if [[ -n "$DNS_PROVIDER" ]]; then

--- a/image/cli/mascli/templates/gitops/appset-configs/cluster/instance/ibm-mas-instance-base.yaml.j2
+++ b/image/cli/mascli/templates/gitops/appset-configs/cluster/instance/ibm-mas-instance-base.yaml.j2
@@ -80,3 +80,13 @@ cli_image_repo: {{ MAS_CLI_IMAGE_REPO }}
 production_database_access:
   type: {{ PRODUCTION_DATABASE_ACCESS_TYPE }}
 {%- endif %}
+
+{%- if FVT_GITOPS_ENABLED is defined and FVT_GITOPS_ENABLED == 'true' %}
+fvt_gitops:
+  enabled: true
+  # enabled_apps: "suite" always runs; append app names from mas-apps-params.yaml
+  # that have a matching suite directory in the fvt-gitops image.
+  enabled_apps: "{{ FVT_GITOPS_ENABLED_APPS | default('suite') }}"
+  image_repo: "{{ FVT_GITOPS_IMAGE_REPO | default('docker-na-public.artifactory.swg-devops.com/wiotp-docker-local/mas-devops/fvt-gitops') }}"
+  image_tag: "{{ FVT_GITOPS_IMAGE_TAG | default('latest') }}"
+{%- endif %}

--- a/image/cli/mascli/templates/gitops/appset-configs/cluster/instance/ibm-mas-instance-base.yaml.j2
+++ b/image/cli/mascli/templates/gitops/appset-configs/cluster/instance/ibm-mas-instance-base.yaml.j2
@@ -86,7 +86,7 @@ fvt_gitops:
   enabled: true
   # enabled_apps: "suite" always runs; append app names from mas-apps-params.yaml
   # that have a matching suite directory in the fvt-gitops image.
-  enabled_apps: "{{ FVT_GITOPS_ENABLED_APPS | default('suite') }}"
+  enabled_apps: "{{ FVT_GITOPS_ENABLED_APPS | default('suite,manage') }}"
   image_repo: "{{ FVT_GITOPS_IMAGE_REPO | default('docker-na-public.artifactory.swg-devops.com/wiotp-docker-local/mas-devops/fvt-gitops') }}"
   image_tag: "{{ FVT_GITOPS_IMAGE_TAG | default('latest') }}"
 {%- endif %}

--- a/tekton/src/pipelines/gitops/gitops-mas-instance.yml.j2
+++ b/tekton/src/pipelines/gitops/gitops-mas-instance.yml.j2
@@ -300,6 +300,12 @@ spec:
     - name: production_database_access_type
       type: string
       default: ""
+    - name: fvt_gitops_enabled
+      type: string
+      default: "false"
+    - name: fvt_gitops_enabled_apps
+      type: string
+      default: "suite,manage"
 
   tasks:
 
@@ -559,6 +565,10 @@ spec:
           value: $(params.mas_use_service_mesh)
         - name: production_database_access_type
           value: $(params.production_database_access_type)
+        - name: fvt_gitops_enabled
+          value: $(params.fvt_gitops_enabled)
+        - name: fvt_gitops_enabled_apps
+          value: $(params.fvt_gitops_enabled_apps)
       taskRef:
         kind: Task
         name: gitops-suite

--- a/tekton/src/tasks/gitops/gitops-suite.yml.j2
+++ b/tekton/src/tasks/gitops/gitops-suite.yml.j2
@@ -184,6 +184,12 @@ spec:
     - name: production_database_access_type
       type: string
       default: ""
+    - name: fvt_gitops_enabled
+      type: string
+      default: "false"
+    - name: fvt_gitops_enabled_apps
+      type: string
+      default: "suite,manage"
   stepTemplate:
     env:
       - name: CLUSTER_URL
@@ -322,6 +328,10 @@ spec:
         value: $(params.application_admin_sa_namespace)
       - name: PRODUCTION_DATABASE_ACCESS_TYPE
         value: $(params.production_database_access_type)
+      - name: FVT_GITOPS_ENABLED
+        value: $(params.fvt_gitops_enabled)
+      - name: FVT_GITOPS_ENABLED_APPS
+        value: $(params.fvt_gitops_enabled_apps)
 
     envFrom:
       - configMapRef:


### PR DESCRIPTION
## Issue

Epic: https://jsw.ibm.com/browse/MASR-10793
Story: https://jsw.ibm.com/browse/MASCORE-17804

## Description

It adds support for rendering the fvt_gitops configuration block into the instance-base config file when FVT_GITOPS_ENABLED=true is passed to the gitops-suite CLI command. This enables the fvt-gitops-runner Helm chart (PostSync Job) in the gitops repo to be conditionally activated per instance.

## Test Results
Validated locally by running jinjanate against the template with FVT_GITOPS_ENABLED=true — fvt_gitops block renders correctly.
Validated with FVT_GITOPS_ENABLED unset / set to false — block is absent from output (no regression to existing instances).


### :warning: Notes for Reviewers
* Ensure you have understood the [[guidelines](https://pages.github.ibm.com/maximoappsuite/playbook/tools/github/#guidelines)](https://pages.github.ibm.com/maximoappsuite/playbook/tools/github/#guidelines) before proceeding with a review.
* Ensure all sections in the PR template are appropriately completed.