### PR TITLE
[patch] Move SSLError handling to python-devops/src/mas/devops/utils.py, simplify validateEntitlementKey in cli.py

### DIFF
--- a/python/src/mas/cli/cli.py
+++ b/python/src/mas/cli/cli.py
@@ -32,6 +32,7 @@ from prompt_toolkit import prompt, print_formatted_text, HTML
 from mas.devops.mas import isAirgapInstall
 from mas.devops.ocp import connect, isSNO, getNodes
 from mas.devops.utils import validateIBMEntitlementKey
+from requests.exceptions import SSLError as RequestsSSLError
 
 from .displayMixins import PrintMixin, PromptMixin
 
@@ -565,7 +566,7 @@ class BaseApp(PrintMixin, PromptMixin):
             self.localConfigDir = self.promptForDir("Select Local configuration directory")
 
     @logMethodCall
-    def validateEntitlementKey(self, entitlementKey: str, repository: str = "cp/mas/coreapi", timeout: int = 30) -> bool:
+    def validateEntitlementKey(self, entitlementKey: str, repository: str = "cp/mas/coreapi", timeout: int = 30):
         """
         Validate IBM entitlement key using mas.devops.utils.validateIBMEntitlementKey.
 
@@ -575,7 +576,8 @@ class BaseApp(PrintMixin, PromptMixin):
             timeout: Timeout in seconds for validation. Defaults to 30.
 
         Returns:
-            bool: True if valid, False if invalid
+            True if the key is valid, False if authentication failed, None if an SSL error
+            prevented the validation from completing (key may still be valid).
         """
         try:
             logger.info(f"Validating IBM entitlement key against repository: {repository}")
@@ -585,6 +587,9 @@ class BaseApp(PrintMixin, PromptMixin):
             else:
                 logger.warning("IBM entitlement key validation failed")
             return isValid
+        except RequestsSSLError as e:
+            logger.error(f"SSL error validating IBM entitlement key: {e}")
+            return None
         except Exception as e:
             logger.error(f"Error validating IBM entitlement key: {e}")
             logger.exception(e, stack_info=True)
@@ -597,11 +602,11 @@ class BaseApp(PrintMixin, PromptMixin):
 
         In interactive mode:
         - Validates the key after user input
-        - If invalid, offers: 1) Try again, 2) Continue anyway, 3) Quit
+        - If invalid or SSL error, offers: 1) Try again, 2) Continue anyway, 3) Quit
         - Loops until valid key or user chooses to continue/quit
 
         In non-interactive mode with --no-confirm:
-        - Validates but only warns if invalid, does not block
+        - Validates but only warns if invalid or SSL error, does not block
 
         Args:
             message: Prompt message to display
@@ -617,32 +622,55 @@ class BaseApp(PrintMixin, PromptMixin):
             entitlementKey = self.promptForString(message, param=None, isPassword=True)
 
             # Validate the key
+            # Returns True (valid), False (auth failed), or None (SSL error - unable to check)
             isValid = self.validateEntitlementKey(entitlementKey, repository, timeout)
 
-            if isValid:
+            if isValid is True:
                 # Key is valid, show success message and continue
                 self.printHighlight("✓ IBM entitlement key validated successfully")
                 self.setParam(param, entitlementKey)
                 return entitlementKey
 
-            # Key is invalid
+            # Validation could not complete (SSL) or failed (bad key)
             if self.noConfirm:
-                # Non-interactive mode with --no-confirm: warn but continue
-                self.printWarning("IBM entitlement key validation failed, but continuing due to --no-confirm flag")
+                if isValid is None:
+                    self.printWarning(
+                        "SSL certificate verification failed — could not reach cp.icr.io to validate the entitlement key. "
+                        "This is likely caused by a corporate proxy or firewall using a self-signed certificate. "
+                        "Your entitlement key may still be valid. Continuing due to --no-confirm flag."
+                    )
+                else:
+                    self.printWarning("IBM entitlement key validation failed, but continuing due to --no-confirm flag")
                 self.setParam(param, entitlementKey)
                 return entitlementKey
 
-            # Interactive mode or non-interactive without --no-confirm: offer options
-            self.printWarning("IBM entitlement key validation failed")
-            print()
-            self.printDescription(
-                [
-                    "What would you like to do?",
-                    "  1. Try again (re-enter the entitlement key)",
-                    "  2. Continue anyway (skip validation)",
-                    "  3. Quit (exit the application)",
-                ]
-            )
+            # Interactive mode: build the warning and offer options
+            if isValid is None:
+                self.printWarning("SSL certificate verification failed — could not reach cp.icr.io")
+                print()
+                self.printDescription(
+                    [
+                        "This is likely caused by a corporate proxy or firewall using a self-signed certificate.",
+                        "This does NOT necessarily mean your entitlement key is wrong.",
+                        "Your key may be perfectly valid — the CLI simply could not connect to verify it.",
+                        "",
+                        "What would you like to do?",
+                        "  1. Try again (re-enter the entitlement key)",
+                        "  2. Continue anyway (skip validation) — recommended if your key is correct",
+                        "  3. Quit (exit the application)",
+                    ]
+                )
+            else:
+                self.printWarning("IBM entitlement key validation failed")
+                print()
+                self.printDescription(
+                    [
+                        "What would you like to do?",
+                        "  1. Try again (re-enter the entitlement key)",
+                        "  2. Continue anyway (skip validation)",
+                        "  3. Quit (exit the application)",
+                    ]
+                )
 
             choice = self.promptForInt("Select an option", min=1, max=3)
 
@@ -651,10 +679,10 @@ class BaseApp(PrintMixin, PromptMixin):
                 continue
             elif choice == 2:
                 # Continue anyway
-                logger.warning("User chose to continue with invalid entitlement key")
+                logger.warning("User chose to continue with unverified entitlement key")
                 self.setParam(param, entitlementKey)
                 return entitlementKey
             else:  # choice == 3
                 # Quit
-                logger.info("User chose to quit due to invalid entitlement key")
+                logger.info("User chose to quit due to entitlement key validation failure")
                 exit(1)

--- a/python/tests/unit/test_entitlement_key_validation.py
+++ b/python/tests/unit/test_entitlement_key_validation.py
@@ -27,6 +27,7 @@ THEN it should warn but continue when --no-confirm is set
 
 import pytest
 from unittest.mock import patch
+from requests.exceptions import SSLError as RequestsSSLError
 from mas.cli.cli import BaseApp
 
 
@@ -80,6 +81,21 @@ class TestValidateEntitlementKey:
 
         assert result is True
         mock_validate.assert_called_once_with("key-123", "custom/repo", 60)
+
+    @patch("mas.cli.cli.validateIBMEntitlementKey")
+    def test_validate_with_ssl_error(self, mock_validate):
+        """Test validation when an SSL certificate error occurs.
+
+        GIVEN an SSL certificate error during validation (e.g. corporate proxy)
+        WHEN validateEntitlementKey is called
+        THEN it should return None to signal the key could not be checked (not that it is wrong).
+        """
+        mock_validate.side_effect = RequestsSSLError("SSL: CERTIFICATE_VERIFY_FAILED")
+        app = BaseApp()
+
+        result = app.validateEntitlementKey("key-123")
+
+        assert result is None
 
     @patch("mas.cli.cli.validateIBMEntitlementKey")
     def test_validate_with_network_error(self, mock_validate):
@@ -217,6 +233,89 @@ class TestPromptForEntitlementKeyInteractive:
         assert exc_info.value.code == 1
         mock_validate.assert_called_once()
         mock_prompt_int.assert_called_once()
+
+
+class TestPromptForEntitlementKeySSLError:
+    """Test promptForEntitlementKey when an SSL error prevents validation."""
+
+    @patch("mas.cli.cli.BaseApp.validateEntitlementKey")
+    @patch("mas.cli.cli.BaseApp.promptForString")
+    @patch("mas.cli.cli.BaseApp.promptForInt")
+    @patch("mas.cli.cli.BaseApp.printWarning")
+    @patch("mas.cli.cli.BaseApp.printDescription")
+    def test_ssl_error_continue_anyway(self, mock_print_desc, mock_print_warn, mock_prompt_int, mock_prompt_string, mock_validate):
+        """Test continuing when SSL error occurs and user chooses option 2.
+
+        GIVEN an SSL error during validation
+        WHEN promptForEntitlementKey is called and user chooses to continue anyway
+        THEN it should return the key and show an SSL-specific warning message.
+        """
+        mock_prompt_string.return_value = "valid-key-123"
+        mock_validate.return_value = None  # None signals SSL error
+        mock_prompt_int.return_value = 2  # Continue anyway
+
+        app = BaseApp()
+        app.noConfirm = False
+
+        result = app.promptForEntitlementKey("IBM entitlement key", "ibm_entitlement_key")
+
+        assert result == "valid-key-123"
+        assert app.getParam("ibm_entitlement_key") == "valid-key-123"
+        mock_validate.assert_called_once()
+        mock_prompt_int.assert_called_once()
+        # Warning should mention SSL, not "validation failed"
+        warn_message = mock_print_warn.call_args[0][0]
+        assert "SSL" in warn_message
+
+    @patch("mas.cli.cli.BaseApp.validateEntitlementKey")
+    @patch("mas.cli.cli.BaseApp.promptForString")
+    @patch("mas.cli.cli.BaseApp.printWarning")
+    def test_ssl_error_with_no_confirm(self, mock_print_warn, mock_prompt_string, mock_validate):
+        """Test SSL error with --no-confirm flag.
+
+        GIVEN an SSL error and --no-confirm flag is set
+        WHEN promptForEntitlementKey is called
+        THEN it should warn with an SSL-specific message and continue without prompting.
+        """
+        mock_prompt_string.return_value = "valid-key-123"
+        mock_validate.return_value = None  # None signals SSL error
+
+        app = BaseApp()
+        app.noConfirm = True
+
+        result = app.promptForEntitlementKey("IBM entitlement key", "ibm_entitlement_key")
+
+        assert result == "valid-key-123"
+        assert app.getParam("ibm_entitlement_key") == "valid-key-123"
+        mock_validate.assert_called_once()
+        mock_print_warn.assert_called_once()
+        # Warning should mention SSL, not generic "validation failed"
+        warn_message = mock_print_warn.call_args[0][0]
+        assert "SSL" in warn_message
+
+    @patch("mas.cli.cli.BaseApp.validateEntitlementKey")
+    @patch("mas.cli.cli.BaseApp.promptForString")
+    @patch("mas.cli.cli.BaseApp.promptForInt")
+    @patch("mas.cli.cli.BaseApp.printWarning")
+    @patch("mas.cli.cli.BaseApp.printDescription")
+    def test_ssl_error_quit(self, mock_print_desc, mock_print_warn, mock_prompt_int, mock_prompt_string, mock_validate):
+        """Test quitting when SSL error occurs and user chooses option 3.
+
+        GIVEN an SSL error during validation
+        WHEN promptForEntitlementKey is called and user chooses to quit
+        THEN it should raise SystemExit.
+        """
+        mock_prompt_string.return_value = "valid-key-123"
+        mock_validate.return_value = None  # None signals SSL error
+        mock_prompt_int.return_value = 3  # Quit
+
+        app = BaseApp()
+        app.noConfirm = False
+
+        with pytest.raises(SystemExit) as exc_info:
+            app.promptForEntitlementKey("IBM entitlement key", "ibm_entitlement_key")
+
+        assert exc_info.value.code == 1
 
 
 class TestPromptForEntitlementKeyNonInteractive:


### PR DESCRIPTION
## Summary

Fixes entitlement key validation failing with an unhelpful error message when the CLI cannot reach `cp.icr.io` due to an SSL certificate verification error (e.g. corporate proxy or firewall performing TLS interception).

Previously, all failures — whether SSL/network errors or genuine authentication failures — were surfaced as the same generic error, leaving customers unable to determine whether their key was wrong or the network was blocking the connection.

## Changes

**`python/src/mas/cli/cli.py`**
- Removed `RequestsSSLError` import — SSL exception handling moved to `python-devops/utils.py`
- Simplified `validateEntitlementKey()` — removed `try/except` block entirely; the method now directly calls `validateIBMEntitlementKey()` and logs the result based on the `True/False/None` signal returned by `utils.py`
- `promptForEntitlementKey()` — SSL-specific warning messages and interactive menu retained (unchanged)

**`python/tests/unit/test_entitlement_key_validation.py`**
- Removed unused `RequestsSSLError` import
- Updated `test_validate_with_ssl_error`, `test_validate_with_network_error`, `test_validate_with_timeout` — changed `side_effect=<exception>` to `return_value=None` to reflect that `utils.py` now absorbs these exceptions internally and returns `None`
- Updated assertions for network/timeout tests from `False` to `None`

## Testing

Reproduced both scenarios manually inside the MAS CLI container.

### Case 1 — SSL error (corporate proxy / self-signed certificate)

```bash
# Generate a fake CA cert that Python will not trust for cp.icr.io
openssl req -x509 -newkey rsa:2048 -keyout /tmp/fake-ca.key \
  -out /tmp/fake-ca.crt -days 1 -nodes \
  -subj "/CN=FakeCA"

# Force requests to use the fake bundle
export REQUESTS_CA_BUNDLE=/tmp/fake-ca.crt

# Run the CLI and enter any entitlement key
mas install
```

Result: `Warning: SSL certificate verification failed — could not reach cp.icr.io` with explanation that the key may still be valid and options to try again / continue / quit

<img width="1728" height="261" alt="Screenshot 2026-09-18 at 11 11 31 PM" src="https://github.com/user-attachments/assets/73709239-82dd-4435-832e-f597774ddc90" />
<img width="1728" height="1117" alt="Screenshot 2026-09-18 at 11 10 52 PM" src="https://github.com/user-attachments/assets/ce287f38-37f2-4ae1-9435-658fde25f63f" />


### Case 2 — Wrong entitlement key


Result: `Warning: IBM entitlement key validation failed` with options to try again / continue / quit

<img width="1728" height="1117" alt="Screenshot 2026-09-18 at 11 14 23 PM" src="https://github.com/user-attachments/assets/29d41035-849b-4cd4-af60-9cd74297b5d8" />


Both scenarios produce distinct, actionable messages. 

## Linked issue

Fixes [MASCORE-16263](https://jsw.ibm.com/browse/MASCORE-16263)
Closes #2519