### PR TITLE
[patch] Add Scheduler MAXADMIN Automation

### DIFF
--- a/tekton/src/pipelines/taskdefs/fvt-manage/phase3.yml.j2
+++ b/tekton/src/pipelines/taskdefs/fvt-manage/phase3.yml.j2
@@ -8,6 +8,7 @@
 # - fvt-manage-base-api-scheduler-planning (pytest)
 # - fvt-manage-base-api-scheduler-dispatching (pytest)
 # - fvt-manage-base-api-scheduler-scheduling (pytest)
+# - fvt-manage-base-api-scheduler-maxadmin (pytest)
 # -------------------------------------------------------------
 
 # Manage FVT Classification
@@ -189,3 +190,18 @@
   runAfter:
     - fvt-manage-base-api-scheduler-scheduling
     - fvt-manage-base-api-scheduler-dispatching
+
+# Manage Scheduler FVT - MAXADMIN Delete schedules
+- name: fvt-manage-base-api-scheduler-maxadmin
+  {{ lookup('template', pipeline_src_dir ~ '/taskdefs/fvt-manage/api/taskref.yml.j2') | indent(2) }}
+  params:
+    {{ lookup('template', pipeline_src_dir ~ '/taskdefs/fvt-manage/api/params.yml.j2') | indent(4) }}
+    - name: fvt_test_suite
+      value: base-api-scheduler-maxadmin
+  when:
+    - input: "base"
+      operator: in
+      values: ["$(tasks.fvt-component.results.component_names[*])"]
+  runAfter:
+    - fvt-manage-base-api-system
+    - fvt-manage-base-api-mif

--- a/tekton/src/pipelines/taskdefs/fvt-manage/phase4.yml.j2
+++ b/tekton/src/pipelines/taskdefs/fvt-manage/phase4.yml.j2
@@ -32,6 +32,7 @@
     - fvt-manage-base-api-scheduler-planning
     - fvt-manage-base-api-scheduler-dispatching
     - fvt-manage-base-api-scheduler-scheduling
+    - fvt-manage-base-api-scheduler-maxadmin
 
 # Manage FVT BIRT Reports
 - name: fvt-manage-base-ui-birt-report
@@ -56,6 +57,7 @@
     - fvt-manage-base-api-scheduler-planning
     - fvt-manage-base-api-scheduler-dispatching
     - fvt-manage-base-api-scheduler-scheduling
+    - fvt-manage-base-api-scheduler-maxadmin
 
 # Manage FVT New User Update/Delete/Verufy
 - name: fvt-manage-base-ui-user-crud
@@ -81,6 +83,7 @@
     - fvt-manage-base-api-scheduler-planning
     - fvt-manage-base-api-scheduler-dispatching
     - fvt-manage-base-api-scheduler-scheduling
+    - fvt-manage-base-api-scheduler-maxadmin
 
 # Manage FVT User Consumption verification
 - name: fvt-manage-base-ui-user-consumption
@@ -106,6 +109,7 @@
     - fvt-manage-base-api-scheduler-planning
     - fvt-manage-base-api-scheduler-dispatching
     - fvt-manage-base-api-scheduler-scheduling
+    - fvt-manage-base-api-scheduler-maxadmin
 
 # Manage FVT Communication Template
 - name: fvt-manage-base-ui-communication-temp
@@ -131,6 +135,7 @@
     - fvt-manage-base-api-scheduler-planning
     - fvt-manage-base-api-scheduler-dispatching
     - fvt-manage-base-api-scheduler-scheduling
+    - fvt-manage-base-api-scheduler-maxadmin
 
 # Scheduler Classic Apps Cypress tests
 - name: fvt-manage-base-ui-scheduler-classic
@@ -165,3 +170,4 @@
     - fvt-manage-base-api-scheduler-planning
     - fvt-manage-base-api-scheduler-dispatching
     - fvt-manage-base-api-scheduler-scheduling
+    - fvt-manage-base-api-scheduler-maxadmin


### PR DESCRIPTION
This PR adds the new Scheduler pytest of MASR-4748 Epic (MAXADMIN to delete schedules).

### Evidences

**ansible-playbooks:** 
- generate-tekton-tasks

<img width="1314" height="817" alt="image" src="https://github.com/user-attachments/assets/a22db4d9-8a78-4afb-87a6-cc634c5af355" />

- generate-tekton-pipelines

<img width="1314" height="819" alt="image" src="https://github.com/user-attachments/assets/2dd32ff5-b2a6-4425-85be-8c9ddbb88228" />

**pytest test_schema.py:**

<img width="1376" height="393" alt="image" src="https://github.com/user-attachments/assets/11f6a3a4-c810-4e5a-969c-2e0dbcb7f975" />
